### PR TITLE
make sure cost is not close to zero

### DIFF
--- a/test/acquisition/test_cost_aware.py
+++ b/test/acquisition/test_cost_aware.py
@@ -83,3 +83,13 @@ class TestCostAwareUtilities(BotorchTestCase):
                 self.assertTrue(
                     torch.equal(ratios, deltas / samples.squeeze(-1).sum(dim=-1))
                 )
+
+                # test min cost
+                mm = MockModel(MockPosterior(mean=mean))
+                icwu = InverseCostWeightedUtility(mm, min_cost=1.5)
+                ratios = icwu(X, deltas)
+                self.assertTrue(
+                    torch.equal(
+                        ratios, deltas / mean.clamp_min(1.5).squeeze(-1).sum(dim=-1)
+                    )
+                )


### PR DESCRIPTION
Summary: to avoid numerical issues (although this does not seem to be causing issues currently after examining some runs)

Reviewed By: Balandat

Differential Revision: D18604233

