### PR TITLE
Support specifying observation noise explicitly

### DIFF
--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -8,7 +8,7 @@ r"""
 Gaussian Process Regression models based on GPyTorch models.
 """
 
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import torch
 from gpytorch.constraints.constraints import GreaterThan
@@ -178,15 +178,16 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         self,
         X: Tensor,
         sampler: MCSampler,
-        observation_noise: bool = True,
+        observation_noise: Union[bool, Tensor] = True,
         **kwargs: Any,
     ) -> "FixedNoiseGP":
         r"""Construct a fantasy model.
 
         Constructs a fantasy model in the following fashion:
         (1) compute the model posterior at `X` (if `observation_noise=True`,
-        this includes observation noise, which is taken as the mean across
-        the observation noise in the training data).
+        this includes observation noise taken as the mean across the observation
+        noise in the training data. If `observation_noise` is a Tensor, use
+        it directly as the observation noise to add).
         (2) sample from this posterior (using `sampler`) to generate "fake"
         observations.
         (3) condition the model on the new fake observations.
@@ -199,7 +200,8 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
             sampler: The sampler used for sampling from the posterior at `X`.
             observation_noise: If True, include the mean across the observation
                 noise in the training data as observation noise in the posterior
-                from which the samples are drawn.
+                from which the samples are drawn. If a Tensor, use it directly
+                as the specified measurement noise.
 
         Returns:
             The constructed fantasy model.

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -82,6 +82,14 @@ class TestGPyTorchModel(BotorchTestCase):
             posterior = model.posterior(test_X, observation_noise=True)
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertEqual(posterior.mean.shape, torch.Size([2, 1]))
+            posterior = model.posterior(
+                test_X, observation_noise=torch.rand(2, 1, **tkwargs)
+            )
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+            self.assertEqual(posterior.mean.shape, torch.Size([2, 1]))
+            # test noise shape validation
+            with self.assertRaises(BotorchTensorDimensionError):
+                model.posterior(test_X, observation_noise=torch.rand(2, **tkwargs))
             # test conditioning on observations
             cm = model.condition_on_observations(
                 torch.rand(2, 1, **tkwargs), torch.rand(2, **tkwargs)
@@ -95,6 +103,13 @@ class TestGPyTorchModel(BotorchTestCase):
             self.assertEqual(cm.train_targets.shape, torch.Size([2, 7]))
             cm = model.fantasize(
                 torch.rand(2, 1, **tkwargs), sampler=sampler, observation_noise=True
+            )
+            self.assertIsInstance(cm, SimpleGPyTorchModel)
+            self.assertEqual(cm.train_targets.shape, torch.Size([2, 7]))
+            cm = model.fantasize(
+                torch.rand(2, 1, **tkwargs),
+                sampler=sampler,
+                observation_noise=torch.rand(2, 1, **tkwargs),
             )
             self.assertIsInstance(cm, SimpleGPyTorchModel)
             self.assertEqual(cm.train_targets.shape, torch.Size([2, 7]))
@@ -154,6 +169,11 @@ class TestBatchedMultiOutputGPyTorchModel(BotorchTestCase):
             posterior = model.posterior(test_X, observation_noise=True)
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertEqual(posterior.mean.shape, torch.Size([2, 2]))
+            posterior = model.posterior(
+                test_X, observation_noise=torch.rand(2, 2, **tkwargs)
+            )
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+            self.assertEqual(posterior.mean.shape, torch.Size([2, 2]))
             # test conditioning on observations
             cm = model.condition_on_observations(
                 torch.rand(2, 1, **tkwargs), torch.rand(2, 2, **tkwargs)
@@ -167,6 +187,13 @@ class TestBatchedMultiOutputGPyTorchModel(BotorchTestCase):
             self.assertEqual(cm.train_targets.shape, torch.Size([2, 2, 7]))
             cm = model.fantasize(
                 torch.rand(2, 1, **tkwargs), sampler=sampler, observation_noise=True
+            )
+            self.assertIsInstance(cm, SimpleBatchedMultiOutputGPyTorchModel)
+            self.assertEqual(cm.train_targets.shape, torch.Size([2, 2, 7]))
+            cm = model.fantasize(
+                torch.rand(2, 1, **tkwargs),
+                sampler=sampler,
+                observation_noise=torch.rand(2, 2, **tkwargs),
             )
             self.assertIsInstance(cm, SimpleBatchedMultiOutputGPyTorchModel)
             self.assertEqual(cm.train_targets.shape, torch.Size([2, 2, 7]))
@@ -189,10 +216,24 @@ class TestModelListGPyTorchModel(BotorchTestCase):
             posterior = model.posterior(test_X)
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertEqual(posterior.mean.shape, torch.Size([2, 2]))
+            # test output indices
+            posterior = model.posterior(test_X, output_indices=[0])
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+            self.assertEqual(posterior.mean.shape, torch.Size([2, 1]))
             # test observation noise
             posterior = model.posterior(test_X, observation_noise=True)
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertEqual(posterior.mean.shape, torch.Size([2, 2]))
+            posterior = model.posterior(
+                test_X, observation_noise=torch.rand(2, **tkwargs)
+            )
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+            self.assertEqual(posterior.mean.shape, torch.Size([2, 2]))
+            posterior = model.posterior(
+                test_X, output_indices=[0], observation_noise=torch.rand(2, **tkwargs)
+            )
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+            self.assertEqual(posterior.mean.shape, torch.Size([2, 1]))
             # conditioning is not implemented (see ModelListGP for tests)
             with self.assertRaises(NotImplementedError):
                 model.condition_on_observations(

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -98,12 +98,11 @@ class TestMultiTaskGP(BotorchTestCase):
             self.assertEqual(posterior_f.mean.shape, torch.Size([2, 2]))
             self.assertEqual(posterior_f.variance.shape, torch.Size([2, 2]))
 
-            # test posterior w/ observation noise
-            posterior_o = model.posterior(test_x, observation_noise=True)
-            self.assertIsInstance(posterior_o, GPyTorchPosterior)
-            self.assertIsInstance(posterior_f.mvn, MultitaskMultivariateNormal)
-            self.assertEqual(posterior_f.mean.shape, torch.Size([2, 2]))
-            self.assertEqual(posterior_f.variance.shape, torch.Size([2, 2]))
+            # test that posterior w/ observation noise raises appropriate error
+            with self.assertRaises(NotImplementedError):
+                model.posterior(test_x, observation_noise=True)
+            with self.assertRaises(NotImplementedError):
+                model.posterior(test_x, observation_noise=torch.rand(2, **tkwargs))
 
             # test posterior w/ single output index
             posterior_f = model.posterior(test_x, output_indices=[0])
@@ -209,7 +208,11 @@ class TestFixedNoiseMultiTaskGP(BotorchTestCase):
             self.assertEqual(posterior_f.mean.shape, torch.Size([2, 2]))
             self.assertEqual(posterior_f.variance.shape, torch.Size([2, 2]))
 
-            # TODO: test posterior w/ observation noise
+            # test that posterior w/ observation noise raises appropriate error
+            with self.assertRaises(NotImplementedError):
+                model.posterior(test_x, observation_noise=True)
+            with self.assertRaises(NotImplementedError):
+                model.posterior(test_x, observation_noise=torch.rand(2, **tkwargs))
 
             # test posterior w/ single output index
             posterior_f = model.posterior(test_x, output_indices=[0])

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -5,9 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+from botorch import settings
 from botorch.utils.testing import BotorchTestCase
 from botorch.utils.transforms import (
     concatenate_pending_points,
+    gpt_posterior_settings,
     match_batch_shape,
     normalize,
     squeeze_last_dim,
@@ -15,6 +17,7 @@ from botorch.utils.transforms import (
     t_batch_mode_transform,
     unnormalize,
 )
+from gpytorch import settings as gpt_settings
 from torch import Tensor
 
 
@@ -185,3 +188,16 @@ class TestSqueezeLastDim(BotorchTestCase):
         Y = torch.rand(2, 1, 1)
         Y_squeezed = squeeze_last_dim(Y=Y)
         self.assertTrue(torch.equal(Y_squeezed, Y.squeeze(-1)))
+
+
+class TestGPTPosteriorSettings(BotorchTestCase):
+    def test_gpt_posterior_settings(self):
+        for propagate_grads in (False, True):
+            with settings.propagate_grads(propagate_grads):
+                with gpt_posterior_settings():
+                    self.assertTrue(gpt_settings.debug.off())
+                    self.assertTrue(gpt_settings.fast_pred_var.on())
+                    if settings.propagate_grads.off():
+                        self.assertTrue(gpt_settings.detach_test_caches.on())
+                    else:
+                        self.assertTrue(gpt_settings.detach_test_caches.off())


### PR DESCRIPTION
This adds support for specifying the observation noise in `posterior` and `fantasize`.

In addition to using the observation noise from the likelihood by setting `observation_noise=True`, now `observation_noise` can be a tensor. In that case, the provided noise levels are used directly as the observation noise in the posterior predictive (not in performing inference).

The primary use case for this is if we have auxiliary noise models that should not be used as the likelihood during posterior computations (e.g. b/c the model is fitted to already smoothed data), or because we have some dependency of the observation noise on parameters that we may control, e.g. the fidelity of the evaluation/sample size.

Note: This depends on https://github.com/cornellius-gp/gpytorch/pull/865

Also, this cleans up some of the boilerplate code in the gpytorch wrappers by defining the `gpt_posterior_settings` contextmanager that wraps the settings we use for posterior computation.
