### PR TITLE
Temporarily peg miniconda3 to version 4.6.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,8 @@ jobs:
 
   lint_test_py37_conda:
     docker:
-      - image: continuumio/miniconda3
+      # TODO: Use latest once "conda not found" issue resolved
+      - image: continuumio/miniconda3:4.6.14
     steps:
       - checkout
       - conda_install:


### PR DESCRIPTION
There seems to be an issue with the most recent miniconda 3 docker container, see discussion here: https://discuss.circleci.com/t/conda-not-found-in-miniconda-docker-image/32075

This temporarily pegs the miniconda container to the old version until this gets resolved upstream.
