### PR TITLE
Fix ExponentialDecayKernel

### DIFF
--- a/botorch/models/fidelity_kernels/exponential_decay.py
+++ b/botorch/models/fidelity_kernels/exponential_decay.py
@@ -37,6 +37,8 @@ class ExponentialDecayKernel(Kernel):
             should equal `num_dimensions`.
     """
 
+    has_lengthscale = True
+
     def __init__(
         self,
         power_prior: Optional[Prior] = None,
@@ -45,7 +47,7 @@ class ExponentialDecayKernel(Kernel):
         offset_constraint: Optional[Interval] = None,
         **kwargs
     ):
-        super().__init__(has_lengthscale=True, **kwargs)
+        super().__init__(**kwargs)
 
         if power_constraint is None:
             power_constraint = Positive()


### PR DESCRIPTION
Summary:
Upstream changes in https://github.com/cornellius-gp/gpytorch/pull/925 require this fix.
This means that botorch master will require gpytroch master to run.

Differential Revision: D18456276

