### PR TITLE
Remove duplicate tests

### DIFF
--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -406,7 +406,3 @@ class TestOptimizeAcqfCyclic(BotorchTestCase):
                             )
                         else:
                             self.assertEqual(expected_call_args[k], v)
-
-    def test_optimize_acqf_cyclic_cuda(self):
-        if torch.cuda.is_available():
-            self.test_optimize_acqf_cyclic(cuda=True)

--- a/test/optim/test_utils.py
+++ b/test/optim/test_utils.py
@@ -30,9 +30,8 @@ from gpytorch.priors.torch_priors import GammaPrior
 
 class TestConvergenceCriterion(BotorchTestCase):
     def test_convergence_criterion(self, cuda=False):
-        tkwargs = {"device": torch.device("cuda" if cuda else "cpu")}
         for dtype in (torch.float, torch.double):
-            tkwargs["dtype"] = dtype
+            tkwargs = {"device": self.device, "dtype": dtype}
 
             # test max iter
             max_iter_convergence_criterion = ConvergenceCriterion(maxiter=2)
@@ -66,10 +65,6 @@ class TestConvergenceCriterion(BotorchTestCase):
                         fvals=(-1) ** exp * torch.tensor([0.0, -0.5], **tkwargs)
                     )
                 )
-
-    def test_convergence_criterion_cuda(self):
-        if torch.cuda.is_available():
-            self.test_convergence_criterion(cuda=True)
 
 
 class TestColumnWiseClamp(BotorchTestCase):


### PR DESCRIPTION
Summary:
Since https://github.com/pytorch/botorch/pull/261 there is no need to
have explicit `_cuda` tests, as long as we test against `self.device`. This
removes two duplicate tests.

Differential Revision: D17557626

