### PR TITLE
Update footer links

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -71,8 +71,8 @@ class Footer extends React.Component {
             <h5>Docs</h5>
             <a href={this.docUrl('introduction')}>Introduction</a>
             <a href={this.docUrl('getting_started')}>Getting Started</a>
-            <a href={`${this.props.config.baseUrl}tutorials`}>Tutorials</a>
-            <a href={`${this.props.config.baseUrl}api`}>API Reference</a>
+            <a href={`${this.props.config.baseUrl}tutorials/`}>Tutorials</a>
+            <a href={`${this.props.config.baseUrl}api/`}>API Reference</a>
           </div>
           <SocialFooter config={this.props.config} />
         </section>


### PR DESCRIPTION
This should fix #255

The basic issue is that `https://botorch.org/tutorials/` renders correctly, but `https://botorch.org/tutorials` (without the slash) does not render css.
Not quite sure what causes this.