### PR TITLE
Fix getting started example on website

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -115,11 +115,13 @@ class Index extends React.Component {
 import torch
 from botorch.models import SingleTaskGP
 from botorch.fit import fit_gpytorch_model
+from botorch.utils import standardize
 from gpytorch.mlls import ExactMarginalLogLikelihood
 
 train_X = torch.rand(10, 2)
-Y = 1 - torch.norm(train_X - 0.5, dim=-1) + 0.1 * torch.rand(10)
-train_Y = (Y - Y.mean()) / Y.std()
+Y = 1 - torch.norm(train_X - 0.5, dim=-1, keepdim=True)
+Y = Y + 0.1 * torch.randn_like(Y)  # add some noise
+train_Y = standardize(Y)
 
 gp = SingleTaskGP(train_X, train_Y)
 mll = ExactMarginalLogLikelihood(gp.likelihood, gp)


### PR DESCRIPTION
This makes sure the example uses the convention of explicit output dimensions.

Test Plan:
Tested locally in nb
