### PR TITLE
Do not use approx. mll computation for deterministic fitting.

### DIFF
--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -46,7 +46,8 @@ def fit_gpytorch_model(
         optimizer: The optimizer function.
         kwargs: Arguments passed along to the optimizer function, including
             `max_retries` and `sequential` (controls the fitting of `ModelListGP`
-            and `BatchedMultiOutputGPyTorchModel` models).
+            and `BatchedMultiOutputGPyTorchModel` models) or `approx_mll`
+            (whether to use gpytorch's approximate MLL computation).
 
     Returns:
         MarginalLogLikelihood with optimized parameters.

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -192,6 +192,29 @@ class TestFitGPyTorchModel(BotorchTestCase):
             )
             self.assertGreater(model.covar_module.raw_outputscale.abs().item(), 1e-3)
 
+            # test non-defaut setting for approximate MLL computation
+            is_scipy = optimizer == fit_gpytorch_scipy
+            mll = self._getModel(double=double)
+            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+                mll = fit_gpytorch_model(
+                    mll,
+                    optimizer=optimizer,
+                    options=options,
+                    max_retries=1,
+                    approx_mll=is_scipy,
+                )
+                if is_scipy:
+                    self.assertEqual(len(ws), 1)
+                    self.assertTrue(MAX_RETRY_MSG in str(ws[0].message))
+            model = mll.model
+            # Make sure all of the parameters changed
+            self.assertGreater(model.likelihood.raw_noise.abs().item(), 1e-3)
+            self.assertLess(model.mean_module.constant.abs().item(), 0.1)
+            self.assertGreater(
+                model.covar_module.base_kernel.raw_lengthscale.abs().item(), 0.1
+            )
+            self.assertGreater(model.covar_module.raw_outputscale.abs().item(), 1e-3)
+
     def test_fit_gpytorch_model_singular(self):
         options = {"disp": False, "maxiter": 5}
         for dtype in (torch.float, torch.double):


### PR DESCRIPTION
The stochastic nature of the Lanczos log prob estimates used by gpytorch by default for `n>128` does not play well with deterministic optimization we do by default in in `fit_gpytorch_scipy` / `fit_gpytorch_model`. Some recent benchmarking has also shown that the deterministic Cholesky-based computation is faster for up to `n>1000` (including both forward and backward pass), at least if no structure in the covariance is being exploited.

This changes the default setting in these fitting procedures to not use approximate MLL computations. For large models (say `n>2000`, especially on the CPU), this may result in significant slowdowns, so the setting can be overridden by using `approx_mll=True` in the fitting procedure.

![approx_log_prob_backward](https://user-images.githubusercontent.com/1605878/68493464-5efbbb00-0201-11ea-9435-3e1edb1c703c.png)
