### PR TITLE
Properly handle observation_noise kwarg for BatchedMultiOutputGPyTorchModel

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -185,6 +185,8 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
                     X=X, original_batch_shape=self._input_batch_shape
                 )
             mvn = self(X)
+            if observation_noise:
+                mvn = self.likelihood(mvn, X)
             mean_x = mvn.mean
             covar_x = mvn.covariance_matrix
             if self._num_outputs > 1:


### PR DESCRIPTION
Fixes a bug where the `observation_noise` kwarg was disregarded for models of the class `BatchedMultiOutputGPyTorchModel`.