### PR TITLE
silence botorch warnings outside of explicit tests

### DIFF
--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -10,6 +10,7 @@ from unittest import TestCase
 import torch
 from torch import Tensor
 
+from .. import settings
 from ..models.model import Model
 from ..posteriors import Posterior
 from ..test_functions.synthetic import SyntheticTestFunction
@@ -29,7 +30,9 @@ class BotorchTestCase(TestCase):
     device = torch.device("cpu")
 
     def setUp(self):
-        warnings.simplefilter("always")
+        warnings.resetwarnings()
+        settings.debug._set_state(False)
+        warnings.simplefilter("always", append=True)
 
 
 class SyntheticTestFunctionBaseTestCase:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -12,24 +12,23 @@ to the GPU running out of memory.
 
 import unittest
 from typing import Union
-from unittest import TestCase, TestSuite
 
 import torch
 from botorch.utils.testing import BotorchTestCase
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-class TestBotorchCUDA(TestCase):
+class TestBotorchCUDA(unittest.TestCase):
     def test_cuda(self):
         tests = unittest.TestLoader().discover(".")
         run_cuda_tests(tests)
 
 
-def run_cuda_tests(tests: Union[TestCase, TestSuite]) -> None:
+def run_cuda_tests(tests: Union[unittest.TestCase, unittest.TestSuite]) -> None:
     """Function for running all tests on cuda (except TestBotorchCUDA itself)"""
     if isinstance(tests, BotorchTestCase):
         tests.device = torch.device("cuda")
         tests.run()
-    elif isinstance(tests, TestSuite):
+    elif isinstance(tests, unittest.TestSuite):
         for tests_ in tests:
             run_cuda_tests(tests_)


### PR DESCRIPTION
Summary: This first silences BotorchWarnings, then sets the filter to always emit other warnings. For a new warning, each filter is evaluated sequentially until a match is found.

Reviewed By: Balandat

Differential Revision: D17798731

