### PR TITLE
Catch gpytorch numerical issues and return NaN to the optimizer

### DIFF
--- a/botorch/exceptions/warnings.py
+++ b/botorch/exceptions/warnings.py
@@ -13,6 +13,12 @@ class BotorchWarning(Warning):
     pass
 
 
+class OptimizationWarning(BotorchWarning):
+    r"""Optimization-releated warnings."""
+
+    pass
+
+
 class BadInitialCandidatesWarning(BotorchWarning):
     r"""Warning issued if set of initial candidates for optimziation is bad."""
 

--- a/test/exceptions/test_warnings.py
+++ b/test/exceptions/test_warnings.py
@@ -8,6 +8,7 @@ import warnings
 from botorch.exceptions.warnings import (
     BadInitialCandidatesWarning,
     BotorchWarning,
+    OptimizationWarning,
     SamplingWarning,
 )
 
@@ -16,12 +17,14 @@ class TestBotorchWarnings(unittest.TestCase):
     def test_botorch_warnings_hierarchy(self):
         self.assertIsInstance(BotorchWarning(), Warning)
         self.assertIsInstance(BadInitialCandidatesWarning(), BotorchWarning)
+        self.assertIsInstance(OptimizationWarning(), BotorchWarning)
         self.assertIsInstance(SamplingWarning(), BotorchWarning)
 
     def test_botorch_warnings(self):
         for WarningClass in (
             BotorchWarning,
             BadInitialCandidatesWarning,
+            OptimizationWarning,
             SamplingWarning,
         ):
             with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
Summary:
scipy's minimize can (sort of, not really) handle NaNs - doing this for the fitting may help us with the robustness issues.

Basically, in `_scipy_objective_and_grad` we catch the "singularity error" in gpytorch and return `NaN` instead.
L-BFGS-B will then terminate with `success=False` and an "abnormal termination in line search" message.
From some simple toy experiments it appears as if the solver isn't smart enough to back off gradually during the line search.
We'll have to hope that this degeneracy only occurs after the optimizer has mostly converged, in which case terminating at the current iterate will not be terrible.

Therefore it may still be necessary to add enforce explicit bounds that (i) avoid numerical issues and (ii) are not too conservative so as to exclude the actual minimum from the feasible set.

Also, the "overstepping" will be dependent on the initial condition, so it would be desirable to re-start the optimization if the optimizer does not report success.

Reviewed By: danielrjiang

Differential Revision: D15977143

