### PR TITLE
fit_model -> fit_gpytorch_model (#9)

### DIFF
--- a/botorch/__init__.py
+++ b/botorch/__init__.py
@@ -2,7 +2,7 @@
 
 from . import acquisition, exceptions, models, optim, posteriors, test_functions
 from .cross_validation import batch_cross_validation
-from .fit import fit_model
+from .fit import fit_gpytorch_model
 from .gen import gen_candidates_scipy, gen_candidates_torch, get_best_candidates
 from .utils import manual_seed
 
@@ -11,7 +11,7 @@ __all__ = [
     "acquisition",
     "batch_cross_validation",
     "exceptions",
-    "fit_model",
+    "fit_gpytorch_model",
     "gen_candidates_scipy",
     "gen_candidates_torch",
     "get_best_candidates",

--- a/botorch/benchmarks/optimize.py
+++ b/botorch/benchmarks/optimize.py
@@ -8,7 +8,7 @@ import torch
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from torch import Tensor
 
-from .. import fit_model
+from .. import fit_gpytorch_model
 from ..acquisition.objective import (
     ConstrainedMCObjective,
     IdentityMCObjective,
@@ -51,7 +51,7 @@ def _get_fitted_model(
     )
     mll = ExactMarginalLogLikelihood(model.likelihood, model)
     mll.to(dtype=train_X.dtype, device=train_X.device)
-    mll = fit_model(mll, options=options)
+    mll = fit_gpytorch_model(mll, options=options)
     return model
 
 

--- a/botorch/cross_validation.py
+++ b/botorch/cross_validation.py
@@ -10,7 +10,7 @@ from gpytorch.models import ExactGP
 from torch import Tensor
 from torch.distributions import Distribution
 
-from .fit import fit_model
+from .fit import fit_gpytorch_model
 
 
 class CVFolds(NamedTuple):
@@ -66,7 +66,7 @@ def batch_cross_validation(
             non-batch and in batch mode, and take a "batch_size" kwarg in its
             constructor
         cv_folds: A CVFolds tuple
-        fit_args: Arguments passed along to fit_model
+        fit_args: Arguments passed along to fit_gpytorch_model
 
     Returns:
         A CVResults tuple with the following fields:
@@ -89,7 +89,7 @@ def batch_cross_validation(
         model_cv.double()
 
     mll_cv = ExactMarginalLogLikelihood(likelihood_cv, model_cv)
-    mll_cv = fit_model(mll_cv, **fit_args)
+    mll_cv = fit_gpytorch_model(mll_cv, **fit_args)
 
     # Evaluate on the hold-out set in batch mode
     with torch.no_grad(), gpytorch.settings.fast_pred_var():

--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 
-from typing import Callable
+from typing import Any, Callable
 
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 
-from .optim.fit import fit_scipy
+from .optim.fit import fit_gpytorch_scipy
 
 
-def fit_model(
-    mll: MarginalLogLikelihood, optimizer: Callable = fit_scipy, **kwargs
+def fit_gpytorch_model(
+    mll: MarginalLogLikelihood, optimizer: Callable = fit_gpytorch_scipy, **kwargs: Any
 ) -> MarginalLogLikelihood:
     """Fit hyperparameters of a gpytorch model.
 
@@ -22,11 +22,7 @@ def fit_model(
     Returns:
         mll with optimized parameters.
     """
-    mll.model.train()
-    mll.likelihood.train()
-
+    mll.train()
     mll, _ = optimizer(mll, track_iterations=False, **kwargs)
-
-    mll.model.eval()
-    mll.likelihood.eval()
+    mll.eval()
     return mll

--- a/botorch/optim/fit.py
+++ b/botorch/optim/fit.py
@@ -4,7 +4,6 @@ import time
 from collections import OrderedDict
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
-import gpytorch
 import numpy as np
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from scipy.optimize import Bounds, minimize
@@ -25,7 +24,7 @@ class OptimizationIteration(NamedTuple):
     time: float
 
 
-def fit_torch(
+def fit_gpytorch_torch(
     mll: MarginalLogLikelihood,
     optimizer_cls: Optimizer = Adam,
     lr: float = 0.05,
@@ -95,7 +94,7 @@ def fit_torch(
     return mll, iterations
 
 
-def fit_scipy(
+def fit_gpytorch_scipy(
     mll: MarginalLogLikelihood,
     bounds: Optional[ParameterBounds] = None,
     method: str = "L-BFGS-B",

--- a/test/benchmarks/test_optimize.py
+++ b/test/benchmarks/test_optimize.py
@@ -422,7 +422,7 @@ class TestGreedy(unittest.TestCase):
 
 
 class TestGetFittedModel(unittest.TestCase):
-    @mock.patch("botorch.benchmarks.optimize.fit_model")
+    @mock.patch("botorch.benchmarks.optimize.fit_gpytorch_model")
     def test_get_fitted_model(self, mock_fit_model, cuda=False):
         device = torch.device("cuda") if cuda else torch.device("cpu")
         for dtype in (torch.float, torch.double):

--- a/test/models/test_constant_noise.py
+++ b/test/models/test_constant_noise.py
@@ -5,7 +5,7 @@ import unittest
 from copy import deepcopy
 
 import torch
-from botorch import fit_model
+from botorch import fit_gpytorch_model
 from botorch.models.constant_noise import ConstantNoiseGP
 from botorch.posteriors import GPyTorchPosterior
 from gpytorch.distributions import MultivariateNormal
@@ -47,7 +47,7 @@ class ConstantNoiseGPTest(unittest.TestCase):
 
             # test model fitting
             mll = ExactMarginalLogLikelihood(model.likelihood, model)
-            mll = fit_model(mll, options={"maxiter": 1})
+            mll = fit_gpytorch_model(mll, options={"maxiter": 1})
 
             # test posterior
             test_x = torch.tensor([[0.25], [0.75]]).to(**tkwargs)

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -4,7 +4,7 @@ import math
 import unittest
 
 import torch
-from botorch import fit_model
+from botorch import fit_gpytorch_model
 from botorch.models.gp_regression import HeteroskedasticSingleTaskGP, SingleTaskGP
 from gpytorch.distributions import MultivariateNormal
 from gpytorch.kernels import MaternKernel, ScaleKernel
@@ -28,7 +28,7 @@ class SingleTaskGPTest(unittest.TestCase):
             train_x.cuda() if cuda else train_x, train_y.cuda() if cuda else train_y
         )
         mll = ExactMarginalLogLikelihood(model.likelihood, model)
-        fit_model(mll, options={"maxiter": 1})
+        fit_gpytorch_model(mll, options={"maxiter": 1})
         self.model = model
 
     def test_Init(self):
@@ -63,7 +63,7 @@ class SingleTaskGPTest(unittest.TestCase):
         for p in params:
             self.assertEqual(params[p].item(), 0.0)
         mll = ExactMarginalLogLikelihood(model.likelihood, self.model)
-        fit_model(mll)
+        fit_gpytorch_model(mll)
         # check that some of the parameters changed
         self.assertFalse(all(params[p].item() == 0.0 for p in params))
 
@@ -79,7 +79,7 @@ class HeteroskedasticSingleTaskGPTest(unittest.TestCase):
             train_y_sem.cuda() if cuda else train_y_sem,
         )
         mll = ExactMarginalLogLikelihood(self.model.likelihood, self.model)
-        fit_model(mll, options={"maxiter": 1})
+        fit_gpytorch_model(mll, options={"maxiter": 1})
 
     def test_Init(self):
         self.assertIsInstance(self.model.mean_module, ConstantMean)
@@ -118,6 +118,6 @@ class HeteroskedasticSingleTaskGPTest(unittest.TestCase):
         for p in params:
             self.assertEqual(params[p].item(), 0.0)
         mll = ExactMarginalLogLikelihood(model.likelihood, self.model)
-        fit_model(mll)
+        fit_gpytorch_model(mll)
         # check that some of the parameters changed
         self.assertFalse(all(params[p].item() == 0.0 for p in params))

--- a/test/models/test_multi_output_gp_regression.py
+++ b/test/models/test_multi_output_gp_regression.py
@@ -5,7 +5,7 @@ import unittest
 from copy import deepcopy
 
 import torch
-from botorch import fit_model
+from botorch import fit_gpytorch_model
 from botorch.models import MultiOutputGP
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.posteriors import GPyTorchPosterior
@@ -55,7 +55,7 @@ class MultiOutputGPTest(unittest.TestCase):
             mll = SumMarginalLogLikelihood(model.likelihood, model)
             for mll_ in mll.mlls:
                 self.assertIsInstance(mll_, ExactMarginalLogLikelihood)
-            mll = fit_model(mll, options={"maxiter": 1})
+            mll = fit_gpytorch_model(mll, options={"maxiter": 1})
 
             # test posterior
             test_x = (torch.tensor([0.25, 0.75]).type_as(model.train_targets[0]),)

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -5,7 +5,7 @@ import unittest
 from copy import deepcopy
 
 import torch
-from botorch import fit_model
+from botorch import fit_gpytorch_model
 from botorch.models.multitask import MultiTaskGP
 from botorch.posteriors import GPyTorchPosterior
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
@@ -65,7 +65,7 @@ class MultiTaskGPTest(unittest.TestCase):
 
             # test model fitting
             mll = ExactMarginalLogLikelihood(model.likelihood, model)
-            mll = fit_model(mll, options={"maxiter": 1})
+            mll = fit_gpytorch_model(mll, options={"maxiter": 1})
 
             # test posterior
             test_x = torch.rand(2, 1, **tkwargs)
@@ -122,7 +122,7 @@ class MultiTaskGPTest(unittest.TestCase):
 
             # test model fitting
             mll = ExactMarginalLogLikelihood(model.likelihood, model)
-            mll = fit_model(mll, options={"maxiter": 1})
+            mll = fit_gpytorch_model(mll, options={"maxiter": 1})
 
             # test posterior
             test_x = torch.rand(2, 1, **tkwargs)

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -4,16 +4,16 @@ import math
 import unittest
 
 import torch
-from botorch import fit_model
+from botorch import fit_gpytorch_model
 from botorch.models import SingleTaskGP
-from botorch.optim.fit import fit_torch
+from botorch.optim.fit import fit_gpytorch_torch
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 
 
 NOISE = [0.127, -0.113, -0.345, -0.034, -0.069, -0.272, 0.013, 0.056, 0.087, -0.081]
 
 
-class TestFitModel(unittest.TestCase):
+class TestFitGPyTorchModel(unittest.TestCase):
     def setUp(self):
         self.train_x = torch.linspace(0, 1, 10)
         self.train_y = torch.sin(self.train_x * (2 * math.pi)) + torch.tensor(NOISE)
@@ -25,9 +25,9 @@ class TestFitModel(unittest.TestCase):
         mll = ExactMarginalLogLikelihood(model.likelihood, model)
         return mll.cuda() if cuda else mll
 
-    def test_fit_model_scipy(self, cuda=False):
+    def test_fit_gpytorch_model_scipy(self, cuda=False):
         mll = self._getModel(cuda=cuda)
-        mll = fit_model(mll, options={"maxiter": 1})
+        mll = fit_gpytorch_model(mll, options={"maxiter": 1})
         model = mll.model
         # Make sure all of the parameters changed
         self.assertGreater(model.likelihood.raw_noise.abs().item(), 1e-3)
@@ -37,9 +37,9 @@ class TestFitModel(unittest.TestCase):
         )
         self.assertGreater(model.covar_module.raw_outputscale.abs().item(), 1e-3)
 
-    def test_fit_model_torch(self, cuda=False):
+    def test_fit_gpytorch_model_torch(self, cuda=False):
         mll = self._getModel(cuda=cuda)
-        mll = fit_model(mll, optimizer=fit_torch, maxiter=1)
+        mll = fit_gpytorch_model(mll, optimizer=fit_gpytorch_torch, maxiter=1)
         model = mll.model
         # Make sure all of the parameters changed
         self.assertGreater(model.likelihood.raw_noise.abs().item(), 1e-3)
@@ -49,10 +49,10 @@ class TestFitModel(unittest.TestCase):
         )
         self.assertGreater(model.covar_module.raw_outputscale.abs().item(), 1e-3)
 
-    def test_fit_model_scipy_cuda(self):
+    def test_fit_gpytorch_model_scipy_cuda(self):
         if torch.cuda.is_available():
-            self.test_fit_model_scipy(cuda=True)
+            self.test_fit_gpytorch_model_scipy(cuda=True)
 
-    def test_fit_model_torch_cuda(self):
+    def test_fit_gpytorch_model_torch_cuda(self):
         if torch.cuda.is_available():
-            self.test_fit_model_torch(cuda=True)
+            self.test_fit_gpytorch_model_torch(cuda=True)

--- a/test/test_gen.py
+++ b/test/test_gen.py
@@ -4,7 +4,7 @@ import math
 import unittest
 
 import torch
-from botorch import fit_model, gen_candidates_scipy
+from botorch import fit_gpytorch_model, gen_candidates_scipy
 from botorch.acquisition import qExpectedImprovement
 from botorch.models import SingleTaskGP
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
@@ -34,7 +34,7 @@ class TestBaseCandidateGeneration(unittest.TestCase):
         model = SingleTaskGP(self.train_x, self.train_y)
         self.model = model.to(device=device, dtype=dtype)
         self.mll = ExactMarginalLogLikelihood(self.model.likelihood, self.model)
-        self.mll = fit_model(self.mll, options={"maxiter": 1})
+        self.mll = fit_gpytorch_model(self.mll, options={"maxiter": 1})
 
 
 class TestGenCandidates(TestBaseCandidateGeneration):


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebook/Ax/pull/9

It really only works with gpytorch models right now, so let's have the
name reflect that.

This will require some changes to the docs wherever `fit_model` appears.

Differential Revision: D14748515
