### PR TITLE
Use outcome transforms in models

### DIFF
--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -26,6 +26,7 @@ from .gp_regression import SingleTaskGP
 from .kernels.downsampling import DownsamplingKernel
 from .kernels.exponential_decay import ExponentialDecayKernel
 from .kernels.linear_truncated_fidelity import LinearTruncatedFidelityKernel
+from .transforms.outcome import OutcomeTransform
 
 
 class SingleTaskMultiFidelityGP(SingleTaskGP):
@@ -68,6 +69,7 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         linear_truncated: bool = True,
         nu: float = 2.5,
         likelihood: Optional[Likelihood] = None,
+        outcome_transform: Optional[OutcomeTransform] = None,
     ) -> None:
         if iteration_fidelity is None and data_fidelity is None:
             raise UnsupportedError(
@@ -126,5 +128,10 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
             batch_shape=self._aug_batch_shape,
             outputscale_prior=GammaPrior(2.0, 0.15),
         )
-        super().__init__(train_X=train_X, train_Y=train_Y, covar_module=covar_module)
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            covar_module=covar_module,
+            outcome_transform=outcome_transform,
+        )
         self.to(train_X)

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -36,6 +36,8 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
 
         Args:
             *gp_models: An variable number of single-output BoTorch models.
+                If models have input/output transforms, these are honored
+                individually for each model.
 
         Example:
             >>> model1 = SingleTaskGP(train_X1, train_Y1)

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 import warnings
 
 import torch
@@ -12,6 +13,7 @@ from botorch.exceptions.warnings import OptimizationWarning
 from botorch.fit import fit_gpytorch_model
 from botorch.models import ModelListGP
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
+from botorch.models.transforms import Standardize
 from botorch.posteriors import GPyTorchPosterior
 from botorch.utils.testing import BotorchTestCase, _get_random_data
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
@@ -23,37 +25,47 @@ from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikeliho
 from gpytorch.priors import GammaPrior
 
 
-def _get_model(n, fixed_noise=False, **tkwargs):
+def _get_model(n, fixed_noise=False, use_octf=False, **tkwargs):
     train_x1, train_y1 = _get_random_data(
         batch_shape=torch.Size(), num_outputs=1, n=10, **tkwargs
     )
     train_x2, train_y2 = _get_random_data(
         batch_shape=torch.Size(), num_outputs=1, n=11, **tkwargs
     )
+    octfs = [Standardize(m=1), Standardize(m=1)] if use_octf else [None, None]
     if fixed_noise:
         train_y1_var = 0.1 + 0.1 * torch.rand_like(train_y1, **tkwargs)
         train_y2_var = 0.1 + 0.1 * torch.rand_like(train_y2, **tkwargs)
         model1 = FixedNoiseGP(
-            train_X=train_x1, train_Y=train_y1, train_Yvar=train_y1_var
+            train_X=train_x1,
+            train_Y=train_y1,
+            train_Yvar=train_y1_var,
+            outcome_transform=octfs[0],
         )
         model2 = FixedNoiseGP(
-            train_X=train_x2, train_Y=train_y2, train_Yvar=train_y2_var
+            train_X=train_x2,
+            train_Y=train_y2,
+            train_Yvar=train_y2_var,
+            outcome_transform=octfs[1],
         )
     else:
-        model1 = SingleTaskGP(train_X=train_x1, train_Y=train_y1)
-        model2 = SingleTaskGP(train_X=train_x2, train_Y=train_y2)
+        model1 = SingleTaskGP(
+            train_X=train_x1, train_Y=train_y1, outcome_transform=octfs[0]
+        )
+        model2 = SingleTaskGP(
+            train_X=train_x2, train_Y=train_y2, outcome_transform=octfs[1]
+        )
     model = ModelListGP(model1, model2)
     return model.to(**tkwargs)
 
 
 class TestModelListGP(BotorchTestCase):
     def test_ModelListGP(self):
