### PR TITLE
Turn off auto-deploy of website in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,19 +119,19 @@ jobs:
       - sphinx
       - upload_coverage
 
-  auto_deploy_site:
-    docker:
-      - image: circleci/python:3.6.8-node
-    steps:
-      - checkout
-      - pip_install:
-          args: "-n -d"
-      - lint_flake8
-      - lint_black
-      - unit_tests
-      - sphinx
-      - configure_github_bot
-      - deploy_site
+  # auto_deploy_site:
+  #   docker:
+  #     - image: circleci/python:3.6.8-node
+  #   steps:
+  #     - checkout
+  #     - pip_install:
+  #         args: "-n -d"
+  #     - lint_flake8
+  #     - lint_black
+  #     - unit_tests
+  #     - sphinx
+  #     - configure_github_bot
+  #     - deploy_site
 
 
 aliases:
@@ -152,10 +152,10 @@ workflows:
       - lint_test_py37_conda:
           filters: *exclude_ghpages_fbconfig
 
-  auto_deploy_site:
-    jobs:
-      - auto_deploy_site:
-          filters:
-            branches:
-              only:
-                - master
+  # auto_deploy_site:
+  #   jobs:
+  #     - auto_deploy_site:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master


### PR DESCRIPTION
Summary: Temporarily turn off CircleCI auto-deployment of website so we can get the versioned website up and running.

Differential Revision: D16759240

