### PR TITLE
Use explicit torch.autograd.grad insted of .backward

### DIFF
--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -16,14 +16,7 @@ from torch.nn import Module
 
 
 class MCAcquisitionObjective(Module, ABC):
-    r"""Abstract base class for MC-based objectives.
-
-    Example:
-        >>> # This method is usually not called directly, but via the objective's
-        >>> # `__call__` method:
-        >>> samples = sampler(posterior)
-        >>> outcome = mc_obj(samples)
-    """
+    r"""Abstract base class for MC-based objectives."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -39,6 +32,13 @@ class MCAcquisitionObjective(Module, ABC):
         Returns:
             Tensor: A `sample_shape x batch_shape x q`-dim Tensor of objective
             values (assuming maximization).
+
+        This method is usually not called directly, but via the objectives
+
+        Example:
+            >>> # `__call__` method:
+            >>> samples = sampler(posterior)
+            >>> outcome = mc_obj(samples)
         """
         pass  # pragma: no cover
 
@@ -63,7 +63,8 @@ class LinearMCObjective(MCAcquisitionObjective):
     `mc_obj(samples) = sum_{i} weights[i] * samples[..., i]`
 
     Example:
-        >>> # example for a two outcomes
+        Example for a model with two outcomes:
+
         >>> weights = torch.tensor([0.75, 0.25])
         >>> linear_objective = LinearMCObjective(weights)
         >>> samples = sampler(posterior)

--- a/botorch/test_functions/holder_table.py
+++ b/botorch/test_functions/holder_table.py
@@ -39,7 +39,7 @@ def neg_holder_table(X: Tensor) -> Tensor:
     """
     batch = X.ndimension() > 1
     X = X if batch else X.unsqueeze(0)
-    term = torch.abs(1 - torch.norm(X, dim=1) / math.pi)
+    term = torch.abs(1 - torch.norm(X, dim=-1) / math.pi)
     H = -torch.abs(torch.sin(X[:, 0]) * torch.cos(X[:, 1]) * torch.exp(term))
     result = -H
     return result if batch else result.squeeze(0)

--- a/test/test_functions/test_branin.py
+++ b/test/test_functions/test_branin.py
@@ -42,10 +42,10 @@ class TestNegBranin(unittest.TestCase):
                 GLOBAL_MAXIMIZERS, device=device, dtype=dtype, requires_grad=True
             )
             res = neg_branin(X)
-            res.sum().backward()
             for r in res:
                 self.assertAlmostEqual(r.item(), GLOBAL_MAXIMUM, places=4)
-            self.assertLess(X.grad.abs().max().item(), 1e-4)
+            grad = torch.autograd.grad(res.sum(), X)[0]
+            self.assertLess(grad.abs().max().item(), 1e-4)
 
     def test_neg_branin_global_maxima_cuda(self):
         if torch.cuda.is_available():

--- a/test/test_functions/test_eggholder.py
+++ b/test/test_functions/test_eggholder.py
@@ -46,9 +46,9 @@ class TestNegEggholder(unittest.TestCase):
                 GLOBAL_MAXIMIZER, device=device, dtype=dtype, requires_grad=True
             )
             res = neg_eggholder(X)
-            res.backward()
             self.assertAlmostEqual(res.item(), GLOBAL_MAXIMUM, places=4)
-            self.assertGreater(X.grad.abs().max().item(), 3.0)
+            grad = torch.autograd.grad(res, X)[0]
+            self.assertGreater(grad.abs().max().item(), 3.0)
 
     def test_neg_eggholder_global_maximum_cuda(self):
         if torch.cuda.is_available():

--- a/test/test_functions/test_hartmann6.py
+++ b/test/test_functions/test_hartmann6.py
@@ -46,9 +46,9 @@ class TestNegHartmann6(unittest.TestCase):
                 GLOBAL_MAXIMIZER, device=device, dtype=dtype, requires_grad=True
             )
             res = neg_hartmann6(X)
-            res.backward()
             self.assertAlmostEqual(res.item(), GLOBAL_MAXIMUM, places=4)
-            self.assertLess(X.grad.abs().max().item(), 1e-4)
+            grad = torch.autograd.grad(res, X)[0]
+            self.assertLess(grad.abs().max().item(), 1e-4)
 
     def test_neg_hartmann6_global_maximum_cuda(self):
         if torch.cuda.is_available():

--- a/test/test_functions/test_holder_table.py
+++ b/test/test_functions/test_holder_table.py
@@ -48,9 +48,9 @@ class TestNegHolderTable(unittest.TestCase):
                 GLOBAL_MAXIMIZERS, device=device, dtype=dtype, requires_grad=True
             )
             res = neg_holder_table(X)
-            torch.autograd.backward([*res])
-            self.assertTrue(torch.max((res - GLOBAL_MAXIMUM).abs()) < 1e-5)
-            self.assertLess(X.grad.abs().max().item(), 1e-3)
+            grad = torch.autograd.grad([*res], X)[0]
+            self.assertLess((res - GLOBAL_MAXIMUM).abs().max().item(), 1e-5)
+            self.assertLess(grad.abs().max().item(), 1e-3)
 
     def test_neg_holder_table_global_maxima_cuda(self):
         if torch.cuda.is_available():

--- a/test/test_functions/test_michalewicz.py
+++ b/test/test_functions/test_michalewicz.py
@@ -46,9 +46,9 @@ class TestNegMichalewicz(unittest.TestCase):
                 GLOBAL_MAXIMIZER, device=device, dtype=dtype, requires_grad=True
             )
             res = neg_michalewicz(X)
-            res.backward()
             self.assertAlmostEqual(res.item(), GLOBAL_MAXIMUM, places=4)
-            self.assertLess(X.grad.abs().max().item(), 1e-3)
+            grad = torch.autograd.grad(res, X)[0]
+            self.assertLess(grad.abs().max().item(), 1e-3)
 
     def test_neg_michalewicz_global_maximum_cuda(self):
         if torch.cuda.is_available():

--- a/test/test_functions/test_styblinski_tang.py
+++ b/test/test_functions/test_styblinski_tang.py
@@ -48,9 +48,9 @@ class TestNegStyblinskiTang(unittest.TestCase):
                 (3,), GLOBAL_MAXIMIZER, device=device, dtype=dtype, requires_grad=True
             )
             res = neg_styblinski_tang(X)
-            res.backward()
             self.assertAlmostEqual(res.item(), 3 * GLOBAL_MAXIMUM, places=4)
-            self.assertLess(X.grad.abs().max().item(), 1e-5)
+            grad = torch.autograd.grad(res, X)[0]
+            self.assertLess(grad.abs().max().item(), 1e-5)
 
     def test_neg_styblinski_tang_global_maximum_cuda(self):
         if torch.cuda.is_available():


### PR DESCRIPTION
Being explicit in computing the gradients that we want seems to be the right thing to do.
