### PR TITLE
Upload coverage reports to codecov.io in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,13 @@ commands:
               echo "Skipping deploy."
             fi
 
+  upload_coverage:
+    description: "Upload coverage report to codecov.io"
+    steps:
+      - run:
+          name: "Upload coverage report"
+          command: bash <(curl -s https://codecov.io/bash)
+
 
 jobs:
 
@@ -97,6 +104,7 @@ jobs:
       - lint_black
       - unit_tests
       - sphinx
+      - upload_coverage
 
   lint_test_py37_conda:
     docker:
@@ -109,6 +117,7 @@ jobs:
       - lint_black
       - unit_tests
       - sphinx
+      - upload_coverage
 
   auto_deploy_site:
     docker:


### PR DESCRIPTION
See title. 

Test Plan:
Successful manual run below (see results [here](https://codecov.io/github/pytorch/botorch)).

```
(botorch) balandat-mbp:botorch_upstream balandat$ export CODECOV_TOKEN="XXXXXXXX"
(botorch) balandat-mbp:botorch_upstream balandat$ bash <(curl -s https://codecov.io/bash)

  _____          _
 / ____|        | |
| |     ___   __| | ___  ___ _____   __
| |    / _ \ / _` |/ _ \/ __/ _ \ \ / /
| |___| (_) | (_| |  __/ (_| (_) \ V /
 \_____\___/ \__,_|\___|\___\___/ \_/
                              Bash-8a28df4


x> No CI provider detected.
    Testing inside Docker? http://docs.codecov.io/docs/testing-with-docker
    Testing with Tox? https://docs.codecov.io/docs/python#section-testing-with-tox
    project root: .
--> token set from env
    Yaml not found, that's ok! Learn more at http://docs.codecov.io/docs/codecov-yaml
==> Running gcov in . (disable via -X gcov)
==> Python coveragepy exists disable via -X coveragepy
    -> Running coverage xml
==> Searching for coverage reports in:
    + .
    -> Found 1 reports
==> Detecting git/mercurial file structure
==> Reading reports
    + ./coverage.xml bytes=68655
==> Appending adjustments
    http://docs.codecov.io/docs/fixing-reports
    -> No adjustments found
==> Gzipping contents
==> Uploading reports
    url: https://codecov.io
    query: branch=master&commit=80f71bded4ac90537c0e5febd57be98ce8033ba8&build=&build_url=&name=&tag=&slug=pytorch%2Fbotorch&service=&flags=&pr=&job=
    -> Pinging Codecov
https://codecov.io/upload/v4?package=bash-8a28df4&token=&branch=master&commit=80f71bded4ac90537c0e5febd57be98ce8033ba8&build=&build_url=&name=&tag=&slug=pytorch%2Fbotorch&service=&flags=&pr=&job=
    -> Uploading
    -> View reports at https://codecov.io/github/pytorch/botorch/commit/80f71bded4ac90537c0e5febd57be98ce8033ba8
```