### PR TITLE
Add batch_initial_conditions argument to joint_optimize() function.

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -106,6 +106,7 @@ def joint_optimize(
     equality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]] = None,
     fixed_features: Optional[Dict[int, float]] = None,
     post_processing_func: Optional[Callable[[Tensor], Tensor]] = None,
+    batch_initial_conditions: Optional[Tensor] = None,
 ) -> Tensor:
     r"""Generate a set of candidates via joint multi-start optimization.
 
@@ -129,6 +130,8 @@ def joint_optimize(
             appropriately (i.e., according to `round-trip` transformations).
             Note: post_processing_func is not used by _joint_optimize and is only
             included to match _sequential_optimize.
+        batch_initial_conditions: A tensor to specify the initial conditions. Set
+            this if you do not want to use default initialization strategy.
 
     Returns:
          A `q x d` tensor of generated candidates.
@@ -141,16 +144,18 @@ def joint_optimize(
         >>> candidates = joint_optimize(qEI, bounds, 2, 20, 500)
     """
     # TODO: Generating initial candidates should use parameter constraints.
-
     options = options or {}
-    batch_initial_conditions = gen_batch_initial_conditions(
-        acq_function=acq_function,
-        bounds=bounds,
-        q=None if isinstance(acq_function, AnalyticAcquisitionFunction) else q,
-        num_restarts=num_restarts,
-        raw_samples=raw_samples,
-        options=options,
-    )
+
+    if batch_initial_conditions is None:
+        batch_initial_conditions = gen_batch_initial_conditions(
+            acq_function=acq_function,
+            bounds=bounds,
+            q=None if isinstance(acq_function, AnalyticAcquisitionFunction) else q,
+            num_restarts=num_restarts,
+            raw_samples=raw_samples,
+            options=options,
+        )
+
     batch_limit = options.get("batch_limit", num_restarts)
     batch_candidates_list = []
     batch_acq_values_list = []

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -160,6 +160,7 @@ class TestJointOptimize(TestCase):
         options = {}
         mock_acq_function = MockAcquisitionFunction()
         tkwargs = {"device": torch.device("cuda") if cuda else torch.device("cpu")}
+        cnt = 1
         for dtype in (torch.float, torch.double):
             tkwargs["dtype"] = dtype
             mock_gen_batch_initial_conditions.return_value = torch.zeros(
@@ -182,6 +183,18 @@ class TestJointOptimize(TestCase):
                 options=options,
             )
             self.assertTrue(torch.equal(candidates, expected_candidates))
+
+            candidates = joint_optimize(
+                acq_function=mock_acq_function,
+                bounds=bounds,
+                q=q,
+                num_restarts=num_restarts,
+                raw_samples=raw_samples,
+                options=options,
+                batch_initial_conditions=torch.zeros(num_restarts, q, 3, **tkwargs),
+            )
+            self.assertEqual(mock_gen_batch_initial_conditions.call_count, cnt)
+            cnt += 1
 
     def test_joint_optimize_cuda(self):
         if torch.cuda.is_available():


### PR DESCRIPTION
Summary: Add `batch_initial_conditions` argument to `joint_optimize()` function. This allows users to specify initialization conditions other than default setting.

Differential Revision: D16276002

