### PR TITLE
Changes to resampling behavior in MCSamplers

### DIFF
--- a/test/sampling/test_sampler.py
+++ b/test/sampling/test_sampler.py
@@ -84,7 +84,13 @@ class TestIIDNormalSampler(unittest.TestCase):
             posterior_batched = _get_posterior_batched(cuda=cuda, dtype=dtype)
             samples_batched = sampler(posterior_batched)
             self.assertEqual(samples_batched.shape, torch.Size([4, 3, 2, 1]))
-            self.assertEqual(sampler.seed, 1236)
+            self.assertEqual(sampler.seed, 1235)
+            # ensure this works when changing the dtype
+            new_dtype = torch.float if dtype == torch.double else torch.double
+            posterior_batched = _get_posterior_batched(cuda=cuda, dtype=new_dtype)
+            samples_batched = sampler(posterior_batched)
+            self.assertEqual(samples_batched.shape, torch.Size([4, 3, 2, 1]))
+            self.assertEqual(sampler.seed, 1235)
 
             # resample
             sampler = IIDNormalSampler(num_samples=4, resample=True, seed=None)
@@ -212,7 +218,13 @@ class TestSobolQMCNormalSampler(unittest.TestCase):
             posterior_batched = _get_posterior_batched(cuda=cuda, dtype=dtype)
             samples_batched = sampler(posterior_batched)
             self.assertEqual(samples_batched.shape, torch.Size([4, 3, 2, 1]))
-            self.assertEqual(sampler.seed, 1236)
+            self.assertEqual(sampler.seed, 1235)
+            # ensure this works when changing the dtype
+            new_dtype = torch.float if dtype == torch.double else torch.double
+            posterior_batched = _get_posterior_batched(cuda=cuda, dtype=new_dtype)
+            samples_batched = sampler(posterior_batched)
+            self.assertEqual(samples_batched.shape, torch.Size([4, 3, 2, 1]))
+            self.assertEqual(sampler.seed, 1235)
 
             # resample
             sampler = SobolQMCNormalSampler(num_samples=4, resample=True, seed=None)


### PR DESCRIPTION
Makes the following changes in case `resample=False`:
1. if `collapse_batch_dims=True` and the requested shape is different from the shape of the base samples, only resample if the last (q and o) dimensions are different, otherwise broadcast the base samples to the requested batch shape (will just be a different number of ones)
2. if `dtype` or `device` of the posterior are different from that of the base samples don't resample if not triggered otherwise - instead automatically move the base samples to the correct device/dtype if apppropriate
