### PR TITLE
Require pytorch>=1.3.1

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -15,7 +15,7 @@ requirements:
   host:
     - python>=3.6
   run:
-    - pytorch>=1.3
+    - pytorch>=1.3.1
     - gpytorch>=0.3.5
     - scipy
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Optimization simply use Ax.
 
 **Installation Requirements**
 - Python >= 3.6
-- PyTorch >= 1.3
+- PyTorch >= 1.3.1
 - gpytorch >= 0.3.5
 - scipy
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -14,7 +14,7 @@ Before jumping the gun, we recommend you start with the high-level
 #### Installation Requirements:
 
 - Python >= 3.6
-- PyTorch >= 1.3
+- PyTorch >= 1.3.1
 - gpytorch >= 0.3.5
 - scipy
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,6 @@ channels:
   - pytorch
   - gpytorch
 dependencies:
-  - pytorch>=1.3
+  - pytorch>=1.3.1
   - gpytorch>=0.3.5
   - scipy

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">=3.6",
-    install_requires=["torch>=1.3", "gpytorch>=0.3.5", "scipy"],
+    install_requires=["torch>=1.3.1", "gpytorch>=0.3.5", "scipy"],
     packages=find_packages(),
     extras_require={
         "dev": DEV_REQUIRES,


### PR DESCRIPTION
Comes with some bugfixes, especially for type promotion. We're not using this extensively right now, but I plan on using it going forward to simplify some code.