### PR TITLE
Changing baseUrl to '/' allows building locally

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -11,7 +11,7 @@
 // site configuration options.
 
 // Define this so it can be easily modified in scripts (to host elsewhere)
-const baseUrl = 'https://botorch.org/';
+const baseUrl = '/';
 
 // List of projects/orgs using your project for the users page.
 const users = [];


### PR DESCRIPTION
The previous setting of the full path in the baseUrl resulted in an error when running the site locally. This fix will allow it to run locally without issue.

## Motivation

I wanted to run the site locally but ran into an error.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run locally... visit localhost:3000, note error.
Apply patch, run locally, visit localhost:3000 and see the page load correctly.
