### PR TITLE
Make joint_/sequential_optimize return acq function values

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ For more details see our [Documentation](https://botorch.org/docs/introduction) 
   from botorch.optim import joint_optimize
 
   bounds = torch.stack([torch.zeros(2), torch.ones(2)])
-  candidate = joint_optimize(
+  candidate, acq_value = joint_optimize(
       UCB, bounds=bounds, q=1, num_restarts=5, raw_samples=20,
   )
   ```

--- a/botorch/gen.py
+++ b/botorch/gen.py
@@ -248,5 +248,5 @@ def get_best_candidates(batch_candidates: Tensor, batch_values: Tensor) -> Tenso
             )
         >>> best_candidates = get_best_candidates(batch_candidates, batch_acq_values)
     """
-    best = torch.max(batch_values.view(-1), dim=0)[1].item()
+    best = torch.argmax(batch_values.view(-1), dim=0)
     return batch_candidates[best]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -69,7 +69,7 @@ Here's a quick run down of the main components of a Bayesian Optimization loop.
     from botorch.optim import joint_optimize
 
     bounds = torch.stack([torch.zeros(2), torch.ones(2)])
-    candidate = joint_optimize(
+    candidate, acq_value = joint_optimize(
         UCB, bounds=bounds, q=1, num_restarts=5, raw_samples=20,
     )
     ```

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -59,7 +59,7 @@ class TestEndToEnd(unittest.TestCase):
         for double in (True, False):
             self._setUp(double=double, cuda=cuda)
             qEI = qExpectedImprovement(self.model_st, best_f=0.0)
-            candidates = joint_optimize(
+            candidates, _ = joint_optimize(
                 acq_function=qEI,
                 bounds=self.bounds,
                 q=3,
@@ -70,7 +70,7 @@ class TestEndToEnd(unittest.TestCase):
             self.assertTrue(torch.all(-EPS <= candidates))
             self.assertTrue(torch.all(candidates <= 1 + EPS))
             qEI = qExpectedImprovement(self.model_fn, best_f=0.0)
-            candidates = joint_optimize(
+            candidates, _ = joint_optimize(
                 acq_function=qEI,
                 bounds=self.bounds,
                 q=3,
@@ -80,7 +80,7 @@ class TestEndToEnd(unittest.TestCase):
             )
             self.assertTrue(torch.all(-EPS <= candidates))
             self.assertTrue(torch.all(candidates <= 1 + EPS))
-            candidates_batch_limit = joint_optimize(
+            candidates_batch_limit, _ = joint_optimize(
                 acq_function=qEI,
                 bounds=self.bounds,
                 q=3,
@@ -99,7 +99,7 @@ class TestEndToEnd(unittest.TestCase):
         for double in (True, False):
             self._setUp(double=double, cuda=cuda)
             EI = ExpectedImprovement(self.model_st, best_f=0.0)
-            candidates = joint_optimize(
+            candidates, _ = joint_optimize(
                 acq_function=EI,
                 bounds=self.bounds,
                 q=1,
@@ -109,7 +109,7 @@ class TestEndToEnd(unittest.TestCase):
             )
             self.assertTrue(-EPS <= candidates <= 1 + EPS)
             EI = ExpectedImprovement(self.model_fn, best_f=0.0)
-            candidates = joint_optimize(
+            candidates, _ = joint_optimize(
                 acq_function=EI,
                 bounds=self.bounds,
                 q=1,

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -136,7 +136,7 @@ UCB = UpperConfidenceBound(gp, beta=0.1)
 from botorch.optim import joint_optimize
 
 bounds = torch.stack([torch.zeros(2), torch.ones(2)])
-candidate = joint_optimize(
+candidate, acq_value = joint_optimize(
     UCB, bounds=bounds, q=1, num_restarts=5, raw_samples=20,
 )
 candidate  # tensor([0.4887, 0.5063])


### PR DESCRIPTION
This is useful both for diagnostics as well as making initialization strategies less cumbersome to write (in particular if `return_best_only=False`, and one would like to re-compute the acquisition function values - right now, this means re-evaluating the acquisition function unnecessarily, doing double work).

This means a breaking change, so we'll have to be careful to announce this in a transparent fashion and synchronize the release with Ax. 

We may consider getting rid / deprecating of `get_best_candidates` since this is a one-liner....

Differential Revision: D16695425

