### PR TITLE
restart optimization by re-sampling from prior

### DIFF
--- a/botorch/exceptions/__init__.py
+++ b/botorch/exceptions/__init__.py
@@ -3,7 +3,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from .errors import BotorchError, CandidateGenerationError, UnsupportedError
-from .warnings import BadInitialCandidatesWarning, BotorchWarning, SamplingWarning
+from .warnings import (
+    BadInitialCandidatesWarning,
+    BotorchWarning,
+    OptimizationWarning,
+    SamplingWarning,
+)
 
 
 __all__ = [
@@ -12,5 +17,6 @@ __all__ = [
     "UnsupportedError",
     "BotorchWarning",
     "BadInitialCandidatesWarning",
+    "OptimizationWarning",
     "SamplingWarning",
 ]

--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -6,18 +6,26 @@ r"""
 Utilities for model fitting.
 """
 
+import logging
+import warnings
+from copy import deepcopy
 from typing import Any, Callable
 
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
 
+from .exceptions.warnings import OptimizationWarning
 from .optim.fit import fit_gpytorch_scipy
+from .optim.utils import sample_all_priors
 
 
 def fit_gpytorch_model(
     mll: MarginalLogLikelihood, optimizer: Callable = fit_gpytorch_scipy, **kwargs: Any
 ) -> MarginalLogLikelihood:
-    r"""Fit hyperparameters of a gpytorch model.
+    r"""Fit hyperparameters of a gpytorch model. On optimizer failures, a new
+    initial condition is sampled from the hyperparameter priors and optimization
+    is retried. The maximum number of retries can be passed in as a `max_retries`
+    kwarg (default is 5).
 
     Optimizer functions are in botorch.optim.fit.
 
@@ -39,7 +47,22 @@ def fit_gpytorch_model(
         for mll_ in mll.mlls:
             fit_gpytorch_model(mll=mll_, optimizer=optimizer, **kwargs)
         return mll
+    max_retries = kwargs.pop("max_retries", 5)
+    original_state_dict = deepcopy(mll.model.state_dict())
     mll.train()
-    mll, _ = optimizer(mll, track_iterations=False, **kwargs)
+    retry = 0
+    while retry < max_retries:
+        with warnings.catch_warnings(record=True) as ws:
+            if retry > 0:  # use normal initial conditions on first try
+                mll.model.load_state_dict(original_state_dict)
+                sample_all_priors(mll.model)
+            mll, _ = optimizer(mll, track_iterations=False, **kwargs)
+            if not any(issubclass(w.category, OptimizationWarning) for w in ws):
+                mll.eval()
+                return mll
+            retry += 1
+            logging.warning(f"Fitting failed on try {retry}.")
+
+    warnings.warn("Fitting failed on all retries.", OptimizationWarning)
     mll.eval()
     return mll

--- a/botorch/optim/fit.py
+++ b/botorch/optim/fit.py
@@ -198,13 +198,11 @@ def fit_gpytorch_scipy(
                 x=xk, mll=mll, property_dict=property_dict
             )
             iterations.append(OptimizationIteration(i, obj, ts[i]))
-
     if not res.success:
         msg = res.message.decode("ascii")
         warnings.warn(
             f"Fitting failed with the optimizer reporting '{msg}'", OptimizationWarning
         )
-
     # Set to optimum
     mll = set_params_with_array(mll, res.x, property_dict)
     return mll, iterations

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -63,7 +63,7 @@ class TestSingleTaskGP(unittest.TestCase):
                     mll = ExactMarginalLogLikelihood(model.likelihood, model).to(
                         **tkwargs
                     )
-                    fit_gpytorch_model(mll, options={"maxiter": 1})
+                    fit_gpytorch_model(mll, options={"maxiter": 1}, max_retries=1)
 
                     # test init
                     self.assertIsInstance(model.mean_module, ConstantMean)

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -70,9 +70,11 @@ class TestModelListGP(unittest.TestCase):
                 self.assertIsInstance(mll_, ExactMarginalLogLikelihood)
 
             # test model fitting (sequential)
-            mll = fit_gpytorch_model(mll, options={"maxiter": 1})
+            mll = fit_gpytorch_model(mll, options={"maxiter": 1}, max_retries=1)
             # test model fitting (joint)
-            mll = fit_gpytorch_model(mll, options={"maxiter": 1}, sequential=False)
+            mll = fit_gpytorch_model(
+                mll, options={"maxiter": 1}, max_retries=1, sequential=False
+            )
 
             # test posterior
             test_x = torch.tensor([[0.25], [0.75]], **tkwargs)
@@ -138,7 +140,7 @@ class TestModelListGP(unittest.TestCase):
             mll = SumMarginalLogLikelihood(model.likelihood, model)
             for mll_ in mll.mlls:
                 self.assertIsInstance(mll_, ExactMarginalLogLikelihood)
-            mll = fit_gpytorch_model(mll, options={"maxiter": 1})
+            mll = fit_gpytorch_model(mll, options={"maxiter": 1}, max_retries=1)
 
             # test posterior
             test_x = torch.tensor([[0.25], [0.75]], **tkwargs)

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -82,7 +82,7 @@ class TestMultiTaskGP(unittest.TestCase):
 
             # test model fitting
             mll = ExactMarginalLogLikelihood(model.likelihood, model)
-            mll = fit_gpytorch_model(mll, options={"maxiter": 1})
+            mll = fit_gpytorch_model(mll, options={"maxiter": 1}, max_retries=1)
 
             # test posterior
             test_x = torch.rand(2, 1, **tkwargs)
@@ -155,7 +155,7 @@ class TestMultiTaskGP(unittest.TestCase):
 
             # test model fitting
             mll = ExactMarginalLogLikelihood(model.likelihood, model)
-            mll = fit_gpytorch_model(mll, options={"maxiter": 1})
+            mll = fit_gpytorch_model(mll, options={"maxiter": 1}, max_retries=1)
 
             # test posterior
             test_x = torch.rand(2, 1, **tkwargs)
@@ -197,7 +197,7 @@ class TestFixedNoiseMultiTaskGP(unittest.TestCase):
 
             # test model fitting
             mll = ExactMarginalLogLikelihood(model.likelihood, model)
-            mll = fit_gpytorch_model(mll, options={"maxiter": 1})
+            mll = fit_gpytorch_model(mll, options={"maxiter": 1}, max_retries=1)
 
             # test posterior
             test_x = torch.rand(2, 1, **tkwargs)
@@ -268,7 +268,7 @@ class TestFixedNoiseMultiTaskGP(unittest.TestCase):
 
             # test model fitting
             mll = ExactMarginalLogLikelihood(model.likelihood, model)
-            mll = fit_gpytorch_model(mll, options={"maxiter": 1})
+            mll = fit_gpytorch_model(mll, options={"maxiter": 1}, max_retries=1)
 
             # test posterior
             test_x = torch.rand(2, 1, **tkwargs)

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -35,7 +35,9 @@ class TestEndToEnd(unittest.TestCase):
         self.mll_st = ExactMarginalLogLikelihood(
             self.model_st.likelihood, self.model_st
         )
-        self.mll_st = fit_gpytorch_model(self.mll_st, options={"maxiter": 5})
+        self.mll_st = fit_gpytorch_model(
+            self.mll_st, options={"maxiter": 5}, max_retries=1
+        )
         model_fn = FixedNoiseGP(
             self.train_x, self.train_y, self.train_yvar.expand_as(self.train_y)
         )
@@ -43,7 +45,9 @@ class TestEndToEnd(unittest.TestCase):
         self.mll_fn = ExactMarginalLogLikelihood(
             self.model_fn.likelihood, self.model_fn
         )
-        self.mll_fn = fit_gpytorch_model(self.mll_fn, options={"maxiter": 5})
+        self.mll_fn = fit_gpytorch_model(
+            self.mll_fn, options={"maxiter": 5}, max_retries=1
+        )
 
     def test_qEI(self, cuda=False):
         for double in (True, False):

--- a/test/test_gen.py
+++ b/test/test_gen.py
@@ -37,7 +37,7 @@ class TestBaseCandidateGeneration(unittest.TestCase):
         model = SingleTaskGP(self.train_x, self.train_y)
         self.model = model.to(device=device, dtype=dtype)
         self.mll = ExactMarginalLogLikelihood(self.model.likelihood, self.model)
-        self.mll = fit_gpytorch_model(self.mll, options={"maxiter": 1})
+        self.mll = fit_gpytorch_model(self.mll, options={"maxiter": 1}, max_retries=1)
 
 
 class TestGenCandidates(TestBaseCandidateGeneration):


### PR DESCRIPTION
Summary: when fitting optimization fails, resample initial conditions from HP priors.

Differential Revision: D15980657

