### PR TITLE
Utilites for validating data normalization and standardization

### DIFF
--- a/botorch/exceptions/__init__.py
+++ b/botorch/exceptions/__init__.py
@@ -2,10 +2,16 @@
 
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from .errors import BotorchError, CandidateGenerationError, UnsupportedError
+from .errors import (
+    BotorchError,
+    CandidateGenerationError,
+    InputDataError,
+    UnsupportedError,
+)
 from .warnings import (
     BadInitialCandidatesWarning,
     BotorchWarning,
+    InputDataWarning,
     OptimizationWarning,
     SamplingWarning,
 )
@@ -16,6 +22,8 @@ __all__ = [
     "CandidateGenerationError",
     "UnsupportedError",
     "BotorchWarning",
+    "InputDataWarning",
+    "InputDataError",
     "BadInitialCandidatesWarning",
     "OptimizationWarning",
     "SamplingWarning",

--- a/botorch/exceptions/errors.py
+++ b/botorch/exceptions/errors.py
@@ -19,6 +19,12 @@ class CandidateGenerationError(BotorchError):
     pass
 
 
+class InputDataError(BotorchError):
+    r"""Exception raised when input data does not comply with conventions."""
+
+    pass
+
+
 class UnsupportedError(BotorchError):
     r"""Currently unsupported feature."""
 

--- a/botorch/exceptions/warnings.py
+++ b/botorch/exceptions/warnings.py
@@ -13,14 +13,20 @@ class BotorchWarning(Warning):
     pass
 
 
-class OptimizationWarning(BotorchWarning):
-    r"""Optimization-releated warnings."""
+class BadInitialCandidatesWarning(BotorchWarning):
+    r"""Warning issued if set of initial candidates for optimziation is bad."""
 
     pass
 
 
-class BadInitialCandidatesWarning(BotorchWarning):
-    r"""Warning issued if set of initial candidates for optimziation is bad."""
+class InputDataWarning(BotorchWarning):
+    r"""Warning raised when input data does not comply with conventions."""
+
+    pass
+
+
+class OptimizationWarning(BotorchWarning):
+    r"""Optimization-releated warnings."""
 
     pass
 

--- a/botorch/models/utils.py
+++ b/botorch/models/utils.py
@@ -6,11 +6,14 @@ r"""
 Utiltiy functions for models.
 """
 
+import warnings
 from typing import List, Optional, Tuple
 
 import torch
 from gpytorch.utils.broadcasting import _mul_broadcast_shape
 from torch import Tensor
+
+from ..exceptions import InputDataError, InputDataWarning
 
 
 def _make_X_full(X: Tensor, output_indices: List[int], tf: int) -> Tensor:
@@ -107,3 +110,73 @@ def add_output_dim(X: Tensor, original_batch_shape: torch.Size) -> Tuple[Tensor,
     X = X.unsqueeze(-3)
     output_dim_idx = max(len(original_batch_shape), len(X_batch_shape))
     return X, output_dim_idx
+
+
+def check_no_nans(Z: Tensor) -> None:
+    r"""Check that tensor does not contain NaN values.
+
+    Raises an InputDataError if `Z` contains NaN values.
+
+    Args:
+        Z: The input tensor.
+    """
+    if torch.any(torch.isnan(Z)).item():
+        raise InputDataError("Input data contains NaN values.")
+
+
+def check_min_max_scaling(
+    X: Tensor, strict: bool = False, atol: float = 1e-2, raise_on_fail: bool = False
+) -> None:
+    r"""Check that tensor is normalized to the unit cube.
+
+    Args:
+        X: A `batch_shape x n x d` input tensor. Typically the training inputs
+            of a model.
+        strict: If True, require `X` to be scaled to the unit cube (rather than
+            just to be contained within the unit cube).
+        atol: The tolerance for the boundary check. Only used if `strict=True`.
+        raise_on_fail: If True, raise an exception instead of a warning.
+    """
+    with torch.no_grad():
+        Xmin, Xmax = torch.min(X, dim=-1)[0], torch.max(X, dim=-1)[0]
+        msg = None
+        if strict and max(torch.abs(Xmin).max(), torch.abs(Xmax - 1).max()) > atol:
+            msg = "scaled"
+        if torch.any(Xmin < -atol) or torch.any(Xmax > 1 + atol):
+            msg = "contained"
+        if msg is not None:
+            msg = (
+                f"Input data is not {msg} to the unit cube. "
+                "Please consider min-max scaling the input data."
+            )
+            if raise_on_fail:
+                raise InputDataError(msg)
+            warnings.warn(msg, InputDataWarning)
+
+
+def check_standardization(
+    Y: Tensor,
+    atol_mean: float = 1e-2,
+    atol_std: float = 1e-2,
+    raise_on_fail: bool = False,
+) -> None:
+    r"""Check that tensor is standardized (zero mean, unit variance).
+
+    Args:
+        Y: The input tensor of shape `batch_shape x n x m`. Typically the
+            train targets of a model. Standardization is checked across the
+            `n`-dimension.
+        atol_mean: The tolerance for the mean check.
+        atol_std: The tolerance for the std check.
+        raise_on_fail: If True, raise an exception instead of a warning.
+    """
+    with torch.no_grad():
+        Ymean, Ystd = torch.mean(Y, dim=-2), torch.std(Y, dim=-2)
+        if torch.abs(Ymean).max() > atol_mean or torch.abs(Ystd - 1).max() > atol_std:
+            msg = (
+                "Input data is not standardized. Please consider scaling the "
+                "input to zero mean and unit variance."
+            )
+            if raise_on_fail:
+                raise InputDataError(msg)
+            warnings.warn(msg, InputDataWarning)

--- a/test/exceptions/test_errors.py
+++ b/test/exceptions/test_errors.py
@@ -7,6 +7,7 @@ import unittest
 from botorch.exceptions.errors import (
     BotorchError,
     CandidateGenerationError,
+    InputDataError,
     UnsupportedError,
 )
 
@@ -15,12 +16,15 @@ class TestBotorchExceptions(unittest.TestCase):
     def test_botorch_exception_hierarchy(self):
         self.assertIsInstance(BotorchError(), Exception)
         self.assertIsInstance(CandidateGenerationError(), BotorchError)
+        self.assertIsInstance(InputDataError(), BotorchError)
         self.assertIsInstance(UnsupportedError(), BotorchError)
 
     def test_raise_botorch_exceptions(self):
-        with self.assertRaises(BotorchError):
-            raise BotorchError("message")
-        with self.assertRaises(CandidateGenerationError):
-            raise CandidateGenerationError("message")
-        with self.assertRaises(UnsupportedError):
-            raise UnsupportedError("message")
+        for ErrorClass in (
+            BotorchError,
+            CandidateGenerationError,
+            InputDataError,
+            UnsupportedError,
+        ):
+            with self.assertRaises(ErrorClass):
+                raise ErrorClass("message")

--- a/test/exceptions/test_warnings.py
+++ b/test/exceptions/test_warnings.py
@@ -8,6 +8,7 @@ import warnings
 from botorch.exceptions.warnings import (
     BadInitialCandidatesWarning,
     BotorchWarning,
+    InputDataWarning,
     OptimizationWarning,
     SamplingWarning,
 )
@@ -17,6 +18,7 @@ class TestBotorchWarnings(unittest.TestCase):
     def test_botorch_warnings_hierarchy(self):
         self.assertIsInstance(BotorchWarning(), Warning)
         self.assertIsInstance(BadInitialCandidatesWarning(), BotorchWarning)
+        self.assertIsInstance(InputDataWarning(), BotorchWarning)
         self.assertIsInstance(OptimizationWarning(), BotorchWarning)
         self.assertIsInstance(SamplingWarning(), BotorchWarning)
 
@@ -24,11 +26,12 @@ class TestBotorchWarnings(unittest.TestCase):
         for WarningClass in (
             BotorchWarning,
             BadInitialCandidatesWarning,
+            InputDataWarning,
             OptimizationWarning,
             SamplingWarning,
         ):
-            with warnings.catch_warnings(record=True) as w:
+            with warnings.catch_warnings(record=True) as ws:
                 warnings.warn("message", WarningClass)
-                self.assertEqual(len(w), 1)
-                self.assertTrue(issubclass(w[-1].category, WarningClass))
-                self.assertTrue("message" in str(w[-1].message))
+                self.assertEqual(len(ws), 1)
+                self.assertTrue(issubclass(ws[-1].category, WarningClass))
+                self.assertTrue("message" in str(ws[-1].message))


### PR DESCRIPTION
Adds utilities that make it easy to check whether input data is free of NaNs, normalized (for inputs), and standardized (for targets).

Addresses part of #208 - these utilities will need to be called in the various model constructors, but that will be a separate PR.

We should add some `debug` setting to `settings.py` (on by default) that calls these checks on the input data with `raise_on_fail=False`.