### PR TITLE
make benchmarks support additional models and include observation noise

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -34,6 +34,6 @@ class Model(ABC):
         raise NotImplementedError
 
     def reinitialize(
-        train_X: Tensor, train_Y: Tensor, train_Y_se: Optional[Tensor] = None
+        self, train_X: Tensor, train_Y: Tensor, train_Y_se: Optional[Tensor] = None
     ) -> None:
         raise NotImplementedError


### PR DESCRIPTION
Summary: Add ability to supply an arbitrary model to the benchmarks (so long as it has a likelihood so that we know how to refit it). Also, add support for observation noise.

Reviewed By: Balandat

Differential Revision: D13561279
