### PR TITLE
Do not construct full covarince for single-output models

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -187,9 +187,9 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
             mvn = self(X)
             if observation_noise:
                 mvn = self.likelihood(mvn, X)
-            mean_x = mvn.mean
-            covar_x = mvn.covariance_matrix
             if self._num_outputs > 1:
+                mean_x = mvn.mean
+                covar_x = mvn.covariance_matrix
                 output_indices = output_indices or range(self._num_outputs)
                 mvns = [
                     MultivariateNormal(


### PR DESCRIPTION
Summary:
Currently we unnecessarily construct the full covariance matrix when computing
the posterior of a `BatchedMultiOutputGPyTorchModel`.
This is a quick fix to avoid doing that for single-output models, the case
for multi-output models will require some more thought.

Differential Revision: D16001819

