### PR TITLE
torch.nn.functional.sigmoid -> torch.sigmoid

### DIFF
--- a/botorch/acquisition/functional/batch_acquisition.py
+++ b/botorch/acquisition/functional/batch_acquisition.py
@@ -5,7 +5,6 @@ from typing import Callable, List, Optional
 
 import torch
 from torch import Tensor
-from torch.nn.functional import sigmoid
 
 from ...models import Model
 from ...optim.outcome_constraints import soft_eval_constraint
@@ -455,7 +454,7 @@ def batch_probability_of_improvement(
     samples = posterior.rsample(
         sample_shape=torch.Size([mc_samples]), base_samples=base_samples
     ).max(dim=2)[0]
-    val = sigmoid(samples - best_f).mean(dim=0)
+    val = torch.sigmoid(samples - best_f).mean(dim=0)
     return val
 
 

--- a/botorch/optim/outcome_constraints.py
+++ b/botorch/optim/outcome_constraints.py
@@ -2,8 +2,8 @@
 
 from typing import Dict, Optional, Tuple
 
+import torch
 from torch import Tensor
-from torch.nn.functional import sigmoid
 
 
 ParameterBounds = Dict[str, Tuple[Optional[float], Optional[float]]]
@@ -27,4 +27,4 @@ def soft_eval_constraint(lhs: Tensor, eta: float = 1e-3) -> Tensor:
     """
     if eta <= 0:
         raise ValueError("eta must be positive")
-    return sigmoid(-lhs / eta)
+    return torch.sigmoid(-lhs / eta)


### PR DESCRIPTION
Summary:
Get rid of the following:

```
test/acquisition/functional/test_batch_acquisition.py::TestFunctionalBatchAcquisition::test_batch_expected_improvement
test/acquisition/functional/test_batch_acquisition.py::TestFunctionalBatchAcquisition::test_batch_noisy_expected_improvement
test/acquisition/functional/test_thompson_sampling_utils.py::TestThompsonSamplingUtils::test_discrete_thompson_sample
test/optim/test_outcome_constraints.py::TestSoftEvalConstraint::test_soft_eval_scalar_constraint
test/optim/test_outcome_constraints.py::TestSoftEvalConstraint::test_soft_eval_tensor_constraint
  /anaconda3/envs/bare/lib/python3.6/site-packages/torch/nn/functional.py:1332: UserWarning: nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.
    warnings.warn("nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.")

```

Differential Revision: D14167641
