### PR TITLE
Scalarization for posteriors, ScalarizedObjective

### DIFF
--- a/botorch/acquisition/__init__.py
+++ b/botorch/acquisition/__init__.py
@@ -26,6 +26,7 @@ from .objective import (
     IdentityMCObjective,
     LinearMCObjective,
     MCAcquisitionObjective,
+    ScalarizedObjective,
 )
 from .utils import get_acquisition_function
 
@@ -50,5 +51,6 @@ __all__ = [
     "LinearMCObjective",
     "MCAcquisitionFunction",
     "MCAcquisitionObjective",
+    "ScalarizedObjective",
     "get_acquisition_function",
 ]

--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -23,6 +23,7 @@ from typing import Optional, Union
 import torch
 from torch import Tensor
 
+from ..exceptions.errors import UnsupportedError
 from ..models.model import Model
 from ..sampling.samplers import MCSampler, SobolQMCNormalSampler
 from ..utils.transforms import match_batch_shape, t_batch_mode_transform
@@ -58,6 +59,11 @@ class MCAcquisitionFunction(AcquisitionFunction, ABC):
         self.add_module("sampler", sampler)
         if objective is None:
             objective = IdentityMCObjective()
+        elif not isinstance(objective, MCAcquisitionObjective):
+            raise UnsupportedError(
+                "Only objectives of type MCAcquisitionObjective are supported for "
+                "MC acquisition functions."
+            )
         self.add_module("objective", objective)
         self.set_X_pending(X_pending)
 

--- a/botorch/utils/mock.py
+++ b/botorch/utils/mock.py
@@ -74,7 +74,7 @@ class MockPosterior(Posterior):
 class MockModel(Model):
     """Mock object that implements dummy methods and feeds through specified outputs"""
 
-    def __init__(self, posterior: MockPosterior):
+    def __init__(self, posterior: MockPosterior) -> None:
         super(Model, self).__init__()
         self._posterior = posterior
 

--- a/sphinx/source/acquisition.rst
+++ b/sphinx/source/acquisition.rst
@@ -104,6 +104,11 @@ botorch.acquisition.objective
 .. automodule:: botorch.acquisition.objective
 
 
+:hidden:`ScalarizedObjective`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: ScalarizedObjective
+   :members:
+
 :hidden:`MCAcquisitionObjective`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: MCAcquisitionObjective

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -14,7 +14,8 @@ from botorch.acquisition.monte_carlo import (
     qSimpleRegret,
     qUpperConfidenceBound,
 )
-from botorch.exceptions import BotorchWarning
+from botorch.acquisition.objective import ScalarizedObjective
+from botorch.exceptions import BotorchWarning, UnsupportedError
 from botorch.sampling.samplers import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.mock import MockModel, MockPosterior
 
@@ -90,6 +91,11 @@ class TestQExpectedImprovement(unittest.TestCase):
                 self.assertEqual(acqf.X_pending, X2)
                 self.assertEqual(len(ws), 1)
                 self.assertTrue(issubclass(ws[-1].category, BotorchWarning))
+
+        # test bad objective type
+        obj = ScalarizedObjective(weights=torch.rand(2, device=device, dtype=dtype))
+        with self.assertRaises(UnsupportedError):
+            qExpectedImprovement(model=mm, best_f=0, sampler=sampler, objective=obj)
 
     def test_q_expected_improvement_cuda(self):
         if torch.cuda.is_available():


### PR DESCRIPTION
In some cases we may be interested in some affine function of the modeled outputs. By linearity, the posterior of that function will be a univariate normal (assuming `q=1`). 

This adds some functionality for achieving this for all analytic acquisition functions. 