-        for double in (False, True):
-            tkwargs = {
-                "device": self.device,
-                "dtype": torch.double if double else torch.float,
-            }
-            model = _get_model(n=10, **tkwargs)
+        for dtype, use_octf in itertools.product(
+            (torch.float, torch.double), (False, True)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model = _get_model(n=10, use_octf=use_octf, **tkwargs)
             self.assertIsInstance(model, ModelListGP)
             self.assertIsInstance(model.likelihood, LikelihoodList)
             for m in model.models:
@@ -62,6 +74,8 @@ class TestModelListGP(BotorchTestCase):
                 matern_kernel = m.covar_module.base_kernel
                 self.assertIsInstance(matern_kernel, MaternKernel)
                 self.assertIsInstance(matern_kernel.lengthscale_prior, GammaPrior)
+                if use_octf:
+                    self.assertIsInstance(m.outcome_transform, Standardize)
 
             # test constructing likelihood wrapper
             mll = SumMarginalLogLikelihood(model.likelihood, model)
@@ -84,6 +98,16 @@ class TestModelListGP(BotorchTestCase):
             posterior = model.posterior(test_x)
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertIsInstance(posterior.mvn, MultitaskMultivariateNormal)
+            if use_octf:
+                # ensure un-transformation is applied
+                submodel = model.models[0]
+                p0 = submodel.posterior(test_x)
+                tmp_tf = submodel.outcome_transform
+                del submodel.outcome_transform
+                p0_tf = submodel.posterior(test_x)
+                submodel.outcome_transform = tmp_tf
+                expected_var = tmp_tf.untransform_posterior(p0_tf).variance
+                self.assertTrue(torch.allclose(p0.variance, expected_var))
 
             # test observation_noise
             posterior = model.posterior(test_x, observation_noise=True)
@@ -120,12 +144,11 @@ class TestModelListGP(BotorchTestCase):
                 model.condition_on_observations(f_x, torch.rand(3, 2, 3, **tkwargs))
 
     def test_ModelListGP_fixed_noise(self):
-        for double in (False, True):
-            tkwargs = {
-                "device": self.device,
-                "dtype": torch.double if double else torch.float,
-            }
-            model = _get_model(n=10, fixed_noise=True, **tkwargs)
+        for dtype, use_octf in itertools.product(
+            (torch.float, torch.double), (False, True)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            model = _get_model(n=10, fixed_noise=True, use_octf=use_octf, **tkwargs)
             self.assertIsInstance(model, ModelListGP)
             self.assertIsInstance(model.likelihood, LikelihoodList)
             for m in model.models:
@@ -148,6 +171,16 @@ class TestModelListGP(BotorchTestCase):
             posterior = model.posterior(test_x)
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertIsInstance(posterior.mvn, MultitaskMultivariateNormal)
+            if use_octf:
+                # ensure un-transformation is applied
+                submodel = model.models[0]
+                p0 = submodel.posterior(test_x)
+                tmp_tf = submodel.outcome_transform
+                del submodel.outcome_transform
+                p0_tf = submodel.posterior(test_x)
+                submodel.outcome_transform = tmp_tf
+                expected_var = tmp_tf.untransform_posterior(p0_tf).variance
+                self.assertTrue(torch.allclose(p0.variance, expected_var))
 
             # test output_indices
             posterior = model.posterior(

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -134,6 +134,11 @@ class TestMultiTaskGP(BotorchTestCase):
             with self.assertRaises(RuntimeError):
                 MultiTaskGP(train_X, train_Y, 0, output_tasks=[2])
 
+            # test error if outcome_transform attribute is present
+            model.outcome_transform = None
+            with self.assertRaises(NotImplementedError):
+                model.posterior(test_x)
+
     def test_MultiTaskGP_single_output(self):
         for double in (False, True):
             tkwargs = {


### PR DESCRIPTION
Summary:
Hook up outcome transforms to BoTorch models. The way this is done isn't entirely satisfying, but it's the most reasonable setup I can think of at this point.

This diff does not hook up input transformations.

Also cleans up some unrelated docstrings that I came across.

Differential Revision: D18611595

