### PR TITLE
fixed broken links in tutorials

### DIFF
--- a/tutorials/closed_loop_botorch_only.ipynb
+++ b/tutorials/closed_loop_botorch_only.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "In this tutorial, we illustrate how to implement a simple Bayesian Optimization (BO) closed loop in BoTorch.\n",
     "\n",
-    "In general, we recommend for a relatively simple setup (like this one) to use Ax, since this will simplify your setup (including the amount of code you need to write) considerably. See the [Using BoTorch with Ax](../using_botorch_with_ax) tutorial.\n",
+    "In general, we recommend for a relatively simple setup (like this one) to use Ax, since this will simplify your setup (including the amount of code you need to write) considerably. See the [Using BoTorch with Ax](./custom_botorch_model_in_ax) tutorial.\n",
     "\n",
     "However, you may want to do things that are not easily supported in Ax at this time (like running high-dimensional BO using a VAE+GP model that you jointly train on high-dimensional input data). If you find yourself in such a situation, you will need to write your own optimization loop, as we do in this tutorial.\n",
     "\n",

--- a/tutorials/custom_botorch_model_in_ax.ipynb
+++ b/tutorials/custom_botorch_model_in_ax.ipynb
@@ -8,9 +8,9 @@
     "\n",
     "In this tutorial, we illustrate how to use a custom BoTorch model within Ax's `SimpleExperiment` API. This allows us to harness the convenience of Ax for running Bayesian Optimization loops, while at the same time maintaining full flexibility in terms of the modeling.\n",
     "\n",
-    "Acquisition functions and strategies for optimizing acquisitions can be swapped out in much the same fashion. See for example the tutorial for [Implementing a custom acquisition function](../custom_acquisition).\n",
+    "Acquisition functions and strategies for optimizing acquisitions can be swapped out in much the same fashion. See for example the tutorial for [Implementing a custom acquisition function](./custom_acquisition).\n",
     "\n",
-    "If you want to do something non-standard, or would like to have full insight into every aspect of the implementation, please see [this tutorial](../closed_loop_botorch_only) for how to write your own full optimization loop in BoTorch."
+    "If you want to do something non-standard, or would like to have full insight into every aspect of the implementation, please see [this tutorial](./closed_loop_botorch_only) for how to write your own full optimization loop in BoTorch."
    ]
   },
   {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md
-->

## Motivation

When browsing the documentation, I noted that some links didn't work. In `closed_loop_botorch_only.ipynb` the site `using_botorch_with_ax` doesn't exist, I believe what was meant is `custom_botorch_model_in_ax`. For `custom_botorch_model_in_ax.ipynb` the links point to one directory above the desired tutorials directory.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The original notebooks are not covered by tests, and I believe that the changes do not need to be covered by tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)