### PR TITLE
Make standardize work on the second to last dimension

### DIFF
--- a/botorch/utils/transforms.py
+++ b/botorch/utils/transforms.py
@@ -29,22 +29,27 @@ def squeeze_last_dim(Y: Tensor) -> Tensor:
     return Y.squeeze(-1)
 
 
-def standardize(X: Tensor) -> Tensor:
-    r"""Standardize a tensor by dim=0.
+def standardize(Y: Tensor) -> Tensor:
+    r"""Standardizes (zero mean, unit variance) a tensor by dim=-2.
+
+    If the tensor is single-dimensional, simply standardizes the tensor.
+    If for some batch index all elements are equal (of if there is only a single
+    data point), this function will return 0 for that batch index.
 
     Args:
-        X: A `n` or `n x d`-dim tensor
+        Y: A `batch_shape x n x m`-dim tensor.
 
     Returns:
-        The standardized `X`.
+        The standardized `Y`.
 
     Example:
-        >>> X = torch.rand(4, 3)
-        >>> X_standardized = standardize(X)
+        >>> Y = torch.rand(4, 3)
+        >>> Y_standardized = standardize(Y)
     """
-    X_std = X.std(dim=0)
-    X_std = X_std.where(X_std >= 1e-9, torch.full_like(X_std, 1.0))
-    return (X - X.mean(dim=0)) / X_std
+    stddim = -1 if Y.dim() < 2 else -2
+    Y_std = Y.std(dim=stddim, keepdim=True)
+    Y_std = Y_std.where(Y_std >= 1e-9, torch.full_like(Y_std, 1.0))
+    return (Y - Y.mean(dim=stddim, keepdim=True)) / Y_std
 
 
 def normalize(X: Tensor, bounds: Tensor) -> Tensor:

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -23,17 +23,22 @@ class TestStandardize(BotorchTestCase):
         tkwargs = {"device": torch.device("cuda" if cuda else "cpu")}
         for dtype in (torch.float, torch.double):
             tkwargs["dtype"] = dtype
-            X = torch.tensor([0.0, 0.0], **tkwargs)
-            self.assertTrue(torch.equal(X, standardize(X)))
-            X2 = torch.tensor([0.0, 1.0, 1.0, 1.0], **tkwargs)
-            expected_X2_stdized = torch.tensor([-1.5, 0.5, 0.5, 0.5], **tkwargs)
-            self.assertTrue(torch.equal(expected_X2_stdized, standardize(X2)))
-            X3 = torch.tensor(
+            Y = torch.tensor([0.0, 0.0], **tkwargs)
+            self.assertTrue(torch.equal(Y, standardize(Y)))
+            Y2 = torch.tensor([0.0, 1.0, 1.0, 1.0], **tkwargs)
+            expected_Y2_stdized = torch.tensor([-1.5, 0.5, 0.5, 0.5], **tkwargs)
+            self.assertTrue(torch.equal(expected_Y2_stdized, standardize(Y2)))
+            Y3 = torch.tensor(
                 [[0.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0]], **tkwargs
             ).transpose(1, 0)
-            X3_stdized = standardize(X3)
-            self.assertTrue(torch.equal(X3_stdized[:, 0], expected_X2_stdized))
-            self.assertTrue(torch.equal(X3_stdized[:, 1], torch.zeros(4, **tkwargs)))
+            Y3_stdized = standardize(Y3)
+            self.assertTrue(torch.equal(Y3_stdized[:, 0], expected_Y2_stdized))
+            self.assertTrue(torch.equal(Y3_stdized[:, 1], torch.zeros(4, **tkwargs)))
+            Y4 = torch.cat([Y3, Y2.unsqueeze(-1)], dim=-1)
+            Y4_stdized = standardize(Y4)
+            self.assertTrue(torch.equal(Y4_stdized[:, 0], expected_Y2_stdized))
+            self.assertTrue(torch.equal(Y4_stdized[:, 1], torch.zeros(4, **tkwargs)))
+            self.assertTrue(torch.equal(Y4_stdized[:, 2], expected_Y2_stdized))
 
     def test_standardize_cuda(self):
         if torch.cuda.is_available():


### PR DESCRIPTION
Summary:
Previously, `standardize` worked on the batch (leading) dimension of a tensor.
This is not the typical use case for batched tensors in BoTorch, now that we
require an explicit output dimension.

This changes `standardize` to standardize on `dim=-2` (and just standardize if the tensor happens to be single-dimensional)

Note that while this is a breaking change, it does not look like it does not require updates in other places.

Differential Revision: D16965564

