### PR TITLE
Clean up tests

### DIFF
--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import math
 import warnings
 from collections import OrderedDict
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from unittest import TestCase
 
 import torch
@@ -179,3 +180,25 @@ class MockAcquisitionFunction:
 
     def set_X_pending(self, X_pending: Optional[Tensor] = None):
         self.X_pending = X_pending
+
+
+def _get_random_data(
+    batch_shape: torch.Size, num_outputs: int, n: int = 10, **tkwargs
+) -> Tuple[Tensor, Tensor]:
+    r"""Generate random data for testing pursposes.
+
+    Args:
+        batch_shape: The batch shape of the data.
+        num_outputs: The number of outputs.
+        n: The number of data points.
+        tkwargs: `device` and `dtype` tensor constructor kwargs.
+
+    Returns:
+        A tuple `(train_X, train_Y)` with randomly generated training data.
+    """
+    rep_shape = batch_shape + torch.Size([1, 1])
+    train_x = torch.linspace(0, 0.95, n, **tkwargs).unsqueeze(-1)
+    train_x = train_x + 0.05 * torch.rand(n, 1, **tkwargs).repeat(rep_shape)
+    train_y = torch.sin(train_x * (2 * math.pi))
+    train_y = train_y + 0.2 * torch.randn(n, num_outputs, **tkwargs).repeat(rep_shape)
+    return train_x, train_y

--- a/test/acquisition/test_max_value_entropy_search.py
+++ b/test/acquisition/test_max_value_entropy_search.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# from unittest import mock
-
 from typing import Callable
 from unittest import mock
 
@@ -136,9 +134,6 @@ class TestMaxValueEntropySearch(BotorchTestCase):
 
 class MESMockModel(Model):
     r"""Mock object that implements dummy methods and feeds through specified outputs"""
-
-    def __init__(self) -> None:
-        super(Model, self).__init__()
 
     def posterior(self, X: Tensor, observation_noise: bool = False) -> MockPosterior:
         m_shape = X.shape[:-1]

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 from unittest import mock
 
 import torch
@@ -350,101 +351,81 @@ class TestPruneInferiorPoints(BotorchTestCase):
 
 class TestFidelityUtils(BotorchTestCase):
     def test_project_to_target_fidelity(self):
-        for dtype in (torch.float, torch.double):
-            for batch_shape in ([], [2]):
-                X = torch.rand(*batch_shape, 3, 4, device=self.device, dtype=dtype)
-                # test default behavior
-                X_proj = project_to_target_fidelity(X)
-                ones = torch.ones(*X.shape[:-1], 1, device=self.device, dtype=dtype)
-                self.assertTrue(torch.equal(X_proj[..., :, [-1]], ones))
-                self.assertTrue(torch.equal(X_proj[..., :-1], X[..., :-1]))
-                # test custom target fidelity
-                target_fids = {2: 0.5}
-                X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
-                self.assertTrue(torch.equal(X_proj[..., :, [2]], 0.5 * ones))
-                # test multiple target fidelities
-                target_fids = {2: 0.5, 0: 0.1}
-                X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
-                self.assertTrue(torch.equal(X_proj[..., :, [0]], 0.1 * ones))
-                self.assertTrue(torch.equal(X_proj[..., :, [2]], 0.5 * ones))
-                # test gradients
-                X.requires_grad_(True)
-                X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
-                out = (X_proj ** 2).sum()
-                out.backward()
-                self.assertTrue(torch.all(X.grad[..., [0, 2]] == 0))
-                self.assertTrue(torch.equal(X.grad[..., [1, 3]], 2 * X[..., [1, 3]]))
+        for batch_shape, dtype in itertools.product(
+            ([], [2]), (torch.float, torch.double)
+        ):
+            X = torch.rand(*batch_shape, 3, 4, device=self.device, dtype=dtype)
+            # test default behavior
+            X_proj = project_to_target_fidelity(X)
+            ones = torch.ones(*X.shape[:-1], 1, device=self.device, dtype=dtype)
+            self.assertTrue(torch.equal(X_proj[..., :, [-1]], ones))
+            self.assertTrue(torch.equal(X_proj[..., :-1], X[..., :-1]))
+            # test custom target fidelity
+            target_fids = {2: 0.5}
+            X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
+            self.assertTrue(torch.equal(X_proj[..., :, [2]], 0.5 * ones))
+            # test multiple target fidelities
+            target_fids = {2: 0.5, 0: 0.1}
+            X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
+            self.assertTrue(torch.equal(X_proj[..., :, [0]], 0.1 * ones))
+            self.assertTrue(torch.equal(X_proj[..., :, [2]], 0.5 * ones))
+            # test gradients
+            X.requires_grad_(True)
+            X_proj = project_to_target_fidelity(X, target_fidelities=target_fids)
+            out = (X_proj ** 2).sum()
+            out.backward()
+            self.assertTrue(torch.all(X.grad[..., [0, 2]] == 0))
+            self.assertTrue(torch.equal(X.grad[..., [1, 3]], 2 * X[..., [1, 3]]))
 
     def test_expand_trace_observations(self):
-        for dtype in (torch.float, torch.double):
-            for batch_shape in ([], [2]):
-                q, d = 3, 4
-                X = torch.rand(*batch_shape, q, d, device=self.device, dtype=dtype)
-                # test nullop behavior
-                self.assertTrue(torch.equal(expand_trace_observations(X), X))
-                self.assertTrue(
-                    torch.equal(expand_trace_observations(X, fidelity_dims=[1]), X)
-                )
-                # test default behavior
-                num_tr = 2
-                X_expanded = expand_trace_observations(X, num_trace_obs=num_tr)
-                self.assertEqual(
-                    X_expanded.shape, torch.Size(batch_shape + [q * (1 + num_tr), d])
-                )
-                self.assertTrue(
-                    all(
-                        torch.equal(
-                            X_expanded[..., q * i : q * (i + 1), :-1], X[..., :-1]
-                        )
-                        for i in range(num_tr)
-                    )
-                )
-                self.assertTrue(
-                    all(
-                        torch.allclose(
-                            X_expanded[..., q * i : q * (i + 1), -1],
-                            (1 - i / (num_tr + 1)) * X[..., :q, -1],
-                        )
-                        for i in range(num_tr)
-                    )
-                )
-                # test custom fidelity dims
-                fdims = [0, 2]
-                num_tr = 3
-                X_expanded = expand_trace_observations(
-                    X, fidelity_dims=fdims, num_trace_obs=num_tr
-                )
-                self.assertEqual(
-                    X_expanded.shape, torch.Size(batch_shape + [q * (1 + num_tr), d])
-                )
-                self.assertTrue(
-                    all(
-                        torch.equal(X_expanded[..., q * i : q * (i + 1), j], X[..., j])
-                        for i in range(num_tr)
-                    )
-                    for j in [1, 3]
-                )
-                self.assertTrue(
-                    all(
-                        torch.allclose(
-                            X_expanded[..., q * i : q * (i + 1), j],
-                            (1 - i / (1 + num_tr)) * X[..., :q, j],
-                        )
-                        for i in range(num_tr)
-                        for j in fdims
-                    )
-                )
-                # test gradients
-                num_tr = 2
-                fdims = [1]
-                X.requires_grad_(True)
-                X_expanded = expand_trace_observations(
-                    X, fidelity_dims=fdims, num_trace_obs=num_tr
-                )
-                out = X_expanded.sum()
-                out.backward()
-                grad_exp = torch.full_like(X, 1 + num_tr)
-                grad_exp[..., fdims] = 1 + sum(
-                    (i + 1) / (num_tr + 1) for i in range(num_tr)
-                )
-                self.assertTrue(torch.allclose(X.grad, grad_exp))
+        for batch_shape, dtype in itertools.product(
+            ([], [2]), (torch.float, torch.double)
+        ):
+            q, d = 3, 4
+            X = torch.rand(*batch_shape, q, d, device=self.device, dtype=dtype)
+            # test nullop behavior
+            self.assertTrue(torch.equal(expand_trace_observations(X), X))
+            self.assertTrue(
+                torch.equal(expand_trace_observations(X, fidelity_dims=[1]), X)
+            )
+            # test default behavior
+            num_tr = 2
+            X_expanded = expand_trace_observations(X, num_trace_obs=num_tr)
+            self.assertEqual(
+                X_expanded.shape, torch.Size(batch_shape + [q * (1 + num_tr), d])
+            )
+            for i in range(num_tr):
+                X_sub = X_expanded[..., q * i : q * (i + 1), :]
+                self.assertTrue(torch.equal(X_sub[..., :-1], X[..., :-1]))
+                X_sub_expected = (1 - i / (num_tr + 1)) * X[..., :q, -1]
+                self.assertTrue(torch.equal(X_sub[..., -1], X_sub_expected))
+            # test custom fidelity dims
+            fdims = [0, 2]
+            num_tr = 3
+            X_expanded = expand_trace_observations(
+                X, fidelity_dims=fdims, num_trace_obs=num_tr
+            )
+            self.assertEqual(
+                X_expanded.shape, torch.Size(batch_shape + [q * (1 + num_tr), d])
+            )
+            for j, i in itertools.product([1, 3], range(num_tr)):
+                X_sub = X_expanded[..., q * i : q * (i + 1), j]
+                self.assertTrue(torch.equal(X_sub, X[..., j]))
+            for j, i in itertools.product(fdims, range(num_tr)):
+                X_sub = X_expanded[..., q * i : q * (i + 1), j]
+                X_sub_expected = (1 - i / (1 + num_tr)) * X[..., :q, j]
+                self.assertTrue(torch.equal(X_sub, X_sub_expected))
+            # test gradients
+            num_tr = 2
+            fdims = [1]
+            X.requires_grad_(True)
+            X_expanded = expand_trace_observations(
+                X, fidelity_dims=fdims, num_trace_obs=num_tr
+            )
+            out = X_expanded.sum()
+            out.backward()
+            grad_exp = torch.full_like(X, 1 + num_tr)
+            grad_exp[..., fdims] = 1 + sum(
+                (i + 1) / (num_tr + 1) for i in range(num_tr)
+            )
+            self.assertTrue(torch.allclose(X.grad, grad_exp))

