### PR TITLE
Allow subsetting SingleTaskMultiFidelityGP

### DIFF
--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -141,4 +141,34 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
             covar_module=covar_module,
             outcome_transform=outcome_transform,
         )
+        if linear_truncated:
+            subset_batch_dict = {
+                "covar_module.base_kernel.raw_power": -2,
+                "covar_module.base_kernel.covar_module_unbiased.raw_lengthscale": -3,
+                "covar_module.base_kernel.covar_module_biased.raw_lengthscale": -3,
+            }
+        else:
+            subset_batch_dict = {
+                "covar_module.base_kernel.kernels.0.raw_lengthscale": -3,
+                "covar_module.base_kernel.kernels.1.raw_power": -2,
+                "covar_module.base_kernel.kernels.1.raw_offset": -2,
+            }
+            if iteration_fidelity is not None:
+                subset_batch_dict = {
+                    "covar_module.base_kernel.kernels.1.raw_lengthscale": -3,
+                    **subset_batch_dict,
+                }
+                if data_fidelity is not None:
+                    subset_batch_dict = {
+                        "covar_module.base_kernel.kernels.2.raw_power": -2,
+                        "covar_module.base_kernel.kernels.2.raw_offset": -2,
+                        **subset_batch_dict,
+                    }
+        self._subset_batch_dict = {
+            "likelihood.noise_covar.raw_noise": -2,
+            "mean_module.constant": -2,
+            "covar_module.raw_outputscale": -1,
+            **subset_batch_dict,
+        }
+
         self.to(train_X)

--- a/botorch/models/kernels/downsampling.py
+++ b/botorch/models/kernels/downsampling.py
@@ -111,8 +111,8 @@ class DownsamplingKernel(Kernel):
         last_dim_is_batch: Optional[bool] = False,
         **params,
     ) -> Tensor:
-        offset = self.offset.view(*self.batch_shape, 1, 1)
-        exponent = 1 + self.power.view(*self.batch_shape, 1, 1)
+        offset = self.offset.unsqueeze(-1)  # unsqueeze enables batch evaluation
+        exponent = 1 + self.power.unsqueeze(-1)  # unsqueeze enables batch evaluation
         if last_dim_is_batch:
             x1 = x1.transpose(-1, -2).unsqueeze(-1)
             x2 = x2.transpose(-1, -2).unsqueeze(-1)

--- a/botorch/models/kernels/exponential_decay.py
+++ b/botorch/models/kernels/exponential_decay.py
@@ -110,8 +110,8 @@ class ExponentialDecayKernel(Kernel):
         self.initialize(raw_offset=self.raw_offset_constraint.inverse_transform(value))
 
     def forward(self, x1: Tensor, x2: Tensor, **params) -> Tensor:
-        offset = self.offset.view(*self.batch_shape, 1, 1)
-        power = self.power.view(*self.batch_shape, 1, 1)
+        offset = self.offset.unsqueeze(-1)  # unsqueeze enables batch evaluation
+        power = self.power.unsqueeze(-1)  # unsqueeze enables batch evaluation
         x1_ = x1.div(self.lengthscale)
         x2_ = x2.div(self.lengthscale)
         diff = self.covar_dist(x1_, -x2_, **params)


### PR DESCRIPTION
Summary: Support `subset_output` method on multi-fidelity models.

Reviewed By: danielrjiang

Differential Revision: D19546885

