### PR TITLE
Knowledge Gradient (one-shot)

### DIFF
--- a/botorch/acquisition/__init__.py
+++ b/botorch/acquisition/__init__.py
@@ -2,7 +2,7 @@
 
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from .acquisition import AcquisitionFunction
+from .acquisition import AcquisitionFunction, OneShotAcquisitionFunction
 from .analytic import (
     AnalyticAcquisitionFunction,
     ConstrainedExpectedImprovement,
@@ -13,6 +13,7 @@ from .analytic import (
     UpperConfidenceBound,
 )
 from .fixed_feature import FixedFeatureAcquisitionFunction
+from .knowledge_gradient import qKnowledgeGradient
 from .monte_carlo import (
     MCAcquisitionFunction,
     qExpectedImprovement,
@@ -39,10 +40,12 @@ __all__ = [
     "ExpectedImprovement",
     "FixedFeatureAcquisitionFunction",
     "NoisyExpectedImprovement",
+    "OneShotAcquisitionFunction",
     "PosteriorMean",
     "ProbabilityOfImprovement",
     "UpperConfidenceBound",
     "qExpectedImprovement",
+    "qKnowledgeGradient",
     "qNoisyExpectedImprovement",
     "qProbabilityOfImprovement",
     "qSimpleRegret",

--- a/botorch/acquisition/acquisition.py
+++ b/botorch/acquisition/acquisition.py
@@ -60,3 +60,33 @@ class AcquisitionFunction(Module, ABC):
             design points `X`.
         """
         pass  # pragma: no cover
+
+
+class OneShotAcquisitionFunction(AcquisitionFunction, ABC):
+    r"""Abstract base class for acquisition functions using one-shot optimization"""
+
+    @abstractmethod
+    def get_augmented_q_batch_size(self, q: int) -> int:
+        r"""Get augmented q batch size for one-shot optimzation.
+
+        Args:
+            q: The number of candidates to consider jointly.
+
+        Returns:
+            The augmented size for one-shot optimzation (including variables
+            parameterizing the fantasy solutions).
+        """
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def extract_candidates(self, X_full: Tensor) -> Tensor:
+        r"""Extract the candidates from a full "one-shot" parameterization.
+
+        Args:
+            X_full: A `b x q_aug x d`-dim Tensor with `b` t-batches of `q_aug`
+                design points each.
+
+        Returns:
+            A `b x q x d`-dim Tensor with `b` t-batches of `q` design points each.
+        """
+        pass  # pragma: no cover

--- a/botorch/acquisition/knowledge_gradient.py
+++ b/botorch/acquisition/knowledge_gradient.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+r"""
+Batch Knowledge Gradient (KG) via one-shot optimization as introduced in
+[Balandat2019botorch]_. For broader discussion of KG see also
+[Frazier2008knowledge]_, [Wu2016parallelkg]_.
+
+.. [Balandat2019botorch]
+    M. Balandat, B. Karrer, D. R. Jiang, S. Daulton, B. Letham, A. G. Wilson,
+    and E. Bakshy. BoTorch: Programmable Bayesian Optimziation in PyTorch.
+    ArXiv 2019.
+
+.. [Frazier2008knowledge]
+    P. Frazier, W. Powell, and S. Dayanik. A Knowledge-Gradient policy for
+    sequential information collection. SIAM Journal on Control and Optimization,
+    2008.
+
+.. [Wu2016parallelkg]
+    J. Wu and P. Frazier. The parallel knowledge gradient method for batch
+    bayesian optimization. NIPS 2016.
+"""
+
+from typing import Optional, Union
+
+import torch
+from torch import Tensor
+
+from .. import settings
+from ..models.model import Model
+from ..sampling.samplers import MCSampler, SobolQMCNormalSampler
+from ..utils.transforms import match_batch_shape
+from .acquisition import AcquisitionFunction, OneShotAcquisitionFunction
+from .analytic import PosteriorMean
+from .monte_carlo import MCAcquisitionFunction, qSimpleRegret
+from .objective import AcquisitionObjective, MCAcquisitionObjective, ScalarizedObjective
+
+
+class qKnowledgeGradient(MCAcquisitionFunction, OneShotAcquisitionFunction):
+    r"""Batch Knowledge Gradient using one-shot optimization.
+
+    This computes the batch Knowledge Gradient using fantasies for the outer
+    expectation and either the model posterior mean or MC-sampling for the inner
+    expectation.
+
+    In addition to the design variables, the input `X` also includes variables
+    for the optimal designs for each of the fantasy models. For a fixed number
+    of fantasies, all parts of `X` can be optimized in a "one-shot" fashion.
+    """
+
+    def __init__(
+        self,
+        model: Model,
+        num_fantasies: Optional[int] = 64,
+        sampler: Optional[MCSampler] = None,
+        objective: Optional[AcquisitionObjective] = None,
+        inner_sampler: Optional[MCSampler] = None,
+        X_pending: Optional[Tensor] = None,
+        current_value: Optional[Tensor] = None,
+    ) -> None:
+        r"""q-Knowledge Gradient (one-shot optimization).
+
+        Args:
+            model: A fitted model. Must support fantasizing.
+            num_fantasies: The number of fantasy points to use. More fantasy
+                points result in a better approximation, at the expense of
+                memory and wall time. Unused if `sampler` is specified.
+            sampler: The sampler used to sample fantasy observations. Optional
+                if `num_fantasies` is specified.
+            objective: The objective under which the samples are evaluated. If
+                `None` or a ScalarizedObjective, then the analytic posterior mean
+                is used, otherwise the objective is MC-evaluated (using
+                inner_sampler).
+            inner_sampler: The sampler used for inner sampling. Ignored if the
+                objective is `None` or a ScalarizedObjective.
+            X_pending: A `m x d`-dim Tensor of `m` design points that have
+                points that have been submitted for function evaluation
+                but have not yet been evaluated.
+            current_value: The current value, i.e. the expected best objective
+                given the observed points `D`. If omitted, forward will not
+                return the actual KG value, but the expected best objective
+                given the data set `D u X`.
+        """
+        if sampler is None:
+            if num_fantasies is None:
+                raise ValueError(
+                    "Must specify `num_fantasies` if no `sampler` is provided."
+                )
+            # base samples should be fixed for joint optimization over X, X_fantasies
+            sampler = SobolQMCNormalSampler(
+                num_samples=num_fantasies, resample=False, collapse_batch_dims=True
+            )
+        elif num_fantasies is not None:
+            if sampler.sample_shape != torch.Size([num_fantasies]):
+                raise ValueError(
+                    f"The sampler shape must match num_fantasies={num_fantasies}."
+                )
+        else:
+            num_fantasies = sampler.sample_shape[0]
+        super().__init__(model=model, sampler=sampler, X_pending=X_pending)
+        # if not explicitly specified, we use the posterior mean for linear objs
+        if isinstance(objective, MCAcquisitionObjective) and inner_sampler is None:
+            inner_sampler = SobolQMCNormalSampler(
+                num_samples=128, resample=False, collapse_batch_dims=True
+            )
+        self.inner_sampler = inner_sampler
+        self.objective = objective
+        self.num_fantasies = num_fantasies
+        self.current_value = current_value
+
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Evaluate qKnowledgeGradient on the candidate set `X`.
+
+        Args:
+            X: A `b x (q + num_fantasies) x d` Tensor with `b` t-batches of
+                `q + num_fantasies` design points each. We split this X tensor
+                into two parts in the `q` dimension (`dim=-2`). The first `q`
+                are the q-batch of design points and the last num_fantasies are
+                the current solutions of the inner optimization problem.
+
+                `X_fantasies = X[..., -num_fantasies:, :]`
+                `X_fantasies.shape = b x num_fantasies x d`
+
+                `X_actual = X[..., :-num_fantasies, :]`
+                `X_actual.shape = b x q x d`
+
+        Returns:
+            A Tensor of shape `b`. For t-batch b, the q-KG value of the design
+                `X_actual[b]` is averaged across the fantasy models, where
+                `X_fantasies[b, i]` is chosen as the final selection for the
+                `i`-th fantasy model.
+                NOTE: If `current_value` is not provided, then this is not the
+                true KG value of `X_actual[b]`, and `X_fantasies[b, : ]` must be
+                maximized at fixed `X_actual[b]`.
+        """
+        split_sizes = [X.size(-2) - self.num_fantasies, self.num_fantasies]
+        X_actual, X_fantasies = torch.split(X, split_sizes, dim=-2)
+
+        # X_fantasies is b x num_fantasies x d, needs to be num_fantasies x b x 1 x d
+        # for batch mode evaluation with batch shape num_fantasies x b.
+        # b x num_fantasies x d --> num_fantasies x b x d
+        X_fantasies = X_fantasies.permute(-2, *range(X_fantasies.dim() - 2), -1)
+        # num_fantasies x b x 1 x d
+        X_fantasies = X_fantasies.unsqueeze(dim=-2)
+
+        # We only concatenate X_pending into the X part after splitting
+        if self.X_pending is not None:
+            X_actual = torch.cat(
+                [X_actual, match_batch_shape(self.X_pending, X_actual)], dim=-2
+            )
+
+        # construct the fantasy model of shape `num_fantasies x b`
+        fantasy_model = self.model.fantasize(
+            X=X_actual, sampler=self.sampler, observation_noise=True
+        )
+        value_function = _get_value_function(
+            model=fantasy_model, objective=self.objective, sampler=self.inner_sampler
+        )
+        # we need to make sure to propagate gradients to the fantasy model train inputs
+        with settings.propagate_grads(True):
+            values = value_function(X=X_fantasies)  # num_fantasies x b
+
+        # average over the fantasy samples
+        result = values.mean(dim=0)
+
+        if self.current_value is not None:
+            result = result - self.current_value
+
+        return result
+
+    def get_augmented_q_batch_size(self, q: int) -> int:
+        r"""Get augmented q batch size for one-shot optimzation.
+
+        Args:
+            q: The number of candidates to consider jointly.
+
+        Returns:
+            The augmented size for one-shot optimzation (including variables
+            parameterizing the fantasy solutions).
+        """
+        return q + self.num_fantasies
+
+    def extract_candidates(self, X_full: Tensor) -> Tensor:
+        r"""We only return X as the set of candidates post-optimization.
+
+        Args:
+            X_full: A `b x (q + num_fantasies) x d`-dim Tensor with `b`
+                t-batches of `q + num_fantasies` design points each.
+
+        Returns:
+            A `b x q x d`-dim Tensor with `b` t-batches of `q` design points each.
+        """
+        return X_full[..., : -self.num_fantasies, :]
+
+
+def _get_value_function(
+    model: Model,
+    objective: Optional[Union[MCAcquisitionObjective, ScalarizedObjective]] = None,
+    sampler: Optional[MCSampler] = None,
+) -> AcquisitionFunction:
+    r"""Construct value function (i.e. inner acquisition function)."""
+    if isinstance(objective, MCAcquisitionObjective):
+        return qSimpleRegret(model=model, sampler=sampler, objective=objective)
+    else:
+        return PosteriorMean(model=model, objective=objective)

--- a/test/acquisition/test_acquisition.py
+++ b/test/acquisition/test_acquisition.py
@@ -2,7 +2,10 @@
 
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.acquisition import (
+    AcquisitionFunction,
+    OneShotAcquisitionFunction,
+)
 from botorch.utils.testing import BotorchTestCase
 
 
@@ -10,3 +13,9 @@ class TestAcquisitionFunction(BotorchTestCase):
     def test_abstract_raises(self):
         with self.assertRaises(TypeError):
             AcquisitionFunction()
+
+
+class TestOneShotAcquisitionFunction(BotorchTestCase):
+    def test_abstract_raises(self):
+        with self.assertRaises(TypeError):
+            OneShotAcquisitionFunction()

--- a/test/acquisition/test_knowledge_gradient.py
+++ b/test/acquisition/test_knowledge_gradient.py
@@ -1,0 +1,147 @@
+#! /usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from unittest import mock
+
+import torch
+from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
+from botorch.acquisition.objective import GenericMCObjective
+from botorch.sampling.samplers import IIDNormalSampler, SobolQMCNormalSampler
+from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
+
+
+class TestQKnowledgeGradient(BotorchTestCase):
+    def test_initialize_q_knowledge_gradient(self):
+        for dtype in (torch.float, torch.double):
+            mm = MockModel(MockPosterior())
+            # test error when neither specifying neither sampler nor num_fantasies
+            with self.assertRaises(ValueError):
+                qKnowledgeGradient(model=mm, num_fantasies=None)
+            # test error when sampler and num_fantasies arg are inconsistent
+            sampler = IIDNormalSampler(num_samples=16)
+            with self.assertRaises(ValueError):
+                qKnowledgeGradient(model=mm, num_fantasies=32, sampler=sampler)
+            # test default construction
+            qKG = qKnowledgeGradient(model=mm, num_fantasies=32)
+            self.assertEqual(qKG.num_fantasies, 32)
+            self.assertIsInstance(qKG.sampler, SobolQMCNormalSampler)
+            self.assertEqual(qKG.sampler.sample_shape, torch.Size([32]))
+            self.assertIsNone(qKG.objective)
+            self.assertIsNone(qKG.inner_sampler)
+            self.assertIsNone(qKG.X_pending)
+            self.assertIsNone(qKG.current_value)
+            self.assertEqual(qKG.get_augmented_q_batch_size(q=3), 32 + 3)
+            # test custom construction
+            obj = GenericMCObjective(lambda Y: Y.mean(dim=-1))
+            sampler = IIDNormalSampler(num_samples=16)
+            X_pending = torch.zeros(2, 2, device=self.device, dtype=dtype)
+            qKG = qKnowledgeGradient(
+                model=mm,
+                num_fantasies=16,
+                sampler=sampler,
+                objective=obj,
+                X_pending=X_pending,
+            )
+            self.assertEqual(qKG.num_fantasies, 16)
+            self.assertEqual(qKG.sampler, sampler)
+            self.assertEqual(qKG.sampler.sample_shape, torch.Size([16]))
+            self.assertEqual(qKG.objective, obj)
+            self.assertIsInstance(qKG.inner_sampler, SobolQMCNormalSampler)
+            self.assertEqual(qKG.inner_sampler.sample_shape, torch.Size([128]))
+            self.assertTrue(torch.equal(qKG.X_pending, X_pending))
+            self.assertIsNone(qKG.current_value)
+            self.assertEqual(qKG.get_augmented_q_batch_size(q=3), 16 + 3)
+            # test assignment of num_fantasies from sampler if not provided
+            qKG = qKnowledgeGradient(model=mm, num_fantasies=None, sampler=sampler)
+            self.assertEqual(qKG.sampler.sample_shape, torch.Size([16]))
+            # test custom construction with inner sampler and current value
+            inner_sampler = SobolQMCNormalSampler(num_samples=256)
+            current_value = torch.zeros(1, device=self.device, dtype=dtype)
+            qKG = qKnowledgeGradient(
+                model=mm,
+                num_fantasies=8,
+                objective=obj,
+                inner_sampler=inner_sampler,
+                current_value=current_value,
+            )
+            self.assertEqual(qKG.num_fantasies, 8)
+            self.assertEqual(qKG.sampler.sample_shape, torch.Size([8]))
+            self.assertEqual(qKG.objective, obj)
+            self.assertIsInstance(qKG.inner_sampler, SobolQMCNormalSampler)
+            self.assertEqual(qKG.inner_sampler, inner_sampler)
+            self.assertIsNone(qKG.X_pending)
+            self.assertTrue(torch.equal(qKG.current_value, current_value))
+            self.assertEqual(qKG.get_augmented_q_batch_size(q=3), 8 + 3)
+
+    def test_evaluate_q_knowledge_gradient(self):
+        for dtype in (torch.float, torch.double):
+            # basic test
+            n_f = 4
+            mean = torch.rand(n_f, 1, device=self.device, dtype=dtype)
+            variance = torch.rand(n_f, 1, device=self.device, dtype=dtype)
+            mfm = MockModel(MockPosterior(mean=mean, variance=variance))
+            with mock.patch.object(MockModel, "fantasize", return_value=mfm) as patch_f:
+                mm = MockModel(None)
+                qKG = qKnowledgeGradient(model=mm, num_fantasies=n_f)
+                X = torch.rand(n_f + 1, 1, device=self.device, dtype=dtype)
+                val = qKG(X)
+                patch_f.assert_called_once()
+                cargs, ckwargs = patch_f.call_args
+                self.assertEqual(ckwargs["X"].shape, torch.Size([1, 1]))
+            self.assertTrue(torch.allclose(val, mean.mean(), atol=1e-4))
+            self.assertTrue(torch.equal(qKG.extract_candidates(X), X[..., :-n_f, :]))
+            # batched evaluation
+            b = 2
+            mean = torch.rand(n_f, b, 1, device=self.device, dtype=dtype)
+            variance = torch.rand(n_f, b, 1, device=self.device, dtype=dtype)
+            mfm = MockModel(MockPosterior(mean=mean, variance=variance))
+            X = torch.rand(b, n_f + 1, 1, device=self.device, dtype=dtype)
+            with mock.patch.object(MockModel, "fantasize", return_value=mfm) as patch_f:
+                mm = MockModel(None)
+                qKG = qKnowledgeGradient(model=mm, num_fantasies=n_f)
+                val = qKG(X)
+                patch_f.assert_called_once()
+                cargs, ckwargs = patch_f.call_args
+                self.assertEqual(ckwargs["X"].shape, torch.Size([b, 1, 1]))
+            self.assertTrue(
+                torch.allclose(val, mean.mean(dim=0).squeeze(-1), atol=1e-4)
+            )
+            self.assertTrue(torch.equal(qKG.extract_candidates(X), X[..., :-n_f, :]))
+            # pending points and current value
+            mean = torch.rand(n_f, 1, device=self.device, dtype=dtype)
+            variance = torch.rand(n_f, 1, device=self.device, dtype=dtype)
+            X_pending = torch.rand(2, 1, device=self.device, dtype=dtype)
+            mfm = MockModel(MockPosterior(mean=mean, variance=variance))
+            current_value = torch.rand(1, device=self.device, dtype=dtype)
+            X = torch.rand(n_f + 1, 1, device=self.device, dtype=dtype)
+            with mock.patch.object(MockModel, "fantasize", return_value=mfm) as patch_f:
+                mm = MockModel(None)
+                qKG = qKnowledgeGradient(
+                    model=mm,
+                    num_fantasies=n_f,
+                    X_pending=X_pending,
+                    current_value=current_value,
+                )
+                val = qKG(X)
+                patch_f.assert_called_once()
+                cargs, ckwargs = patch_f.call_args
+                self.assertEqual(ckwargs["X"].shape, torch.Size([3, 1]))
+            self.assertTrue(torch.allclose(val, mean.mean() - current_value, atol=1e-4))
+            self.assertTrue(torch.equal(qKG.extract_candidates(X), X[..., :-n_f, :]))
+            # test objective (inner MC sampling)
+            objective = GenericMCObjective(objective=lambda Y: Y.norm(dim=-1))
+            samples = torch.randn(3, 1, 1, device=self.device, dtype=dtype)
+            mfm = MockModel(MockPosterior(samples=samples))
+            X = torch.rand(n_f + 1, 1, device=self.device, dtype=dtype)
+            with mock.patch.object(MockModel, "fantasize", return_value=mfm) as patch_f:
+                mm = MockModel(None)
+                qKG = qKnowledgeGradient(
+                    model=mm, num_fantasies=n_f, objective=objective
+                )
+                val = qKG(X)
+                patch_f.assert_called_once()
+                cargs, ckwargs = patch_f.call_args
+                self.assertEqual(ckwargs["X"].shape, torch.Size([1, 1]))
+            self.assertTrue(torch.allclose(val, objective(samples).mean(), atol=1e-4))
+            self.assertTrue(torch.equal(qKG.extract_candidates(X), X[..., :-n_f, :]))

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -3,12 +3,24 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import warnings
+from contextlib import ExitStack
+from unittest import mock
 
 import torch
 from botorch import settings
-from botorch.exceptions import BadInitialCandidatesWarning
+from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
+from botorch.exceptions import BadInitialCandidatesWarning, SamplingWarning
 from botorch.optim import initialize_q_batch, initialize_q_batch_nonneg
-from botorch.utils.testing import BotorchTestCase
+from botorch.optim.optimize import (
+    gen_batch_initial_conditions,
+    gen_one_shot_kg_initial_conditions,
+)
+from botorch.utils.testing import (
+    BotorchTestCase,
+    MockAcquisitionFunction,
+    MockModel,
+    MockPosterior,
+)
 
 
 class TestInitializeQBatch(BotorchTestCase):
@@ -83,3 +95,146 @@ class TestInitializeQBatch(BotorchTestCase):
             Y = torch.tensor([-1e12, 0, 0, 0, 1e12], device=self.device, dtype=dtype)
             ics = initialize_q_batch(X=X, Y=Y, n=2, eta=100)
             self.assertEqual(ics.shape[0], 2)
+
+
+class TestGenBatchInitialCandidates(BotorchTestCase):
+    def test_gen_batch_initial_conditions(self):
+        for dtype in (torch.float, torch.double):
+            bounds = torch.tensor([[0, 0], [1, 1]], device=self.device, dtype=dtype)
+            for nonnegative in (True, False):
+                for seed in (None, 1234):
+                    batch_initial_conditions = gen_batch_initial_conditions(
+                        acq_function=MockAcquisitionFunction(),
+                        bounds=bounds,
+                        q=1,
+                        num_restarts=2,
+                        raw_samples=10,
+                        options={
+                            "nonnegative": nonnegative,
+                            "eta": 0.01,
+                            "alpha": 0.1,
+                            "seed": seed,
+                        },
+                    )
+                    expected_shape = torch.Size([2, 1, 2])
+                    self.assertEqual(batch_initial_conditions.shape, expected_shape)
+                    self.assertEqual(batch_initial_conditions.device, bounds.device)
+                    self.assertEqual(batch_initial_conditions.dtype, bounds.dtype)
+
+    def test_gen_batch_initial_conditions_highdim(self):
+        d = 120
+        bounds = torch.stack([torch.zeros(d), torch.ones(d)])
+        for dtype in (torch.float, torch.double):
+            bounds = bounds.to(device=self.device, dtype=dtype)
+            for nonnegative in (True, False):
+                for seed in (None, 1234):
+                    with warnings.catch_warnings(record=True) as ws, settings.debug(
+                        True
+                    ):
+                        batch_initial_conditions = gen_batch_initial_conditions(
+                            acq_function=MockAcquisitionFunction(),
+                            bounds=bounds,
+                            q=10,
+                            num_restarts=1,
+                            raw_samples=2,
+                            options={
+                                "nonnegative": nonnegative,
+                                "eta": 0.01,
+                                "alpha": 0.1,
+                                "seed": seed,
+                            },
+                        )
+                        self.assertTrue(
+                            any(issubclass(w.category, SamplingWarning) for w in ws)
+                        )
+                    expected_shape = torch.Size([1, 10, d])
+                    self.assertEqual(batch_initial_conditions.shape, expected_shape)
+                    self.assertEqual(batch_initial_conditions.device, bounds.device)
+                    self.assertEqual(batch_initial_conditions.dtype, bounds.dtype)
+
+    def test_gen_batch_initial_conditions_warning(self):
+        for dtype in (torch.float, torch.double):
+            bounds = torch.tensor([[0, 0], [1, 1]], device=self.device, dtype=dtype)
+            samples = torch.zeros(10, 1, 2, device=self.device, dtype=dtype)
+            with ExitStack() as es:
+                ws = es.enter_context(warnings.catch_warnings(record=True))
+                es.enter_context(settings.debug(True))
+                es.enter_context(
+                    mock.patch(
+                        "botorch.optim.initializers.draw_sobol_samples",
+                        return_value=samples,
+                    )
+                )
+                batch_initial_conditions = gen_batch_initial_conditions(
+                    acq_function=MockAcquisitionFunction(),
+                    bounds=bounds,
+                    q=1,
+                    num_restarts=2,
+                    raw_samples=10,
+                    options={"seed": 1234},
+                )
+                self.assertEqual(len(ws), 1)
+                self.assertTrue(
+                    any(issubclass(w.category, BadInitialCandidatesWarning) for w in ws)
+                )
+                self.assertTrue(
+                    torch.equal(
+                        batch_initial_conditions,
+                        torch.zeros(2, 1, 2, device=self.device, dtype=dtype),
+                    )
+                )
+
+
+class TestGenOneShotKGInitialConditions(BotorchTestCase):
+    def test_gen_one_shot_kg_initial_conditions(self):
+        mm = MockModel(MockPosterior())
+        num_fantasies = 8
+        num_restarts = 4
+        raw_samples = 16
+        for dtype in (torch.float, torch.double):
+            mock_kg = qKnowledgeGradient(model=mm, num_fantasies=num_fantasies)
+            bounds = torch.tensor([[0, 0], [1, 1]], device=self.device, dtype=dtype)
+            # test option error
+            with self.assertRaises(ValueError):
+                gen_one_shot_kg_initial_conditions(
+                    acq_function=mock_kg,
+                    bounds=bounds,
+                    q=1,
+                    num_restarts=num_restarts,
+                    raw_samples=raw_samples,
+                    options={"frac_random": 2.0},
+                )
+            # test generation logic
+            q = 2
+            mock_random_ics = torch.rand(num_restarts, q + num_fantasies, 2)
+            mock_fantasy_cands = torch.ones(20, 1, 2)
+            mock_fantasy_vals = torch.randn(20)
+            with ExitStack() as es:
+                mock_gbics = es.enter_context(
+                    mock.patch(
+                        "botorch.optim.initializers.gen_batch_initial_conditions",
+                        return_value=mock_random_ics,
+                    )
+                )
+                mock_optacqf = es.enter_context(
+                    mock.patch(
+                        "botorch.optim.optimize.optimize_acqf",
+                        return_value=(mock_fantasy_cands, mock_fantasy_vals),
+                    )
+                )
+                ics = gen_one_shot_kg_initial_conditions(
+                    acq_function=mock_kg,
+                    bounds=bounds,
+                    q=q,
+                    num_restarts=num_restarts,
+                    raw_samples=raw_samples,
+                )
+                mock_gbics.assert_called_once()
+                mock_optacqf.assert_called_once()
+                n_value = int((1 - 0.1) * num_fantasies)
+                self.assertTrue(
+                    torch.equal(
+                        ics[..., :-n_value, :], mock_random_ics[..., :-n_value, :]
+                    )
+                )
+                self.assertTrue(torch.all(ics[..., -n_value:, :] == 1))


### PR DESCRIPTION
Summary:
One-Shot formulation of the Knowledge Gradient.

For now this does not include any `multi-fidelity` functionality.

This diff also adds a `OneShotAcquisitionFunction` abstraction that will also be useful for multi-step KG.

Will add a tutorial notebook for optimizing qKG in a separate PR.

Differential Revision: D17414700