--- a/test/models/kernels/test_linear_truncated_fidelity.py
+++ b/test/models/kernels/test_linear_truncated_fidelity.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
+
 import torch
 from botorch.exceptions import UnsupportedError
 from botorch.models.kernels.linear_truncated_fidelity import (
@@ -37,33 +39,32 @@ class TestLinearTruncatedFidelityKernel(BotorchTestCase, BaseKernelTestCase):
         t_1 = torch.tensor([0.3584, 0.1856, 0.2976, 0.1584], dtype=torch.float).view(
             2, 2
         )
-        for nu in {0.5, 1.5, 2.5}:
-            for fidelity_dims in ([2], [1, 2]):
-                kernel = LinearTruncatedFidelityKernel(
-                    fidelity_dims=fidelity_dims, dimension=3, nu=nu
-                )
-                kernel.power = 1
-                if len(fidelity_dims) > 1:
-                    active_dimsM = [0]
-                    t_2 = torch.tensor(
-                        [0.4725, 0.2889, 0.4025, 0.2541], dtype=torch.float
-                    ).view(2, 2)
-                    t_3 = torch.tensor(
-                        [0.1685, 0.0531, 0.1168, 0.0386], dtype=torch.float
-                    ).view(2, 2)
-                    t = 1 + t_1 + t_2 + t_3
-                else:
-                    active_dimsM = [0, 1]
-                    t = 1 + t_1
+        for nu, fidelity_dims in itertools.product({0.5, 1.5, 2.5}, ([2], [1, 2])):
+            kernel = LinearTruncatedFidelityKernel(
+                fidelity_dims=fidelity_dims, dimension=3, nu=nu
+            )
+            kernel.power = 1
+            if len(fidelity_dims) > 1:
+                active_dimsM = [0]
+                t_2 = torch.tensor(
+                    [0.4725, 0.2889, 0.4025, 0.2541], dtype=torch.float
+                ).view(2, 2)
+                t_3 = torch.tensor(
+                    [0.1685, 0.0531, 0.1168, 0.0386], dtype=torch.float
+                ).view(2, 2)
+                t = 1 + t_1 + t_2 + t_3
+            else:
+                active_dimsM = [0, 1]
+                t = 1 + t_1
 
-                matern_ker = MaternKernel(nu=nu, active_dims=active_dimsM)
-                matern_term = matern_ker(x1, x2).evaluate()
-                actual = t * matern_term
-                res = kernel(x1, x2).evaluate()
-                self.assertLess(torch.norm(res - actual), 1e-4)
-                # test diagonal mode
-                res_diag = kernel(x1, x2, diag=True)
-                self.assertLess(torch.norm(res_diag - actual.diag()), 1e-4)
+            matern_ker = MaternKernel(nu=nu, active_dims=active_dimsM)
+            matern_term = matern_ker(x1, x2).evaluate()
+            actual = t * matern_term
+            res = kernel(x1, x2).evaluate()
+            self.assertLess(torch.norm(res - actual), 1e-4)
+            # test diagonal mode
+            res_diag = kernel(x1, x2, diag=True)
+            self.assertLess(torch.norm(res_diag - actual.diag()), 1e-4)
         # make sure that we error out if last_dim_is_batch=True
         with self.assertRaises(NotImplementedError):
             kernel(x1, x2, diag=True, last_dim_is_batch=True)
@@ -80,43 +81,38 @@ class TestLinearTruncatedFidelityKernel(BotorchTestCase, BaseKernelTestCase):
             dtype=torch.float,
         ).view(2, 2, 2)
         batch_shape = torch.Size([2])
-        for nu in {0.5, 1.5, 2.5}:
-            for fidelity_dims in ([2], [1, 2]):
-                kernel = LinearTruncatedFidelityKernel(
-                    fidelity_dims=fidelity_dims,
-                    dimension=3,
-                    nu=nu,
-                    batch_shape=batch_shape,
-                )
-                kernel.power = 1
-                if len(fidelity_dims) > 1:
-                    active_dimsM = [0]
-                    t_2 = torch.tensor(
-                        [0.0527, 0.167, 0.0383, 0.1159, 0.1159, 0.167, 0.0383, 0.0527],
-                        dtype=torch.float,
-                    ).view(2, 2, 2)
-                    t_3 = torch.tensor(
-                        [0.1944, 0.3816, 0.1736, 0.3304, 0.36, 0.44, 0.2304, 0.2736],
-                        dtype=torch.float,
-                    ).view(2, 2, 2)
-                    t = 1 + t_1 + t_2 + t_3
-                else:
-                    active_dimsM = [0, 1]
-                    t = 1 + t_1
+        for nu, fidelity_dims in itertools.product({0.5, 1.5, 2.5}, ([2], [1, 2])):
+            kernel = LinearTruncatedFidelityKernel(
+                fidelity_dims=fidelity_dims, dimension=3, nu=nu, batch_shape=batch_shape
+            )
+            kernel.power = 1
+            if len(fidelity_dims) > 1:
+                active_dimsM = [0]
+                t_2 = torch.tensor(
+                    [0.0527, 0.167, 0.0383, 0.1159, 0.1159, 0.167, 0.0383, 0.0527],
+                    dtype=torch.float,
+                ).view(2, 2, 2)
+                t_3 = torch.tensor(
+                    [0.1944, 0.3816, 0.1736, 0.3304, 0.36, 0.44, 0.2304, 0.2736],
+                    dtype=torch.float,
+                ).view(2, 2, 2)
+                t = 1 + t_1 + t_2 + t_3
+            else:
+                active_dimsM = [0, 1]
+                t = 1 + t_1
 
-                matern_ker = MaternKernel(
-                    nu=nu, active_dims=active_dimsM, batch_shape=batch_shape
-                )
-                matern_term = matern_ker(x1, x2).evaluate()
-                actual = t * matern_term
-                res = kernel(x1, x2).evaluate()
-                self.assertLess(torch.norm(res - actual), 1e-4)
-                # test diagonal mode
-                res_diag = kernel(x1, x2, diag=True)
-                self.assertLess(
-                    torch.norm(res_diag - torch.diagonal(actual, dim1=-1, dim2=-2)),
-                    1e-4,
-                )
+            matern_ker = MaternKernel(
+                nu=nu, active_dims=active_dimsM, batch_shape=batch_shape
+            )
+            matern_term = matern_ker(x1, x2).evaluate()
+            actual = t * matern_term
+            res = kernel(x1, x2).evaluate()
+            self.assertLess(torch.norm(res - actual), 1e-4)
+            # test diagonal mode
+            res_diag = kernel(x1, x2, diag=True)
+            self.assertLess(
+                torch.norm(res_diag - torch.diagonal(actual, dim1=-1, dim2=-2)), 1e-4
+            )
         # make sure that we error out if last_dim_is_batch=True
         with self.assertRaises(NotImplementedError):
             kernel(x1, x2, diag=True, last_dim_is_batch=True)

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import math
+import itertools
 import warnings
 
 import torch
