### PR TITLE
Move mock utils from test folder to botorch.utils.mock

### DIFF
--- a/botorch/utils/mock.py
+++ b/botorch/utils/mock.py
@@ -6,9 +6,10 @@ from collections import OrderedDict
 from typing import List, Optional
 
 import torch
-from botorch.models.model import Model
-from botorch.posteriors import Posterior
 from torch import Tensor
+
+from ..models.model import Model
+from ..posteriors import Posterior
 
 
 EMPTY_SIZE = torch.Size()

--- a/test/acquisition/test_analytic.py
+++ b/test/acquisition/test_analytic.py
@@ -17,8 +17,7 @@ from botorch.acquisition.analytic import (
 )
 from botorch.exceptions import UnsupportedError
 from botorch.models import FixedNoiseGP, SingleTaskGP
-
-from ..mock import MockModel, MockPosterior
+from botorch.utils.mock import MockModel, MockPosterior
 
 
 NEI_NOISE = [-0.099, -0.004, 0.227, -0.182, 0.018, 0.334, -0.270, 0.156, -0.237, 0.052]

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -14,11 +14,7 @@ from botorch.acquisition.monte_carlo import (
     qUpperConfidenceBound,
 )
 from botorch.acquisition.sampler import IIDNormalSampler, SobolQMCNormalSampler
-
-from ..mock import MockModel, MockPosterior
-
-
-# TODO: T41739913 Implement tests for all MCAcquisitionFunctions
+from botorch.utils.mock import MockModel, MockPosterior
 
 
 class TestMCAcquisitionFunction(unittest.TestCase):

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -9,9 +9,8 @@ import torch
 from botorch.acquisition import monte_carlo, utils
 from botorch.acquisition.objective import MCAcquisitionObjective
 from botorch.acquisition.sampler import IIDNormalSampler, SobolQMCNormalSampler
+from botorch.utils.mock import MockModel, MockPosterior
 from torch import Tensor
-
-from ..mock import MockModel, MockPosterior
 
 
 class DummyMCObjective(MCAcquisitionObjective):

--- a/test/exceptions/__init__.py
+++ b/test/exceptions/__init__.py
@@ -1,0 +1,3 @@
+#! /usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/test/utils/test_mock.py
+++ b/test/utils/test_mock.py
@@ -5,25 +5,40 @@
 import unittest
 
 import torch
-
-from .mock import MockModel, MockPosterior
+from botorch.utils.mock import MockModel, MockPosterior
 
 
 class TestMock(unittest.TestCase):
     def test_MockPosterior(self):
+        # test basic logic
+        mp = MockPosterior()
+        self.assertEqual(mp.device.type, "cpu")
+        self.assertEqual(mp.dtype, torch.float32)
+        self.assertEqual(mp.event_shape, torch.Size())
+        self.assertEqual(
+            MockPosterior(variance=torch.rand(2)).event_shape, torch.Size([2])
+        )
+        # test passing in tensors
         mean = torch.rand(2)
         variance = torch.eye(2)
         samples = torch.rand(1, 2)
         mp = MockPosterior(mean=mean, variance=variance, samples=samples)
+        self.assertEqual(mp.device.type, "cpu")
+        self.assertEqual(mp.dtype, torch.float32)
         self.assertTrue(torch.equal(mp.mean, mean))
         self.assertTrue(torch.equal(mp.variance, variance))
         self.assertTrue(torch.all(mp.sample() == samples.unsqueeze(0)))
         self.assertTrue(
             torch.all(mp.sample(torch.Size([2])) == samples.repeat(2, 1, 1))
         )
+        with self.assertRaises(RuntimeError):
+            mp.sample(sample_shape=torch.Size([2]), base_samples=torch.rand(3))
 
     def test_MockModel(self):
         mp = MockPosterior()
         mm = MockModel(mp)
         X = torch.empty(0)
         self.assertEqual(mm.posterior(X), mp)
+        self.assertEqual(mm.num_outputs, 0)
+        mm.state_dict()
+        mm.load_state_dict()


### PR DESCRIPTION
Summary: This makes it easier to import MockModel and MockPosterior for testing purposes.

Differential Revision: D15795194

