### PR TITLE
Error out on unexpected dims in parameter constraint generation

### DIFF
--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -194,10 +194,11 @@ def _make_linear_constraints(
 
     Args:
         indices: A tensor of shape `c` or `c x 2`, where c is the number of terms
-            in the constraint.  If single-dimensional, contains the indices of
-            the dimensions of the feature space that occur in the linear constraint.  If
-            two-dimensional, contains pairs of indices of the q-batch (0) and
-            the feature space (1) that occur in the linear constraint.
+            in the constraint. If single-dimensional, contains the indices of
+            the dimensions of the feature space that occur in the linear
+            constraint. If two-dimensional, contains pairs of indices of the
+            q-batch (0) and the feature space (1) that occur in the linear
+            constraint.
         coefficients: A single-dimensional tensor of coefficients with the same
             number of elements as `indices`.
         rhs: The right hand side of the constraint.
@@ -260,4 +261,6 @@ def _make_linear_constraints(
                 )
                 jac = partial(lin_constraint_jac, flat_idxr=idxr, coeffs=coeffs, n=n)
                 constraints.append({"type": ctype, "fun": fun, "jac": jac})
+    else:
+        raise ValueError("`indices` must be at least one-dimensional")
     return constraints

--- a/test/optim/test_parameter_constraints.py
+++ b/test/optim/test_parameter_constraints.py
@@ -105,6 +105,15 @@ class TestParameterConstraints(BotorchTestCase):
                 jac_exp = np.zeros(shapeX.numel())
                 jac_exp[[pos1, pos2]] = [1, 2]
                 self.assertTrue(np.allclose(constraints[i]["jac"](x), jac_exp))
+        # make sure error is raised for scalar tensors
+        with self.assertRaises(ValueError):
+            constraints = _make_linear_constraints(
+                indices=torch.tensor(0),
+                coefficients=torch.tensor([1.0]),
+                rhs=1.0,
+                shapeX=torch.Size([1, 1, 2]),
+                eq=False,
+            )
 
     def test_make_scipy_linear_constraints(self):
         shapeX = torch.Size([2, 1, 4])


### PR DESCRIPTION
Summary:
This caused a bug in ax: https://github.com/facebook/Ax/issues/169
This explicitly checks for the dimension to be at least one, and errors out if otherwise

Differential Revision: D17505547