@@ -18,7 +18,7 @@ from botorch.models.gp_regression import (
 from botorch.models.utils import add_output_dim
 from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling import SobolQMCNormalSampler
-from botorch.utils.testing import BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, _get_random_data
 from gpytorch.kernels import MaternKernel, ScaleKernel
 from gpytorch.likelihoods import (
     FixedNoiseGaussianLikelihood,
@@ -32,17 +32,6 @@ from gpytorch.mlls.noise_model_added_loss_term import NoiseModelAddedLossTerm
 from gpytorch.priors import GammaPrior
 
 
-def _get_random_data(batch_shape, num_outputs, n=10, **tkwargs):
-    train_x = torch.linspace(0, 0.95, n, **tkwargs).unsqueeze(-1) + 0.05 * torch.rand(
-        n, 1, **tkwargs
-    ).repeat(batch_shape + torch.Size([1, 1]))
-    train_y = torch.sin(train_x * (2 * math.pi)) + 0.2 * torch.randn(
-        n, num_outputs, **tkwargs
-    ).repeat(batch_shape + torch.Size([1, 1]))
-
-    return train_x, train_y
-
-
 class TestSingleTaskGP(BotorchTestCase):
     def _get_model_and_data(self, batch_shape, num_outputs, **tkwargs):
         train_X, train_Y = _get_random_data(
@@ -53,204 +42,179 @@ class TestSingleTaskGP(BotorchTestCase):
         return model, model_kwargs
 
     def test_gp(self):
-        for batch_shape in (torch.Size(), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for double in (False, True):
-                    tkwargs = {
-                        "device": self.device,
-                        "dtype": torch.double if double else torch.float,
-                    }
-                    model, _ = self._get_model_and_data(
-                        batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
-                    )
-                    mll = ExactMarginalLogLikelihood(model.likelihood, model).to(
-                        **tkwargs
-                    )
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings("ignore", category=OptimizationWarning)
-                        fit_gpytorch_model(mll, options={"maxiter": 1}, max_retries=1)
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model, _ = self._get_model_and_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
+            )
+            mll = ExactMarginalLogLikelihood(model.likelihood, model).to(**tkwargs)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=OptimizationWarning)
+                fit_gpytorch_model(mll, options={"maxiter": 1}, max_retries=1)
 
-                    # test init
-                    self.assertIsInstance(model.mean_module, ConstantMean)
-                    self.assertIsInstance(model.covar_module, ScaleKernel)
-                    matern_kernel = model.covar_module.base_kernel
-                    self.assertIsInstance(matern_kernel, MaternKernel)
-                    self.assertIsInstance(matern_kernel.lengthscale_prior, GammaPrior)
+            # test init
+            self.assertIsInstance(model.mean_module, ConstantMean)
+            self.assertIsInstance(model.covar_module, ScaleKernel)
+            matern_kernel = model.covar_module.base_kernel
+            self.assertIsInstance(matern_kernel, MaternKernel)
+            self.assertIsInstance(matern_kernel.lengthscale_prior, GammaPrior)
 
-                    # test param sizes
-                    params = dict(model.named_parameters())
-                    for p in params:
-                        self.assertEqual(
-                            params[p].numel(),
-                            num_outputs * torch.tensor(batch_shape).prod().item(),
-                        )
+            # test param sizes
+            params = dict(model.named_parameters())
+            for p in params:
+                self.assertEqual(
+                    params[p].numel(),
+                    num_outputs * torch.tensor(batch_shape).prod().item(),
+                )
 
-                    # test posterior
-                    # test non batch evaluation
-                    X = torch.rand(batch_shape + torch.Size([3, 1]), **tkwargs)
-                    expected_mean_shape = batch_shape + torch.Size([3, num_outputs])
-                    posterior = model.posterior(X)
-                    self.assertIsInstance(posterior, GPyTorchPosterior)
-                    self.assertEqual(posterior.mean.shape, expected_mean_shape)
-                    # test adding observation noise
-                    posterior_pred = model.posterior(X, observation_noise=True)
-                    self.assertIsInstance(posterior_pred, GPyTorchPosterior)
-                    self.assertEqual(posterior_pred.mean.shape, expected_mean_shape)
-                    pvar = posterior_pred.variance
-                    pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
-                    self.assertTrue(
-                        torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05)
-                    )
+            # test posterior
+            # test non batch evaluation
+            X = torch.rand(batch_shape + torch.Size([3, 1]), **tkwargs)
+            expected_mean_shape = batch_shape + torch.Size([3, num_outputs])
+            posterior = model.posterior(X)
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+            self.assertEqual(posterior.mean.shape, expected_mean_shape)
+            # test adding observation noise
+            posterior_pred = model.posterior(X, observation_noise=True)
+            self.assertIsInstance(posterior_pred, GPyTorchPosterior)
+            self.assertEqual(posterior_pred.mean.shape, expected_mean_shape)
+            pvar = posterior_pred.variance
+            pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
+            self.assertTrue(torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05))
 
-                    # test batch evaluation
-                    X = torch.rand(
-                        torch.Size([2]) + batch_shape + torch.Size([3, 1]), **tkwargs
-                    )
-                    expected_mean_shape = (
-                        torch.Size([2]) + batch_shape + torch.Size([3, num_outputs])
-                    )
+            # test batch evaluation
+            X = torch.rand(
+                torch.Size([2]) + batch_shape + torch.Size([3, 1]), **tkwargs
+            )
+            expected_mean_shape = (
+                torch.Size([2]) + batch_shape + torch.Size([3, num_outputs])
+            )
 
-                    posterior = model.posterior(X)
-                    self.assertIsInstance(posterior, GPyTorchPosterior)
-                    self.assertEqual(posterior.mean.shape, expected_mean_shape)
-                    # test adding observation noise in batch mode
-                    posterior_pred = model.posterior(X, observation_noise=True)
-                    self.assertIsInstance(posterior_pred, GPyTorchPosterior)
-                    self.assertEqual(posterior_pred.mean.shape, expected_mean_shape)
-                    pvar = posterior_pred.variance
-                    pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
-                    self.assertTrue(
-                        torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05)
-                    )
+            posterior = model.posterior(X)
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+            self.assertEqual(posterior.mean.shape, expected_mean_shape)
+            # test adding observation noise in batch mode
+            posterior_pred = model.posterior(X, observation_noise=True)
+            self.assertIsInstance(posterior_pred, GPyTorchPosterior)
+            self.assertEqual(posterior_pred.mean.shape, expected_mean_shape)
+            pvar = posterior_pred.variance
+            pvar_exp = _get_pvar_expected(posterior, model, X, num_outputs)
+            self.assertTrue(torch.allclose(pvar, pvar_exp, rtol=1e-4, atol=1e-05))
 
     def test_condition_on_observations(self):
