### PR TITLE
[RFC] Outcome transforms

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -26,6 +26,7 @@ from ..exceptions.warnings import BotorchTensorDimensionWarning
 from ..posteriors.gpytorch import GPyTorchPosterior
 from ..utils.transforms import gpt_posterior_settings
 from .model import Model
+from .transforms.outcome import OutcomeTransform
 from .utils import _make_X_full, add_output_dim, multioutput_to_batch_mode_transform
 
 
@@ -35,6 +36,8 @@ class GPyTorchModel(Model, ABC):
     The easiest way to use this is to subclass a model from a GPyTorch model
     class (e.g. an `ExactGP`) and this `GPyTorchModel`. See e.g. `SingleTaskGP`.
     """
+
+    outcome_transform: Optional[OutcomeTransform] = None
 
     @staticmethod
     def _validate_tensor_args(

--- a/botorch/models/transforms/__init__.py
+++ b/botorch/models/transforms/__init__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .input import ChainedInputTransform, Normalize
+from .outcome import ChainedOutcomeTransform, Log, Standardize
+
+
+__all__ = [
+    "ChainedInputTransform",
+    "ChainedOutcomeTransform",
+    "Log",
+    "Normalize",
+    "Standardize",
+]

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import torch
+from torch import Tensor
+from torch.nn import Module, ModuleDict
+
+from ...exceptions.errors import BotorchTensorDimensionError
+
+
+class InputTransform(Module, ABC):
+    r"""Abstract base class for input transforms."""
+
+    @abstractmethod
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Transform the inputs to a model.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of transformed inputs.
+        """
+        pass  # pragma: no cover
+
+    def untransform(self, X: Tensor) -> Tensor:
+        r"""Un-transform the inputs to a model.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of transformed inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of un-transformed inputs.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement the `untransform` method"
+        )
+
+
+class ChainedInputTransform(InputTransform, ModuleDict):
+    r"""An input transform representing the chaining of individual transforms"""
+
+    def __init__(self, **transforms: InputTransform) -> None:
+        r"""Chaining of input transforms.
+
+        Args:
+            transforms: The transforms to chain. Internally, the names of the
+                kwargs are used as the keys for accessing the individual
+                transforms on the module.
+        """
+        super().__init__(transforms)
+
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Transform the inputs to a model.
+
+        Individual transforms are applied in sequence.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of transformed inputs.
+        """
+        for tf in self.values():
+            X = tf.forward(X)
+        return X
+
+    def untransform(self, X: Tensor) -> Tensor:
+        r"""Un-transform the inputs to a model.
+
+        Un-transforms of the individual transforms are applied in reverse sequence.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of transformed inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of un-transformed inputs.
+        """
+        for tf in reversed(self.values()):
+            X = tf.untransform(X)
+        return X
+
+
+class Normalize(InputTransform):
+    r"""Normalize the inputs to the unit cube.
+
+    If no explicit bounds are provided this module is stateful: If in train mode,
+    calling `forward` updates the module state (i.e. the normalizing bounds). If
+    in eval mode, calling `forward` simply applies the normalization using the
+    current module state.
+    """
+
+    def __init__(
+        self,
+        d: int,
+        bounds: Optional[Tensor] = None,
+        batch_shape: torch.Size = torch.Size(),  # noqa: B008
+    ) -> None:
+        r"""Normalize the inputs to the unit cube.
+
+        Args:
+            d: The dimension of the input space.
+            bounds: If provided, use these bounds to normalize the inputs. If
+                omitted, learn the bounds in train mode.
+            batch_shape: The batch shape of the inputs (asssuming input tensors
+                of shape `batch_shape x n x d`). If provided, perform individual
+                normalization per batch, otherwise uses a single normalization.
+        """
+        super().__init__()
+        if bounds is not None:
+            if bounds.size(-1) != d:
+                raise BotorchTensorDimensionError(
+                    "Incompatible dimensions of provided bounds"
+                )
+            mins = bounds[..., [0], :]
+            ranges = bounds[..., [1], :] - mins
+            self.learn_bounds = False
+        else:
+            mins = torch.zeros(*batch_shape, 1, d)
+            ranges = torch.zeros(*batch_shape, 1, d)
+            self.learn_bounds = True
+        self.register_buffer("mins", mins)
+        self.register_buffer("ranges", ranges)
+        self._d = d
+
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Normalize the inputs.
+
+        If no explicit bounds are provided, this is stateful: In train mode,
+        calling `forward` updates the module state (i.e. the normalizing bounds).
+        In eval mode, calling `forward` simply applies the normalization using
+        the current module state.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of inputs normalized to the
+            module's bounds.
+        """
+        if self.learn_bounds and self.training:
+            if X.size(-1) != self.mins.size(-1):
+                raise BotorchTensorDimensionError(
+                    f"Wrong input. dimension. Received {X.size(-1)}, "
+                    f"expected {self.mins.size(-1)}"
+                )
+            self.mins = X.min(dim=-2, keepdim=True)[0]
+            self.ranges = X.max(dim=-2, keepdim=True)[0] - self.mins
+        return (X - self.mins) / self.ranges
+
+    def untransform(self, X: Tensor) -> Tensor:
+        r"""Un-normalize the inputs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of normalized inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of un-normalized inputs.
+        """
+        return self.mins + X * self.ranges
+
+    @property
+    def bounds(self) -> Tensor:
+        r"""The bounds used for normalizing the inputs."""
+        return torch.cat([self.mins, self.mins + self.ranges], dim=-2)

--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+from typing import List, Optional, Tuple
+
+import torch
+from botorch.posteriors import GPyTorchPosterior, Posterior, TransformedPosterior
+from gpytorch.lazy import CholLazyTensor, DiagLazyTensor
+from torch import Tensor
+from torch.nn import Module, ModuleDict
+
+from ...utils.transforms import normalize_indices
+from .utils import norm_to_lognorm_mean, norm_to_lognorm_variance
+
+
+class OutcomeTransform(Module, ABC):
+    r"""Abstract base class for outcome transforms."""
+
+    @abstractmethod
+    def forward(
+        self, Y: Tensor, Yvar: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""Transform the outcomes in a model's training targets
+
+        Args:
+            Y: A `batch_shape x n x m`-dim tensor of training targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of observation noises
+                associated with the training targets (if applicable).
+
+        Returns:
+            A two-tuple with the transformed outcomes:
+
+            - The transformed outcome observations.
+            - The transformed observation noise (if applicable).
+        """
+        pass  # pragma: no cover
+
+    def untransform(
+        self, Y: Tensor, Yvar: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""Un-transform previously transformed outcomes
+
+        Args:
+            Y: A `batch_shape x n x m`-dim tensor of transfomred training targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of transformed observation
+                noises associated with the training targets (if applicable).
+
+        Returns:
+            A two-tuple with the un-transformed outcomes:
+
+            - The un-transformed outcome observations.
+            - The un-transformed observation noise (if applicable).
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement the `untransform` method"
+        )
+
+    def untransform_posterior(self, posterior: Posterior) -> Posterior:
+        r"""Un-transform a posterior
+
+        Args:
+            posterior: A posterior in the transformed space.
+
+        Returns:
+            The un-transformed posterior.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement the "
+            "`untransform_posterior` method"
+        )
+
+
+class ChainedOutcomeTransform(OutcomeTransform, ModuleDict):
+    r"""An outcome transform representing the chaining of individual transforms"""
+
+    def __init__(self, **transforms: OutcomeTransform) -> None:
+        r"""Chaining of outcome transforms.
+
+        Args:
+            transforms: The transforms to chain. Internally, the names of the
+                kwargs are used as the keys for accessing the individual
+                transforms on the module.
+        """
+        super().__init__(transforms)
+
+    def forward(
+        self, Y: Tensor, Yvar: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""Transform the outcomes in a model's training targets
+
+        Args:
+            Y: A `batch_shape x n x m`-dim tensor of training targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of observation noises
+                associated with the training targets (if applicable).
+
+        Returns:
+            A two-tuple with the transformed outcomes:
+
+            - The transformed outcome observations.
+            - The transformed observation noise (if applicable).
+        """
+        for tf in self.values():
+            Y, Yvar = tf.forward(Y, Yvar)
+        return Y, Yvar
+
+    def untransform(
+        self, Y: Tensor, Yvar: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""Un-transform previously transformed outcomes
+
+        Args:
+            Y: A `batch_shape x n x m`-dim tensor of transfomred training targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of transformed observation
+                noises associated with the training targets (if applicable).
+
+        Returns:
+            A two-tuple with the un-transformed outcomes:
+
+            - The un-transformed outcome observations.
+            - The un-transformed observation noise (if applicable).
+        """
+        for tf in reversed(self.values()):
+            Y, Yvar = tf.untransform(Y, Yvar)
+        return Y, Yvar
+
+    def untransform_posterior(self, posterior: Posterior) -> Posterior:
+        r"""Un-transform a posterior
+
+        Args:
+            posterior: A posterior in the transformed space.
+
+        Returns:
+            The un-transformed posterior.
+        """
+        for tf in reversed(self.values()):
+            posterior = tf.untransform_posterior(posterior)
+        return posterior
+
+
+class Standardize(OutcomeTransform):
+    r"""Standardize outcomes (zero mean, unit variance).
+
+    This module is stateful: If in train mode, calling forward updates the
+    module state (i.e. the mean/std normalizing constants). If in eval mode,
+    calling forward simply applies the standradization using the current module
+    state.
+    """
+
+    def __init__(
+        self,
+        m: int,
+        outputs: Optional[List[int]] = None,
+        batch_shape: torch.Size = torch.Size(),  # noqa: B008
+        min_stdv: float = 1e-8,
+    ) -> None:
+        r"""Standardize outcomes (zero mean, unit variance).
+
+        Args:
+            m: The output dimension.
+            outputs: Which of the outputs to standardize. If omitted, all
+                outputs will be standardized.
+            batch_shape: The batch_shape of the training targets.
+            min_stddv: The minimum standard deviation for which to perform
+                standardization (if lower, only de-mean the data).
+        """
+        super().__init__()
+        self.register_buffer("means", torch.zeros(*batch_shape, 1, m))
+        self.register_buffer("stdvs", torch.zeros(*batch_shape, 1, m))
+        self._outputs = normalize_indices(outputs, d=m)
+        self._m = m
+        self._batch_shape = batch_shape
+        self._min_stdv = min_stdv
+
+    def forward(
+        self, Y: Tensor, Yvar: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""Standardize outcomes.
+
+        If the module is in train mode, this updates the module state (i.e. the
+        mean/std normalizing constants). If the module is in eval mode, simply
+        applies the normalization using the module state.
+
+        Args:
+            Y: A `batch_shape x n x m`-dim tensor of training targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of observation noises
+                associated with the training targets (if applicable).
+
+        Returns:
+            A two-tuple with the transformed outcomes:
+
+            - The transformed outcome observations.
+            - The transformed observation noise (if applicable).
+        """
+        if self.training:
+            if Y.shape[:-2] != self._batch_shape:
+                raise RuntimeError("wrong batch shape")
+            if Y.size(-1) != self._m:
+                raise RuntimeError("wrong output dimension")
+            stdvs = Y.std(dim=-2, keepdim=True)
+            stdvs = stdvs.where(stdvs >= self._min_stdv, torch.full_like(stdvs, 1.0))
+            means = Y.mean(dim=-2, keepdim=True)
+            if self._outputs is not None:
+                unused = [i for i in range(self._m) if i not in self._outputs]
+                means[..., unused] = 0.0
+                stdvs[..., unused] = 1.0
+            self.means = means
+            self.stdvs = stdvs
+            self._stdvs_sq = stdvs.pow(2)
+
+        Y_tf = (Y - self.means) / self.stdvs
+        Yvar_tf = Yvar / self._stdvs_sq if Yvar is not None else None
+        return Y_tf, Yvar_tf
+
+    def untransform(
+        self, Y: Tensor, Yvar: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""Un-standardize outcomes.
+
+        Args:
+            Y: A `batch_shape x n x m`-dim tensor of standardized targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of standardized observation
+                noises associated with the targets (if applicable).
+
+        Returns:
+            A two-tuple with the un-standardized outcomes:
+
+            - The un-standardized outcome observations.
+            - The un-standardized observation noise (if applicable).
+        """
+        Y_utf = self.means + self.stdvs * Y
+        Yvar_utf = self._stdvs_sq * Yvar if Yvar is not None else None
+        return Y_utf, Yvar_utf
+
+    def untransform_posterior(self, posterior: Posterior) -> Posterior:
+        r"""Un-standardize the posterior.
+
+        Args:
+            posterior: A posterior in the standardized space.
+
+        Returns:
+            The un-standardized posterior. If the input posterior is a MVN,
+            the transformed posterior is again an MVN.
+        """
+        if self._outputs is not None:
+            raise NotImplementedError(
+                "Standardize does not yet support output selection for "
+                "untransform_posterior"
+            )
+        if not self._m == posterior.event_shape[-1]:
+            raise RuntimeError(
+                "Incompatible output dimensions encountered for transform "
+                f"{self._m} and posterior {posterior.event_shape[-1]}"
+            )
+        if not isinstance(posterior, GPyTorchPosterior):
+            # fall back to TransformedPosterior
+            return TransformedPosterior(
+                posterior=posterior,
+                sample_transform=lambda s: self.means + self.stdvs * s,
+                mean_transform=lambda m, v: self.means + self.stdvs * m,
+                variance_transform=lambda m, v: self._stdvs_sq * v,
+            )
+        # GPyTorchPosterior (TODO: Should we Lazy-evaluate the mean here as well?)
+        mvn = posterior.mvn
+        offset = self.means
+        scale_fac = self.stdvs
+        if not posterior._is_mt:
+            mean_tf = offset.squeeze(-1) + scale_fac.squeeze(-1) * mvn.mean
+            scale_fac = scale_fac.squeeze(-1).expand_as(mean_tf)
+        else:
+            mean_tf = offset + scale_fac * mvn.mean
+            reps = mean_tf.shape[-2:].numel() // scale_fac.size(-1)
+            scale_fac = scale_fac.squeeze(-2)
+            if mvn._interleaved:
+                scale_fac = scale_fac.repeat(*[1 for _ in scale_fac.shape[:-1]], reps)
+            else:
+                scale_fac = torch.repeat_interleave(scale_fac, reps, dim=-1)
+
+        if (
+            not mvn.islazy
+            # TODO: Figure out attribute namming weirdness here
+            or mvn._MultivariateNormal__unbroadcasted_scale_tril is not None
+        ):
+            # if already computed, we can save a lot of time using scale_tril
+            covar_tf = CholLazyTensor(mvn.scale_tril * scale_fac.unsqueeze(-1))
+        else:
+            scale_mat = DiagLazyTensor(scale_fac)
+            covar_tf = scale_mat @ mvn.lazy_covariance_matrix @ scale_mat
+
+        kwargs = {"interleaved": mvn._interleaved} if posterior._is_mt else {}
+        mvn_tf = mvn.__class__(mean=mean_tf, covariance_matrix=covar_tf, **kwargs)
+        return GPyTorchPosterior(mvn_tf)
+
+
+class Log(OutcomeTransform):
+    r"""Log-transform outcomes.
+
+    Useful if the targets are modeld using a (multivariate) log-Normal
+    distribution. This means that we can use a standard GP model on the
+    log-transformed outcomes and un-transform the model posterior of that GP.
+    """
+
+    def __init__(self, outputs: Optional[List[int]] = None) -> None:
+        r"""Log-transform outcomes.
+
+        Args:
+            outputs: Which of the outputs to log-transform. If omitted, all
+                outputs will be standardized.
+        """
+        super().__init__()
+        self._outputs = outputs
+
+    def forward(
+        self, Y: Tensor, Yvar: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""Log-transform outcomes.
+
+        Args:
+            Y: A `batch_shape x n x m`-dim tensor of training targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of observation noises
+                associated with the training targets (if applicable).
+
+        Returns:
+            A two-tuple with the transformed outcomes:
+
+            - The transformed outcome observations.
+            - The transformed observation noise (if applicable).
+        """
+        Y_tf = torch.log(Y)
+        outputs = normalize_indices(self._outputs, d=Y.size(-1))
+        if outputs is not None:
+            Y_tf = torch.stack(
+                [
+                    Y_tf[..., i] if i in outputs else Y[..., i]
+                    for i in range(Y.size(-1))
+                ],
+                dim=-1,
+            )
+        if Yvar is not None:
+            # TODO: Delta method, possibly issue warning
+            raise NotImplementedError(
+                "Log does not yet support transforming observation noise"
+            )
+        return Y_tf, Yvar
+
+    def untransform(
+        self, Y: Tensor, Yvar: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""Un-transform log-transformed outcomes
+
+        Args:
+            Y: A `batch_shape x n x m`-dim tensor of log-transfomred targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of log- transformed
+                observation noises associated with the training targets
+                (if applicable).
+
+        Returns:
+            A two-tuple with the un-transformed outcomes:
+
+            - The exponentiated outcome observations.
+            - The exponentiated observation noise (if applicable).
+        """
+        Y_utf = torch.exp(Y)
+        outputs = normalize_indices(self._outputs, d=Y.size(-1))
+        if outputs is not None:
+            Y_utf = torch.stack(
+                [
+                    Y_utf[..., i] if i in outputs else Y[..., i]
+                    for i in range(Y.size(-1))
+                ],
+                dim=-1,
+            )
+        if Yvar is not None:
+            # TODO: Delta method, possibly issue warning
+            raise NotImplementedError(
+                "Log does not yet support transforming observation noise"
+            )
+        return Y_utf, Yvar
+
+    def untransform_posterior(self, posterior: Posterior) -> Posterior:
+        r"""Un-transform the log-transformed posterior.
+
+        Args:
+            posterior: A posterior in the log-transformed space.
+
+        Returns:
+            The un-transformed posterior.
+        """
+        if self._outputs is not None:
+            raise NotImplementedError(
+                "Log does not yet support output selection for untransform_posterior"
+            )
+        return TransformedPosterior(
+            posterior=posterior,
+            sample_transform=torch.exp,
+            mean_transform=norm_to_lognorm_mean,
+            variance_transform=norm_to_lognorm_variance,
+        )

--- a/botorch/models/transforms/utils.py
+++ b/botorch/models/transforms/utils.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import torch
+from torch import Tensor
+
+
+def lognorm_to_norm(mu: Tensor, Cov: Tensor) -> Tuple[Tensor, Tensor]:
+    """Compute mean and covariance of a MVN from those of the associated log-MVN
+
+    If `Y` is log-normal with mean mu_ln and covariance Cov_ln, then
+    `X ~ N(mu_n, Cov_n)` with
+
+        Cov_n_{ij} = log(1 + Cov_ln_{ij} / (mu_ln_{i} * mu_n_{j}))
+        mu_n_{i} = log(mu_ln_{i}) - 0.5 * log(1 + Cov_ln_{ii} / mu_ln_{i}**2)
+
+    Args:
+        mu: A `batch_shape x n` mean vector of the log-Normal distribution.
+        Cov: A `batch_shape x n x n` covariance matrix of the log-Normal
+            distribution.
+
+    Returns:
+        A two-tuple containing:
+
+        - The `batch_shape x n` mean vector of the Normal distribution
+        - The `batch_shape x n x n` covariance matrix of the Normal distribution
+    """
+    Cov_n = torch.log(1 + Cov / (mu.unsqueeze(-1) * mu.unsqueeze(-2)))
+    mu_n = torch.log(mu) - 0.5 * torch.diagonal(Cov_n, dim1=-1, dim2=-2)
+    return mu_n, Cov_n
+
+
+def norm_to_lognorm(mu: Tensor, Cov: Tensor) -> Tuple[Tensor, Tensor]:
+    """Compute mean and covariance of a log-MVN from its MVN sufficient statistics
+
+    If `X ~ N(mu, Cov)` and `Y = exp(X)`, then `Y` is log-normal with
+
+        mu_ln_{i} = exp(mu_{i} + 0.5 * Cov_{ii})
+        Cov_ln_{ij} = exp(mu_{i} + mu_{j} + 0.5 * (Cov_{ii} + Cov_{jj})) *
+        (exp(Cov_{ij}) - 1)
+
+    Args:
+        mu: A `batch_shape x n` mean vector of the Normal distribution.
+        Cov: A `batch_shape x n x n` covariance matrix of the Normal distribution.
+
+    Returns:
+        A two-tuple containing:
+
+        - The `batch_shape x n` mean vector of the log-Normal distribution.
+        - The `batch_shape x n x n` covariance matrix of the log-Normal
+            distribution.
+    """
+    diag = torch.diagonal(Cov, dim1=-1, dim2=-2)
+    b = mu + 0.5 * diag
+    mu_ln = torch.exp(b)
+    Cov_ln = (torch.exp(Cov) - 1) * torch.exp(b.unsqueeze(-1) + b.unsqueeze(-2))
+    return mu_ln, Cov_ln
+
+
+def norm_to_lognorm_mean(mu: Tensor, var: Tensor) -> Tensor:
+    """Compute mean of a log-MVN from its MVN marginals
+
+    Args:
+        mu: A `batch_shape x n` mean vector of the Normal distribution.
+        var: A `batch_shape x n` variance vectorof the Normal distribution.
+
+    Returns:
+        The `batch_shape x n` mean vector of the log-Normal distribution
+    """
+    return torch.exp(mu + 0.5 * var)
+
+
+def norm_to_lognorm_variance(mu: Tensor, var: Tensor) -> Tensor:
+    """Compute variance of a log-MVN from its MVN marginals
+
+    Args:
+        mu: A `batch_shape x n` mean vector of the Normal distribution.
+        var: A `batch_shape x n` variance vectorof the Normal distribution.
+
+    Returns:
+        The `batch_shape x n` variance vector of the log-Normal distribution.
+    """
+    b = mu + 0.5 * var
+    return (torch.exp(var) - 1) * torch.exp(2 * b)

--- a/botorch/posteriors/__init__.py
+++ b/botorch/posteriors/__init__.py
@@ -7,6 +7,12 @@
 from .deterministic import DeterministicPosterior
 from .gpytorch import GPyTorchPosterior
 from .posterior import Posterior
+from .transformed import TransformedPosterior
 
 
-__all__ = ["DeterministicPosterior", "GPyTorchPosterior", "Posterior"]
+__all__ = [
+    "DeterministicPosterior",
+    "GPyTorchPosterior",
+    "Posterior",
+    "TransformedPosterior",
+]

--- a/botorch/posteriors/transformed.py
+++ b/botorch/posteriors/transformed.py
@@ -1,0 +1,95 @@
+#! /usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, Optional
+
+import torch
+from torch import Tensor
+
+from .posterior import Posterior
+
+
+class TransformedPosterior(Posterior):
+    r"""An generic transformation of a posterior (implicitly represented)"""
+
+    def __init__(
+        self,
+        posterior: Posterior,
+        sample_transform: Callable[[Tensor], Tensor],
+        mean_transform: Optional[Callable[[Tensor, Tensor], Tensor]] = None,
+        variance_transform: Optional[Callable[[Tensor, Tensor], Tensor]] = None,
+    ) -> None:
+        r"""An implicitly represented transformed posterior
+
+        Args:
+            posterior: The posterior object to be transformed.
+            sample_transform: A callable applying a sample-level transform to a
+                `sample_shape x batch_shape x q x m`-dim tensor of samples from
+                the original posterior, returning a tensor of samples of the
+                same shape.
+            mean_transform: A callable transforming a 2-tuple of mean and
+                variance (both of shape `batch_shape x m x o`) of the original
+                posterior to the mean of the transformed posterior.
+            variance_transform: A callable transforming a 2-tuple of mean and
+                variance (both of shape `batch_shape x m x o`) of the original
+                posterior to a variance of the transformed posterior.
+        """
+        self._posterior = posterior
+        self._sample_transform = sample_transform
+        self._mean_transform = mean_transform
+        self._variance_transform = variance_transform
+
+    @property
+    def device(self) -> torch.device:
+        r"""The torch device of the posterior."""
+        return self._posterior.device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        r"""The torch dtype of the posterior."""
+        return self._posterior.dtype
+
+    @property
+    def event_shape(self) -> torch.Size:
+        r"""The event shape (i.e. the shape of a single sample)."""
+        return self._posterior.event_shape
+
+    @property
+    def mean(self) -> Tensor:
+        r"""The mean of the posterior as a `batch_shape x n x m`-dim Tensor."""
+        if self._mean_transform is None:
+            raise NotImplementedError("No mean transform provided.")
+        return self._mean_transform(self._posterior.mean, self._posterior.variance)
+
+    @property
+    def variance(self) -> Tensor:
+        r"""The variance of the posterior as a `batch_shape x n x m`-dim Tensor."""
+        if self._variance_transform is None:
+            raise NotImplementedError("No variance transform provided.")
+        return self._variance_transform(self._posterior.mean, self._posterior.variance)
+
+    def rsample(
+        self,
+        sample_shape: Optional[torch.Size] = None,
+        base_samples: Optional[Tensor] = None,
+    ) -> Tensor:
+        r"""Sample from the posterior (with gradients).
+
+        Args:
+            sample_shape: A `torch.Size` object specifying the sample shape. To
+                draw `n` samples, set to `torch.Size([n])`. To draw `b` batches
+                of `n` samples each, set to `torch.Size([b, n])`.
+            base_samples: An (optional) Tensor of `N(0, I)` base samples of
+                appropriate dimension, typically obtained from a `Sampler`.
+                This is used for deterministic optimization.
+
+        Returns:
+            A `sample_shape x event`-dim Tensor of samples from the posterior.
+        """
+        samples = self._posterior.rsample(
+            sample_shape=sample_shape, base_samples=base_samples
+        )
+        return self._sample_transform(samples)

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import math
 import warnings
 from collections import OrderedDict
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from unittest import TestCase
 
 import torch
@@ -179,3 +180,25 @@ class MockAcquisitionFunction:
 
     def set_X_pending(self, X_pending: Optional[Tensor] = None):
         self.X_pending = X_pending
+
+
+def _get_random_data(
+    batch_shape: torch.Size, num_outputs: int, n: int = 10, **tkwargs
+) -> Tuple[Tensor, Tensor]:
+    r"""Generate random data for testing pursposes.
+
+    Args:
+        batch_shape: The batch shape of the data.
+        num_outputs: The number of outputs.
+        n: The number of data points.
+        tkwargs: `device` and `dtype` tensor constructor kwargs.
+
+    Returns:
+        A tuple `(train_X, train_Y)` with randomly generated training data.
+    """
+    rep_shape = batch_shape + torch.Size([1, 1])
+    train_x = torch.linspace(0, 0.95, n, **tkwargs).unsqueeze(-1)
+    train_x = train_x + 0.05 * torch.rand(n, 1, **tkwargs).repeat(rep_shape)
+    train_y = torch.sin(train_x * (2 * math.pi))
+    train_y = train_y + 0.2 * torch.randn(n, num_outputs, **tkwargs).repeat(rep_shape)
+    return train_x, train_y

--- a/botorch/utils/transforms.py
+++ b/botorch/utils/transforms.py
@@ -10,7 +10,7 @@ Some basic data transformation helpers.
 
 from contextlib import ExitStack, contextmanager
 from functools import wraps
-from typing import Any, Callable, Optional
+from typing import Any, Callable, List, Optional
 
 import torch
 from gpytorch import settings as gpt_settings
@@ -100,6 +100,30 @@ def unnormalize(X: Tensor, bounds: Tensor) -> Tensor:
         >>> X = unnormalize(X_normalized, bounds)
     """
     return X * (bounds[1] - bounds[0]) + bounds[0]
+
+
+def normalize_indices(indices: Optional[List[int]], d: int) -> Optional[List[int]]:
+    r"""Normalize a list of indices to ensure that they are positive.
+
+    Args:
+        indices: A list of indices (may contain negative indices for indexing
+            "from the back").
+        d: The dimension of the tensor to index.
+
+    Returns:
+        A normalized list of indices such that each index is between `0` and
+        `d-1`, or None if indices is None.
+    """
+    if indices is None:
+        return indices
+    normalized_indices = []
+    for i in indices:
+        if i < 0:
+            i = i + d
+        if i < 0 or i > d - 1:
+            raise ValueError(f"Index {i} out of bounds for tensor or length {d}.")
+        normalized_indices.append(i)
+    return normalized_indices
 
 
 def t_batch_mode_transform(

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -70,6 +70,25 @@ Kernels
 .. autoclass:: LinearTruncatedFidelityKernel
 
 
+Transforms
+-------------------------------------------
+
+Outcome Transforms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.transforms.outcome
+    :members:
+
+Input Transforms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.transforms.input
+    :members:
+
+Transform Utilities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.transforms.utils
+    :members:
+
+
 Utilities
 -------------------------------------------
 

--- a/sphinx/source/posteriors.rst
+++ b/sphinx/source/posteriors.rst
@@ -28,3 +28,8 @@ Determinstic Posterior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.posteriors.deterministic
     :members:
+
+Transformed Posterior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.posteriors.transformed
+    :members:

--- a/test/acquisition/test_max_value_entropy_search.py
+++ b/test/acquisition/test_max_value_entropy_search.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# from unittest import mock
-
 from typing import Callable
 from unittest import mock
 
@@ -136,9 +134,6 @@ class TestMaxValueEntropySearch(BotorchTestCase):
 
 class MESMockModel(Model):
     r"""Mock object that implements dummy methods and feeds through specified outputs"""
-
-    def __init__(self) -> None:
-        super(Model, self).__init__()
 
     def posterior(self, X: Tensor, observation_noise: bool = False) -> MockPosterior:
         m_shape = X.shape[:-1]

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 from unittest import mock
 
 import torch
@@ -350,101 +351,81 @@ class TestPruneInferiorPoints(BotorchTestCase):
 
 class TestFidelityUtils(BotorchTestCase):
     def test_project_to_target_fidelity(self):
-        for dtype in (torch.float, torch.double):
-            for batch_shape in ([], [2]):
-                X = torch.rand(*batch_shape, 3, 4, device=self.device, dtype=dtype)
-                # test default behavior
-                X_proj = project_to_target_fidelity(X)
-                ones = torch.ones(*X.shape[:-1], 1, device=self.device, dtype=dtype)
-                self.assertTrue(torch.equal(X_proj[..., :, [-1]], ones))
-                self.assertTrue(torch.equal(X_proj[..., :-1], X[..., :-1]))
-                # test custom target fidelity
-                target_fids = {2: 0.5}
-                X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
-                self.assertTrue(torch.equal(X_proj[..., :, [2]], 0.5 * ones))
-                # test multiple target fidelities
-                target_fids = {2: 0.5, 0: 0.1}
-                X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
-                self.assertTrue(torch.equal(X_proj[..., :, [0]], 0.1 * ones))
-                self.assertTrue(torch.equal(X_proj[..., :, [2]], 0.5 * ones))
-                # test gradients
-                X.requires_grad_(True)
-                X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
-                out = (X_proj ** 2).sum()
-                out.backward()
-                self.assertTrue(torch.all(X.grad[..., [0, 2]] == 0))
-                self.assertTrue(torch.equal(X.grad[..., [1, 3]], 2 * X[..., [1, 3]]))
+        for batch_shape, dtype in itertools.product(
+            ([], [2]), (torch.float, torch.double)
+        ):
+            X = torch.rand(*batch_shape, 3, 4, device=self.device, dtype=dtype)
+            # test default behavior
+            X_proj = project_to_target_fidelity(X)
+            ones = torch.ones(*X.shape[:-1], 1, device=self.device, dtype=dtype)
+            self.assertTrue(torch.equal(X_proj[..., :, [-1]], ones))
+            self.assertTrue(torch.equal(X_proj[..., :-1], X[..., :-1]))
+            # test custom target fidelity
+            target_fids = {2: 0.5}
+            X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
+            self.assertTrue(torch.equal(X_proj[..., :, [2]], 0.5 * ones))
+            # test multiple target fidelities
+            target_fids = {2: 0.5, 0: 0.1}
+            X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
+            self.assertTrue(torch.equal(X_proj[..., :, [0]], 0.1 * ones))
+            self.assertTrue(torch.equal(X_proj[..., :, [2]], 0.5 * ones))
+            # test gradients
+            X.requires_grad_(True)
+            X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
+            out = (X_proj ** 2).sum()
+            out.backward()
+            self.assertTrue(torch.all(X.grad[..., [0, 2]] == 0))
+            self.assertTrue(torch.equal(X.grad[..., [1, 3]], 2 * X[..., [1, 3]]))
 
     def test_expand_trace_observations(self):
-        for dtype in (torch.float, torch.double):
-            for batch_shape in ([], [2]):
-                q, d = 3, 4
-                X = torch.rand(*batch_shape, q, d, device=self.device, dtype=dtype)
-                # test nullop behavior
-                self.assertTrue(torch.equal(expand_trace_observations(X), X))
-                self.assertTrue(
-                    torch.equal(expand_trace_observations(X, fidelity_dims=[1]), X)
-                )
-                # test default behavior
-                num_tr = 2
-                X_expanded = expand_trace_observations(X, num_trace_obs=num_tr)
-                self.assertEqual(
-                    X_expanded.shape, torch.Size(batch_shape + [q * (1 + num_tr), d])
-                )
-                self.assertTrue(
-                    all(
-                        torch.equal(
-                            X_expanded[..., q * i : q * (i + 1), :-1], X[..., :-1]
-                        )
-                        for i in range(num_tr)
-                    )
-                )
-                self.assertTrue(
-                    all(
-                        torch.allclose(
-                            X_expanded[..., q * i : q * (i + 1), -1],
-                            (1 - i / (num_tr + 1)) * X[..., :q, -1],
-                        )
-                        for i in range(num_tr)
-                    )
-                )
-                # test custom fidelity dims
-                fdims = [0, 2]
-                num_tr = 3
-                X_expanded = expand_trace_observations(
-                    X, fidelity_dims=fdims, num_trace_obs=num_tr
-                )
-                self.assertEqual(
-                    X_expanded.shape, torch.Size(batch_shape + [q * (1 + num_tr), d])
-                )
-                self.assertTrue(
-                    all(
-                        torch.equal(X_expanded[..., q * i : q * (i + 1), j], X[..., j])
-                        for i in range(num_tr)
-                    )
-                    for j in [1, 3]
-                )
-                self.assertTrue(
-                    all(
-                        torch.allclose(
-                            X_expanded[..., q * i : q * (i + 1), j],
-                            (1 - i / (1 + num_tr)) * X[..., :q, j],
-                        )
-                        for i in range(num_tr)
-                        for j in fdims
-                    )
-                )
-                # test gradients
-                num_tr = 2
-                fdims = [1]
-                X.requires_grad_(True)
-                X_expanded = expand_trace_observations(
-                    X, fidelity_dims=fdims, num_trace_obs=num_tr
-                )
-                out = X_expanded.sum()
-                out.backward()
-                grad_exp = torch.full_like(X, 1 + num_tr)
-                grad_exp[..., fdims] = 1 + sum(
-                    (i + 1) / (num_tr + 1) for i in range(num_tr)
-                )
-                self.assertTrue(torch.allclose(X.grad, grad_exp))
+        for batch_shape, dtype in itertools.product(
+            ([], [2]), (torch.float, torch.double)
+        ):
+            q, d = 3, 4
+            X = torch.rand(*batch_shape, q, d, device=self.device, dtype=dtype)
+            # test nullop behavior
+            self.assertTrue(torch.equal(expand_trace_observations(X), X))
+            self.assertTrue(
+                torch.equal(expand_trace_observations(X, fidelity_dims=[1]), X)
+            )
+            # test default behavior
+            num_tr = 2
+            X_expanded = expand_trace_observations(X, num_trace_obs=num_tr)
+            self.assertEqual(
+                X_expanded.shape, torch.Size(batch_shape + [q * (1 + num_tr), d])
+            )
+            for i in range(num_tr):
+                X_sub = X_expanded[..., q * i : q * (i + 1), :]
+                self.assertTrue(torch.equal(X_sub[..., :-1], X[..., :-1]))
+                X_sub_expected = (1 - i / (num_tr + 1)) * X[..., :q, -1]
+                self.assertTrue(torch.equal(X_sub[..., -1], X_sub_expected))
+            # test custom fidelity dims
+            fdims = [0, 2]
+            num_tr = 3
+            X_expanded = expand_trace_observations(
+                X, fidelity_dims=fdims, num_trace_obs=num_tr
+            )
+            self.assertEqual(
+                X_expanded.shape, torch.Size(batch_shape + [q * (1 + num_tr), d])
+            )
+            for j, i in itertools.product([1, 3], range(num_tr)):
+                X_sub = X_expanded[..., q * i : q * (i + 1), j]
+                self.assertTrue(torch.equal(X_sub, X[..., j]))
+            for j, i in itertools.product(fdims, range(num_tr)):
+                X_sub = X_expanded[..., q * i : q * (i + 1), j]
+                X_sub_expected = (1 - i / (1 + num_tr)) * X[..., :q, j]
+                self.assertTrue(torch.equal(X_sub, X_sub_expected))
+            # test gradients
+            num_tr = 2
+            fdims = [1]
+            X.requires_grad_(True)
+            X_expanded = expand_trace_observations(
+                X, fidelity_dims=fdims, num_trace_obs=num_tr
+            )
+            out = X_expanded.sum()
+            out.backward()
+            grad_exp = torch.full_like(X, 1 + num_tr)
+            grad_exp[..., fdims] = 1 + sum(
+                (i + 1) / (num_tr + 1) for i in range(num_tr)
+            )
+            self.assertTrue(torch.allclose(X.grad, grad_exp))

--- a/test/models/kernels/test_linear_truncated_fidelity.py
+++ b/test/models/kernels/test_linear_truncated_fidelity.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
+
 import torch
 from botorch.exceptions import UnsupportedError
 from botorch.models.kernels.linear_truncated_fidelity import (
@@ -37,33 +39,32 @@ class TestLinearTruncatedFidelityKernel(BotorchTestCase, BaseKernelTestCase):
         t_1 = torch.tensor([0.3584, 0.1856, 0.2976, 0.1584], dtype=torch.float).view(
             2, 2
         )
-        for nu in {0.5, 1.5, 2.5}:
-            for fidelity_dims in ([2], [1, 2]):
-                kernel = LinearTruncatedFidelityKernel(
-                    fidelity_dims=fidelity_dims, dimension=3, nu=nu
-                )
-                kernel.power = 1
-                if len(fidelity_dims) > 1:
-                    active_dimsM = [0]
-                    t_2 = torch.tensor(
-                        [0.4725, 0.2889, 0.4025, 0.2541], dtype=torch.float
-                    ).view(2, 2)
-                    t_3 = torch.tensor(
-                        [0.1685, 0.0531, 0.1168, 0.0386], dtype=torch.float
-                    ).view(2, 2)
-                    t = 1 + t_1 + t_2 + t_3
-                else:
-                    active_dimsM = [0, 1]
-                    t = 1 + t_1
+        for nu, fidelity_dims in itertools.product({0.5, 1.5, 2.5}, ([2], [1, 2])):
+            kernel = LinearTruncatedFidelityKernel(
+                fidelity_dims=fidelity_dims, dimension=3, nu=nu
+            )
+            kernel.power = 1
+            if len(fidelity_dims) > 1:
+                active_dimsM = [0]
+                t_2 = torch.tensor(
+                    [0.4725, 0.2889, 0.4025, 0.2541], dtype=torch.float
+                ).view(2, 2)
+                t_3 = torch.tensor(
+                    [0.1685, 0.0531, 0.1168, 0.0386], dtype=torch.float
+                ).view(2, 2)
+                t = 1 + t_1 + t_2 + t_3
+            else:
+                active_dimsM = [0, 1]
+                t = 1 + t_1
 
-                matern_ker = MaternKernel(nu=nu, active_dims=active_dimsM)
-                matern_term = matern_ker(x1, x2).evaluate()
-                actual = t * matern_term
-                res = kernel(x1, x2).evaluate()
-                self.assertLess(torch.norm(res - actual), 1e-4)
-                # test diagonal mode
-                res_diag = kernel(x1, x2, diag=True)
-                self.assertLess(torch.norm(res_diag - actual.diag()), 1e-4)
+            matern_ker = MaternKernel(nu=nu, active_dims=active_dimsM)
+            matern_term = matern_ker(x1, x2).evaluate()
+            actual = t * matern_term
+            res = kernel(x1, x2).evaluate()
+            self.assertLess(torch.norm(res - actual), 1e-4)
+            # test diagonal mode
+            res_diag = kernel(x1, x2, diag=True)
+            self.assertLess(torch.norm(res_diag - actual.diag()), 1e-4)
         # make sure that we error out if last_dim_is_batch=True
         with self.assertRaises(NotImplementedError):
             kernel(x1, x2, diag=True, last_dim_is_batch=True)
@@ -80,43 +81,38 @@ class TestLinearTruncatedFidelityKernel(BotorchTestCase, BaseKernelTestCase):
             dtype=torch.float,
         ).view(2, 2, 2)
         batch_shape = torch.Size([2])
-        for nu in {0.5, 1.5, 2.5}:
-            for fidelity_dims in ([2], [1, 2]):
-                kernel = LinearTruncatedFidelityKernel(
-                    fidelity_dims=fidelity_dims,
-                    dimension=3,
-                    nu=nu,
-                    batch_shape=batch_shape,
-                )
-                kernel.power = 1
-                if len(fidelity_dims) > 1:
-                    active_dimsM = [0]
-                    t_2 = torch.tensor(
-                        [0.0527, 0.167, 0.0383, 0.1159, 0.1159, 0.167, 0.0383, 0.0527],
-                        dtype=torch.float,
-                    ).view(2, 2, 2)
-                    t_3 = torch.tensor(
-                        [0.1944, 0.3816, 0.1736, 0.3304, 0.36, 0.44, 0.2304, 0.2736],
-                        dtype=torch.float,
-                    ).view(2, 2, 2)
-                    t = 1 + t_1 + t_2 + t_3
-                else:
-                    active_dimsM = [0, 1]
-                    t = 1 + t_1
+        for nu, fidelity_dims in itertools.product({0.5, 1.5, 2.5}, ([2], [1, 2])):
+            kernel = LinearTruncatedFidelityKernel(
+                fidelity_dims=fidelity_dims, dimension=3, nu=nu, batch_shape=batch_shape
+            )
+            kernel.power = 1
+            if len(fidelity_dims) > 1:
+                active_dimsM = [0]
+                t_2 = torch.tensor(
+                    [0.0527, 0.167, 0.0383, 0.1159, 0.1159, 0.167, 0.0383, 0.0527],
+                    dtype=torch.float,
+                ).view(2, 2, 2)
+                t_3 = torch.tensor(
+                    [0.1944, 0.3816, 0.1736, 0.3304, 0.36, 0.44, 0.2304, 0.2736],
+                    dtype=torch.float,
+                ).view(2, 2, 2)
+                t = 1 + t_1 + t_2 + t_3
+            else:
+                active_dimsM = [0, 1]
+                t = 1 + t_1
 
-                matern_ker = MaternKernel(
-                    nu=nu, active_dims=active_dimsM, batch_shape=batch_shape
-                )
-                matern_term = matern_ker(x1, x2).evaluate()
-                actual = t * matern_term
-                res = kernel(x1, x2).evaluate()
-                self.assertLess(torch.norm(res - actual), 1e-4)
-                # test diagonal mode
-                res_diag = kernel(x1, x2, diag=True)
-                self.assertLess(
-                    torch.norm(res_diag - torch.diagonal(actual, dim1=-1, dim2=-2)),
-                    1e-4,
-                )
+            matern_ker = MaternKernel(
+                nu=nu, active_dims=active_dimsM, batch_shape=batch_shape
+            )
+            matern_term = matern_ker(x1, x2).evaluate()
+            actual = t * matern_term
+            res = kernel(x1, x2).evaluate()
+            self.assertLess(torch.norm(res - actual), 1e-4)
+            # test diagonal mode
+            res_diag = kernel(x1, x2, diag=True)
+            self.assertLess(
+                torch.norm(res_diag - torch.diagonal(actual, dim1=-1, dim2=-2)), 1e-4
+            )
         # make sure that we error out if last_dim_is_batch=True
         with self.assertRaises(NotImplementedError):
             kernel(x1, x2, diag=True, last_dim_is_batch=True)

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -82,7 +82,7 @@ class TestSingleTaskGP(BotorchTestCase):
             self.assertEqual(posterior_pred.mean.shape, expected_mean_shape)
             pvar = posterior_pred.variance
             pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
-            self.assertTrue(torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05))
+            self.assertTrue(torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-5))
 
             # test batch evaluation
             X = torch.rand(
@@ -101,7 +101,7 @@ class TestSingleTaskGP(BotorchTestCase):
             self.assertEqual(posterior_pred.mean.shape, expected_mean_shape)
             pvar = posterior_pred.variance
             pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
-            self.assertTrue(torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05))
+            self.assertTrue(torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-5))
 
     def test_condition_on_observations(self):
         for batch_shape, num_outputs, dtype in itertools.product(

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import math
+import itertools
 import warnings
 
 import torch
@@ -18,7 +18,7 @@ from botorch.models.gp_regression import (
 from botorch.models.utils import add_output_dim
 from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling import SobolQMCNormalSampler
-from botorch.utils.testing import BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, _get_random_data
 from gpytorch.kernels import MaternKernel, ScaleKernel
 from gpytorch.likelihoods import (
     FixedNoiseGaussianLikelihood,
@@ -32,17 +32,6 @@ from gpytorch.mlls.noise_model_added_loss_term import NoiseModelAddedLossTerm
 from gpytorch.priors import GammaPrior
 
 
-def _get_random_data(batch_shape, num_outputs, n=10, **tkwargs):
-    train_x = torch.linspace(0, 0.95, n, **tkwargs).unsqueeze(-1) + 0.05 * torch.rand(
-        n, 1, **tkwargs
-    ).repeat(batch_shape + torch.Size([1, 1]))
-    train_y = torch.sin(train_x * (2 * math.pi)) + 0.2 * torch.randn(
-        n, num_outputs, **tkwargs
-    ).repeat(batch_shape + torch.Size([1, 1]))
-
-    return train_x, train_y
-
-
 class TestSingleTaskGP(BotorchTestCase):
     def _get_model_and_data(self, batch_shape, num_outputs, **tkwargs):
         train_X, train_Y = _get_random_data(
@@ -53,204 +42,179 @@ class TestSingleTaskGP(BotorchTestCase):
         return model, model_kwargs
 
     def test_gp(self):
-        for batch_shape in (torch.Size(), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for double in (False, True):
-                    tkwargs = {
-                        "device": self.device,
-                        "dtype": torch.double if double else torch.float,
-                    }
-                    model, _ = self._get_model_and_data(
-                        batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
-                    )
-                    mll = ExactMarginalLogLikelihood(model.likelihood, model).to(
-                        **tkwargs
-                    )
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings("ignore", category=OptimizationWarning)
-                        fit_gpytorch_model(mll, options={"maxiter": 1}, max_retries=1)
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model, _ = self._get_model_and_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
+            )
+            mll = ExactMarginalLogLikelihood(model.likelihood, model).to(**tkwargs)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=OptimizationWarning)
+                fit_gpytorch_model(mll, options={"maxiter": 1}, max_retries=1)
 
-                    # test init
-                    self.assertIsInstance(model.mean_module, ConstantMean)
-                    self.assertIsInstance(model.covar_module, ScaleKernel)
-                    matern_kernel = model.covar_module.base_kernel
-                    self.assertIsInstance(matern_kernel, MaternKernel)
-                    self.assertIsInstance(matern_kernel.lengthscale_prior, GammaPrior)
+            # test init
+            self.assertIsInstance(model.mean_module, ConstantMean)
+            self.assertIsInstance(model.covar_module, ScaleKernel)
+            matern_kernel = model.covar_module.base_kernel
+            self.assertIsInstance(matern_kernel, MaternKernel)
+            self.assertIsInstance(matern_kernel.lengthscale_prior, GammaPrior)
 
-                    # test param sizes
-                    params = dict(model.named_parameters())
-                    for p in params:
-                        self.assertEqual(
-                            params[p].numel(),
-                            num_outputs * torch.tensor(batch_shape).prod().item(),
-                        )
+            # test param sizes
+            params = dict(model.named_parameters())
+            for p in params:
+                self.assertEqual(
+                    params[p].numel(),
+                    num_outputs * torch.tensor(batch_shape).prod().item(),
+                )
 
-                    # test posterior
-                    # test non batch evaluation
-                    X = torch.rand(batch_shape + torch.Size([3, 1]), **tkwargs)
-                    expected_mean_shape = batch_shape + torch.Size([3, num_outputs])
-                    posterior = model.posterior(X)
-                    self.assertIsInstance(posterior, GPyTorchPosterior)
-                    self.assertEqual(posterior.mean.shape, expected_mean_shape)
-                    # test adding observation noise
-                    posterior_pred = model.posterior(X, observation_noise=True)
-                    self.assertIsInstance(posterior_pred, GPyTorchPosterior)
-                    self.assertEqual(posterior_pred.mean.shape, expected_mean_shape)
-                    pvar = posterior_pred.variance
-                    pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
-                    self.assertTrue(
-                        torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05)
-                    )
+            # test posterior
+            # test non batch evaluation
+            X = torch.rand(batch_shape + torch.Size([3, 1]), **tkwargs)
+            expected_mean_shape = batch_shape + torch.Size([3, num_outputs])
+            posterior = model.posterior(X)
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+            self.assertEqual(posterior.mean.shape, expected_mean_shape)
+            # test adding observation noise
+            posterior_pred = model.posterior(X, observation_noise=True)
+            self.assertIsInstance(posterior_pred, GPyTorchPosterior)
+            self.assertEqual(posterior_pred.mean.shape, expected_mean_shape)
+            pvar = posterior_pred.variance
+            pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
+            self.assertTrue(torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05))
 
-                    # test batch evaluation
-                    X = torch.rand(
-                        torch.Size([2]) + batch_shape + torch.Size([3, 1]), **tkwargs
-                    )
-                    expected_mean_shape = (
-                        torch.Size([2]) + batch_shape + torch.Size([3, num_outputs])
-                    )
+            # test batch evaluation
+            X = torch.rand(
+                torch.Size([2]) + batch_shape + torch.Size([3, 1]), **tkwargs
+            )
+            expected_mean_shape = (
+                torch.Size([2]) + batch_shape + torch.Size([3, num_outputs])
+            )
 
-                    posterior = model.posterior(X)
-                    self.assertIsInstance(posterior, GPyTorchPosterior)
-                    self.assertEqual(posterior.mean.shape, expected_mean_shape)
-                    # test adding observation noise in batch mode
-                    posterior_pred = model.posterior(X, observation_noise=True)
-                    self.assertIsInstance(posterior_pred, GPyTorchPosterior)
-                    self.assertEqual(posterior_pred.mean.shape, expected_mean_shape)
-                    pvar = posterior_pred.variance
-                    pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
-                    self.assertTrue(
-                        torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05)
-                    )
+            posterior = model.posterior(X)
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+            self.assertEqual(posterior.mean.shape, expected_mean_shape)
+            # test adding observation noise in batch mode
+            posterior_pred = model.posterior(X, observation_noise=True)
+            self.assertIsInstance(posterior_pred, GPyTorchPosterior)
+            self.assertEqual(posterior_pred.mean.shape, expected_mean_shape)
+            pvar = posterior_pred.variance
+            pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
+            self.assertTrue(torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05))
 
     def test_condition_on_observations(self):
