### PR TITLE
Validate tensor args before checking input scaling

### DIFF
--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -86,8 +86,8 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         """
         if outcome_transform is not None:
             train_Y, _ = outcome_transform(train_Y)
-        validate_input_scaling(train_X=train_X, train_Y=train_Y)
         self._validate_tensor_args(X=train_X, Y=train_Y)
+        validate_input_scaling(train_X=train_X, train_Y=train_Y)
         self._set_dimensions(train_X=train_X, train_Y=train_Y)
         train_X, train_Y, _ = self._transform_tensor_args(X=train_X, Y=train_Y)
         if likelihood is None:
@@ -174,8 +174,8 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         """
         if outcome_transform is not None:
             train_Y, train_Yvar = outcome_transform(train_Y, train_Yvar)
-        validate_input_scaling(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
         self._validate_tensor_args(X=train_X, Y=train_Y, Yvar=train_Yvar)
+        validate_input_scaling(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
         self._set_dimensions(train_X=train_X, train_Y=train_Y)
         train_X, train_Y, train_Yvar = self._transform_tensor_args(
             X=train_X, Y=train_Y, Yvar=train_Yvar
@@ -308,8 +308,8 @@ class HeteroskedasticSingleTaskGP(SingleTaskGP):
         """
         if outcome_transform is not None:
             train_Y, train_Yvar = outcome_transform(train_Y, train_Yvar)
-        validate_input_scaling(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
         self._validate_tensor_args(X=train_X, Y=train_Y, Yvar=train_Yvar)
+        validate_input_scaling(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
         self._set_dimensions(train_X=train_X, train_Y=train_Y)
         noise_likelihood = GaussianLikelihood(
             noise_prior=SmoothedBoxPrior(-3, 5, 0.5, transform=torch.log),


### PR DESCRIPTION
The current order causes a hard-to-parse and non-actionable error message (see #315).
By changing the order the proper error message relating to the root cause is raised instead.