### PR TITLE
Fix fit_gpytorch_model for batched models with custom modules

### DIFF
--- a/test/models/test_converter.py
+++ b/test/models/test_converter.py
@@ -13,6 +13,7 @@ from botorch.models import (
     SingleTaskGP,
 )
 from botorch.models.converter import batched_to_model_list, model_list_to_batched
+from gpytorch.likelihoods import GaussianLikelihood
 
 from .test_gpytorch import SimpleGPyTorchModel
 
@@ -93,6 +94,10 @@ class TestConverters(unittest.TestCase):
             gp2 = HeteroskedasticSingleTaskGP(
                 train_X, train_Y1, torch.ones_like(train_Y1)
             )
+            with self.assertRaises(NotImplementedError):
+                model_list_to_batched(ModelListGP(gp2))
+            # test custom likelihood
+            gp2 = SingleTaskGP(train_X, train_Y2, likelihood=GaussianLikelihood())
             with self.assertRaises(NotImplementedError):
                 model_list_to_batched(ModelListGP(gp2))
             # test FixedNoiseGP

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -98,7 +98,7 @@ class TestSingleTaskGP(unittest.TestCase):
                     pvar = posterior_pred.variance
                     pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
                     self.assertTrue(
-                        torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-06)
+                        torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05)
                     )
 
                     # test batch evaluation
@@ -119,7 +119,7 @@ class TestSingleTaskGP(unittest.TestCase):
                     pvar = posterior_pred.variance
                     pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
                     self.assertTrue(
-                        torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-06)
+                        torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05)
                     )
 
     def test_gp_cuda(self):


### PR DESCRIPTION
Previously model fitting with sequential=True would break for custom batched models due to shortcomings of the converter.

This makes sure to catch the respective errors in the fitting and resort to fitting with sequential=False in this case.
