### PR TITLE
Remove redundant check in ModelListGP

### DIFF
--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -11,6 +11,7 @@ from typing import Any
 from gpytorch.models import IndependentModelList
 from torch import Tensor
 
+from ..exceptions.errors import BotorchTensorDimensionError
 from .gpytorch import GPyTorchModel, ModelListGPyTorchModel
 
 
@@ -71,7 +72,7 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
         )
         inputs = [X] * self.num_outputs
         if Y.shape[-1] != self.num_outputs:
-            raise ValueError(
+            raise BotorchTensorDimensionError(
                 "Incorrect number of outputs for observations. Received "
                 f"{Y.shape[-1]} observation outputs, but model has "
                 f"{self.num_outputs} outputs."
@@ -79,12 +80,7 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
         targets = [Y[..., i] for i in range(Y.shape[-1])]
         if "noise" in kwargs:
             noise = kwargs.pop("noise")
-            if noise.shape[-1] != self.num_outputs:
-                raise ValueError(
-                    "Incorrect number of outputs for noise observations. "
-                    f"Received {noise.shape[-1]} observation outputs, but "
-                    f"model has {self.num_outputs} outputs."
-                )
+            # Note: dimension checks were performed in _validate_tensor_args
             kwargs_ = {**kwargs, "noise": [noise[..., i] for i in range(Y.shape[-1])]}
         else:
             kwargs_ = kwargs

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -123,7 +123,7 @@ class TestModelListGP(BotorchTestCase):
             self.assertIsInstance(cm, ModelListGP)
 
             # test condition_on_observations (incorrect input shape error)
-            with self.assertRaises(ValueError):
+            with self.assertRaises(BotorchTensorDimensionError):
                 model.condition_on_observations(f_x, torch.rand(3, 2, 3, **tkwargs))
 
     def test_ModelListGP_cuda(self):
@@ -194,6 +194,7 @@ class TestModelListGP(BotorchTestCase):
                     f_x, torch.rand(3, 2, 3, **tkwargs), noise=noise
                 )
             # test condition_on_observations (incorrect noise shape error)
+            f_y = torch.rand(2, 2, **tkwargs)
             with self.assertRaises(BotorchTensorDimensionError):
                 model.condition_on_observations(
                     f_x, f_y, noise=torch.rand(2, 3, **tkwargs)


### PR DESCRIPTION
Removing a dimension check that was made obsolete by recent changes in #238
This part was also never reached by any test, so this puts us back to full test coverage