### PR TITLE
Importance sampling for (q)MC acquisition functions

### DIFF
--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -155,11 +155,12 @@ class qExpectedImprovement(MCAcquisitionFunction):
             design points `X`.
         """
         posterior = self.model.posterior(X)
-        samples = self.sampler(posterior)
+        samples, sample_weights = self.sampler(posterior)
         obj = self.objective(samples)
-        obj = (obj - self.best_f).clamp_min(0)
-        q_ei = obj.max(dim=-1)[0].mean(dim=0)
-        return q_ei
+        obj = (obj - self.best_f).clamp_min(0).max(dim=-1)[0]
+        if sample_weights is not None:
+            obj = obj * sample_weights
+        return obj.mean(dim=0)
 
 
 class qNoisyExpectedImprovement(MCAcquisitionFunction):


### PR DESCRIPTION
Summary:
This diff implements importance sampling for the `MCSampler` classes, and hooks a basic version of this up into qExpectedImprovement.

If `best_f` is relatively close to the posterior's maximum mean, and if the variance is low, then a lot of the qEI MC objective samples will have zero contribution to the estimate.

This diff allows to inflates the variance of the base samples, record the likelihood ratio for each sample (relative to a `N(0, I)` base sample)  and then applies a weighted mean to the individual sample contributions.

No doubt smarter things could be done for this.

This results in a reduced variance of the estimator. Note that if `best_f` is low, this will instead *increase* the variance of the estimator. Likely the latter is less of a problem since `best_f` will typically close be to the best modeled values in practice. Additional empirical evaluation, in particular of the closed-loop optimization behavior, is needed.

Here is a nb with some initial results: [MC_acq_importance_sampling.ipynb.txt](https://github.com/pytorch/botorch/files/4100962/MC_acq_importance_sampling.ipynb.txt)

Quite a bit more work is needed before this can go in.

Differential Revision: D18553363
