### PR TITLE
Add `__getitem__` method to LinearTruncatedFidelityKernel

### DIFF
--- a/botorch/models/fidelity_kernels/linear_truncated_fidelity.py
+++ b/botorch/models/fidelity_kernels/linear_truncated_fidelity.py
@@ -2,6 +2,7 @@
 
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from copy import deepcopy
 from typing import Any, Optional
 
 import torch
@@ -211,3 +212,9 @@ class LinearTruncatedFidelityKernel(Kernel):
                 + (1 - x11_) * (1 - x21t_) * (1 + x11_ * x21t_).pow(power) * covar_1
             )
         return res
+
+    def __getitem__(self, index):
+        new_kernel = deepcopy(self)
+        new_kernel.covar_module_1 = self.covar_module_1[index]
+        new_kernel.covar_module_2 = self.covar_module_2[index]
+        return new_kernel

--- a/botorch/optim/utils.py
+++ b/botorch/optim/utils.py
@@ -211,7 +211,7 @@ def _expand_bounds(
 
 
 def _get_extra_mll_args(
-    mll: MarginalLogLikelihood
+    mll: MarginalLogLikelihood,
 ) -> Union[List[Tensor], List[List[Tensor]]]:
     r"""Obtain extra arguments for MarginalLogLikelihood objects.
 

--- a/botorch/utils/objective.py
+++ b/botorch/utils/objective.py
@@ -13,7 +13,7 @@ from torch import Tensor
 
 
 def get_objective_weights_transform(
-    weights: Optional[Tensor]
+    weights: Optional[Tensor],
 ) -> Callable[[Tensor], Tensor]:
     r"""Create a linear objective callable from a set of weights.
 


### PR DESCRIPTION
Addresses test failure against gpytorch master after recent changes to kernels' `__getitem__`

Also updates to black 19.10b0 style that has caused test failures