### PR TITLE
Fix batch-list conversion of SingleTaskMultiFidelityGP

### DIFF
--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -71,6 +71,13 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         likelihood: Optional[Likelihood] = None,
         outcome_transform: Optional[OutcomeTransform] = None,
     ) -> None:
+        self._init_args = {
+            "iteration_fidelity": iteration_fidelity,
+            "data_fidelity": data_fidelity,
+            "linear_truncated": linear_truncated,
+            "nu": nu,
+            "outcome_transform": outcome_transform,
+        }
         if iteration_fidelity is None and data_fidelity is None:
             raise UnsupportedError(
                 "SingleTaskMultiFidelityGP requires at least one fidelity parameter."


### PR DESCRIPTION
This fixes an issue where fitting a `SingleTaskMultiFidelityGP` resulted in `fit_gpytorch_model` erroring out white it was trying to perform batch-list conversion for fitting. 

This fix isn't particularly pretty. We eventually probably want to change this setup to be a method on the model instead, similar to subset_model.
