### PR TITLE
Fix inv_transform

### DIFF
--- a/botorch/qmc/normal.py
+++ b/botorch/qmc/normal.py
@@ -71,7 +71,7 @@ class NormalQMCEngine:
         samples = self._sobol_engine.draw(n, dtype=dtype)
         if self._inv_transform:
             # apply inverse transform (values to close to 0/1 result in inf values)
-            v = 0.5 + (1 - 1e-10) * (samples - 0.5)
+            v = 0.5 + (1 - 1e-6) * (samples - 0.5)
             samples_tf = torch.erfinv(2 * v - 1) * math.sqrt(2)
         else:
             # apply Box-Muller transform (note: [1] indexes starting from 1)

--- a/botorch/qmc/normal.py
+++ b/botorch/qmc/normal.py
@@ -71,7 +71,7 @@ class NormalQMCEngine:
         samples = self._sobol_engine.draw(n, dtype=dtype)
         if self._inv_transform:
             # apply inverse transform (values to close to 0/1 result in inf values)
-            v = 0.5 + (1 - 1e-6) * (samples - 0.5)
+            v = 0.5 + (1 - torch.finfo(samples.dtype).eps) * (samples - 0.5)
             samples_tf = torch.erfinv(2 * v - 1) * math.sqrt(2)
         else:
             # apply Box-Muller transform (note: [1] indexes starting from 1)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md
-->

## Motivation

inv_transform was crapping out when drawing a large number of samples because the base sample was exactly 1.0( see issue #161).  While we were previously subtracting off a small number (1e-10), this number wasn't sufficient.  I found that (1-e6) was the smallest base 10 number we could subtract off to get rid of the -inf.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

```
import torch
from botorch.qmc.normal import NormalQMCEngine
normal_qmc_engine = NormalQMCEngine(d=2, seed=343, inv_transform=True)
samples = normal_qmc_engine.draw(10000, dtype=torch.float)
print(samples.max())
```
previously returned `tensor(inf)`, but now it returns `tensor(4.9010)`.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
