### PR TITLE
Add .nojekyll file to built site, build website on more changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
           name: "Deploy website to GitHub Pages"
             # TODO: make the installation above conditional on there being relevant changes (no need to install if there are none)
           command: |
-            if ! git diff-tree --no-commit-id --name-only -r HEAD | grep -E "(^docs\/.*)|(website\/.*)"; then
+            if ! git diff-tree --no-commit-id --name-only -r HEAD | grep -E "(^docs\/.*)|(^website\/.*)|(^scripts\/.*)|(^sphinx\/.*)|(^tutorials\/.*)"; then
               echo "Skipping deploy. No relevant website files have changed"
             elif [[ $CIRCLE_PROJECT_USERNAME == "pytorch" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then
               ./scripts/build_docs.sh -b


### PR DESCRIPTION
- .nojekyll is needed to properly serve the sphinx sources:
https://github.community/t5/GitHub-Pages/Cannot-access-nested-pages/td-p/5081

- grep now checks also for changes to tutorials and scripts when deploying the website