### PR TITLE
Remove learning to walk case study from docusaurus docs

### DIFF
--- a/docs/learning_to_walk.md
+++ b/docs/learning_to_walk.md
@@ -1,7 +1,0 @@
----
-id: learning_to_walk
-title: Teaching Robots How to Walk
----
-
-**TODO:** Check w/ Akshara & Roberto if we can get some material on how they
-use botorch for teaching their robot how to walk.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -3,7 +3,6 @@
     "About": ["introduction", "design_philosophy", "botorch_and_ax"],
     "General": ["installation", "contributing"],
     "Basic Concepts": ["overview", "models", "posteriors", "acquisition", "optimization"],
-    "Advanced Topics": ["more_on_batching", "objectives", "samplers", "mtmo_models"],
-    "Case Studies": ["learning_to_walk"]
+    "Advanced Topics": ["more_on_batching", "objectives", "samplers", "mtmo_models"]
   }
 }


### PR DESCRIPTION
We'll make that a tutorial instead.