### PR TITLE
Fix conda command for pytorch nightlies

### DIFF
--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -20,10 +20,11 @@ conda install -y conda-build
 
 if [[ $PYTORCH_NIGHTLY == true ]]; then
   # install CPU version for much smaller download
-  conda install -y -c pytorch pytorch-nightly-cpu
+  conda install -y -c pytorch-nightly pytorch cpuonly
+
 else
   # install CPU version for much smaller download
-  conda install -y -c pytorch pytorch-cpu
+  conda install -y -c pytorch pytorch cpuonly
 fi
 
 # get gpytorch master


### PR DESCRIPTION
The location of the pytorch nightlies in conda has changed, this updates the installation script accordingly.

Test Plan:
Tested locally with circleci cmd line + docker