### PR TITLE
Add input scaling check to standard models

### DIFF
--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -29,6 +29,7 @@ from torch import Tensor
 
 from ..sampling.samplers import MCSampler
 from .gpytorch import BatchedMultiOutputGPyTorchModel
+from .utils import validate_input_scaling
 
 
 MIN_INFERRED_NOISE_LEVEL = 1e-4
@@ -75,6 +76,7 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP):
             >>> train_Y = torch.sin(train_X).sum(dim=1, keepdim=True)
             >>> model = SingleTaskGP(train_X, train_Y)
         """
+        validate_input_scaling(train_X=train_X, train_Y=train_Y)
         self._validate_tensor_args(X=train_X, Y=train_Y)
         self._set_dimensions(train_X=train_X, train_Y=train_Y)
         train_X, train_Y, _ = self._transform_tensor_args(X=train_X, Y=train_Y)
@@ -143,6 +145,7 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
             >>> train_Yvar = torch.full_like(train_Y, 0.2)
             >>> model = FixedNoiseGP(train_X, train_Y, train_Yvar)
         """
+        validate_input_scaling(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
         self._validate_tensor_args(X=train_X, Y=train_Y, Yvar=train_Yvar)
         self._set_dimensions(train_X=train_X, train_Y=train_Y)
         train_X, train_Y, train_Yvar = self._transform_tensor_args(
@@ -238,6 +241,7 @@ class HeteroskedasticSingleTaskGP(SingleTaskGP):
             >>> train_Yvar = 0.1 + se * torch.rand_like(train_Y)
             >>> model = HeteroskedasticSingleTaskGP(train_X, train_Y, train_Yvar)
         """
+        validate_input_scaling(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
         self._validate_tensor_args(X=train_X, Y=train_Y, Yvar=train_Yvar)
         self._set_dimensions(train_X=train_X, train_Y=train_Y)
         noise_likelihood = GaussianLikelihood(

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -70,6 +70,7 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel):
             >>> train_Y = torch.cat(f1(X1), f2(X2))
             >>> model = MultiTaskGP(train_X, train_Y, task_feature=-1)
         """
+        # TODO: Validate input normalization/scaling
         if train_X.ndimension() != 2:
             # Currently, batch mode MTGPs are blocked upstream in GPyTorch
             raise ValueError(f"Unsupported shape {train_X.shape} for train_X.")

--- a/botorch/settings.py
+++ b/botorch/settings.py
@@ -74,3 +74,18 @@ class debug(_Flag):
     def _set_state(cls, state: bool) -> None:
         cls._state = state
         suppress_botorch_warnings(suppress=not cls._state)
+
+
+class validate_input_scaling(_Flag):
+    r"""Flag for validating input normalization/standardization.
+
+    When set to `True`, standard botorch models will validate (up to reasonable
+    tolerance) that
+    (i) none of the inputs contain NaN values
+    (ii) the training data (`train_X`) is normalized to the unit cube
+    (iii) the training targets (`train_Y`) are standardized (zero mean, unit var)
+    No checks (other than the NaN check) are performed for observed variances
+    (`train_Y_var`) at this point.
+    """
+
+    _state: bool = True


### PR DESCRIPTION
Introduces a `settings.validate_input_scaling` flag that when active results in the input data being checked for normalization/standardization.

In this PR this check is on by default, we may want to make it optional if this is too much of a hassle in practice. Right now as used in the models this by default emits warnings and raises errors only on `NaN` values or negative variances.

Addresses #208