-        for batch_shape in (torch.Size(), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for double in (False, True):
-                    tkwargs = {
-                        "device": self.device,
-                        "dtype": torch.double if double else torch.float,
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model, model_kwargs = self._get_model_and_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
+            )
+            # evaluate model
+            model.posterior(torch.rand(torch.Size([4, 1]), **tkwargs))
+            # test condition_on_observations
+            fant_shape = torch.Size([2])
+            # fantasize at different input points
+            X_fant, Y_fant = _get_random_data(
+                fant_shape + batch_shape, num_outputs, n=3, **tkwargs
+            )
+            c_kwargs = (
+                {"noise": torch.full_like(Y_fant, 0.01)}
+                if isinstance(model, FixedNoiseGP)
+                else {}
+            )
+            cm = model.condition_on_observations(X_fant, Y_fant, **c_kwargs)
+            # fantasize at different same input points
+            c_kwargs_same_inputs = (
+                {"noise": torch.full_like(Y_fant[0], 0.01)}
+                if isinstance(model, FixedNoiseGP)
+                else {}
+            )
+            cm_same_inputs = model.condition_on_observations(
+                X_fant[0], Y_fant, **c_kwargs_same_inputs
+            )
+
+            test_Xs = [
+                # test broadcasting single input across fantasy and
+                # model batches
+                torch.rand(4, 1, **tkwargs),
+                # separate input for each model batch and broadcast across
+                # fantasy batches
+                torch.rand(batch_shape + torch.Size([4, 1]), **tkwargs),
+                # separate input for each model and fantasy batch
+                torch.rand(fant_shape + batch_shape + torch.Size([4, 1]), **tkwargs),
+            ]
+            for test_X in test_Xs:
+                posterior = cm.posterior(test_X)
+                self.assertEqual(
+                    posterior.mean.shape,
+                    fant_shape + batch_shape + torch.Size([4, num_outputs]),
+                )
+                posterior_same_inputs = cm_same_inputs.posterior(test_X)
+                self.assertEqual(
+                    posterior_same_inputs.mean.shape,
+                    fant_shape + batch_shape + torch.Size([4, num_outputs]),
+                )
+
+                # check that fantasies of batched model are correct
+                if len(batch_shape) > 0 and test_X.dim() == 2:
+                    state_dict_non_batch = {
+                        key: (val[0] if val.numel() > 1 else val)
+                        for key, val in model.state_dict().items()
                     }
-                    model, model_kwargs = self._get_model_and_data(
-                        batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
-                    )
-                    # evaluate model
-                    model.posterior(torch.rand(torch.Size([4, 1]), **tkwargs))
-                    # test condition_on_observations
-                    fant_shape = torch.Size([2])
-                    # fantasize at different input points
-                    X_fant, Y_fant = _get_random_data(
-                        fant_shape + batch_shape, num_outputs, n=3, **tkwargs
-                    )
+                    model_kwargs_non_batch = {
+                        "train_X": model_kwargs["train_X"][0],
+                        "train_Y": model_kwargs["train_Y"][0],
+                    }
+                    if "train_Yvar" in model_kwargs:
+                        model_kwargs_non_batch["train_Yvar"] = model_kwargs[
+                            "train_Yvar"
+                        ][0]
+                    model_non_batch = type(model)(**model_kwargs_non_batch)
+                    model_non_batch.load_state_dict(state_dict_non_batch)
+                    model_non_batch.eval()
+                    model_non_batch.likelihood.eval()
+                    model_non_batch.posterior(torch.rand(torch.Size([4, 1]), **tkwargs))
                     c_kwargs = (
-                        {"noise": torch.full_like(Y_fant, 0.01)}
+                        {"noise": torch.full_like(Y_fant[0, 0, :], 0.01)}
                         if isinstance(model, FixedNoiseGP)
                         else {}
                     )
-                    cm = model.condition_on_observations(X_fant, Y_fant, **c_kwargs)
-                    # fantasize at different same input points
-                    c_kwargs_same_inputs = (
-                        {"noise": torch.full_like(Y_fant[0], 0.01)}
-                        if isinstance(model, FixedNoiseGP)
-                        else {}
+                    cm_non_batch = model_non_batch.condition_on_observations(
+                        X_fant[0][0], Y_fant[:, 0, :], **c_kwargs
                     )
-                    cm_same_inputs = model.condition_on_observations(
-                        X_fant[0], Y_fant, **c_kwargs_same_inputs
+                    non_batch_posterior = cm_non_batch.posterior(test_X)
+                    self.assertTrue(
+                        torch.allclose(
+                            posterior_same_inputs.mean[:, 0, ...],
+                            non_batch_posterior.mean,
+                            atol=1e-3,
+                        )
                     )
-
-                    test_Xs = [
-                        # test broadcasting single input across fantasy and
-                        # model batches
-                        torch.rand(4, 1, **tkwargs),
-                        # separate input for each model batch and broadcast across
-                        # fantasy batches
-                        torch.rand(batch_shape + torch.Size([4, 1]), **tkwargs),
-                        # separate input for each model and fantasy batch
-                        torch.rand(
-                            fant_shape + batch_shape + torch.Size([4, 1]), **tkwargs
-                        ),
-                    ]
-                    for test_X in test_Xs:
-                        posterior = cm.posterior(test_X)
-                        self.assertEqual(
-                            posterior.mean.shape,
-                            fant_shape + batch_shape + torch.Size([4, num_outputs]),
+                    self.assertTrue(
+                        torch.allclose(
+                            posterior_same_inputs.mvn.covariance_matrix[:, 0, :, :],
+                            non_batch_posterior.mvn.covariance_matrix,
+                            atol=1e-3,
                         )
-                        posterior_same_inputs = cm_same_inputs.posterior(test_X)
-                        self.assertEqual(
-                            posterior_same_inputs.mean.shape,
-                            fant_shape + batch_shape + torch.Size([4, num_outputs]),
-                        )
-
-                        # check that fantasies of batched model are correct
-                        if len(batch_shape) > 0 and test_X.dim() == 2:
-                            state_dict_non_batch = {
-                                key: (val[0] if val.numel() > 1 else val)
-                                for key, val in model.state_dict().items()
-                            }
-                            model_kwargs_non_batch = {
-                                "train_X": model_kwargs["train_X"][0],
-                                "train_Y": model_kwargs["train_Y"][0],
-                            }
-                            if "train_Yvar" in model_kwargs:
-                                model_kwargs_non_batch["train_Yvar"] = model_kwargs[
-                                    "train_Yvar"
-                                ][0]
-                            model_non_batch = type(model)(**model_kwargs_non_batch)
-                            model_non_batch.load_state_dict(state_dict_non_batch)
-                            model_non_batch.eval()
-                            model_non_batch.likelihood.eval()
-                            model_non_batch.posterior(
-                                torch.rand(torch.Size([4, 1]), **tkwargs)
-                            )
-                            c_kwargs = (
-                                {"noise": torch.full_like(Y_fant[0, 0, :], 0.01)}
-                                if isinstance(model, FixedNoiseGP)
-                                else {}
-                            )
-                            cm_non_batch = model_non_batch.condition_on_observations(
-                                X_fant[0][0], Y_fant[:, 0, :], **c_kwargs
-                            )
-                            non_batch_posterior = cm_non_batch.posterior(test_X)
-                            self.assertTrue(
-                                torch.allclose(
-                                    posterior_same_inputs.mean[:, 0, ...],
-                                    non_batch_posterior.mean,
-                                    atol=1e-3,
-                                )
-                            )
-                            self.assertTrue(
-                                torch.allclose(
-                                    posterior_same_inputs.mvn.covariance_matrix[
-                                        :, 0, :, :
-                                    ],
-                                    non_batch_posterior.mvn.covariance_matrix,
-                                    atol=1e-3,
-                                )
-                            )
+                    )
 
     def test_fantasize(self):
-        for batch_shape in (torch.Size(), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for double in (False, True):
-                    tkwargs = {
-                        "device": self.device,
-                        "dtype": torch.double if double else torch.float,
-                    }
-                    model, model_kwargs = self._get_model_and_data(
-                        batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
-                    )
-                    # fantasize
-                    X_f = torch.rand(
-                        torch.Size(batch_shape + torch.Size([4, 1])), **tkwargs
-                    )
-                    sampler = SobolQMCNormalSampler(num_samples=3)
-                    fm = model.fantasize(X=X_f, sampler=sampler)
-                    self.assertIsInstance(fm, model.__class__)
-                    fm = model.fantasize(
-                        X=X_f, sampler=sampler, observation_noise=False
-                    )
-                    self.assertIsInstance(fm, model.__class__)
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model, model_kwargs = self._get_model_and_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
+            )
+            # fantasize
+            X_f = torch.rand(torch.Size(batch_shape + torch.Size([4, 1])), **tkwargs)
+            sampler = SobolQMCNormalSampler(num_samples=3)
+            fm = model.fantasize(X=X_f, sampler=sampler)
+            self.assertIsInstance(fm, model.__class__)
+            fm = model.fantasize(X=X_f, sampler=sampler, observation_noise=False)
+            self.assertIsInstance(fm, model.__class__)
 
 
 class TestFixedNoiseGP(TestSingleTaskGP):
@@ -267,25 +231,20 @@ class TestFixedNoiseGP(TestSingleTaskGP):
         return model, model_kwargs
 
     def test_fixed_noise_likelihood(self):
-        for batch_shape in (torch.Size(), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for double in (False, True):
-                    tkwargs = {
-                        "device": self.device,
-                        "dtype": torch.double if double else torch.float,
-                    }
-                    model, model_kwargs = self._get_model_and_data(
-                        batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
-                    )
-                    self.assertIsInstance(
-                        model.likelihood, FixedNoiseGaussianLikelihood
-                    )
-                    self.assertTrue(
-                        torch.equal(
-                            model.likelihood.noise.contiguous().view(-1),
-                            model_kwargs["train_Yvar"].contiguous().view(-1),
-                        )
-                    )
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model, model_kwargs = self._get_model_and_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
+            )
+            self.assertIsInstance(model.likelihood, FixedNoiseGaussianLikelihood)
+            self.assertTrue(
+                torch.equal(
+                    model.likelihood.noise.contiguous().view(-1),
+                    model_kwargs["train_Yvar"].contiguous().view(-1),
+                )
+            )
 
 
 class TestHeteroskedasticSingleTaskGP(TestSingleTaskGP):
@@ -303,28 +262,22 @@ class TestHeteroskedasticSingleTaskGP(TestSingleTaskGP):
         return model, model_kwargs
 
     def test_heteroskedastic_likelihood(self):
-        for batch_shape in (torch.Size(), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for double in (False, True):
-                    tkwargs = {
-                        "device": self.device,
-                        "dtype": torch.double if double else torch.float,
-                    }
-                    model, _ = self._get_model_and_data(
-                        batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
-                    )
-                    self.assertIsInstance(model.likelihood, _GaussianLikelihoodBase)
-                    self.assertFalse(isinstance(model.likelihood, GaussianLikelihood))
-                    self.assertIsInstance(
-                        model.likelihood.noise_covar, HeteroskedasticNoise
-                    )
-                    self.assertIsInstance(
-                        model.likelihood.noise_covar.noise_model, SingleTaskGP
-                    )
-                    self.assertIsInstance(
-                        model._added_loss_terms["noise_added_loss"],
-                        NoiseModelAddedLossTerm,
-                    )
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model, _ = self._get_model_and_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
+            )
+            self.assertIsInstance(model.likelihood, _GaussianLikelihoodBase)
+            self.assertFalse(isinstance(model.likelihood, GaussianLikelihood))
+            self.assertIsInstance(model.likelihood.noise_covar, HeteroskedasticNoise)
+            self.assertIsInstance(
+                model.likelihood.noise_covar.noise_model, SingleTaskGP
+            )
+            self.assertIsInstance(
+                model._added_loss_terms["noise_added_loss"], NoiseModelAddedLossTerm
+            )
 
     def test_condition_on_observations(self):
         with self.assertRaises(NotImplementedError):

--- a/test/models/test_utils.py
+++ b/test/models/test_utils.py
@@ -22,11 +22,8 @@ from botorch.utils.testing import BotorchTestCase
 
 class TestMultiOutputToBatchModeTransform(BotorchTestCase):
     def test_multioutput_to_batch_mode_transform(self):
-        for double in (False, True):
-            tkwargs = {
-                "device": self.device,
-                "dtype": torch.double if double else torch.float,
-            }
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"device": self.device, "dtype": dtype}
             n = 3
             num_outputs = 2
             train_X = torch.rand(n, 1, **tkwargs)
@@ -46,11 +43,8 @@ class TestMultiOutputToBatchModeTransform(BotorchTestCase):
 
 class TestAddOutputDim(BotorchTestCase):
     def test_add_output_dim(self):
-        for double in (False, True):
-            tkwargs = {
-                "device": self.device,
-                "dtype": torch.double if double else torch.float,
-            }
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"device": self.device, "dtype": dtype}
             original_batch_shape = torch.Size([2])
             # check exception is raised when trailing batch dims do not line up
             X = torch.rand(2, 3, 2, 1, **tkwargs)

--- a/test/models/transforms/__init__.py
+++ b/test/models/transforms/__init__.py
@@ -1,0 +1,5 @@
+#! /usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+from copy import deepcopy
+
+import torch
+from botorch.exceptions.errors import BotorchTensorDimensionError
+from botorch.models.transforms.input import (
+    ChainedInputTransform,
+    InputTransform,
+    Normalize,
+)
+from botorch.utils.testing import BotorchTestCase
+
+
+class NotSoAbstractInputTransform(InputTransform):
+    def forward(self, X):
+        pass
+
+
+class TestInputTransforms(BotorchTestCase):
+    def test_abstract_base_input_transform(self):
+        with self.assertRaises(TypeError):
+            InputTransform()
+        ipt = NotSoAbstractInputTransform()
+        with self.assertRaises(NotImplementedError):
+            ipt.untransform(None)
+
+    def test_normalize(self):
+        for dtype in (torch.float, torch.double):
+
+            # basic init, learned bounds
+            nlz = Normalize(d=2)
+            self.assertTrue(nlz.learn_bounds)
+            self.assertTrue(nlz.training)
+            self.assertEqual(nlz._d, 2)
+            self.assertEqual(nlz.mins.shape, torch.Size([1, 2]))
+            self.assertEqual(nlz.ranges.shape, torch.Size([1, 2]))
+            nlz = Normalize(d=2, batch_shape=torch.Size([3]))
+            self.assertTrue(nlz.learn_bounds)
+            self.assertTrue(nlz.training)
+            self.assertEqual(nlz._d, 2)
+            self.assertEqual(nlz.mins.shape, torch.Size([3, 1, 2]))
+            self.assertEqual(nlz.ranges.shape, torch.Size([3, 1, 2]))
+
+            # basic init, fixed bounds
+            bounds = torch.zeros(2, 2, device=self.device, dtype=dtype)
+            nlz = Normalize(d=2, bounds=bounds)
+            self.assertFalse(nlz.learn_bounds)
+            self.assertTrue(nlz.training)
+            self.assertEqual(nlz._d, 2)
+            self.assertTrue(torch.equal(nlz.mins, bounds[..., [0], :]))
+            self.assertTrue(
+                torch.equal(nlz.mins, bounds[..., [1], :] - bounds[..., [0], :])
+            )
+            # test .to
+            other_dtype = torch.float if dtype == torch.double else torch.double
+            nlz.to(other_dtype)
+            self.assertTrue(nlz.mins.dtype == other_dtype)
+            # test incompatible dimensions of specified bounds
+            with self.assertRaises(BotorchTensorDimensionError):
+                bounds = torch.zeros(2, 3, device=self.device, dtype=dtype)
+                Normalize(d=2, bounds=bounds)
+
+            # basic usage
+            for batch_shape in (torch.Size(), torch.Size([3])):
+                # learned bounds
+                nlz = Normalize(d=2, batch_shape=batch_shape)
+                X = torch.randn(*batch_shape, 4, 2, device=self.device, dtype=dtype)
+                X_nlzd = nlz(X)
+                self.assertEqual(X_nlzd.min().item(), 0.0)
+                self.assertEqual(X_nlzd.max().item(), 1.0)
+                nlz.eval()
+                X_unnlzd = nlz.untransform(X_nlzd)
+                self.assertTrue(torch.allclose(X, X_unnlzd))
+                expected_bounds = torch.cat(
+                    [X.min(dim=-2, keepdim=True)[0], X.max(dim=-2, keepdim=True)[0]],
+                    dim=-2,
+                )
+                self.assertTrue(torch.allclose(nlz.bounds, expected_bounds))
+                # test errors on wrong shape
+                nlz = Normalize(d=2, batch_shape=batch_shape)
+                X = torch.randn(*batch_shape, 2, 1, device=self.device, dtype=dtype)
+                with self.assertRaises(BotorchTensorDimensionError):
+                    nlz(X)
+
+                # fixed bounds
+                bounds = torch.tensor(
+                    [[-2.0, -1], [1, 2.0]], device=self.device, dtype=dtype
+                ).expand(*batch_shape, 2, 2)
+                nlz = Normalize(d=2, bounds=bounds)
+                X = torch.rand(*batch_shape, 4, 2, device=self.device, dtype=dtype)
+                X_nlzd = nlz(X)
+                self.assertTrue(torch.equal(nlz.bounds, bounds))
+                X_unnlzd = nlz.untransform(X_nlzd)
+                self.assertTrue(torch.allclose(X, X_unnlzd, atol=1e-4, rtol=1e-4))
+
+    def test_chained_input_transform(self):
+
+        ds = (1, 2)
+        batch_shapes = (torch.Size(), torch.Size([2]))
+        dtypes = (torch.float, torch.double)
+
+        for d, batch_shape, dtype in itertools.product(ds, batch_shapes, dtypes):
+            bounds = torch.tensor(
+                [[-2.0] * d, [2.0] * d], device=self.device, dtype=dtype
+            )
+            tf1 = Normalize(d=d, bounds=bounds, batch_shape=batch_shape)
+            tf2 = Normalize(d=d, batch_shape=batch_shape)
+            tf = ChainedInputTransform(stz_fixed=tf1, stz_learned=tf2)
+            tf1_, tf2_ = deepcopy(tf1), deepcopy(tf2)
+            self.assertTrue(tf.training)
+            self.assertEqual(sorted(tf.keys()), ["stz_fixed", "stz_learned"])
+            self.assertEqual(tf["stz_fixed"], tf1)
+            self.assertEqual(tf["stz_learned"], tf2)
+
+            # make copies for validation below
+            tf1_, tf2_ = deepcopy(tf1), deepcopy(tf2)
+
+            X = torch.rand(*batch_shape, 4, d, device=self.device, dtype=dtype)
+            X_tf = tf(X)
+            X_tf_ = tf2_(tf1_(X))
+            self.assertTrue(tf1.training)
+            self.assertTrue(tf2.training)
+            self.assertTrue(torch.equal(X_tf, X_tf_))
+            X_utf = tf.untransform(X_tf)
+            self.assertTrue(torch.allclose(X_utf, X, atol=1e-4, rtol=1e-4))

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+from copy import deepcopy
+
+import torch
+from botorch.models.transforms.outcome import (
+    ChainedOutcomeTransform,
+    Log,
+    OutcomeTransform,
+    Standardize,
+)
+from botorch.models.transforms.utils import (
+    norm_to_lognorm_mean,
+    norm_to_lognorm_variance,
+)
+from botorch.posteriors import GPyTorchPosterior, TransformedPosterior
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
+from gpytorch.lazy import NonLazyTensor
+
+
+def _get_test_posterior(shape, device, dtype, interleaved=True, lazy=False):
+    mean = torch.rand(shape, device=device, dtype=dtype)
+    n_covar = shape[-2:].numel()
+    diag = torch.rand(shape, device=device, dtype=dtype)
+    diag = diag.view(*diag.shape[:-2], n_covar)
+    a = torch.rand(*shape[:-2], n_covar, n_covar, device=device, dtype=dtype)
+    covar = a @ a.transpose(-1, -2) + torch.diag_embed(diag)
+    if lazy:
+        covar = NonLazyTensor(covar)
+    if shape[-1] == 1:
+        mvn = MultivariateNormal(mean.squeeze(-1), covar)
+    else:
+        mvn = MultitaskMultivariateNormal(mean, covar, interleaved=interleaved)
+    return GPyTorchPosterior(mvn)
+
+
+class NotSoAbstractOutcomeTransform(OutcomeTransform):
+    def forward(self, Y, Yvar):
+        pass
+
+
+class TestOutcomeTransforms(BotorchTestCase):
+    def test_abstract_base_outcome_transform(self):
+        with self.assertRaises(TypeError):
+            OutcomeTransform()
+        oct = NotSoAbstractOutcomeTransform()
+        with self.assertRaises(NotImplementedError):
+            oct.untransform(None, None)
+        with self.assertRaises(NotImplementedError):
+            oct.untransform_posterior(None)
+
+    def test_standardize(self):
+
+        # test error on incompatible dim
+        tf = Standardize(m=1)
+        with self.assertRaises(RuntimeError):
+            tf(torch.zeros(3, 2, device=self.device), None)
+        # test error on incompatible batch shape
+        with self.assertRaises(RuntimeError):
+            tf(torch.zeros(2, 3, 1, device=self.device), None)
+
+        ms = (1, 2)
+        batch_shapes = (torch.Size(), torch.Size([2]))
+        dtypes = (torch.float, torch.double)
+
+        # test transform, untransform, untransform_posterior
+        for m, batch_shape, dtype in itertools.product(ms, batch_shapes, dtypes):
+
+            # test init
+            tf = Standardize(m=m, batch_shape=batch_shape)
+            self.assertTrue(tf.training)
+            self.assertEqual(tf._m, m)
+            self.assertIsNone(tf._outputs)
+            self.assertEqual(tf._batch_shape, batch_shape)
+            self.assertEqual(tf._min_stdv, 1e-8)
+
+            # no observation noise
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Y_tf, Yvar_tf = tf(Y, None)
+            self.assertTrue(tf.training)
+            self.assertTrue(torch.all(Y_tf.mean(dim=-2).abs() < 1e-4))
+            self.assertIsNone(Yvar_tf)
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            torch.allclose(Y_utf, Y)
+            self.assertIsNone(Yvar_utf)
+
+            # with observation noise
+            tf = Standardize(m=m, batch_shape=batch_shape)
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Yvar = 1e-8 + torch.rand(
+                *batch_shape, 3, m, device=self.device, dtype=dtype
+            )
+            Y_tf, Yvar_tf = tf(Y, Yvar)
+            self.assertTrue(tf.training)
+            self.assertTrue(torch.all(Y_tf.mean(dim=-2).abs() < 1e-4))
+            Yvar_tf_expected = Yvar / Y.std(dim=-2, keepdim=True) ** 2
+            self.assertTrue(torch.allclose(Yvar_tf, Yvar_tf_expected))
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            torch.allclose(Y_utf, Y)
+            torch.allclose(Yvar_utf, Yvar)
+
+            # untransform_posterior
+            for interleaved, lazy in itertools.product((True, False), (True, False)):
+                if m == 1 and interleaved:  # interleave has no meaning for m=1
+                    continue
+                shape = batch_shape + torch.Size([3, m])
+                posterior = _get_test_posterior(
+                    shape,
+                    device=self.device,
+                    dtype=dtype,
+                    interleaved=interleaved,
+                    lazy=lazy,
+                )
+                p_utf = tf.untransform_posterior(posterior)
+                self.assertEqual(p_utf.device.type, self.device.type)
+                self.assertTrue(p_utf.dtype == dtype)
+                mean_expected = tf.means + tf.stdvs * posterior.mean
+                variance_expected = tf.stdvs ** 2 * posterior.variance
+                self.assertTrue(torch.allclose(p_utf.mean, mean_expected))
+                self.assertTrue(torch.allclose(p_utf.variance, variance_expected))
+                samples = p_utf.rsample()
+                self.assertEqual(samples.shape, torch.Size([1]) + shape)
+                samples = p_utf.rsample(sample_shape=torch.Size([4]))
+                self.assertEqual(samples.shape, torch.Size([4]) + shape)
+                samples2 = p_utf.rsample(sample_shape=torch.Size([4, 2]))
+                self.assertEqual(samples2.shape, torch.Size([4, 2]) + shape)
+                # TODO: Test expected covar (both interleaved and non-interleaved)
+
+            # untransform_posterior for non-GPyTorch posterior
+            posterior2 = TransformedPosterior(
+                posterior=posterior,
+                sample_transform=lambda s: s,
+                mean_transform=lambda m, v: m,
+                variance_transform=lambda m, v: v,
+            )
+            p_utf2 = tf.untransform_posterior(posterior2)
+            self.assertEqual(p_utf2.device.type, self.device.type)
+            self.assertTrue(p_utf2.dtype == dtype)
+            mean_expected = tf.means + tf.stdvs * posterior.mean
+            variance_expected = tf.stdvs ** 2 * posterior.variance
+            self.assertTrue(torch.allclose(p_utf2.mean, mean_expected))
+            self.assertTrue(torch.allclose(p_utf2.variance, variance_expected))
+            # TODO: Test expected covar (both interleaved and non-interleaved)
+            samples = p_utf2.rsample()
+            self.assertEqual(samples.shape, torch.Size([1]) + shape)
+            samples = p_utf2.rsample(sample_shape=torch.Size([4]))
+            self.assertEqual(samples.shape, torch.Size([4]) + shape)
+            samples2 = p_utf2.rsample(sample_shape=torch.Size([4, 2]))
+            self.assertEqual(samples2.shape, torch.Size([4, 2]) + shape)
+
+            # test error on incompatible output dimension
+            tf_big = Standardize(m=4).eval()
+            with self.assertRaises(RuntimeError) as e:
+                tf_big.untransform_posterior(posterior2)
+                self.assertTrue("Incompatible output dimensions" in str(e))
+
+        # test subset outcomes
+        for batch_shape, dtype in itertools.product(batch_shapes, dtypes):
+
+            m = 2
+            outputs = [-1]
+
+            # test init
+            tf = Standardize(m=m, outputs=outputs, batch_shape=batch_shape)
+            self.assertTrue(tf.training)
+            self.assertEqual(tf._m, m)
+            self.assertEqual(tf._outputs, [1])
+            self.assertEqual(tf._batch_shape, batch_shape)
+            self.assertEqual(tf._min_stdv, 1e-8)
+
+            # no observation noise
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Y_tf, Yvar_tf = tf(Y, None)
+            self.assertTrue(tf.training)
+            Y_tf_mean = Y_tf.mean(dim=-2)
+            self.assertTrue(torch.all(Y_tf_mean[..., 1].abs() < 1e-4))
+            self.assertTrue(torch.allclose(Y_tf_mean[..., 0], Y.mean(dim=-2)[..., 0]))
+            self.assertIsNone(Yvar_tf)
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            torch.allclose(Y_utf, Y)
+            self.assertIsNone(Yvar_utf)
+
+            # with observation noise
+            tf = Standardize(m=m, outputs=outputs, batch_shape=batch_shape)
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Yvar = 1e-8 + torch.rand(
+                *batch_shape, 3, m, device=self.device, dtype=dtype
+            )
+            Y_tf, Yvar_tf = tf(Y, Yvar)
+            self.assertTrue(tf.training)
+            Y_tf_mean = Y_tf.mean(dim=-2)
+            self.assertTrue(torch.all(Y_tf_mean[..., 1].abs() < 1e-4))
+            self.assertTrue(torch.allclose(Y_tf_mean[..., 0], Y.mean(dim=-2)[..., 0]))
+            Yvar_tf_expected = Yvar / Y.std(dim=-2, keepdim=True) ** 2
+            self.assertTrue(torch.allclose(Yvar_tf[..., 1], Yvar_tf_expected[..., 1]))
+            self.assertTrue(torch.allclose(Yvar_tf[..., 0], Yvar[..., 0]))
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            torch.allclose(Y_utf, Y)
+            torch.allclose(Yvar_utf, Yvar)
+
+            # error on untransform_posterior
+            with self.assertRaises(NotImplementedError):
+                tf.untransform_posterior(None)
+
+    def test_log(self):
+
+        ms = (1, 2)
+        batch_shapes = (torch.Size(), torch.Size([2]))
+        dtypes = (torch.float, torch.double)
+
+        # test transform and untransform
+        for m, batch_shape, dtype in itertools.product(ms, batch_shapes, dtypes):
+
+            # test init
+            tf = Log()
+            self.assertTrue(tf.training)
+            self.assertIsNone(tf._outputs)
+
+            # no observation noise
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Y_tf, Yvar_tf = tf(Y, None)
+            self.assertTrue(tf.training)
+            self.assertTrue(torch.allclose(Y_tf, torch.log(Y)))
+            self.assertIsNone(Yvar_tf)
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            torch.allclose(Y_utf, Y)
+            self.assertIsNone(Yvar_utf)
+
+            # test error if observation noise present
+            tf = Log()
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Yvar = 1e-8 + torch.rand(
+                *batch_shape, 3, m, device=self.device, dtype=dtype
+            )
+            with self.assertRaises(NotImplementedError):
+                tf(Y, Yvar)
+            tf.eval()
+            with self.assertRaises(NotImplementedError):
+                tf.untransform(Y, Yvar)
+
+            # untransform_posterior
+            tf = Log()
+            Y_tf, Yvar_tf = tf(Y, None)
+            tf.eval()
+            shape = batch_shape + torch.Size([3, m])
+            posterior = _get_test_posterior(shape, device=self.device, dtype=dtype)
+            p_utf = tf.untransform_posterior(posterior)
+            self.assertIsInstance(p_utf, TransformedPosterior)
+            self.assertEqual(p_utf.device.type, self.device.type)
+            self.assertTrue(p_utf.dtype == dtype)
+            self.assertTrue(p_utf._sample_transform == torch.exp)
+            mean_expected = norm_to_lognorm_mean(posterior.mean, posterior.variance)
+            variance_expected = norm_to_lognorm_variance(
+                posterior.mean, posterior.variance
+            )
+            self.assertTrue(torch.allclose(p_utf.mean, mean_expected))
+            self.assertTrue(torch.allclose(p_utf.variance, variance_expected))
+            samples = p_utf.rsample()
+            self.assertEqual(samples.shape, torch.Size([1]) + shape)
+            samples = p_utf.rsample(sample_shape=torch.Size([4]))
+            self.assertEqual(samples.shape, torch.Size([4]) + shape)
+            samples2 = p_utf.rsample(sample_shape=torch.Size([4, 2]))
+            self.assertEqual(samples2.shape, torch.Size([4, 2]) + shape)
+
+        # test subset outcomes
+        for batch_shape, dtype in itertools.product(batch_shapes, dtypes):
+
+            m = 2
+            outputs = [-1]
+
+            # test init
+            tf = Log(outputs=outputs)
+            self.assertTrue(tf.training)
+            # cannot normalize indices b/c we don't know dimension yet
+            self.assertEqual(tf._outputs, [-1])
+
+            # no observation noise
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Y_tf, Yvar_tf = tf(Y, None)
+            self.assertTrue(tf.training)
+            self.assertTrue(torch.allclose(Y_tf[..., 1], torch.log(Y[..., 1])))
+            self.assertTrue(torch.allclose(Y_tf[..., 0], Y[..., 0]))
+            self.assertIsNone(Yvar_tf)
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            torch.allclose(Y_utf, Y)
+            self.assertIsNone(Yvar_utf)
+
+            # with observation noise
+            tf = Log(outputs=outputs)
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Yvar = 1e-8 + torch.rand(
+                *batch_shape, 3, m, device=self.device, dtype=dtype
+            )
+            with self.assertRaises(NotImplementedError):
+                tf(Y, Yvar)
+
+            # error on untransform_posterior
+            with self.assertRaises(NotImplementedError):
+                tf.untransform_posterior(None)
+
+    def test_chained_outcome_transform(self):
+
+        ms = (1, 2)
+        batch_shapes = (torch.Size(), torch.Size([2]))
+        dtypes = (torch.float, torch.double)
+
+        # test transform and untransform
+        for m, batch_shape, dtype in itertools.product(ms, batch_shapes, dtypes):
+
+            # test init
+            tf1 = Log()
+            tf2 = Standardize(m=m, batch_shape=batch_shape)
+            tf = ChainedOutcomeTransform(log=tf1, standardize=tf2)
+            self.assertTrue(tf.training)
+            self.assertEqual(sorted(tf.keys()), ["log", "standardize"])
+            self.assertEqual(tf["log"], tf1)
+            self.assertEqual(tf["standardize"], tf2)
+
+            # make copies for validation below
+            tf1_, tf2_ = deepcopy(tf1), deepcopy(tf2)
+
+            # no observation noise
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Y_tf, Yvar_tf = tf(Y, None)
+            Y_tf_, Yvar_tf_ = tf2_(*tf1_(Y, None))
+            self.assertTrue(tf.training)
+            self.assertIsNone(Yvar_tf_)
+            self.assertTrue(torch.allclose(Y_tf, Y_tf_))
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            torch.allclose(Y_utf, Y)
+            self.assertIsNone(Yvar_utf)
+
+            # test error if observation noise present
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Yvar = 1e-8 + torch.rand(
+                *batch_shape, 3, m, device=self.device, dtype=dtype
+            )
+            with self.assertRaises(NotImplementedError):
+                tf(Y, Yvar)
+
+            # untransform_posterior
+            tf1 = Log()
+            tf2 = Standardize(m=m, batch_shape=batch_shape)
+            tf = ChainedOutcomeTransform(log=tf1, standardize=tf2)
+            Y_tf, Yvar_tf = tf(Y, None)
+            tf.eval()
+            shape = batch_shape + torch.Size([3, m])
+            posterior = _get_test_posterior(shape, device=self.device, dtype=dtype)
+            p_utf = tf.untransform_posterior(posterior)
+            self.assertIsInstance(p_utf, TransformedPosterior)
+            self.assertEqual(p_utf.device.type, self.device.type)
+            self.assertTrue(p_utf.dtype == dtype)
+            samples = p_utf.rsample()
+            self.assertEqual(samples.shape, torch.Size([1]) + shape)
+            samples = p_utf.rsample(sample_shape=torch.Size([4]))
+            self.assertEqual(samples.shape, torch.Size([4]) + shape)
+            samples2 = p_utf.rsample(sample_shape=torch.Size([4, 2]))
+            self.assertEqual(samples2.shape, torch.Size([4, 2]) + shape)
+
+        # test subset outcomes
+        for batch_shape, dtype in itertools.product(batch_shapes, dtypes):
+
+            m = 2
+            outputs = [-1]
+
+            # test init
+            tf1 = Log(outputs=outputs)
+            tf2 = Standardize(m=m, outputs=outputs, batch_shape=batch_shape)
+            tf = ChainedOutcomeTransform(log=tf1, standardize=tf2)
+            self.assertTrue(tf.training)
+            self.assertEqual(sorted(tf.keys()), ["log", "standardize"])
+            self.assertEqual(tf["log"], tf1)
+            self.assertEqual(tf["standardize"], tf2)
+            self.assertEqual(tf["log"]._outputs, [-1])  # don't know dimension yet
+            self.assertEqual(tf["standardize"]._outputs, [1])
+
+            # make copies for validation below
+            tf1_, tf2_ = deepcopy(tf1), deepcopy(tf2)
+
+            # no observation noise
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Y_tf, Yvar_tf = tf(Y, None)
+            Y_tf_, Yvar_tf_ = tf2_(*tf1_(Y, None))
+            self.assertTrue(tf.training)
+            self.assertIsNone(Yvar_tf_)
+            self.assertTrue(torch.allclose(Y_tf, Y_tf_))
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            torch.allclose(Y_utf, Y)
+            self.assertIsNone(Yvar_utf)
+
+            # with observation noise
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Yvar = 1e-8 + torch.rand(
+                *batch_shape, 3, m, device=self.device, dtype=dtype
+            )
+            with self.assertRaises(NotImplementedError):
+                tf(Y, Yvar)
+
+            # error on untransform_posterior
+            with self.assertRaises(NotImplementedError):
+                tf.untransform_posterior(None)

--- a/test/models/transforms/test_utils.py
+++ b/test/models/transforms/test_utils.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+import torch
+from botorch.models.transforms.utils import (
+    lognorm_to_norm,
+    norm_to_lognorm,
+    norm_to_lognorm_mean,
+    norm_to_lognorm_variance,
+)
+from botorch.utils.testing import BotorchTestCase
+
+
+class TestTransformUtils(BotorchTestCase):
+    def test_lognorm_to_norm(self):
+        for dtype in (torch.float, torch.double):
+
+            # independent case
+            mu = torch.tensor([0.25, 0.5, 1.0], device=self.device, dtype=dtype)
+            diag = torch.tensor([0.5, 2.0, 1.0], device=self.device, dtype=dtype)
+            Cov = torch.diag_embed((math.exp(1) - 1) * diag)
+            mu_n, Cov_n = lognorm_to_norm(mu, Cov)
+            mu_n_expected = torch.tensor(
+                [-2.73179, -2.03864, -0.5], device=self.device, dtype=dtype
+            )
+            diag_expected = torch.tensor(
+                [2.69099, 2.69099, 1.0], device=self.device, dtype=dtype
+            )
+            self.assertTrue(torch.allclose(mu_n, mu_n_expected))
+            self.assertTrue(torch.allclose(Cov_n, torch.diag_embed(diag_expected)))
+
+            # correlated case
+            Z = torch.zeros(3, 3, device=self.device, dtype=dtype)
+            Z[0, 2] = math.sqrt(math.exp(1)) - 1
+            Z[2, 0] = math.sqrt(math.exp(1)) - 1
+            mu = torch.ones(3, device=self.device, dtype=dtype)
+            Cov = torch.diag_embed(mu * (math.exp(1) - 1)) + Z
+            mu_n, Cov_n = lognorm_to_norm(mu, Cov)
+            mu_n_expected = -0.5 * torch.ones(3, device=self.device, dtype=dtype)
+            Cov_n_expected = torch.tensor(
+                [[1.0, 0.0, 0.5], [0.0, 1.0, 0.0], [0.5, 0.0, 1.0]],
+                device=self.device,
+                dtype=dtype,
+            )
+            self.assertTrue(torch.allclose(mu_n, mu_n_expected, atol=1e-4))
+            self.assertTrue(torch.allclose(Cov_n, Cov_n_expected, atol=1e-4))
+
+    def test_norm_to_lognorm(self):
+        for dtype in (torch.float, torch.double):
+
+            # Test joint, independent
+            expmu = torch.tensor([1.0, 2.0, 3.0], device=self.device, dtype=dtype)
+            expdiag = torch.tensor([1.5, 2.0, 3], device=self.device, dtype=dtype)
+            mu = torch.log(expmu)
+            diag = torch.log(expdiag)
+            Cov = torch.diag_embed(diag)
+            mu_ln, Cov_ln = norm_to_lognorm(mu, Cov)
+            mu_ln_expected = expmu * torch.exp(0.5 * diag)
+            diag_ln_expected = torch.tensor(
+                [0.75, 8.0, 54.0], device=self.device, dtype=dtype
+            )
+            Cov_ln_expected = torch.diag_embed(diag_ln_expected)
+            self.assertTrue(torch.allclose(Cov_ln, Cov_ln_expected))
+            self.assertTrue(torch.allclose(mu_ln, mu_ln_expected))
+
+            # Test joint, correlated
+            Cov[0, 2] = 0.1
+            Cov[2, 0] = 0.1
+            mu_ln, Cov_ln = norm_to_lognorm(mu, Cov)
+            Cov_ln_expected[0, 2] = 0.669304
+            Cov_ln_expected[2, 0] = 0.669304
+            self.assertTrue(torch.allclose(Cov_ln, Cov_ln_expected))
+            self.assertTrue(torch.allclose(mu_ln, mu_ln_expected))
+
+            # Test marginal
+            mu = torch.tensor([-1.0, 0.0, 1.0], device=self.device, dtype=dtype)
+            v = torch.tensor([1.0, 2.0, 3.0], device=self.device, dtype=dtype)
+            var = 2 * (torch.log(v) - mu)
+            mu_ln = norm_to_lognorm_mean(mu, var)
+            var_ln = norm_to_lognorm_variance(mu, var)
+            mu_ln_expected = torch.tensor(
+                [1.0, 2.0, 3.0], device=self.device, dtype=dtype
+            )
+            var_ln_expected = (torch.exp(var) - 1) * mu_ln_expected ** 2
+            self.assertTrue(torch.allclose(mu_ln, mu_ln_expected))
+            self.assertTrue(torch.allclose(var_ln, var_ln_expected))
+
+    def test_round_trip(self):
+        for dtype in (torch.float, torch.double):
+            for batch_shape in ([], [2]):
+                mu = 5 + torch.rand(*batch_shape, 4, device=self.device, dtype=dtype)
+                a = 0.2 * torch.randn(
+                    *batch_shape, 4, 4, device=self.device, dtype=dtype
+                )
+                diag = 3.0 + 2 * torch.rand(
+                    *batch_shape, 4, device=self.device, dtype=dtype
+                )
+                Cov = a @ a.transpose(-1, -2) + torch.diag_embed(diag)
+                mu_n, Cov_n = lognorm_to_norm(mu, Cov)
+                mu_rt, Cov_rt = norm_to_lognorm(mu_n, Cov_n)
+                self.assertTrue(torch.allclose(mu_rt, mu, atol=1e-4))
+                self.assertTrue(torch.allclose(Cov_rt, Cov, atol=1e-4))

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 import warnings
 from unittest import mock
 
@@ -242,7 +243,7 @@ class TestOptimizeAcqf(BotorchTestCase):
 
 
 class TestOptimizeAcqfCyclic(BotorchTestCase):
-    @mock.patch("botorch.optim.optimize.optimize_acqf")
+    @mock.patch("botorch.optim.optimize.optimize_acqf")  # noqa: C901
     def test_optimize_acqf_cyclic(self, mock_optimize_acqf):
         num_restarts = 2
         raw_samples = 10
@@ -254,110 +255,105 @@ class TestOptimizeAcqfCyclic(BotorchTestCase):
             [torch.tensor([3]), torch.tensor([4]), torch.tensor(5)]
         ]
         mock_acq_function = MockAcquisitionFunction()
-        for q in [1, 3]:
-            for dtype in (torch.float, torch.double):
-                inequality_constraints[0] = [
-                    t.to(**tkwargs) for t in inequality_constraints[0]
+        for q, dtype in itertools.product([1, 3], (torch.float, torch.double)):
+            inequality_constraints[0] = [
+                t.to(**tkwargs) for t in inequality_constraints[0]
+            ]
+            mock_optimize_acqf.reset_mock()
+            tkwargs["dtype"] = dtype
+            bounds = bounds.to(**tkwargs)
+            candidate_rvs = []
+            acq_val_rvs = []
+            for cycle_j in range(num_cycles):
+                gcs_return_vals = [
+                    (torch.rand(1, 3, **tkwargs), torch.rand(1, **tkwargs))
+                    for _ in range(q)
                 ]
-                mock_optimize_acqf.reset_mock()
-                tkwargs["dtype"] = dtype
-                bounds = bounds.to(**tkwargs)
-                candidate_rvs = []
-                acq_val_rvs = []
-                for cycle_j in range(num_cycles):
-                    gcs_return_vals = [
-                        (torch.rand(1, 3, **tkwargs), torch.rand(1, **tkwargs))
-                        for _ in range(q)
-                    ]
-                    if cycle_j == 0:
-                        # return `q` candidates for first call
-                        candidate_rvs.append(
-                            torch.cat([rv[0] for rv in gcs_return_vals], dim=-2)
-                        )
-                        acq_val_rvs.append(torch.cat([rv[1] for rv in gcs_return_vals]))
-                    else:
-                        # return 1 candidate for subsequent calls
-                        for rv in gcs_return_vals:
-                            candidate_rvs.append(rv[0])
-                            acq_val_rvs.append(rv[1])
-                mock_optimize_acqf.side_effect = list(zip(candidate_rvs, acq_val_rvs))
-                orig_candidates = candidate_rvs[0].clone()
-                # wrap the set_X_pending method for checking that call arguments
-                with mock.patch.object(
-                    MockAcquisitionFunction,
-                    "set_X_pending",
-                    wraps=mock_acq_function.set_X_pending,
-                ) as mock_set_X_pending:
-                    candidates, acq_value = optimize_acqf_cyclic(
-                        acq_function=mock_acq_function,
-                        bounds=bounds,
-                        q=q,
-                        num_restarts=num_restarts,
-                        raw_samples=raw_samples,
-                        options=options,
-                        inequality_constraints=inequality_constraints,
-                        post_processing_func=rounding_func,
-                        cyclic_options={"maxiter": num_cycles},
+                if cycle_j == 0:
+                    # return `q` candidates for first call
+                    candidate_rvs.append(
+                        torch.cat([rv[0] for rv in gcs_return_vals], dim=-2)
                     )
-                    # check that X_pending is set correctly in cyclic optimization
-                    if q > 1:
-                        x_pending_call_args_list = mock_set_X_pending.call_args_list
-                        idxr = torch.ones(q, dtype=torch.bool, device=self.device)
-                        for i in range(len(x_pending_call_args_list) - 1):
-                            idxr[i] = 0
-                            self.assertTrue(
-                                torch.equal(
-                                    x_pending_call_args_list[i][0][0],
-                                    orig_candidates[idxr],
-                                )
-                            )
-                            idxr[i] = 1
-                            orig_candidates[i] = candidate_rvs[i + 1]
-                        # check reset to base_X_pendingg
-                        self.assertIsNone(x_pending_call_args_list[-1][0][0])
-                    else:
-                        mock_set_X_pending.assert_not_called()
-                # check final candidates
-                expected_candidates = (
-                    torch.cat(candidate_rvs[-q:], dim=0) if q > 1 else candidate_rvs[0]
+                    acq_val_rvs.append(torch.cat([rv[1] for rv in gcs_return_vals]))
+                else:
+                    # return 1 candidate for subsequent calls
+                    for rv in gcs_return_vals:
+                        candidate_rvs.append(rv[0])
+                        acq_val_rvs.append(rv[1])
+            mock_optimize_acqf.side_effect = list(zip(candidate_rvs, acq_val_rvs))
+            orig_candidates = candidate_rvs[0].clone()
+            # wrap the set_X_pending method for checking that call arguments
+            with mock.patch.object(
+                MockAcquisitionFunction,
+                "set_X_pending",
+                wraps=mock_acq_function.set_X_pending,
+            ) as mock_set_X_pending:
+                candidates, acq_value = optimize_acqf_cyclic(
+                    acq_function=mock_acq_function,
+                    bounds=bounds,
+                    q=q,
+                    num_restarts=num_restarts,
+                    raw_samples=raw_samples,
+                    options=options,
+                    inequality_constraints=inequality_constraints,
+                    post_processing_func=rounding_func,
+                    cyclic_options={"maxiter": num_cycles},
                 )
-                self.assertTrue(torch.equal(candidates, expected_candidates))
-                # check call arguments for optimize_acqf
-                call_args_list = mock_optimize_acqf.call_args_list
-                expected_call_args = {
-                    "acq_function": mock_acq_function,
-                    "bounds": bounds,
-                    "num_restarts": num_restarts,
-                    "raw_samples": raw_samples,
-                    "options": options,
-                    "inequality_constraints": inequality_constraints,
-                    "equality_constraints": None,
-                    "fixed_features": None,
-                    "post_processing_func": rounding_func,
-                    "return_best_only": True,
-                    "sequential": True,
-                }
-                orig_candidates = candidate_rvs[0].clone()
-                for i in range(len(call_args_list)):
-                    if i == 0:
-                        # first cycle
-                        expected_call_args.update(
-                            {"batch_initial_conditions": None, "q": q}
+                # check that X_pending is set correctly in cyclic optimization
+                if q > 1:
+                    x_pending_call_args_list = mock_set_X_pending.call_args_list
+                    idxr = torch.ones(q, dtype=torch.bool, device=self.device)
+                    for i in range(len(x_pending_call_args_list) - 1):
+                        idxr[i] = 0
+                        self.assertTrue(
+                            torch.equal(
+                                x_pending_call_args_list[i][0][0], orig_candidates[idxr]
+                            )
+                        )
+                        idxr[i] = 1
+                        orig_candidates[i] = candidate_rvs[i + 1]
+                    # check reset to base_X_pendingg
+                    self.assertIsNone(x_pending_call_args_list[-1][0][0])
+                else:
+                    mock_set_X_pending.assert_not_called()
+            # check final candidates
+            expected_candidates = (
+                torch.cat(candidate_rvs[-q:], dim=0) if q > 1 else candidate_rvs[0]
+            )
+            self.assertTrue(torch.equal(candidates, expected_candidates))
+            # check call arguments for optimize_acqf
+            call_args_list = mock_optimize_acqf.call_args_list
+            expected_call_args = {
+                "acq_function": mock_acq_function,
+                "bounds": bounds,
+                "num_restarts": num_restarts,
+                "raw_samples": raw_samples,
+                "options": options,
+                "inequality_constraints": inequality_constraints,
+                "equality_constraints": None,
+                "fixed_features": None,
+                "post_processing_func": rounding_func,
+                "return_best_only": True,
+                "sequential": True,
+            }
+            orig_candidates = candidate_rvs[0].clone()
+            for i in range(len(call_args_list)):
+                if i == 0:
+                    # first cycle
+                    expected_call_args.update(
+                        {"batch_initial_conditions": None, "q": q}
+                    )
+                else:
+                    expected_call_args.update(
+                        {"batch_initial_conditions": orig_candidates[i - 1 : i], "q": 1}
+                    )
+                    orig_candidates[i - 1] = candidate_rvs[i]
+                for k, v in call_args_list[i][1].items():
+                    if torch.is_tensor(v):
+                        self.assertTrue(torch.equal(expected_call_args[k], v))
+                    elif k == "acq_function":
+                        self.assertIsInstance(
+                            mock_acq_function, MockAcquisitionFunction
                         )
                     else:
-                        expected_call_args.update(
-                            {
-                                "batch_initial_conditions": orig_candidates[i - 1 : i],
-                                "q": 1,
-                            }
-                        )
-                        orig_candidates[i - 1] = candidate_rvs[i]
-                    for k, v in call_args_list[i][1].items():
-                        if torch.is_tensor(v):
-                            self.assertTrue(torch.equal(expected_call_args[k], v))
-                        elif k == "acq_function":
-                            self.assertIsInstance(
-                                mock_acq_function, MockAcquisitionFunction
-                            )
-                        else:
-                            self.assertEqual(expected_call_args[k], v)
+                        self.assertEqual(expected_call_args[k], v)

--- a/test/optim/test_utils.py
+++ b/test/optim/test_utils.py
@@ -164,7 +164,7 @@ class TestFixFeatures(BotorchTestCase):
         )
 
 
-class testGetExtraMllArgs(BotorchTestCase):
+class TestGetExtraMllArgs(BotorchTestCase):
     def test_get_extra_mll_args(self):
         train_X = torch.rand(3, 5)
         train_Y = torch.rand(3, 1)
@@ -194,7 +194,7 @@ class testGetExtraMllArgs(BotorchTestCase):
             _get_extra_mll_args(mll=unsupported_mll)
 
 
-class testExpandBounds(BotorchTestCase):
+class TestExpandBounds(BotorchTestCase):
     def test_expand_bounds(self):
         X = torch.zeros(2, 3)
         expected_bounds = torch.zeros(1, 3)

--- a/test/posteriors/test_deterministic.py
+++ b/test/posteriors/test_deterministic.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
+
 import torch
 from botorch.posteriors.deterministic import DeterministicPosterior
 from botorch.utils.testing import BotorchTestCase
@@ -11,24 +13,25 @@ from botorch.utils.testing import BotorchTestCase
 
 class TestDeterministicPosterior(BotorchTestCase):
     def test_DeterministicPosterior(self):
-        for dtype in (torch.float, torch.double):
-            for shape in ((3, 2), (2, 3, 1)):
-                values = torch.randn(*shape, device=self.device, dtype=dtype)
-                p = DeterministicPosterior(values)
-                self.assertEqual(p.device, self.device)
-                self.assertEqual(p.dtype, dtype)
-                self.assertEqual(p.event_shape, values.shape)
-                self.assertTrue(torch.equal(p.mean, values))
-                self.assertTrue(torch.equal(p.variance, torch.zeros_like(values)))
-                # test sampling
-                samples = p.rsample()
-                self.assertTrue(torch.equal(samples, values.unsqueeze(0)))
-                samples = p.rsample(torch.Size([2]))
-                self.assertTrue(torch.equal(samples, values.expand(2, *values.shape)))
-                base_samples = torch.randn(2, *shape, device=self.device, dtype=dtype)
-                samples = p.rsample(torch.Size([2]), base_samples)
-                self.assertTrue(torch.equal(samples, values.expand(2, *values.shape)))
-                with self.assertRaises(RuntimeError):
-                    samples = p.rsample(
-                        torch.Size([2]), base_samples.expand(3, *base_samples.shape)
-                    )
+        for shape, dtype in itertools.product(
+            ((3, 2), (2, 3, 1)), (torch.float, torch.double)
+        ):
+            values = torch.randn(*shape, device=self.device, dtype=dtype)
+            p = DeterministicPosterior(values)
+            self.assertEqual(p.device, self.device)
+            self.assertEqual(p.dtype, dtype)
+            self.assertEqual(p.event_shape, values.shape)
+            self.assertTrue(torch.equal(p.mean, values))
+            self.assertTrue(torch.equal(p.variance, torch.zeros_like(values)))
+            # test sampling
+            samples = p.rsample()
+            self.assertTrue(torch.equal(samples, values.unsqueeze(0)))
+            samples = p.rsample(torch.Size([2]))
+            self.assertTrue(torch.equal(samples, values.expand(2, *values.shape)))
+            base_samples = torch.randn(2, *shape, device=self.device, dtype=dtype)
+            samples = p.rsample(torch.Size([2]), base_samples)
+            self.assertTrue(torch.equal(samples, values.expand(2, *values.shape)))
+            with self.assertRaises(RuntimeError):
+                samples = p.rsample(
+                    torch.Size([2]), base_samples.expand(3, *base_samples.shape)
+                )

--- a/test/posteriors/test_transformed.py
+++ b/test/posteriors/test_transformed.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from botorch.posteriors.gpytorch import GPyTorchPosterior
+from botorch.posteriors.transformed import TransformedPosterior
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
+from gpytorch.lazy.non_lazy_tensor import lazify
+
+
+class TestTransformedPosterior(BotorchTestCase):
+    def test_transformed_posterior(self):
+        for dtype in (torch.float, torch.double):
+            for m in (1, 2):
+                shape = torch.Size([3, m])
+                mean = torch.rand(shape, dtype=dtype, device=self.device)
+                variance = 1 + torch.rand(shape, dtype=dtype, device=self.device)
+                if m == 1:
+                    covar = torch.diag_embed(variance.squeeze(-1))
+                    mvn = MultivariateNormal(mean.squeeze(-1), lazify(covar))
+                else:
+                    covar = torch.diag_embed(variance.view(*variance.shape[:-2], -1))
+                    mvn = MultitaskMultivariateNormal(mean, lazify(covar))
+                p_base = GPyTorchPosterior(mvn=mvn)
+                p_tf = TransformedPosterior(  # dummy transforms
+                    posterior=p_base,
+                    sample_transform=lambda s: s + 2,
+                    mean_transform=lambda m, v: 2 * m + v,
+                    variance_transform=lambda m, v: m + 2 * v,
+                )
+                # mean, variance
+                self.assertEqual(p_tf.device.type, self.device.type)
+                self.assertTrue(p_tf.dtype == dtype)
+                self.assertEqual(p_tf.event_shape, shape)
+                self.assertTrue(torch.equal(p_tf.mean, 2 * mean + variance))
+                self.assertTrue(torch.equal(p_tf.variance, mean + 2 * variance))
+                # rsample
+                samples = p_tf.rsample()
+                self.assertEqual(samples.shape, torch.Size([1]) + shape)
+                samples = p_tf.rsample(sample_shape=torch.Size([4]))
+                self.assertEqual(samples.shape, torch.Size([4]) + shape)
+                samples2 = p_tf.rsample(sample_shape=torch.Size([4, 2]))
+                self.assertEqual(samples2.shape, torch.Size([4, 2]) + shape)
+                # rsample w/ base samples
+                base_samples = torch.randn(4, *shape, device=self.device, dtype=dtype)
+                # incompatible shapes
+                with self.assertRaises(RuntimeError):
+                    p_tf.rsample(
+                        sample_shape=torch.Size([3]), base_samples=base_samples
+                    )
+                # make sure sample transform is applied correctly
+                samples_base = p_base.rsample(
+                    sample_shape=torch.Size([4]), base_samples=base_samples
+                )
+                samples_tf = p_tf.rsample(
+                    sample_shape=torch.Size([4]), base_samples=base_samples
+                )
+                self.assertTrue(torch.equal(samples_tf, samples_base + 2))
+                # check error handling
+                p_tf_2 = TransformedPosterior(
+                    posterior=p_base, sample_transform=lambda s: s + 2
+                )
+                with self.assertRaises(NotImplementedError):
+                    p_tf_2.mean
+                with self.assertRaises(NotImplementedError):
+                    p_tf_2.variance

--- a/test/test_cross_validation.py
+++ b/test/test_cross_validation.py
@@ -4,118 +4,78 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import math
+import itertools
 import warnings
 
 import torch
 from botorch.cross_validation import batch_cross_validation, gen_loo_cv_folds
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
-from botorch.utils.testing import BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, _get_random_data
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
-
-
-def _get_random_data(batch_shape, num_outputs, n, device, dtype):
-    train_x = torch.linspace(0, 0.95, n, device=device, dtype=dtype).unsqueeze(
-        -1
-    ) + 0.05 * torch.rand(n, 1, device=device, dtype=dtype).repeat(
-        batch_shape + torch.Size([1, 1])
-    )
-    train_y = torch.sin(train_x * (2 * math.pi)) + 0.2 * torch.randn(
-        n, num_outputs, device=device, dtype=dtype
-    ).repeat(batch_shape + torch.Size([1, 1]))
-
-    if num_outputs == 1:
-        train_y = train_y.squeeze(-1)
-    return train_x, train_y
 
 
 class TestFitBatchCrossValidation(BotorchTestCase):
     def test_single_task_batch_cv(self):
         n = 10
-        for batch_shape in (torch.Size([]), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for dtype in (torch.double, torch.float):
-                    train_X, train_Y = _get_random_data(
-                        batch_shape=batch_shape,
-                        num_outputs=num_outputs,
-                        n=n,
-                        device=self.device,
-                        dtype=dtype,
-                    )
-                    train_Yvar = torch.full_like(train_Y, 0.01)
-                    noiseless_cv_folds = gen_loo_cv_folds(
-                        train_X=train_X, train_Y=train_Y
-                    )
-                    # check shapes
-                    expected_shape_train_X = batch_shape + torch.Size(
-                        [n, n - 1, train_X.shape[-1]]
-                    )
-                    expected_shape_test_X = batch_shape + torch.Size(
-                        [n, 1, train_X.shape[-1]]
-                    )
-                    self.assertEqual(
-                        noiseless_cv_folds.train_X.shape, expected_shape_train_X
-                    )
-                    self.assertEqual(
-                        noiseless_cv_folds.test_X.shape, expected_shape_test_X
-                    )
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            train_X, train_Y = _get_random_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, n=n, **tkwargs
+            )
+            if num_outputs == 1:
+                train_Y = train_Y.squeeze(-1)
+            train_Yvar = torch.full_like(train_Y, 0.01)
+            noiseless_cv_folds = gen_loo_cv_folds(train_X=train_X, train_Y=train_Y)
+            # check shapes
+            expected_shape_train_X = batch_shape + torch.Size(
+                [n, n - 1, train_X.shape[-1]]
+            )
+            expected_shape_test_X = batch_shape + torch.Size([n, 1, train_X.shape[-1]])
+            self.assertEqual(noiseless_cv_folds.train_X.shape, expected_shape_train_X)
+            self.assertEqual(noiseless_cv_folds.test_X.shape, expected_shape_test_X)
 
-                    expected_shape_train_Y = batch_shape + torch.Size(
-                        [n, n - 1, num_outputs]
-                    )
-                    expected_shape_test_Y = batch_shape + torch.Size(
-                        [n, 1, num_outputs]
-                    )
+            expected_shape_train_Y = batch_shape + torch.Size([n, n - 1, num_outputs])
+            expected_shape_test_Y = batch_shape + torch.Size([n, 1, num_outputs])
 
-                    self.assertEqual(
-                        noiseless_cv_folds.train_Y.shape, expected_shape_train_Y
-                    )
-                    self.assertEqual(
-                        noiseless_cv_folds.test_Y.shape, expected_shape_test_Y
-                    )
-                    self.assertIsNone(noiseless_cv_folds.train_Yvar)
-                    self.assertIsNone(noiseless_cv_folds.test_Yvar)
-                    # Test SingleTaskGP
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings("ignore", category=OptimizationWarning)
-                        cv_results = batch_cross_validation(
-                            model_cls=SingleTaskGP,
-                            mll_cls=ExactMarginalLogLikelihood,
-                            cv_folds=noiseless_cv_folds,
-                            fit_args={"options": {"maxiter": 1}},
-                        )
-                    expected_shape = batch_shape + torch.Size([n, 1, num_outputs])
-                    self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
-                    self.assertEqual(cv_results.observed_Y.shape, expected_shape)
+            self.assertEqual(noiseless_cv_folds.train_Y.shape, expected_shape_train_Y)
+            self.assertEqual(noiseless_cv_folds.test_Y.shape, expected_shape_test_Y)
+            self.assertIsNone(noiseless_cv_folds.train_Yvar)
+            self.assertIsNone(noiseless_cv_folds.test_Yvar)
+            # Test SingleTaskGP
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=OptimizationWarning)
+                cv_results = batch_cross_validation(
+                    model_cls=SingleTaskGP,
+                    mll_cls=ExactMarginalLogLikelihood,
+                    cv_folds=noiseless_cv_folds,
+                    fit_args={"options": {"maxiter": 1}},
+                )
+            expected_shape = batch_shape + torch.Size([n, 1, num_outputs])
+            self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
+            self.assertEqual(cv_results.observed_Y.shape, expected_shape)
 
-                    # Test FixedNoiseGP
-                    noisy_cv_folds = gen_loo_cv_folds(
-                        train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar
-                    )
-                    # check shapes
-                    self.assertEqual(
-                        noisy_cv_folds.train_X.shape, expected_shape_train_X
-                    )
-                    self.assertEqual(noisy_cv_folds.test_X.shape, expected_shape_test_X)
-                    self.assertEqual(
-                        noisy_cv_folds.train_Y.shape, expected_shape_train_Y
-                    )
-                    self.assertEqual(noisy_cv_folds.test_Y.shape, expected_shape_test_Y)
-                    self.assertEqual(
-                        noisy_cv_folds.train_Yvar.shape, expected_shape_train_Y
-                    )
-                    self.assertEqual(
-                        noisy_cv_folds.test_Yvar.shape, expected_shape_test_Y
-                    )
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings("ignore", category=OptimizationWarning)
-                        cv_results = batch_cross_validation(
-                            model_cls=FixedNoiseGP,
-                            mll_cls=ExactMarginalLogLikelihood,
-                            cv_folds=noisy_cv_folds,
-                            fit_args={"options": {"maxiter": 1}},
-                        )
-                    self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
-                    self.assertEqual(cv_results.observed_Y.shape, expected_shape)
-                    self.assertEqual(cv_results.observed_Y.shape, expected_shape)
+            # Test FixedNoiseGP
+            noisy_cv_folds = gen_loo_cv_folds(
+                train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar
+            )
+            # check shapes
+            self.assertEqual(noisy_cv_folds.train_X.shape, expected_shape_train_X)
+            self.assertEqual(noisy_cv_folds.test_X.shape, expected_shape_test_X)
+            self.assertEqual(noisy_cv_folds.train_Y.shape, expected_shape_train_Y)
+            self.assertEqual(noisy_cv_folds.test_Y.shape, expected_shape_test_Y)
+            self.assertEqual(noisy_cv_folds.train_Yvar.shape, expected_shape_train_Y)
+            self.assertEqual(noisy_cv_folds.test_Yvar.shape, expected_shape_test_Y)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=OptimizationWarning)
+                cv_results = batch_cross_validation(
+                    model_cls=FixedNoiseGP,
+                    mll_cls=ExactMarginalLogLikelihood,
+                    cv_folds=noisy_cv_folds,
+                    fit_args={"options": {"maxiter": 1}},
+                )
+            self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
+            self.assertEqual(cv_results.observed_Y.shape, expected_shape)
+            self.assertEqual(cv_results.observed_Y.shape, expected_shape)

--- a/test/utils/test_sampling.py
+++ b/test/utils/test_sampling.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 import warnings
 
 import torch
@@ -27,26 +28,25 @@ class TestConstructBaseSamples(BotorchTestCase):
             {"batch": [1], "output": [5, 3], "sample": [5, 6]},
             {"batch": [2, 3], "output": [2, 3], "sample": [5]},
         ]
-        for tshape in test_shapes:
+        for tshape, qmc, seed, dtype in itertools.product(
+            test_shapes, (False, True), (None, 1234), (torch.float, torch.double)
+        ):
             batch_shape = torch.Size(tshape["batch"])
             output_shape = torch.Size(tshape["output"])
             sample_shape = torch.Size(tshape["sample"])
             expected_shape = sample_shape + batch_shape + output_shape
-            for dtype in (torch.float, torch.double):
-                for qmc in (False, True):
-                    for seed in (None, 1234):
-                        samples = construct_base_samples(
-                            batch_shape=batch_shape,
-                            output_shape=output_shape,
-                            sample_shape=sample_shape,
-                            qmc=qmc,
-                            seed=seed,
-                            device=self.device,
-                            dtype=dtype,
-                        )
-                        self.assertEqual(samples.shape, expected_shape)
-                        self.assertEqual(samples.device.type, self.device.type)
-                        self.assertEqual(samples.dtype, dtype)
+            samples = construct_base_samples(
+                batch_shape=batch_shape,
+                output_shape=output_shape,
+                sample_shape=sample_shape,
+                qmc=qmc,
+                seed=seed,
+                device=self.device,
+                dtype=dtype,
+            )
+            self.assertEqual(samples.shape, expected_shape)
+            self.assertEqual(samples.device.type, self.device.type)
+            self.assertEqual(samples.dtype, dtype)
         # check that warning is issued if dimensionality is too large
         with warnings.catch_warnings(record=True) as w, settings.debug(True):
             construct_base_samples(
@@ -67,83 +67,81 @@ class TestConstructBaseSamples(BotorchTestCase):
             cov = torch.eye(2, device=self.device, dtype=dtype)
             mvn = MultivariateNormal(mean=mean, covariance_matrix=cov)
             posterior = GPyTorchPosterior(mvn=mvn)
-            for sample_shape in (torch.Size([5]), torch.Size([5, 3])):
-                for qmc in (False, True):
-                    for seed in (None, 1234):
-                        expected_shape = sample_shape + torch.Size([2, 1])
-                        samples = construct_base_samples_from_posterior(
-                            posterior=posterior,
-                            sample_shape=sample_shape,
-                            qmc=qmc,
-                            seed=seed,
-                        )
-                        self.assertEqual(samples.shape, expected_shape)
-                        self.assertEqual(samples.device.type, self.device.type)
-                        self.assertEqual(samples.dtype, dtype)
+            for sample_shape, qmc, seed in itertools.product(
+                (torch.Size([5]), torch.Size([5, 3])), (False, True), (None, 1234)
+            ):
+                expected_shape = sample_shape + torch.Size([2, 1])
+                samples = construct_base_samples_from_posterior(
+                    posterior=posterior, sample_shape=sample_shape, qmc=qmc, seed=seed
+                )
+                self.assertEqual(samples.shape, expected_shape)
+                self.assertEqual(samples.device.type, self.device.type)
+                self.assertEqual(samples.dtype, dtype)
             # single-output, batch mode
             mean = torch.zeros(2, 2, device=self.device, dtype=dtype)
             cov = torch.eye(2, device=self.device, dtype=dtype).expand(2, 2, 2)
             mvn = MultivariateNormal(mean=mean, covariance_matrix=cov)
             posterior = GPyTorchPosterior(mvn=mvn)
-            for sample_shape in (torch.Size([5]), torch.Size([5, 3])):
-                for qmc in (False, True):
-                    for seed in (None, 1234):
-                        for collapse_batch_dims in (False, True):
-                            if collapse_batch_dims:
-                                expected_shape = sample_shape + torch.Size([1, 2, 1])
-                            else:
-                                expected_shape = sample_shape + torch.Size([2, 2, 1])
-                            samples = construct_base_samples_from_posterior(
-                                posterior=posterior,
-                                sample_shape=sample_shape,
-                                qmc=qmc,
-                                collapse_batch_dims=collapse_batch_dims,
-                                seed=seed,
-                            )
-                            self.assertEqual(samples.shape, expected_shape)
-                            self.assertEqual(samples.device.type, self.device.type)
-                            self.assertEqual(samples.dtype, dtype)
+            for sample_shape, qmc, seed, collapse_batch_dims in itertools.product(
+                (torch.Size([5]), torch.Size([5, 3])),
+                (False, True),
+                (None, 1234),
+                (False, True),
+            ):
+                if collapse_batch_dims:
+                    expected_shape = sample_shape + torch.Size([1, 2, 1])
+                else:
+                    expected_shape = sample_shape + torch.Size([2, 2, 1])
+                samples = construct_base_samples_from_posterior(
+                    posterior=posterior,
+                    sample_shape=sample_shape,
+                    qmc=qmc,
+                    collapse_batch_dims=collapse_batch_dims,
+                    seed=seed,
+                )
+                self.assertEqual(samples.shape, expected_shape)
+                self.assertEqual(samples.device.type, self.device.type)
+                self.assertEqual(samples.dtype, dtype)
             # multi-output
             mean = torch.zeros(2, 2, device=self.device, dtype=dtype)
             cov = torch.eye(4, device=self.device, dtype=dtype)
             mtmvn = MultitaskMultivariateNormal(mean=mean, covariance_matrix=cov)
             posterior = GPyTorchPosterior(mvn=mtmvn)
-            for sample_shape in (torch.Size([5]), torch.Size([5, 3])):
-                for qmc in (False, True):
-                    for seed in (None, 1234):
-                        expected_shape = sample_shape + torch.Size([2, 2])
-                        samples = construct_base_samples_from_posterior(
-                            posterior=posterior,
-                            sample_shape=sample_shape,
-                            qmc=qmc,
-                            seed=seed,
-                        )
-                        self.assertEqual(samples.shape, expected_shape)
-                        self.assertEqual(samples.device.type, self.device.type)
-                        self.assertEqual(samples.dtype, dtype)
+            for sample_shape, qmc, seed in itertools.product(
+                (torch.Size([5]), torch.Size([5, 3])), (False, True), (None, 1234)
+            ):
+                expected_shape = sample_shape + torch.Size([2, 2])
+                samples = construct_base_samples_from_posterior(
+                    posterior=posterior, sample_shape=sample_shape, qmc=qmc, seed=seed
+                )
+                self.assertEqual(samples.shape, expected_shape)
+                self.assertEqual(samples.device.type, self.device.type)
+                self.assertEqual(samples.dtype, dtype)
             # multi-output, batch mode
             mean = torch.zeros(2, 2, 2, device=self.device, dtype=dtype)
             cov = torch.eye(4, device=self.device, dtype=dtype).expand(2, 4, 4)
             mtmvn = MultitaskMultivariateNormal(mean=mean, covariance_matrix=cov)
             posterior = GPyTorchPosterior(mvn=mtmvn)
-            for sample_shape in (torch.Size([5]), torch.Size([5, 3])):
-                for qmc in (False, True):
-                    for seed in (None, 1234):
-                        for collapse_batch_dims in (False, True):
-                            if collapse_batch_dims:
-                                expected_shape = sample_shape + torch.Size([1, 2, 2])
-                            else:
-                                expected_shape = sample_shape + torch.Size([2, 2, 2])
-                            samples = construct_base_samples_from_posterior(
-                                posterior=posterior,
-                                sample_shape=sample_shape,
-                                qmc=qmc,
-                                collapse_batch_dims=collapse_batch_dims,
-                                seed=seed,
-                            )
-                            self.assertEqual(samples.shape, expected_shape)
-                            self.assertEqual(samples.device.type, self.device.type)
-                            self.assertEqual(samples.dtype, dtype)
+            for sample_shape, qmc, seed, collapse_batch_dims in itertools.product(
+                (torch.Size([5]), torch.Size([5, 3])),
+                (False, True),
+                (None, 1234),
+                (False, True),
+            ):
+                if collapse_batch_dims:
+                    expected_shape = sample_shape + torch.Size([1, 2, 2])
+                else:
+                    expected_shape = sample_shape + torch.Size([2, 2, 2])
+                samples = construct_base_samples_from_posterior(
+                    posterior=posterior,
+                    sample_shape=sample_shape,
+                    qmc=qmc,
+                    collapse_batch_dims=collapse_batch_dims,
+                    seed=seed,
+                )
+                self.assertEqual(samples.shape, expected_shape)
+                self.assertEqual(samples.device.type, self.device.type)
+                self.assertEqual(samples.dtype, dtype)
 
 
 class TestManualSeed(BotorchTestCase):

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -12,6 +12,7 @@ from botorch.utils.transforms import (
     gpt_posterior_settings,
     match_batch_shape,
     normalize,
+    normalize_indices,
     squeeze_last_dim,
     standardize,
     t_batch_mode_transform,
@@ -181,6 +182,23 @@ class TestMatchBatchShape(BotorchTestCase):
         Y = torch.rand(4, 3, 3, 2)
         with self.assertRaises(RuntimeError):
             match_batch_shape(X, Y)
+
+
+class TorchNormalizeIndices(BotorchTestCase):
+    def test_normalize_indices(self):
+        self.assertIsNone(normalize_indices(None, 3))
+        indices = [0, 2]
+        nlzd_indices = normalize_indices(indices, 3)
+        self.assertEqual(nlzd_indices, indices)
+        nlzd_indices = normalize_indices(indices, 4)
+        self.assertEqual(nlzd_indices, indices)
+        indices = [0, -1]
+        nlzd_indices = normalize_indices(indices, 3)
+        self.assertEqual(nlzd_indices, [0, 2])
+        with self.assertRaises(ValueError):
+            nlzd_indices = normalize_indices([3], 3)
+        with self.assertRaises(ValueError):
+            nlzd_indices = normalize_indices([-4], 3)
 
 
 class TestSqueezeLastDim(BotorchTestCase):


### PR DESCRIPTION
# RFC: Transforms in BoTorch

**tldr:** Here's a proposal for simplifying the transform business in BoTorch. 

#### Why:
1. For multi-fidelity optimization, we need to make sure that outcomes and costs are on a comparable scale. This is currently ad-hoc, opaque, and has led to many issues in the past.
2. A stateful transform that keeps track of data-dependent parameters whose inverse (if it exists) can be automatically applied, simplifying things and reducing potential for error. 
2. Often it makes sense to model costs using log-transforms (this ensures the samples/predictions are positive, and it also means that the noise is modeled as multiplicative rather than additive).


#### Why not use Ax transforms for this?
1. Ax transforms are more general in nature (including one-hot encoding etc) and work with all model types. A lot of these bells and whistles are not needed for BoTorch.
2. Ax transforms are slow b/c they loop over each individual datapoint. This is fine for constructing models, plotting etc., but not fast enough for acquisition function optimization.
3. We want to differentiate through the transformations using autograd. The Ax transforms cannot do this.

### Proposed Design

**Outcome Transforms**

- Outcome transforms are `torch.nn.Module` objects that implement a `forward` pass on the input tuple `Y, Yvar`. 
    - When in `train` mode, passing data through the transform (thus calling `forward` under the hood) populates internal state (if applicable, e.g. means & standard errors for standardization) and performs the transform. This is similar to `torch`'s `BatchNormXd` behavior, but handles general batch shapes. 
    - When in `eval` mode, passing data through the transform only applies the transform and does not change internal state.

- Transforms have an `untransform` method that operates on a tuple `Y, Yvar`, doing the obvious thing.
- Transforms have an `untransform_posterior` method that operates on `Posterior` objects. This transforms the posterior back to the original scale.
    - If the posterior is a `GPyTorchPosterior` (i.e. a [MT]MVN) and the transformation is affine (in particular standardize), this posterior is simply another `GPyTorchPosterior` with appropriately scaled mean/covariance
    - If the transformation is non-linear, then the untransformed posterior implements the standard Posterior API - in the simplest case this is a lightweight `TransformedPosterior` wrapper that keeps the original posterior, and applies `untransform` to the samples from that posterior in `rsample`.
    - The (optional) `mean` and `variance` properties provided by the posterior can be computed from the base posterior e.g. using the delta method.


**Input Transforms**

Input transforms are very similar to outcome transforms. Since we can usually work in the transformed space since we don't have to worry about proper relative scaling during acquisition function optimization, these are mostly for convenience and should probably not be evaluated during acquisition function optimization. 


### TODO:

Currently the transforms exist somewhat in a vacuum. There is an example in the demo notebook for how this could be achieved more generally. We will want to think a little harder what makes the most sense for this though. One option would be to have a pytorchic `register_outcome_transform` method on the `Model` that then does the proper thing in the base class. 


#### Demo notebook:
[botorch_transforms_demo.ipynb.txt](https://github.com/pytorch/botorch/files/3860242/botorch_transforms_demo.ipynb.txt)

