### PR TITLE
clean up and update batching docs

### DIFF
--- a/docs/batching.md
+++ b/docs/batching.md
@@ -28,9 +28,9 @@ Internally, q-batch acquisition functions operate on input tensors of shape
 $b \times q \times d$, where $b$ is the number of t-batches, $q$ is the number
 of design points to be considered concurrently, and $d$ is the dimension of the
 parameter space. Their output is a one-dimensional tensor with $b$ elements,
-with the $i$-th element corresponding to the $i$-th t-batch. Always requiring a
-explicit t-batch dimension makes it much easier and less ambiguous to work with
-samples from the posterior in a consistent fashion.
+with the $i$-th element corresponding to the $i$-th t-batch. Always requiring
+explicit t-batch and q-batch dimensions makes it easier and less ambiguous to work
+with samples from the posterior in a consistent fashion.
 
 
 #### Batch-Mode Decorator
@@ -39,11 +39,10 @@ In order to simplify the user-facing API for evaluating acquisition functions,
 BoTorch implements the
 [`@t_batch_mode_transform`](../api/utils.html#botorch.utils.transforms.t_batch_mode_transform)
 decorator, which allows the use of non-batch mode inputs. If applied to an
-instance method with a single `Tensor`
-argument, an input tensor to that method without a t-batch dimension (i.e.
-tensors of shape $q \times d$) will automatically be converted to a t-batch of
-size 1 (i.e. of `batch_shape` `torch.Size([1])`), This is typically used on the
-`forward` method of an `AcquisitionFunction`.
+instance method with a single `Tensor` argument, an input tensor to that method
+without a t-batch dimension (i.e. tensors of shape $q \times d$) will automatically
+be converted to a t-batch of size 1 (i.e. of `batch_shape` `torch.Size([1])`),
+This is typically used on the `forward` method of an `AcquisitionFunction`.
 The `@t_batch_mode_transform` decorator takes an `expected_q` argument that, if
 specified, checks that the number of q-batches in the input is equal to the
 one specified in the decorator. This is typically used for acquisition functions
@@ -59,26 +58,28 @@ dimension corresponding to the MC samples we draw. We use the PyTorch notions of
 `sample_shape` and `event_shape`.
 
 `event_shape` is the shape of a single sample drawn from the underlying
-distribution. For instance,
-- evaluating a single-output model at a $1 \times n \times d$ tensor,
+distribution:
+- Evaluating a single-output model at a $1 \times n \times d$ tensor,
   representing $n$ data points in $d$ dimensions each, yields a posterior with
-  `event_shape` $1 \times n \times 1$. Evaluating the same model at a
-  $\textit{batch_shape} \times n \times d$ tensor (representing a t-batch-shape
-  of $\textit{batch_shape}$, with $n$ $d$-dimensional data points in each batch)
-  yields a posterior with `event_shape` $\textit{batch_shape} \times n \times 1$.
-- evaluating a multi-output model with $t$ outputs at a $\textit{batch_shape}   
-  \times n \times d$ tensor yields a posterior with `event_shape`
-  $\textit{batch_shape} \times n \times t$.
-- recall from the previous section that internally, all acquisition functions
-  are evaluated using a single t-batch dimension.
+  `event_shape` being $1 \times n \times 1$. Evaluating the same model at a
+  $b_1 \times \cdots \times b_k \times n \times d$ tensor (representing a t-batch-shape
+  of $b_1 \times \cdots \times b_k$, with $n$ data points of $d$-dimensions each in every batch)
+  yields a posterior with `event_shape` being $b_1 \times \cdots \times b_k \times n \times 1$.
+  In most cases, the t-batch-shape will be single-dimensional (i.e., $k=1$).
+- Evaluating a multi-output model with $o$ outputs at a $b_1 \times \cdots \times b_k   
+  \times n \times d$ tensor yields a posterior with `event_shape` equal to
+  $b_1 \times \cdots \times b_k \times n \times o$.
+- Recall from the previous section that internally, with the help of the
+  `@t_batch_mode_transform` decorator, all acquisition functions are evaluated using
+  at least one t-batch dimension.
 
 `sample_shape` is the shape (possibly multi-dimensional) of the samples drawn
 *independently* from the distribution with `event_shape`, resulting in a tensor
-of samples of shape `sample_shape` + `event_shape`. For instance,
-- drawing a sample of shape $s1 \times s2$ from a posterior with `event_shape`
-  $b \times n \times t$ results in a tensor of shape
-  $s1 \times s2 \times \textit{batch_shape} \times n \times t$, where each of
-  the $s1 s2$ tensors of shape $\textit{batch_shape} \times n \times t$ are
+of samples of shape `sample_shape` + `event_shape`:
+- Drawing a sample with `sample_shape` being $s_1 \times s_2$ from a posterior with `event_shape`
+  equal to $b_1 \times \cdots \times b_k \times n \times o$ results in a tensor of shape
+  $s_1 \times s_2 \times b_1 \times \cdots \times b_k \times n \times o$, where each of
+  the $s_1 \times s_2$ tensors of shape $b_1 \times \cdots \times b_k \times n \times o$ are
   independent draws.
 
 
@@ -89,7 +90,8 @@ arbitrary t-batch shapes.
 ##### Non-Batched Models
 
 In the simplest case, a model is fit to non-batched training points with shape
-$n \times d$.
+$n \times d$. We use $\textit{batch_shape}$ to represent an arbitrary batch shape
+of the form $b_1 \times \cdots \times b_k$.
 - *Non-batched evaluation* on a set of test points with shape $m \times d$
   yields a joint posterior over the $m$ points.
 - *Batched evaluation* on a set of test points with shape
@@ -97,28 +99,28 @@ $n \times d$.
   joint posteriors over the $m$ points in each respective batch.
 
 ##### Batched Models
-The GPyTorch models can also be fit on batched training points with shape
-$\textit{input_batch_shape} \times n \times d$. Here, each batch is modeled
-independently (each batch has its own hyperparameters).
-For example the training points have shape $b_1 \times b_2 \times n \times d$
+GPyTorch models can also be
+[fit on batched training points](https://github.com/cornellius-gp/gpytorch/blob/master/examples/01_Simple_GP_Regression/Simple_Batch_Mode_GP_Regression.ipynb)
+with shape $\textit{batch_shape} \times n \times d$. Here, each batch is modeled
+independently (i.e., each batch has its own hyperparameters).
+For example, if the training points have shape $b_1 \times b_2 \times n \times d$
 (two batch dimensions), the batched GPyTorch model is effectively $b_1 \times b_2$
 independent models. More generally, suppose we fit a model to training points
-with shape $\textit{input_batch_shape} \times n \times d$.
-Then, the test points must support broadcasting to the $\textit{input_batch_shape}$.
+with shape $\textit{batch_shape} \times n \times d$.
+The shape of the test points must support broadcasting to the $\textit{batch_shape}$.
 
-* *Non-batched evaluation* on a set of test points with shape
-  $\textit{input_batch_shape}^* \times m \times d$, where each dimension of
-  $\textit{input_batch_shape}^*$ either matches the corresponding dimension of
-  $\textit{input_batch_shape}$ or is 1 to support broadcasting, yields
-  $\textit{input_batch_shape}$ joint posteriors over the $m$ points
-  (respectively if not broadcasting).
+* *Non-batched evaluation* on test points with shape
+  $\textit{batch_shape'} \times m \times d$, where each dimension of
+  $\textit{batch_shape'}$ either matches the corresponding dimension of
+  $\textit{batch_shape}$ or is 1 to support broadcasting, yields
+  $\textit{batch_shape}$ joint posteriors over the $m$ points.
 
-* *Batched evaluation* on a set of test points with shape
-  $\textit{new_batch_shape} \times \textit{input_batch_shape}^* \times m \times d$,
-  where $\textit{new_batch_shape}$ is the new batch shape for batched evaluation,
-  yields $\textit{new_batch_shape} \times \textit{input_batch_shape}$ joint
+* *Batched evaluation* on test points with shape
+  $\textit{new_batch_shape} \times \textit{batch_shape'} \times m \times d$,
+  where $\textit{new_batch_shape}$ is the batch shape for batched evaluation,
+  yields $\textit{new_batch_shape} \times \textit{batch_shape'}$ joint
   posteriors over the $m$ points in each respective batch (broadcasting as
-  necessary over $\textit{input_batch_shape}$)
+  necessary over $\textit{batch_shape}$)
 
 #### Batched Multi-Output Models
 The [`BatchedMultiOutputGPyTorchModel`](../api/models.html#batchedmultioutputgpytorchmodel)
@@ -126,22 +128,22 @@ class implements a fast multi-output model (assuming conditional independence of
 the outputs given the input) by batching over the outputs.
 
 ##### Training Inputs/Targets
-Given training inputs with shape $\textit{input_batch_shape} \times n \times d$
-and training outputs with shape $\textit{input_batch_shape} \times n \times o$,
+Given training inputs with shape $\textit{batch_shape} \times n \times d$
+and training outputs with shape $\textit{batch_shape} \times n \times o$,
 the `BatchedMultiOutputGPyTorchModel` permutes the training outputs to make the
 output $o$-dimension a batch dimension such that the augmented training inputs
-have shape $o \times \textit{input_batch_shape} \times n$. The training inputs
+have shape $o \times \textit{batch_shape} \times n$. The training inputs
 (which are required to be the same for all outputs) are expanded to be
-$o \times \textit{input_batch_shape} \times n \times d$.
+$o \times \textit{batch_shape} \times n \times d$.
 
 ##### Evaluation
 When evaluating test points with shape
-$\textit{new_batch_shape} \times \textit{input_batch_shape} \times m \times d$
+$\textit{new_batch_shape} \times \textit{batch_shape} \times m \times d$
 via the `posterior` method, the test points are broadcasted to the model(s) for
 each output. This results in the batched posterior where the mean has shape
-$\textit{new_batch_shape} \times o \times \textit{input_batch_shape} \times m$
+$\textit{new_batch_shape} \times o \times \textit{batch_shape} \times m$
 which then is permuted back to the original multi-output shape
-$\textit{new_batch_shape} \times \textit{input_batch_shape} \times m \times o$.
+$\textit{new_batch_shape} \times \textit{batch_shape} \times m \times o$.
 
 #### Batched Optimization of Random Restarts
 BoTorch uses random restarts to optimize an acquisition function from multiple


### PR DESCRIPTION
-when not confusing, batch_shape --> b1 x ... x b_k to emphasize multi-batch
-input_batch_shape --> batch_shape to make the formulas shorter and reduce formatting weirdness
-input_batch_shape^* --> batch_shape' to reduce confusion with markdown
-add that we are requiring q-batch
-add link to gpytorch tutorial
