### PR TITLE
Add propagate_grads context manager

### DIFF
--- a/botorch/__init__.py
+++ b/botorch/__init__.py
@@ -2,7 +2,15 @@
 
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from . import acquisition, exceptions, models, optim, posteriors, test_functions
+from . import (
+    acquisition,
+    exceptions,
+    models,
+    optim,
+    posteriors,
+    settings,
+    test_functions,
+)
 from .cross_validation import batch_cross_validation
 from .fit import fit_gpytorch_model
 from .gen import gen_candidates_scipy, gen_candidates_torch, get_best_candidates
@@ -24,5 +32,6 @@ __all__ = [
     "models",
     "optim",
     "posteriors",
+    "settings",
     "test_functions",
 ]

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -12,6 +12,7 @@ from typing import Any, List, Optional
 from torch import Tensor
 from torch.nn import Module
 
+from .. import settings
 from ..posteriors import Posterior
 from ..sampling.samplers import MCSampler
 
@@ -96,6 +97,8 @@ class Model(Module, ABC):
         Returns:
             The constructed fantasy model.
         """
-        post_X = self.posterior(X, observation_noise=observation_noise, **kwargs)
+        propagate_grads = kwargs.pop("propagate_grads", False)
+        with settings.propagate_grads(propagate_grads):
+            post_X = self.posterior(X, observation_noise=observation_noise)
         Y_fantasized = sampler(post_X)  # num_fantasies x batch_shape x m x o
         return self.condition_on_observations(X=X, Y=Y_fantasized, **kwargs)

--- a/botorch/settings.py
+++ b/botorch/settings.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import typing  # noqa F401
+
+
+class _Flag:
+    r"""Base class for context managers for a binary setting."""
+
+    _state: bool = False
+
+    @classmethod
+    def on(cls) -> bool:
+        return cls._state
+
+    @classmethod
+    def off(cls) -> bool:
+        return not cls._state
+
+    @classmethod
+    def _set_state(cls, state: bool) -> None:
+        cls._state = state
+
+    def __init__(self, state: bool = True) -> None:
+        self.prev = self.__class__.on()
+        self.state = state
+
+    def __enter__(self) -> None:
+        self.__class__._set_state(self.state)
+
+    def __exit__(self, *args) -> None:
+        self.__class__._set_state(self.prev)
+
+
+class propagate_grads(_Flag):
+    r"""Flag for propagating gradients to model training inputs / training data.
+
+    When set to `True`, gradients will be propagated to the training inputs.
+    This is useful in particular for propating gradients through fantasy models.
+    """
+
+    _state: bool = False

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -18,6 +18,7 @@ BoTorch API Reference
    fit
    gen
    sampling
+   settings
    test_functions
    exceptions
    utils

--- a/sphinx/source/settings.rst
+++ b/sphinx/source/settings.rst
@@ -1,0 +1,7 @@
+.. role:: hidden
+    :class: hidden-section
+
+botorch.settings
+================
+.. automodule:: botorch.settings
+.. currentmodule:: botorch.settings

--- a/test/optim/test_random_restart_optimization.py
+++ b/test/optim/test_random_restart_optimization.py
@@ -5,7 +5,7 @@
 import torch
 from botorch.acquisition import qExpectedImprovement
 from botorch.gen import gen_candidates_scipy, get_best_candidates
-from gpytorch import settings
+from gpytorch import settings as gpt_settings
 
 from ..test_gen import TestBaseCandidateGeneration
 
@@ -17,7 +17,7 @@ class TestRandomRestartOptimization(TestBaseCandidateGeneration):
     def test_random_restart_optimization(self, cuda=False):
         for double in (True, False):
             self._setUp(double=double, cuda=cuda)
-            with settings.debug(False):
+            with gpt_settings.debug(False):
                 best_f = self.model(self.train_x).mean.max().item()
             qEI = qExpectedImprovement(self.model, best_f=best_f)
             bounds = torch.tensor([[0.0], [1.0]]).type_as(self.train_x)

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,0 +1,19 @@
+#! /usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import unittest
+
+from botorch import settings
+
+
+class TestSettings(unittest.TestCase):
+    def test_propagate_grads(self):
+        pgrads = settings.propagate_grads
+        self.assertFalse(pgrads.on())
+        self.assertTrue(pgrads.off())
+        with settings.propagate_grads(True):
+            self.assertTrue(pgrads.on())
+            self.assertFalse(pgrads.off())
+        self.assertFalse(pgrads.on())
+        self.assertTrue(pgrads.off())


### PR DESCRIPTION
Summary:
Adds a `botorch.settings` module that introduces a contextmanager for the `propagate_grads` setting.
This cleans up the API by removing the `propagate_grads` kwarg from `Model.posterior`.

The new pattern for propagating gradients to the training inputs of a model is the following:
```
    with settings.propagate_grads(True):
        post_X = self.posterior(X, observation_noise=observation_noise)
```

Right now this is very much just a wrapper around GPyTorch's `detach_test_caches` setting, but this allows implementing everything in a model-agnostic fashion.

Reviewed By: sdaulton

Differential Revision: D16583422

