### PR TITLE
Pin to gpytorch 0.3.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
       python: "3.6"
       install:
         - pip install -q cython numpy
-        - pip install -q git+https://github.com/cornellius-gp/gpytorch.git@eb96db228b9a1aeb8314ec1d8bc448d11d4cc46c
         - pip install -q -e .[dev]
       script:
         - pytest -ra --cov=.
@@ -22,7 +21,6 @@ matrix:
       dist: xenial
       install:
         - pip install -q cython numpy
-        - pip install -q git+https://github.com/cornellius-gp/gpytorch.git@eb96db228b9a1aeb8314ec1d8bc448d11d4cc46c
         - pip install -q -e .[dev]
       script:
         - pytest -ra --cov=.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following are required to run the setup:
 ##### Installation Requirements
 
 - PyTorch >= 1.0.1
-- gpytorch `eb96db228b9a1aeb8314ec1d8bc448d11d4cc46c` (**TODO:** pin beta to 0.3.0 release)
+- gpytorch >= 0.3.0
 - scipy
 
 **Important:**
@@ -30,21 +30,6 @@ You will want to have you PyTorch build link against **MKL** (the non-optimized
 version of botorch can be up to an order of magnitude slower). Setting this up
 manually can be tricky - to make sure this works please use the Anaconda
 installation instructions on https://pytorch.org/.
-
-
-### Install gpytorch using pip
-
-botorch uses the latest gpytorch features. There is no current release that
-includes these, so we pin gpytorch to a specific version. This will be unnecessary
-for the beta release.
-
-```bash
-pip install git+https://github.com/cornellius-gp/gpytorch.git@eb96db228b9a1aeb8314ec1d8bc448d11d4cc46c
-```
-**Note:** The botorch 0.1a0 alpha release has been tested with the above commit
-of gpytorch - if you already have a version of gpytorch installed, make sure
-you uninstall that (using `pip uninstall gpytorch`) before running the above
-command.
 
 
 ### Install botorch

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     ],
     python_requires=">=3.6",
     setup_requires=["cython", "numpy"],
-    install_requires=["torch>=1.0.1", "gpytorch>=0.2.1", "scipy"],
+    install_requires=["torch>=1.0.1", "gpytorch>=0.3.0", "scipy"],
     include_dirs=[numpy.get_include()],
     packages=find_packages(),
     ext_modules=cythonize(EXTENSIONS),


### PR DESCRIPTION
This will make installation much easier. travis will now run against 0.3.0 gpytorch + pytorch 1.0.1, and against gpytorch master and pytorch-nightly. 

Will put up a separate PR to get rid of cython requirement.