### PR TITLE
Fixing TestLoader local test discovery

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -13,6 +13,7 @@ to the GPU running out of memory.
 """
 
 import unittest
+from pathlib import Path
 from typing import Union
 
 import torch
@@ -22,7 +23,8 @@ from botorch.utils.testing import BotorchTestCase
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
 class TestBotorchCUDA(unittest.TestCase):
     def test_cuda(self):
-        tests = unittest.TestLoader().discover(".")
+        test_dir = Path(__file__).parent.resolve()
+        tests = unittest.TestLoader().discover(test_dir)
         run_cuda_tests(tests)
 
 


### PR DESCRIPTION
Summary: From the difference in runtimes in the test plan (380s this diff vs 15s the base commit), looks like this was really an issue with using `"."` in `discover` for the test runner, and the tests previously didn't run properly on fb infra. They did however run in OSS, where they were run from a proper root dir.

Differential Revision: D19987477

