### PR TITLE
draw independent sample from prior for each hyperparameter

### DIFF
--- a/botorch/optim/utils.py
+++ b/botorch/optim/utils.py
@@ -28,13 +28,13 @@ def sample_all_priors(model: GPyTorchModel) -> None:
     Args:
         model: A GPyTorchModel.
     """
-    for _, prior, _, setting_closure in model.named_priors():
+    for _, prior, closure, setting_closure in model.named_priors():
         if setting_closure is None:
             raise RuntimeError(
                 "Must provide inverse transform to be able to sample from prior."
             )
         try:
-            setting_closure(prior.sample())
+            setting_closure(prior.sample(closure().shape))
         except NotImplementedError:
             warnings.warn(
                 f"`rsample` not implemented for {type(prior)}. Skipping.",

--- a/test/optim/test_utils.py
+++ b/test/optim/test_utils.py
@@ -237,6 +237,9 @@ class TestSampleAllPriors(BotorchTestCase):
                 dict(model.state_dict())["likelihood.noise_covar.raw_noise"]
                 != original_state_dict["likelihood.noise_covar.raw_noise"]
             )
+            # check that lengthscales are all different
+            ls = model.covar_module.base_kernel.raw_lengthscale.view(-1).tolist()
+            self.assertTrue(all(ls[0] != ls[i]) for i in range(1, len(ls)))
 
             # change one of the priors to SmoothedBoxPrior
             model.covar_module = ScaleKernel(


### PR DESCRIPTION
Summary: Previously, the entire hyperparameter tensor was set to a single value. E.g. all lengthscales would be the same when using ARD and d>1. Another example is HPs would be the same across batches in a batch-mode model.

Reviewed By: Balandat

Differential Revision: D16948112

