### PR TITLE
FixedFeatureAcquisitionFucntion wrapper

### DIFF
--- a/botorch/acquisition/__init__.py
+++ b/botorch/acquisition/__init__.py
@@ -12,6 +12,7 @@ from .analytic import (
     ProbabilityOfImprovement,
     UpperConfidenceBound,
 )
+from .fixed_feature import FixedFeatureAcquisitionFunction
 from .monte_carlo import (
     MCAcquisitionFunction,
     qExpectedImprovement,
@@ -36,6 +37,7 @@ __all__ = [
     "AnalyticAcquisitionFunction",
     "ConstrainedExpectedImprovement",
     "ExpectedImprovement",
+    "FixedFeatureAcquisitionFunction",
     "NoisyExpectedImprovement",
     "PosteriorMean",
     "ProbabilityOfImprovement",

--- a/botorch/acquisition/fixed_feature.py
+++ b/botorch/acquisition/fixed_feature.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+r"""
+A wrapper around AquisitionFunctions to fix certain features for optimization.
+This is useful e.g. for performing contextual optimization.
+"""
+
+from typing import List, Union
+
+import torch
+from torch import Tensor
+from torch.nn import Module
+
+from .acquisition import AcquisitionFunction
+
+
+class FixedFeatureAcquisitionFunction(AcquisitionFunction):
+    """A wrapper around AquisitionFunctions to fix a subset of features.
+
+    Example:
+        >>> model = SingleTaskGP(train_X, train_Y)  # d = 5
+        >>> qEI = qExpectedImprovement(model, best_f=0.0)
+        >>> columns = [2, 4]
+        >>> values = X[..., columns]
+        >>> qEI_FF = FixedFeatureAcquisitionFunction(qEI, 5, columns, values)
+        >>> qei = qEI_FF(test_X)  # d' = 3
+    """
+
+    def __init__(
+        self,
+        acq_function: AcquisitionFunction,
+        d: int,
+        columns: List[int],
+        values: Union[Tensor, List[float]],
+    ) -> None:
+        r"""Derived Acquisition Function by fixing a subset of input features.
+
+        Args:
+            acq_function: The base acquisition function, operating on input
+                tensors `X_full` of feature dimension `d`.
+            d: The feature dimension expected by `acq_function`.
+            columns: `d_f < d` indices of columns in `X_full` that are to be
+                fixed to the provided values.
+            values: The values to which to fix the columns in `columns`. Either
+                a full `batch_shape x q x d_f` tensor of values (if values are
+                different for each of the `q` input points), or an array-like of
+                values that is broadcastable to the input across `t`-batch and
+                `q`-batch dimensions, e.g. a list of length `d_f` if values
+                are the same across all `t` and `q`-batch dimensions.
+        """
+        Module.__init__(self)
+        self.acq_func = acq_function
+        self.d = d
+        values = torch.as_tensor(values).clone().detach()
+        self.register_buffer("values", values)
+        # build selector for _construct_X_full
+        self._selector = []
+        idx_X, idx_f = 0, d - values.shape[-1]
+        for i in range(self.d):
+            if i in columns:
+                self._selector.append(idx_f)
+                idx_f += 1
+            else:
+                self._selector.append(idx_X)
+                idx_X += 1
+
+    def forward(self, X: Tensor):
+        r"""Evaluate base acquisition function under the fixed features.
+
+        Args:
+            X: Input tensor of feature dimension `d' < d` such that `d' + d_f = d`.
+
+        Returns:
+            Base acquisition function evaluated on tensor `X_full` constructed
+            by adding `values` in the appropriate places (see
+            `_construct_X_full`).
+        """
+        X_full = self._construct_X_full(X)
+        return self.acq_func(X_full)
+
+    def _construct_X_full(self, X: Tensor) -> Tensor:
+        r"""Constructs the full input for the base acquisition function.
+
+        Args:
+            X: Input tensor with shape `batch_shape x q x d'` such that
+                `d' + d_f = d`.
+
+        Returns:
+            Tensor `X_full` of shape `batch_shape x q x d`, where
+            `X_full[..., i] = values[..., i]` if `i in columns`,
+            and `X_full[..., i] = X[..., j]`, with
+            `j = i - sum_{l<=i} 1_{l in fixed_colunns}`.
+        """
+        d_prime, d_f = X.shape[-1], self.values.shape[-1]
+        if d_prime + d_f != self.d:
+            raise ValueError(
+                f"Feature dimension d' ({d_prime}) of input must be "
+                f"d - d_f ({self.d - d_f})."
+            )
+        # concatenate values to the end
+        values = self.values.to(X).expand(*X.shape[:-1], d_f)
+        X_perm = torch.cat([X, values], dim=-1)
+        # now select the appropriate column order
+        return X_perm[..., self._selector]

--- a/sphinx/source/acquisition.rst
+++ b/sphinx/source/acquisition.rst
@@ -10,7 +10,6 @@ botorch.acquisition
 -----------------------------------------
 .. automodule:: botorch.acquisition.acquisition
 
-
 :hidden:`AcquisitionFunction`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: AcquisitionFunction
@@ -24,12 +23,10 @@ Analytic acquisition functions (not using (q-)MC sampling).
 
 .. automodule:: botorch.acquisition.analytic
 
-
 :hidden:`AnalyticAcquisitionFunction`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: AnalyticAcquisitionFunction
    :members:
-
 
 :hidden:`ExpectedImprovement`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -62,11 +59,21 @@ Analytic acquisition functions (not using (q-)MC sampling).
    :members:
 
 
+botorch.acquisition.fixed_feature
+---------------------------------
+Derived Acquisition Function for fixing features during optimization.
+
+.. automodule:: botorch.acquisition.fixed_feature
+
+:hidden:`FixedFeatureAcquisitionFunction`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: FixedFeatureAcquisitionFunction
+  :members:
+
 
 botorch.acquisition.monte_carlo
 -------------------------------
 .. automodule:: botorch.acquisition.monte_carlo
-
 
 :hidden:`MCAcquisitionFunction`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/acquisition/test_fixed_feature.py
+++ b/test/acquisition/test_fixed_feature.py
@@ -1,0 +1,65 @@
+#! /usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+import torch
+from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
+from botorch.acquisition.monte_carlo import qExpectedImprovement
+from botorch.models import SingleTaskGP
+
+
+class TestFixedFeatureAcquisitionFunction(unittest.TestCase):
+    def test_fixed_features(self, cuda=False):
+        device = torch.device("cuda" if cuda else "cpu")
+        train_X = torch.rand(5, 3, device=device)
+        train_Y = train_X.norm(dim=-1)
+        model = SingleTaskGP(train_X, train_Y).to(device=device).eval()
+        qEI = qExpectedImprovement(model, best_f=0.0)
+        # test single point
+        test_X = torch.rand(1, 3, device=device)
+        qEI_ff = FixedFeatureAcquisitionFunction(
+            qEI, d=3, columns=[2], values=test_X[..., -1:]
+        )
+        qei = qEI(test_X)
+        qei_ff = qEI_ff(test_X[..., :-1])
+        self.assertTrue(torch.allclose(qei, qei_ff))
+        # test list input
+        qEI_ff = FixedFeatureAcquisitionFunction(qEI, d=3, columns=[2], values=[0.5])
+        qei_ff = qEI_ff(test_X[..., :-1])
+        # test q-batch
+        test_X = torch.rand(2, 3, device=device)
+        qEI_ff = FixedFeatureAcquisitionFunction(
+            qEI, d=3, columns=[1], values=test_X[..., [1]]
+        )
+        qei = qEI(test_X)
+        qei_ff = qEI_ff(test_X[..., [0, 2]])
+        self.assertTrue(torch.allclose(qei, qei_ff))
+        # test t-batch with broadcasting
+        test_X = torch.rand(2, 3, device=device).expand(4, 2, 3)
+        qEI_ff = FixedFeatureAcquisitionFunction(
+            qEI, d=3, columns=[2], values=test_X[0, :, -1:]
+        )
+        qei = qEI(test_X)
+        qei_ff = qEI_ff(test_X[..., :-1])
+        self.assertTrue(torch.allclose(qei, qei_ff))
+        # test gradient
+        test_X = torch.rand(1, 3, device=device, requires_grad=True)
+        test_X_ff = test_X[..., :-1].detach().clone().requires_grad_(True)
+        qei = qEI(test_X)
+        qEI_ff = FixedFeatureAcquisitionFunction(
+            qEI, d=3, columns=[2], values=test_X[..., [2]].detach()
+        )
+        qei_ff = qEI_ff(test_X_ff)
+        self.assertTrue(torch.allclose(qei, qei_ff))
+        qei.backward()
+        qei_ff.backward()
+        self.assertTrue(torch.allclose(test_X.grad[..., :-1], test_X_ff.grad))
+        # test error b/c of incompatible input shapes
+        with self.assertRaises(ValueError):
+            qEI_ff(test_X)
+
+    def test_fix_features_cuda(self):
+        if torch.cuda.is_available():
+            self.test_fix_features(cuda=True)


### PR DESCRIPTION
Summary:
Generates a new acquisition function over a lower-dimensional space by wrapping a base acquisition function and inserting fixed values. This is useful e.g. for performing contextual optimization, where a model is fit on a set of features, but then we'd like to optimize conditional on a particular value for the subset of features.

This works in a fashion similar to concatenating in `X_pending`, only that we concatenate the fixed values in to the feature dimension of the input `X`. Hence things are slightly more complicated b/c the order of the columns matters. The convention used here for this is just one way of doing it.

Differential Revision: D16566353

