### PR TITLE
remove fidelity_dims member in botorch MF MVE class

### DIFF
--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -378,7 +378,6 @@ class qMultiFidelityMaxValueEntropy(qMaxValueEntropy):
         if cost_aware_utility is None:
             cost_model = AffineFidelityCostModel(fidelity_weights={-1: 1.0})
             cost_aware_utility = InverseCostWeightedUtility(cost_model=cost_model)
-        self.fidelity_dims = cost_aware_utility.cost_model.fidelity_dims
 
         self.cost_aware_utility = cost_aware_utility
         self.expand = expand

--- a/test/acquisition/test_max_value_entropy_search.py
+++ b/test/acquisition/test_max_value_entropy_search.py
@@ -130,7 +130,6 @@ class TestMaxValueEntropySearch(BotorchTestCase):
             self.assertIsInstance(qMF_MVE.expand, Callable)
             self.assertIsInstance(qMF_MVE.project, Callable)
             self.assertIsNone(qMF_MVE.X_pending)
-            self.assertEqual(qMF_MVE.fidelity_dims, [-1])
             self.assertEqual(qMF_MVE.posterior_max_values.shape, torch.Size([10, 1]))
 
             # test evaluation


### PR DESCRIPTION
Summary: the learned cost model does not have fidelity_dims member. Since it is not used at all, remove it to avoid errors.

Reviewed By: bkarrer

Differential Revision: D18825344

