### PR TITLE
Add environment and recipe for conda

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -1,0 +1,42 @@
+{% set data = load_setup_py_data(setup_file="../setup.py", from_recipe_dir=True) %}
+
+package:
+  name: {{ data.get("name")|lower }}
+  version: {{ data.get("version") }}
+
+source:
+  path: ..
+
+build:
+  noarch: python
+  script: "$PYTHON setup.py install --single-version-externally-managed --record=record.txt"
+
+requirements:
+  host:
+    - python>=3.6
+  run:
+    - pytorch-nightly
+    - gpytorch
+    - scipy
+
+test:
+  imports:
+    - botorch
+    - botorch.acquisition
+    - botorch.exceptions
+    - botorch.models
+    - botorch.optim
+    - botorch.posteriors
+    - botorch.qmc
+    - botorch.test_functions
+    - botorch.utils
+    - botorch.fit
+    - botorch.gen
+
+about:
+  home: https://botorch.org
+  license: MIT
+  license_file: LICENSE
+  summary: Bayesian Optimization in PyTorch
+  doc_url: https://botorch.org/docs
+  dev_url: https://github.com/pytorch/botorch

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: botorch
+channels:
+  - pytorch
+  - gpytorch
+dependencies:
+  - pytorch-nightly
+  - gpytorch
+  - scipy

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,42 @@
+{% set data = load_setup_py_data(setup_file="setup.py", from_recipe_dir=True) %}
+
+package:
+  name: {{ data.get("name")|lower }}
+  version: {{ data.get("version") }}
+
+source:
+  path: ./
+
+build:
+  noarch: python
+  script: "$PYTHON setup.py install --single-version-externally-managed --record=record.txt"
+
+requirements:
+  host:
+    - python>=3.6
+  run:
+    - pytorch-nightly
+    - gpytorch
+    - scipy
+
+test:
+  imports:
+    - botorch
+    - botorch.acquisition
+    - botorch.exceptions
+    - botorch.models
+    - botorch.optim
+    - botorch.posteriors
+    - botorch.qmc
+    - botorch.test_functions
+    - botorch.utils
+    - botorch.fit
+    - botorch.gen
+
+about:
+  home: https://botorch.org
+  license: MIT
+  license_file: LICENSE
+  summary: Bayesian Optimization in PyTorch
+  doc_url: https://botorch.org/docs
+  dev_url: https://github.com/pytorch/botorch

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ if fatals:
     )
 
 
-TEST_REQUIRES = ["pytest>=3.6", "pytest-cov"]
+TEST_REQUIRES = ["pytest", "pytest-cov"]
 
 DEV_REQUIRES = TEST_REQUIRES + ["black", "flake8", "sphinx", "sphinx-autodoc-typehints"]
 
@@ -67,8 +67,7 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     python_requires=">=3.6",
-    setup_requires=["cython", "numpy"],
-    install_requires=["torch>=1.0.1", "gpytorch>=0.3.1", "scipy"],
+    install_requires=["torch>=1.0.1", "gpytorch>=0.3.2", "scipy"],
     packages=find_packages(),
     extras_require={
         "dev": DEV_REQUIRES,


### PR DESCRIPTION
This currently requires pytorch-nightly so that we can use torch.quasirandom.
Once pytorch 1.1 is out we can use `pytorch>=1.1` instead.

Tested building and running package locally as follows:

1. Create clean environment
``` 
conda env create -f environment.yml
```
2. Build conda package
```
cd .conda
conda build .
```
3. Install locally
```
conda install --offline /path/to/botorch-0.1.0a3-0.tar.bz2
```
4. Test everything works
```
python
import botorch
```