### PR TITLE
Add subset_output functionality to (some) models

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -55,6 +55,18 @@ class Model(Module, ABC):
         cls_name = self.__class__.__name__
         raise NotImplementedError(f"{cls_name} does not define num_outputs property")
 
+    def subset_output(self, idcs: List[int]) -> "Model":
+        r"""Subset the model along the output dimension.
+
+        Args:
+            idcs: The output indices to subset the model to.
+
+        Returns:
+            A `Model` object of the same type and with the same parameters as
+            the current model, subset to the specified output indices.
+        """
+        raise NotImplementedError
+
     def condition_on_observations(self, X: Tensor, Y: Tensor, **kwargs: Any) -> "Model":
         r"""Condition the model on new observations.
 

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -8,7 +8,8 @@ r"""
 Model List GP Regression models.
 """
 
-from typing import Any
+from copy import deepcopy
+from typing import Any, List
 
 from gpytorch.models import IndependentModelList
 from torch import Tensor
@@ -89,3 +90,14 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
         else:
             kwargs_ = kwargs
         return super().get_fantasy_model(inputs, targets, **kwargs_)
+
+    def subset_output(self, idcs: List[int]) -> "ModelListGP":
+        r"""Subset the model along the output dimension.
+
+        Args:
+            idcs: The output indices to subset the model to.
+
+        Returns:
+            The current model, subset to the specified output indices.
+        """
+        return self.__class__(*[deepcopy(self.models[i]) for i in idcs])

--- a/test/models/test_deterministic.py
+++ b/test/models/test_deterministic.py
@@ -39,6 +39,11 @@ class TestDeterministicModels(BotorchTestCase):
         self.assertEqual(model.num_outputs, 2)
         p = model.posterior(X, output_indices=[0])
         self.assertTrue(torch.equal(p.mean, X[..., [0]]))
+        # test subset output
+        subset_model = model.subset_output([0])
+        self.assertIsInstance(subset_model, GenericDeterministicModel)
+        p_sub = subset_model.posterior(X)
+        self.assertTrue(torch.equal(p_sub.mean, X[..., [0]]))
 
     def test_AffineDeterministicModel(self):
         # test error on bad shape of a
@@ -65,3 +70,10 @@ class TestDeterministicModels(BotorchTestCase):
             p = model.posterior(X)
             mean_exp = model.b + (X.unsqueeze(-1) * a).sum(dim=-2)
             self.assertTrue(torch.equal(p.mean, mean_exp))
+        # test subset output
+        X = torch.rand(4, 3)
+        subset_model = model.subset_output([0])
+        self.assertIsInstance(subset_model, AffineDeterministicModel)
+        p = model.posterior(X)
+        p_sub = subset_model.posterior(X)
+        self.assertTrue(torch.equal(p_sub.mean, p.mean[..., [0]]))

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -116,6 +116,9 @@ class TestGPyTorchModel(BotorchTestCase):
             )
             self.assertIsInstance(cm, SimpleGPyTorchModel)
             self.assertEqual(cm.train_targets.shape, torch.Size([7]))
+            # test subset_output
+            with self.assertRaises(NotImplementedError):
+                model.subset_output([0])
             # test fantasize
             sampler = SobolQMCNormalSampler(num_samples=2)
             cm = model.fantasize(torch.rand(2, 1, **tkwargs), sampler=sampler)
@@ -191,6 +194,9 @@ class TestBatchedMultiOutputGPyTorchModel(BotorchTestCase):
             )
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertEqual(posterior.mean.shape, torch.Size([2, 2]))
+            # test subset_output
+            with self.assertRaises(NotImplementedError):
+                model.subset_output([0])
             # test conditioning on observations
             cm = model.condition_on_observations(
                 torch.rand(2, 1, **tkwargs), torch.rand(2, 2, **tkwargs)

--- a/test/models/test_model.py
+++ b/test/models/test_model.py
@@ -24,3 +24,5 @@ class TestBaseModel(BotorchTestCase):
             model.condition_on_observations(None, None)
         with self.assertRaises(NotImplementedError):
             model.num_outputs
+        with self.assertRaises(NotImplementedError):
+            model.subset_output([0])

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -93,6 +93,15 @@ class TestModelListGP(BotorchTestCase):
                     mll, options={"maxiter": 1}, max_retries=1, sequential=False
                 )
 
+            # test subset outputs
+            subset_model = model.subset_output([1])
+            self.assertIsInstance(subset_model, ModelListGP)
+            self.assertEqual(len(subset_model.models), 1)
+            sd_subset = subset_model.models[0].state_dict()
+            sd = model.models[1].state_dict()
+            self.assertTrue(set(sd_subset.keys()) == set(sd.keys()))
+            self.assertTrue(all(torch.equal(v, sd[k]) for k, v in sd_subset.items()))
+
             # test posterior
             test_x = torch.tensor([[0.25], [0.75]], **tkwargs)
             posterior = model.posterior(test_x)


### PR DESCRIPTION
Summary:
In some cases we want to be able to subset models along the output dimension.
For instance, if we fit a multi-output model with a number of metrics, we may want to optimize an acquisition function with an objective that only involves a subset of the
outputs. By subsetting the model prior to that, we can save a lot of compute.

This diff adds a `subset_output` function to the model API. Calling this on a model with a list of indices will return a new model object that is restricted to the desired outputs.

For some models (e.g `AffineDeterministicModel` or `ModelListGP`) the implementation is trivial. For others it's a little more involved but doable.The main challenge is with things like passing in generic covariance modules - we really don't have any way of knowing what dimensions of the respective buffers and parameters we need to subset / rescale in this case.

Differential Revision: D18668985

