### PR TITLE
Use ssh for pushing site if not docusaurus_bot

### DIFF
--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -214,7 +214,7 @@ else
   git init
   git add --all
   git commit -m "Publish version ${VERSION} of site"
-  git push --force "https://github.com/pytorch/botorch" master:gh-pages
+  git push --force "git@github.com:pytorch/botorch.git" master:gh-pages
 
 fi
 


### PR DESCRIPTION
We won't push versioned sites automatically for now, so this does not require setting up github tokens.