### PR TITLE
Add README.md as long_description to setup()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,10 @@ TUTORIALS_REQUIRES = ["jupyter", "matplotlib", "cma", "torchvision"]
 with open(os.path.join(os.path.dirname(__file__), "botorch/__init__.py"), "r") as f:
     version = re.search(r"__version__ = ['\"]([^'\"]*)['\"]", f.read(), re.M).group(1)
 
+# read in README.md as the long description
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
     name="botorch",
     version=version,
@@ -57,6 +61,8 @@ setup(
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",
     ],
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     python_requires=">=3.6",
     install_requires=["torch>=1.1", "gpytorch>=0.3.2", "scipy"],
     packages=find_packages(),


### PR DESCRIPTION
Will populate the description on https://pypi.org/project/botorch/ on next release (currently empty). 

This will fail to render the botorch logo on pypi.org - to fix this we'll have to just link to a web-hosted svg (there is [this](https://botorch.org/img/botorch_logo_lockup.svg), but unfortunately the svg gets messed up on deployment for some reason that has to do with copying the svg...) 