-        for batch_shape in (torch.Size(), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for double in (False, True):
-                    tkwargs = {
-                        "device": self.device,
-                        "dtype": torch.double if double else torch.float,
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model, model_kwargs = self._get_model_and_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
+            )
+            # evaluate model
+            model.posterior(torch.rand(torch.Size([4, 1]), **tkwargs))
+            # test condition_on_observations
+            fant_shape = torch.Size([2])
+            # fantasize at different input points
+            X_fant, Y_fant = _get_random_data(
+                fant_shape + batch_shape, num_outputs, n=3, **tkwargs
+            )
+            c_kwargs = (
+                {"noise": torch.full_like(Y_fant, 0.01)}
+                if isinstance(model, FixedNoiseGP)
+                else {}
+            )
+            cm = model.condition_on_observations(X_fant, Y_fant, **c_kwargs)
+            # fantasize at different same input points
+            c_kwargs_same_inputs = (
+                {"noise": torch.full_like(Y_fant[0], 0.01)}
+                if isinstance(model, FixedNoiseGP)
+                else {}
+            )
+            cm_same_inputs = model.condition_on_observations(
+                X_fant[0], Y_fant, **c_kwargs_same_inputs
+            )
+
+            test_Xs = [
+                # test broadcasting single input across fantasy and
+                # model batches
+                torch.rand(4, 1, **tkwargs),
+                # separate input for each model batch and broadcast across
+                # fantasy batches
+                torch.rand(batch_shape + torch.Size([4, 1]), **tkwargs),
+                # separate input for each model and fantasy batch
+                torch.rand(fant_shape + batch_shape + torch.Size([4, 1]), **tkwargs),
+            ]
+            for test_X in test_Xs:
+                posterior = cm.posterior(test_X)
+                self.assertEqual(
+                    posterior.mean.shape,
+                    fant_shape + batch_shape + torch.Size([4, num_outputs]),
+                )
+                posterior_same_inputs = cm_same_inputs.posterior(test_X)
+                self.assertEqual(
+                    posterior_same_inputs.mean.shape,
+                    fant_shape + batch_shape + torch.Size([4, num_outputs]),
+                )
+
+                # check that fantasies of batched model are correct
+                if len(batch_shape) > 0 and test_X.dim() == 2:
+                    state_dict_non_batch = {
+                        key: (val[0] if val.numel() > 1 else val)
+                        for key, val in model.state_dict().items()
                     }
-                    model, model_kwargs = self._get_model_and_data(
-                        batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
-                    )
-                    # evaluate model
-                    model.posterior(torch.rand(torch.Size([4, 1]), **tkwargs))
-                    # test condition_on_observations
-                    fant_shape = torch.Size([2])
-                    # fantasize at different input points
-                    X_fant, Y_fant = _get_random_data(
-                        fant_shape + batch_shape, num_outputs, n=3, **tkwargs
-                    )
+                    model_kwargs_non_batch = {
+                        "train_X": model_kwargs["train_X"][0],
+                        "train_Y": model_kwargs["train_Y"][0],
+                    }
+                    if "train_Yvar" in model_kwargs:
+                        model_kwargs_non_batch["train_Yvar"] = model_kwargs[
+                            "train_Yvar"
+                        ][0]
+                    model_non_batch = type(model)(**model_kwargs_non_batch)
+                    model_non_batch.load_state_dict(state_dict_non_batch)
+                    model_non_batch.eval()
+                    model_non_batch.likelihood.eval()
+                    model_non_batch.posterior(torch.rand(torch.Size([4, 1]), **tkwargs))
                     c_kwargs = (
-                        {"noise": torch.full_like(Y_fant, 0.01)}
+                        {"noise": torch.full_like(Y_fant[0, 0, :], 0.01)}
                         if isinstance(model, FixedNoiseGP)
                         else {}
                     )
-                    cm = model.condition_on_observations(X_fant, Y_fant, **c_kwargs)
-                    # fantasize at different same input points
-                    c_kwargs_same_inputs = (
-                        {"noise": torch.full_like(Y_fant[0], 0.01)}
-                        if isinstance(model, FixedNoiseGP)
-                        else {}
+                    cm_non_batch = model_non_batch.condition_on_observations(
+                        X_fant[0][0], Y_fant[:, 0, :], **c_kwargs
                     )
-                    cm_same_inputs = model.condition_on_observations(
-                        X_fant[0], Y_fant, **c_kwargs_same_inputs
+                    non_batch_posterior = cm_non_batch.posterior(test_X)
+                    self.assertTrue(
+                        torch.allclose(
+                            posterior_same_inputs.mean[:, 0, ...],
+                            non_batch_posterior.mean,
+                            atol=1e-3,
+                        )
                     )
-
-                    test_Xs = [
-                        # test broadcasting single input across fantasy and
-                        # model batches
-                        torch.rand(4, 1, **tkwargs),
-                        # separate input for each model batch and broadcast across
-                        # fantasy batches
-                        torch.rand(batch_shape + torch.Size([4, 1]), **tkwargs),
-                        # separate input for each model and fantasy batch
-                        torch.rand(
-                            fant_shape + batch_shape + torch.Size([4, 1]), **tkwargs
-                        ),
-                    ]
-                    for test_X in test_Xs:
-                        posterior = cm.posterior(test_X)
-                        self.assertEqual(
-                            posterior.mean.shape,
-                            fant_shape + batch_shape + torch.Size([4, num_outputs]),
+                    self.assertTrue(
+                        torch.allclose(
+                            posterior_same_inputs.mvn.covariance_matrix[:, 0, :, :],
+                            non_batch_posterior.mvn.covariance_matrix,
+                            atol=1e-3,
                         )
-                        posterior_same_inputs = cm_same_inputs.posterior(test_X)
-                        self.assertEqual(
-                            posterior_same_inputs.mean.shape,
-                            fant_shape + batch_shape + torch.Size([4, num_outputs]),
-                        )
-
-                        # check that fantasies of batched model are correct
-                        if len(batch_shape) > 0 and test_X.dim() == 2:
-                            state_dict_non_batch = {
-                                key: (val[0] if val.numel() > 1 else val)
-                                for key, val in model.state_dict().items()
-                            }
-                            model_kwargs_non_batch = {
-                                "train_X": model_kwargs["train_X"][0],
-                                "train_Y": model_kwargs["train_Y"][0],
-                            }
-                            if "train_Yvar" in model_kwargs:
-                                model_kwargs_non_batch["train_Yvar"] = model_kwargs[
-                                    "train_Yvar"
-                                ][0]
-                            model_non_batch = type(model)(**model_kwargs_non_batch)
-                            model_non_batch.load_state_dict(state_dict_non_batch)
-                            model_non_batch.eval()
-                            model_non_batch.likelihood.eval()
-                            model_non_batch.posterior(
-                                torch.rand(torch.Size([4, 1]), **tkwargs)
-                            )
-                            c_kwargs = (
-                                {"noise": torch.full_like(Y_fant[0, 0, :], 0.01)}
-                                if isinstance(model, FixedNoiseGP)
-                                else {}
-                            )
-                            cm_non_batch = model_non_batch.condition_on_observations(
-                                X_fant[0][0], Y_fant[:, 0, :], **c_kwargs
-                            )
-                            non_batch_posterior = cm_non_batch.posterior(test_X)
-                            self.assertTrue(
-                                torch.allclose(
-                                    posterior_same_inputs.mean[:, 0, ...],
-                                    non_batch_posterior.mean,
-                                    atol=1e-3,
-                                )
-                            )
-                            self.assertTrue(
-                                torch.allclose(
-                                    posterior_same_inputs.mvn.covariance_matrix[
-                                        :, 0, :, :
-                                    ],
-                                    non_batch_posterior.mvn.covariance_matrix,
-                                    atol=1e-3,
-                                )
-                            )
+                    )
 
     def test_fantasize(self):
-        for batch_shape in (torch.Size(), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for double in (False, True):
-                    tkwargs = {
-                        "device": self.device,
-                        "dtype": torch.double if double else torch.float,
-                    }
-                    model, model_kwargs = self._get_model_and_data(
-                        batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
-                    )
-                    # fantasize
-                    X_f = torch.rand(
-                        torch.Size(batch_shape + torch.Size([4, 1])), **tkwargs
-                    )
-                    sampler = SobolQMCNormalSampler(num_samples=3)
-                    fm = model.fantasize(X=X_f, sampler=sampler)
-                    self.assertIsInstance(fm, model.__class__)
-                    fm = model.fantasize(
-                        X=X_f, sampler=sampler, observation_noise=False
-                    )
-                    self.assertIsInstance(fm, model.__class__)
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model, model_kwargs = self._get_model_and_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
+            )
+            # fantasize
+            X_f = torch.rand(torch.Size(batch_shape + torch.Size([4, 1])), **tkwargs)
+            sampler = SobolQMCNormalSampler(num_samples=3)
+            fm = model.fantasize(X=X_f, sampler=sampler)
+            self.assertIsInstance(fm, model.__class__)
+            fm = model.fantasize(X=X_f, sampler=sampler, observation_noise=False)
+            self.assertIsInstance(fm, model.__class__)
 
 
 class TestFixedNoiseGP(TestSingleTaskGP):
@@ -267,25 +231,20 @@ class TestFixedNoiseGP(TestSingleTaskGP):
         return model, model_kwargs
 
     def test_fixed_noise_likelihood(self):
-        for batch_shape in (torch.Size(), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for double in (False, True):
-                    tkwargs = {
-                        "device": self.device,
-                        "dtype": torch.double if double else torch.float,
-                    }
-                    model, model_kwargs = self._get_model_and_data(
-                        batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
-                    )
-                    self.assertIsInstance(
-                        model.likelihood, FixedNoiseGaussianLikelihood
-                    )
-                    self.assertTrue(
-                        torch.equal(
-                            model.likelihood.noise.contiguous().view(-1),
-                            model_kwargs["train_Yvar"].contiguous().view(-1),
-                        )
-                    )
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model, model_kwargs = self._get_model_and_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
+            )
+            self.assertIsInstance(model.likelihood, FixedNoiseGaussianLikelihood)
+            self.assertTrue(
+                torch.equal(
+                    model.likelihood.noise.contiguous().view(-1),
+                    model_kwargs["train_Yvar"].contiguous().view(-1),
+                )
+            )
 
 
 class TestHeteroskedasticSingleTaskGP(TestSingleTaskGP):
@@ -303,28 +262,22 @@ class TestHeteroskedasticSingleTaskGP(TestSingleTaskGP):
         return model, model_kwargs
 
     def test_heteroskedastic_likelihood(self):
-        for batch_shape in (torch.Size(), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for double in (False, True):
-                    tkwargs = {
-                        "device": self.device,
-                        "dtype": torch.double if double else torch.float,
-                    }
-                    model, _ = self._get_model_and_data(
-                        batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
-                    )
-                    self.assertIsInstance(model.likelihood, _GaussianLikelihoodBase)
-                    self.assertFalse(isinstance(model.likelihood, GaussianLikelihood))
-                    self.assertIsInstance(
-                        model.likelihood.noise_covar, HeteroskedasticNoise
-                    )
-                    self.assertIsInstance(
-                        model.likelihood.noise_covar.noise_model, SingleTaskGP
-                    )
-                    self.assertIsInstance(
-                        model._added_loss_terms["noise_added_loss"],
-                        NoiseModelAddedLossTerm,
-                    )
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model, _ = self._get_model_and_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, **tkwargs
+            )
+            self.assertIsInstance(model.likelihood, _GaussianLikelihoodBase)
+            self.assertFalse(isinstance(model.likelihood, GaussianLikelihood))
+            self.assertIsInstance(model.likelihood.noise_covar, HeteroskedasticNoise)
+            self.assertIsInstance(
+                model.likelihood.noise_covar.noise_model, SingleTaskGP
+            )
+            self.assertIsInstance(
+                model._added_loss_terms["noise_added_loss"], NoiseModelAddedLossTerm
+            )
 
     def test_condition_on_observations(self):
         with self.assertRaises(NotImplementedError):

--- a/test/models/test_utils.py
+++ b/test/models/test_utils.py
@@ -22,11 +22,8 @@ from botorch.utils.testing import BotorchTestCase
 
 class TestMultiOutputToBatchModeTransform(BotorchTestCase):
     def test_multioutput_to_batch_mode_transform(self):
-        for double in (False, True):
-            tkwargs = {
-                "device": self.device,
-                "dtype": torch.double if double else torch.float,
-            }
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"device": self.device, "dtype": dtype}
             n = 3
             num_outputs = 2
             train_X = torch.rand(n, 1, **tkwargs)
@@ -46,11 +43,8 @@ class TestMultiOutputToBatchModeTransform(BotorchTestCase):
 
 class TestAddOutputDim(BotorchTestCase):
     def test_add_output_dim(self):
-        for double in (False, True):
-            tkwargs = {
-                "device": self.device,
-                "dtype": torch.double if double else torch.float,
-            }
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"device": self.device, "dtype": dtype}
             original_batch_shape = torch.Size([2])
             # check exception is raised when trailing batch dims do not line up
             X = torch.rand(2, 3, 2, 1, **tkwargs)

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 import warnings
 from unittest import mock
 
@@ -242,7 +243,7 @@ class TestOptimizeAcqf(BotorchTestCase):
 
 
 class TestOptimizeAcqfCyclic(BotorchTestCase):
-    @mock.patch("botorch.optim.optimize.optimize_acqf")
+    @mock.patch("botorch.optim.optimize.optimize_acqf")  # noqa: C901
     def test_optimize_acqf_cyclic(self, mock_optimize_acqf):
         num_restarts = 2
         raw_samples = 10
@@ -254,110 +255,105 @@ class TestOptimizeAcqfCyclic(BotorchTestCase):
             [torch.tensor([3]), torch.tensor([4]), torch.tensor(5)]
         ]
         mock_acq_function = MockAcquisitionFunction()
-        for q in [1, 3]:
-            for dtype in (torch.float, torch.double):
-                inequality_constraints[0] = [
-                    t.to(**tkwargs) for t in inequality_constraints[0]
+        for q, dtype in itertools.product([1, 3], (torch.float, torch.double)):
+            inequality_constraints[0] = [
+                t.to(**tkwargs) for t in inequality_constraints[0]
+            ]
+            mock_optimize_acqf.reset_mock()
+            tkwargs["dtype"] = dtype
+            bounds = bounds.to(**tkwargs)
+            candidate_rvs = []
+            acq_val_rvs = []
+            for cycle_j in range(num_cycles):
+                gcs_return_vals = [
+                    (torch.rand(1, 3, **tkwargs), torch.rand(1, **tkwargs))
+                    for _ in range(q)
                 ]
-                mock_optimize_acqf.reset_mock()
-                tkwargs["dtype"] = dtype
-                bounds = bounds.to(**tkwargs)
-                candidate_rvs = []
-                acq_val_rvs = []
-                for cycle_j in range(num_cycles):
-                    gcs_return_vals = [
-                        (torch.rand(1, 3, **tkwargs), torch.rand(1, **tkwargs))
-                        for _ in range(q)
-                    ]
-                    if cycle_j == 0:
-                        # return `q` candidates for first call
-                        candidate_rvs.append(
-                            torch.cat([rv[0] for rv in gcs_return_vals], dim=-2)
-                        )
-                        acq_val_rvs.append(torch.cat([rv[1] for rv in gcs_return_vals]))
-                    else:
-                        # return 1 candidate for subsequent calls
-                        for rv in gcs_return_vals:
-                            candidate_rvs.append(rv[0])
-                            acq_val_rvs.append(rv[1])
-                mock_optimize_acqf.side_effect = list(zip(candidate_rvs, acq_val_rvs))
-                orig_candidates = candidate_rvs[0].clone()
-                # wrap the set_X_pending method for checking that call arguments
-                with mock.patch.object(
-                    MockAcquisitionFunction,
-                    "set_X_pending",
-                    wraps=mock_acq_function.set_X_pending,
-                ) as mock_set_X_pending:
-                    candidates, acq_value = optimize_acqf_cyclic(
-                        acq_function=mock_acq_function,
-                        bounds=bounds,
-                        q=q,
-                        num_restarts=num_restarts,
-                        raw_samples=raw_samples,
-                        options=options,
-                        inequality_constraints=inequality_constraints,
-                        post_processing_func=rounding_func,
-                        cyclic_options={"maxiter": num_cycles},
+                if cycle_j == 0:
+                    # return `q` candidates for first call
+                    candidate_rvs.append(
+                        torch.cat([rv[0] for rv in gcs_return_vals], dim=-2)
                     )
-                    # check that X_pending is set correctly in cyclic optimization
-                    if q > 1:
-                        x_pending_call_args_list = mock_set_X_pending.call_args_list
-                        idxr = torch.ones(q, dtype=torch.bool, device=self.device)
-                        for i in range(len(x_pending_call_args_list) - 1):
-                            idxr[i] = 0
-                            self.assertTrue(
-                                torch.equal(
-                                    x_pending_call_args_list[i][0][0],
-                                    orig_candidates[idxr],
-                                )
-                            )
-                            idxr[i] = 1
-                            orig_candidates[i] = candidate_rvs[i + 1]
-                        # check reset to base_X_pendingg
-                        self.assertIsNone(x_pending_call_args_list[-1][0][0])
-                    else:
-                        mock_set_X_pending.assert_not_called()
-                # check final candidates
-                expected_candidates = (
-                    torch.cat(candidate_rvs[-q:], dim=0) if q > 1 else candidate_rvs[0]
+                    acq_val_rvs.append(torch.cat([rv[1] for rv in gcs_return_vals]))
+                else:
+                    # return 1 candidate for subsequent calls
+                    for rv in gcs_return_vals:
+                        candidate_rvs.append(rv[0])
+                        acq_val_rvs.append(rv[1])
+            mock_optimize_acqf.side_effect = list(zip(candidate_rvs, acq_val_rvs))
+            orig_candidates = candidate_rvs[0].clone()
+            # wrap the set_X_pending method for checking that call arguments
+            with mock.patch.object(
+                MockAcquisitionFunction,
+                "set_X_pending",
+                wraps=mock_acq_function.set_X_pending,
+            ) as mock_set_X_pending:
+                candidates, acq_value = optimize_acqf_cyclic(
+                    acq_function=mock_acq_function,
+                    bounds=bounds,
+                    q=q,
+                    num_restarts=num_restarts,
+                    raw_samples=raw_samples,
+                    options=options,
+                    inequality_constraints=inequality_constraints,
+                    post_processing_func=rounding_func,
+                    cyclic_options={"maxiter": num_cycles},
                 )
-                self.assertTrue(torch.equal(candidates, expected_candidates))
-                # check call arguments for optimize_acqf
-                call_args_list = mock_optimize_acqf.call_args_list
-                expected_call_args = {
-                    "acq_function": mock_acq_function,
-                    "bounds": bounds,
-                    "num_restarts": num_restarts,
-                    "raw_samples": raw_samples,
-                    "options": options,
-                    "inequality_constraints": inequality_constraints,
-                    "equality_constraints": None,
-                    "fixed_features": None,
-                    "post_processing_func": rounding_func,
-                    "return_best_only": True,
-                    "sequential": True,
-                }
-                orig_candidates = candidate_rvs[0].clone()
-                for i in range(len(call_args_list)):
-                    if i == 0:
-                        # first cycle
-                        expected_call_args.update(
-                            {"batch_initial_conditions": None, "q": q}
+                # check that X_pending is set correctly in cyclic optimization
+                if q > 1:
+                    x_pending_call_args_list = mock_set_X_pending.call_args_list
+                    idxr = torch.ones(q, dtype=torch.bool, device=self.device)
+                    for i in range(len(x_pending_call_args_list) - 1):
+                        idxr[i] = 0
+                        self.assertTrue(
+                            torch.equal(
+                                x_pending_call_args_list[i][0][0], orig_candidates[idxr]
+                            )
+                        )
+                        idxr[i] = 1
+                        orig_candidates[i] = candidate_rvs[i + 1]
+                    # check reset to base_X_pendingg
+                    self.assertIsNone(x_pending_call_args_list[-1][0][0])
+                else:
+                    mock_set_X_pending.assert_not_called()
+            # check final candidates
+            expected_candidates = (
+                torch.cat(candidate_rvs[-q:], dim=0) if q > 1 else candidate_rvs[0]
+            )
+            self.assertTrue(torch.equal(candidates, expected_candidates))
+            # check call arguments for optimize_acqf
+            call_args_list = mock_optimize_acqf.call_args_list
+            expected_call_args = {
+                "acq_function": mock_acq_function,
+                "bounds": bounds,
+                "num_restarts": num_restarts,
+                "raw_samples": raw_samples,
+                "options": options,
+                "inequality_constraints": inequality_constraints,
+                "equality_constraints": None,
+                "fixed_features": None,
+                "post_processing_func": rounding_func,
+                "return_best_only": True,
+                "sequential": True,
+            }
+            orig_candidates = candidate_rvs[0].clone()
+            for i in range(len(call_args_list)):
+                if i == 0:
+                    # first cycle
+                    expected_call_args.update(
+                        {"batch_initial_conditions": None, "q": q}
+                    )
+                else:
+                    expected_call_args.update(
+                        {"batch_initial_conditions": orig_candidates[i - 1 : i], "q": 1}
+                    )
+                    orig_candidates[i - 1] = candidate_rvs[i]
+                for k, v in call_args_list[i][1].items():
+                    if torch.is_tensor(v):
+                        self.assertTrue(torch.equal(expected_call_args[k], v))
+                    elif k == "acq_function":
+                        self.assertIsInstance(
+                            mock_acq_function, MockAcquisitionFunction
                         )
                     else:
-                        expected_call_args.update(
-                            {
-                                "batch_initial_conditions": orig_candidates[i - 1 : i],
-                                "q": 1,
-                            }
-                        )
-                        orig_candidates[i - 1] = candidate_rvs[i]
-                    for k, v in call_args_list[i][1].items():
-                        if torch.is_tensor(v):
-                            self.assertTrue(torch.equal(expected_call_args[k], v))
-                        elif k == "acq_function":
-                            self.assertIsInstance(
-                                mock_acq_function, MockAcquisitionFunction
-                            )
-                        else:
-                            self.assertEqual(expected_call_args[k], v)
+                        self.assertEqual(expected_call_args[k], v)

--- a/test/optim/test_utils.py
+++ b/test/optim/test_utils.py
@@ -164,7 +164,7 @@ class TestFixFeatures(BotorchTestCase):
         )
 
 
-class testGetExtraMllArgs(BotorchTestCase):
+class TestGetExtraMllArgs(BotorchTestCase):
     def test_get_extra_mll_args(self):
         train_X = torch.rand(3, 5)
         train_Y = torch.rand(3, 1)
@@ -194,7 +194,7 @@ class testGetExtraMllArgs(BotorchTestCase):
             _get_extra_mll_args(mll=unsupported_mll)
 
 
-class testExpandBounds(BotorchTestCase):
+class TestExpandBounds(BotorchTestCase):
     def test_expand_bounds(self):
         X = torch.zeros(2, 3)
         expected_bounds = torch.zeros(1, 3)

--- a/test/posteriors/test_deterministic.py
+++ b/test/posteriors/test_deterministic.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
+
 import torch
 from botorch.posteriors.deterministic import DeterministicPosterior
 from botorch.utils.testing import BotorchTestCase
@@ -11,24 +13,25 @@ from botorch.utils.testing import BotorchTestCase
 
 class TestDeterministicPosterior(BotorchTestCase):
     def test_DeterministicPosterior(self):
-        for dtype in (torch.float, torch.double):
-            for shape in ((3, 2), (2, 3, 1)):
-                values = torch.randn(*shape, device=self.device, dtype=dtype)
-                p = DeterministicPosterior(values)
-                self.assertEqual(p.device, self.device)
-                self.assertEqual(p.dtype, dtype)
-                self.assertEqual(p.event_shape, values.shape)
-                self.assertTrue(torch.equal(p.mean, values))
-                self.assertTrue(torch.equal(p.variance, torch.zeros_like(values)))
-                # test sampling
-                samples = p.rsample()
-                self.assertTrue(torch.equal(samples, values.unsqueeze(0)))
-                samples = p.rsample(torch.Size([2]))
-                self.assertTrue(torch.equal(samples, values.expand(2, *values.shape)))
-                base_samples = torch.randn(2, *shape, device=self.device, dtype=dtype)
-                samples = p.rsample(torch.Size([2]), base_samples)
-                self.assertTrue(torch.equal(samples, values.expand(2, *values.shape)))
-                with self.assertRaises(RuntimeError):
-                    samples = p.rsample(
-                        torch.Size([2]), base_samples.expand(3, *base_samples.shape)
-                    )
+        for shape, dtype in itertools.product(
+            ((3, 2), (2, 3, 1)), (torch.float, torch.double)
+        ):
+            values = torch.randn(*shape, device=self.device, dtype=dtype)
+            p = DeterministicPosterior(values)
+            self.assertEqual(p.device, self.device)
+            self.assertEqual(p.dtype, dtype)
+            self.assertEqual(p.event_shape, values.shape)
+            self.assertTrue(torch.equal(p.mean, values))
+            self.assertTrue(torch.equal(p.variance, torch.zeros_like(values)))
+            # test sampling
+            samples = p.rsample()
+            self.assertTrue(torch.equal(samples, values.unsqueeze(0)))
+            samples = p.rsample(torch.Size([2]))
+            self.assertTrue(torch.equal(samples, values.expand(2, *values.shape)))
+            base_samples = torch.randn(2, *shape, device=self.device, dtype=dtype)
+            samples = p.rsample(torch.Size([2]), base_samples)
+            self.assertTrue(torch.equal(samples, values.expand(2, *values.shape)))
+            with self.assertRaises(RuntimeError):
+                samples = p.rsample(
+                    torch.Size([2]), base_samples.expand(3, *base_samples.shape)
+                )

--- a/test/test_cross_validation.py
+++ b/test/test_cross_validation.py
@@ -4,118 +4,78 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import math
+import itertools
 import warnings
 
 import torch
 from botorch.cross_validation import batch_cross_validation, gen_loo_cv_folds
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
-from botorch.utils.testing import BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, _get_random_data
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
-
-
-def _get_random_data(batch_shape, num_outputs, n, device, dtype):
-    train_x = torch.linspace(0, 0.95, n, device=device, dtype=dtype).unsqueeze(
-        -1
-    ) + 0.05 * torch.rand(n, 1, device=device, dtype=dtype).repeat(
-        batch_shape + torch.Size([1, 1])
-    )
-    train_y = torch.sin(train_x * (2 * math.pi)) + 0.2 * torch.randn(
-        n, num_outputs, device=device, dtype=dtype
-    ).repeat(batch_shape + torch.Size([1, 1]))
-
-    if num_outputs == 1:
-        train_y = train_y.squeeze(-1)
-    return train_x, train_y
 
 
 class TestFitBatchCrossValidation(BotorchTestCase):
     def test_single_task_batch_cv(self):
         n = 10
-        for batch_shape in (torch.Size([]), torch.Size([2])):
-            for num_outputs in (1, 2):
-                for dtype in (torch.double, torch.float):
-                    train_X, train_Y = _get_random_data(
-                        batch_shape=batch_shape,
-                        num_outputs=num_outputs,
-                        n=n,
-                        device=self.device,
-                        dtype=dtype,
-                    )
-                    train_Yvar = torch.full_like(train_Y, 0.01)
-                    noiseless_cv_folds = gen_loo_cv_folds(
-                        train_X=train_X, train_Y=train_Y
-                    )
-                    # check shapes
-                    expected_shape_train_X = batch_shape + torch.Size(
-                        [n, n - 1, train_X.shape[-1]]
-                    )
-                    expected_shape_test_X = batch_shape + torch.Size(
-                        [n, 1, train_X.shape[-1]]
-                    )
-                    self.assertEqual(
-                        noiseless_cv_folds.train_X.shape, expected_shape_train_X
-                    )
-                    self.assertEqual(
-                        noiseless_cv_folds.test_X.shape, expected_shape_test_X
-                    )
+        for batch_shape, num_outputs, dtype in itertools.product(
+            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            train_X, train_Y = _get_random_data(
+                batch_shape=batch_shape, num_outputs=num_outputs, n=n, **tkwargs
+            )
+            if num_outputs == 1:
+                train_Y = train_Y.squeeze(-1)
+            train_Yvar = torch.full_like(train_Y, 0.01)
+            noiseless_cv_folds = gen_loo_cv_folds(train_X=train_X, train_Y=train_Y)
+            # check shapes
+            expected_shape_train_X = batch_shape + torch.Size(
+                [n, n - 1, train_X.shape[-1]]
+            )
+            expected_shape_test_X = batch_shape + torch.Size([n, 1, train_X.shape[-1]])
+            self.assertEqual(noiseless_cv_folds.train_X.shape, expected_shape_train_X)
+            self.assertEqual(noiseless_cv_folds.test_X.shape, expected_shape_test_X)
 
-                    expected_shape_train_Y = batch_shape + torch.Size(
-                        [n, n - 1, num_outputs]
-                    )
-                    expected_shape_test_Y = batch_shape + torch.Size(
-                        [n, 1, num_outputs]
-                    )
+            expected_shape_train_Y = batch_shape + torch.Size([n, n - 1, num_outputs])
+            expected_shape_test_Y = batch_shape + torch.Size([n, 1, num_outputs])
 
-                    self.assertEqual(
-                        noiseless_cv_folds.train_Y.shape, expected_shape_train_Y
-                    )
-                    self.assertEqual(
-                        noiseless_cv_folds.test_Y.shape, expected_shape_test_Y
-                    )
-                    self.assertIsNone(noiseless_cv_folds.train_Yvar)
-                    self.assertIsNone(noiseless_cv_folds.test_Yvar)
-                    # Test SingleTaskGP
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings("ignore", category=OptimizationWarning)
-                        cv_results = batch_cross_validation(
-                            model_cls=SingleTaskGP,
-                            mll_cls=ExactMarginalLogLikelihood,
-                            cv_folds=noiseless_cv_folds,
-                            fit_args={"options": {"maxiter": 1}},
-                        )
-                    expected_shape = batch_shape + torch.Size([n, 1, num_outputs])
-                    self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
-                    self.assertEqual(cv_results.observed_Y.shape, expected_shape)
+            self.assertEqual(noiseless_cv_folds.train_Y.shape, expected_shape_train_Y)
+            self.assertEqual(noiseless_cv_folds.test_Y.shape, expected_shape_test_Y)
+            self.assertIsNone(noiseless_cv_folds.train_Yvar)
+            self.assertIsNone(noiseless_cv_folds.test_Yvar)
+            # Test SingleTaskGP
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=OptimizationWarning)
+                cv_results = batch_cross_validation(
+                    model_cls=SingleTaskGP,
+                    mll_cls=ExactMarginalLogLikelihood,
+                    cv_folds=noiseless_cv_folds,
+                    fit_args={"options": {"maxiter": 1}},
+                )
+            expected_shape = batch_shape + torch.Size([n, 1, num_outputs])
+            self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
+            self.assertEqual(cv_results.observed_Y.shape, expected_shape)
 
-                    # Test FixedNoiseGP
-                    noisy_cv_folds = gen_loo_cv_folds(
-                        train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar
-                    )
-                    # check shapes
-                    self.assertEqual(
-                        noisy_cv_folds.train_X.shape, expected_shape_train_X
-                    )
-                    self.assertEqual(noisy_cv_folds.test_X.shape, expected_shape_test_X)
-                    self.assertEqual(
-                        noisy_cv_folds.train_Y.shape, expected_shape_train_Y
-                    )
-                    self.assertEqual(noisy_cv_folds.test_Y.shape, expected_shape_test_Y)
-                    self.assertEqual(
-                        noisy_cv_folds.train_Yvar.shape, expected_shape_train_Y
-                    )
-                    self.assertEqual(
-                        noisy_cv_folds.test_Yvar.shape, expected_shape_test_Y
-                    )
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings("ignore", category=OptimizationWarning)
-                        cv_results = batch_cross_validation(
-                            model_cls=FixedNoiseGP,
-                            mll_cls=ExactMarginalLogLikelihood,
-                            cv_folds=noisy_cv_folds,
-                            fit_args={"options": {"maxiter": 1}},
-                        )
-                    self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
-                    self.assertEqual(cv_results.observed_Y.shape, expected_shape)
-                    self.assertEqual(cv_results.observed_Y.shape, expected_shape)
+            # Test FixedNoiseGP
+            noisy_cv_folds = gen_loo_cv_folds(
+                train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar
+            )
+            # check shapes
+            self.assertEqual(noisy_cv_folds.train_X.shape, expected_shape_train_X)
+            self.assertEqual(noisy_cv_folds.test_X.shape, expected_shape_test_X)
+            self.assertEqual(noisy_cv_folds.train_Y.shape, expected_shape_train_Y)
+            self.assertEqual(noisy_cv_folds.test_Y.shape, expected_shape_test_Y)
+            self.assertEqual(noisy_cv_folds.train_Yvar.shape, expected_shape_train_Y)
+            self.assertEqual(noisy_cv_folds.test_Yvar.shape, expected_shape_test_Y)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=OptimizationWarning)
+                cv_results = batch_cross_validation(
+                    model_cls=FixedNoiseGP,
+                    mll_cls=ExactMarginalLogLikelihood,
+                    cv_folds=noisy_cv_folds,
+                    fit_args={"options": {"maxiter": 1}},
+                )
+            self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
+            self.assertEqual(cv_results.observed_Y.shape, expected_shape)
+            self.assertEqual(cv_results.observed_Y.shape, expected_shape)

--- a/test/utils/test_sampling.py
+++ b/test/utils/test_sampling.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 import warnings
 
 import torch
@@ -27,26 +28,25 @@ class TestConstructBaseSamples(BotorchTestCase):
             {"batch": [1], "output": [5, 3], "sample": [5, 6]},
             {"batch": [2, 3], "output": [2, 3], "sample": [5]},
         ]
-        for tshape in test_shapes:
+        for tshape, qmc, seed, dtype in itertools.product(
+            test_shapes, (False, True), (None, 1234), (torch.float, torch.double)
+        ):
             batch_shape = torch.Size(tshape["batch"])
             output_shape = torch.Size(tshape["output"])
             sample_shape = torch.Size(tshape["sample"])
             expected_shape = sample_shape + batch_shape + output_shape
-            for dtype in (torch.float, torch.double):
-                for qmc in (False, True):
-                    for seed in (None, 1234):
-                        samples = construct_base_samples(
-                            batch_shape=batch_shape,
-                            output_shape=output_shape,
-                            sample_shape=sample_shape,
-                            qmc=qmc,
-                            seed=seed,
-                            device=self.device,
-                            dtype=dtype,
-                        )
-                        self.assertEqual(samples.shape, expected_shape)
-                        self.assertEqual(samples.device.type, self.device.type)
-                        self.assertEqual(samples.dtype, dtype)
+            samples = construct_base_samples(
+                batch_shape=batch_shape,
+                output_shape=output_shape,
+                sample_shape=sample_shape,
+                qmc=qmc,
+                seed=seed,
+                device=self.device,
+                dtype=dtype,
+            )
+            self.assertEqual(samples.shape, expected_shape)
+            self.assertEqual(samples.device.type, self.device.type)
+            self.assertEqual(samples.dtype, dtype)
         # check that warning is issued if dimensionality is too large
         with warnings.catch_warnings(record=True) as w, settings.debug(True):
             construct_base_samples(
@@ -67,83 +67,81 @@ class TestConstructBaseSamples(BotorchTestCase):
             cov = torch.eye(2, device=self.device, dtype=dtype)
             mvn = MultivariateNormal(mean=mean, covariance_matrix=cov)
             posterior = GPyTorchPosterior(mvn=mvn)
-            for sample_shape in (torch.Size([5]), torch.Size([5, 3])):
-                for qmc in (False, True):
-                    for seed in (None, 1234):
-                        expected_shape = sample_shape + torch.Size([2, 1])
-                        samples = construct_base_samples_from_posterior(
-                            posterior=posterior,
-                            sample_shape=sample_shape,
-                            qmc=qmc,
-                            seed=seed,
-                        )
-                        self.assertEqual(samples.shape, expected_shape)
-                        self.assertEqual(samples.device.type, self.device.type)
-                        self.assertEqual(samples.dtype, dtype)
+            for sample_shape, qmc, seed in itertools.product(
+                (torch.Size([5]), torch.Size([5, 3])), (False, True), (None, 1234)
+            ):
+                expected_shape = sample_shape + torch.Size([2, 1])
+                samples = construct_base_samples_from_posterior(
+                    posterior=posterior, sample_shape=sample_shape, qmc=qmc, seed=seed
+                )
+                self.assertEqual(samples.shape, expected_shape)
+                self.assertEqual(samples.device.type, self.device.type)
+                self.assertEqual(samples.dtype, dtype)
             # single-output, batch mode
             mean = torch.zeros(2, 2, device=self.device, dtype=dtype)
             cov = torch.eye(2, device=self.device, dtype=dtype).expand(2, 2, 2)
             mvn = MultivariateNormal(mean=mean, covariance_matrix=cov)
             posterior = GPyTorchPosterior(mvn=mvn)
-            for sample_shape in (torch.Size([5]), torch.Size([5, 3])):
-                for qmc in (False, True):
-                    for seed in (None, 1234):
-                        for collapse_batch_dims in (False, True):
-                            if collapse_batch_dims:
-                                expected_shape = sample_shape + torch.Size([1, 2, 1])
-                            else:
-                                expected_shape = sample_shape + torch.Size([2, 2, 1])
-                            samples = construct_base_samples_from_posterior(
-                                posterior=posterior,
-                                sample_shape=sample_shape,
-                                qmc=qmc,
-                                collapse_batch_dims=collapse_batch_dims,
-                                seed=seed,
-                            )
-                            self.assertEqual(samples.shape, expected_shape)
-                            self.assertEqual(samples.device.type, self.device.type)
-                            self.assertEqual(samples.dtype, dtype)
+            for sample_shape, qmc, seed, collapse_batch_dims in itertools.product(
+                (torch.Size([5]), torch.Size([5, 3])),
+                (False, True),
+                (None, 1234),
+                (False, True),
+            ):
+                if collapse_batch_dims:
+                    expected_shape = sample_shape + torch.Size([1, 2, 1])
+                else:
+                    expected_shape = sample_shape + torch.Size([2, 2, 1])
+                samples = construct_base_samples_from_posterior(
+                    posterior=posterior,
+                    sample_shape=sample_shape,
+                    qmc=qmc,
+                    collapse_batch_dims=collapse_batch_dims,
+                    seed=seed,
+                )
+                self.assertEqual(samples.shape, expected_shape)
+                self.assertEqual(samples.device.type, self.device.type)
+                self.assertEqual(samples.dtype, dtype)
             # multi-output
             mean = torch.zeros(2, 2, device=self.device, dtype=dtype)
             cov = torch.eye(4, device=self.device, dtype=dtype)
             mtmvn = MultitaskMultivariateNormal(mean=mean, covariance_matrix=cov)
             posterior = GPyTorchPosterior(mvn=mtmvn)
-            for sample_shape in (torch.Size([5]), torch.Size([5, 3])):
-                for qmc in (False, True):
-                    for seed in (None, 1234):
-                        expected_shape = sample_shape + torch.Size([2, 2])
-                        samples = construct_base_samples_from_posterior(
-                            posterior=posterior,
-                            sample_shape=sample_shape,
-                            qmc=qmc,
-                            seed=seed,
-                        )
-                        self.assertEqual(samples.shape, expected_shape)
-                        self.assertEqual(samples.device.type, self.device.type)
-                        self.assertEqual(samples.dtype, dtype)
+            for sample_shape, qmc, seed in itertools.product(
+                (torch.Size([5]), torch.Size([5, 3])), (False, True), (None, 1234)
+            ):
+                expected_shape = sample_shape + torch.Size([2, 2])
+                samples = construct_base_samples_from_posterior(
+                    posterior=posterior, sample_shape=sample_shape, qmc=qmc, seed=seed
+                )
+                self.assertEqual(samples.shape, expected_shape)
+                self.assertEqual(samples.device.type, self.device.type)
+                self.assertEqual(samples.dtype, dtype)
             # multi-output, batch mode
             mean = torch.zeros(2, 2, 2, device=self.device, dtype=dtype)
             cov = torch.eye(4, device=self.device, dtype=dtype).expand(2, 4, 4)
             mtmvn = MultitaskMultivariateNormal(mean=mean, covariance_matrix=cov)
             posterior = GPyTorchPosterior(mvn=mtmvn)
-            for sample_shape in (torch.Size([5]), torch.Size([5, 3])):
-                for qmc in (False, True):
-                    for seed in (None, 1234):
-                        for collapse_batch_dims in (False, True):
-                            if collapse_batch_dims:
-                                expected_shape = sample_shape + torch.Size([1, 2, 2])
-                            else:
-                                expected_shape = sample_shape + torch.Size([2, 2, 2])
-                            samples = construct_base_samples_from_posterior(
-                                posterior=posterior,
-                                sample_shape=sample_shape,
-                                qmc=qmc,
-                                collapse_batch_dims=collapse_batch_dims,
-                                seed=seed,
-                            )
-                            self.assertEqual(samples.shape, expected_shape)
-                            self.assertEqual(samples.device.type, self.device.type)
-                            self.assertEqual(samples.dtype, dtype)
+            for sample_shape, qmc, seed, collapse_batch_dims in itertools.product(
+                (torch.Size([5]), torch.Size([5, 3])),
+                (False, True),
+                (None, 1234),
+                (False, True),
+            ):
+                if collapse_batch_dims:
+                    expected_shape = sample_shape + torch.Size([1, 2, 2])
+                else:
+                    expected_shape = sample_shape + torch.Size([2, 2, 2])
+                samples = construct_base_samples_from_posterior(
+                    posterior=posterior,
+                    sample_shape=sample_shape,
+                    qmc=qmc,
+                    collapse_batch_dims=collapse_batch_dims,
+                    seed=seed,
+                )
+                self.assertEqual(samples.shape, expected_shape)
+                self.assertEqual(samples.device.type, self.device.type)
+                self.assertEqual(samples.dtype, dtype)
 
 
 class TestManualSeed(BotorchTestCase):


### PR DESCRIPTION
Summary:
Some cleanup:
- re-use data generation functions
- make things more concise
- use `itertools.product` to avoid deep indentation.

This will simplify writing tests for the outcome transforms through the code base down the road.

**Note:** This does not touch any of the functionality, it's mostly housekeeping.

Differential Revision: D18727725

