### PR TITLE
Activate mlgp test

### DIFF
--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -155,13 +155,12 @@ class TestModelListGP(BotorchTestCase):
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertIsInstance(posterior.mvn, MultitaskMultivariateNormal)
 
-            # TODO: Add test back in once gpytorch > 0.3.5 is released
-            # # test output_indices
-            # posterior = model.posterior(
-            #     test_x, output_indices=[0], observation_noise=True
-            # )
-            # self.assertIsInstance(posterior, GPyTorchPosterior)
-            # self.assertIsInstance(posterior.mvn, MultivariateNormal)
+            # test output_indices
+            posterior = model.posterior(
+                test_x, output_indices=[0], observation_noise=True
+            )
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+            self.assertIsInstance(posterior.mvn, MultivariateNormal)
 
             # test condition_on_observations
             f_x = torch.rand(2, 1, **tkwargs)


### PR DESCRIPTION
This was temporarily disabled for the 0.1.4 release, re-enabling it as the next release will depend on gpytorch > 0.3.5