### PR TITLE
Better stopping criteria for stochastic optimization

### DIFF
--- a/botorch/optim/__init__.py
+++ b/botorch/optim/__init__.py
@@ -7,6 +7,7 @@
 from .initializers import initialize_q_batch, initialize_q_batch_nonneg
 from .numpy_converter import module_to_array, set_params_with_array
 from .optimize import gen_batch_initial_conditions, optimize_acqf, optimize_acqf_cyclic
+from .stopping import ExpMAStoppingCriterion
 
 
 __all__ = [
@@ -17,4 +18,5 @@ __all__ = [
     "optimize_acqf_cyclic",
     "module_to_array",
     "set_params_with_array",
+    "ExpMAStoppingCriterion",
 ]

--- a/botorch/optim/stopping.py
+++ b/botorch/optim/stopping.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import typing  # noqa F401
+from abc import ABC, abstractmethod
+
+import torch
+from torch import Tensor
+
+
+class StoppingCriterion(ABC):
+    r"""Base class for evaluating optimization convergence.
+
+    Stopping criteria are implemented as a objects rather than a function, so that they
+    can keep track of past function values between optimization steps.
+    """
+
+    @abstractmethod
+    def evaluate(self, fvals: Tensor) -> bool:
+        r"""Evaluate the stopping criterion.
+
+        Args:
+            fvals: tensor containing function values for the current iteration. If
+                `fvals` contains more than one element, then the stopping criterion is
+                evaluated element-wise and True is returned if the stopping criterion is
+                true for all elements.
+
+        Returns:
+            Stopping indicator (if True, stop the optimziation).
+        """
+        pass  # pragma: no cover
+
+
+class ExpMAStoppingCriterion(StoppingCriterion):
+    r"""Exponential moving average stopping criterion.
+
+    Computes an exponentially weighted moving average over window length `n_window`
+    and checks whether the relative decrease in this moving average between steps
+    is less than a provided tolerance level. That is, in iteration `i`, it computes
+
+        ma_i[j] := fvals[i - n_window + j] * w[j]
+
+    for all `j = 0, ..., n_window`, where `w[j] = exp(-eta * (1 - j / n_window))`.
+    Letting `ma_i := sum_j(ma_i[j])`, the criterion evaluates to `True` whenever
+
+        (ma_i-1 - ma_i) / abs(ma_i-1) < rel_tol (if minimize=True)
+        (ma_i - ma_i-1) / abs(ma_i-1) < rel_tol (if minimize=False)
+    """
+
+    def __init__(
+        self,
+        maxiter: int = 10000,
+        minimize: bool = True,
+        n_window: int = 10,
+        eta: float = 1.0,
+        rel_tol: float = 1e-5,
+    ) -> None:
+        r"""Exponential moving average stopping criterion.
+
+        Args:
+            maxiter: Maximum number of iterations.
+            minimize: If True, assume minimization.
+            n_window: The size of the exponential moving average window.
+            eta: The exponential decay factor in the weights.
+            rel_tol: Relative tolerance for termination.
+        """
+        self.maxiter = maxiter
+        self.minimize = minimize
+        self.n_window = n_window
+        self.rel_tol = rel_tol
+        self.iter = 0
+        weights = torch.exp(torch.linspace(-eta, 0, self.n_window))
+        self.weights = weights / weights.sum()
+        self._prev_fvals = None
+
+    def evaluate(self, fvals: Tensor) -> bool:
+        r"""Evaluate the stopping criterion.
+
+        Args:
+            fvals: tensor containing function values for the current iteration. If
+                `fvals` contains more than one element, then the stopping criterion is
+                evaluated element-wise and True is returned if the stopping criterion is
+                true for all elements.
+
+        TODO: add support for utilizing gradient information
+
+        Returns:
+            Stopping indicator (if True, stop the optimziation).
+        """
+        self.iter += 1
+        if self.iter == self.maxiter:
+            return True
+
+        if self._prev_fvals is None:
+            self._prev_fvals = fvals.unsqueeze(0)
+        else:
+            self._prev_fvals = torch.cat(
+                [self._prev_fvals[-self.n_window :], fvals.unsqueeze(0)]
+            )
+
+        if self._prev_fvals.size(0) < self.n_window + 1:
+            return False
+
+        weights = self.weights
+        if self._prev_fvals.ndim > 1:
+            weights = weights.unsqueeze(-1)
+
+        # TODO: Update the exp moving average efficiently
+        prev_ma = (self._prev_fvals[:-1] * weights).sum(dim=0)
+        ma = (self._prev_fvals[1:] * weights).sum(dim=0)
+        # TODO: Handle approx. zero losses (normalize by min/max loss range)
+        rel_delta = (prev_ma - ma) / prev_ma.abs()
+
+        if not self.minimize:
+            rel_delta = -rel_delta
+        if torch.max(rel_delta) < self.rel_tol:
+            return True
+
+        return False

--- a/botorch/optim/utils.py
+++ b/botorch/optim/utils.py
@@ -49,60 +49,6 @@ def sample_all_priors(model: GPyTorchModel) -> None:
             )
 
 
-class ConvergenceCriterion:
-    r"""Basic class for evaluating optimization convergence.
-    """
-
-    def __init__(
-        self,
-        maxiter: int = 15000,
-        ftol: float = 2.220446049250313e-09,
-        minimize: bool = True,
-    ) -> None:
-        r"""Constructor for ConvergenceCriterion.
-
-        Args:
-            maxiter: maximum number of iterations.
-            ftol: Function value relative tolerance for termination.
-            minimize: boolean indicating the optimization direction.
-        """
-        # by default, use the scipy defaults
-        self.maxiter = maxiter
-        self.ftol = ftol
-        self.minimize = minimize
-        self.prev_fvals = None
-        self.iter = 0
-
-    def evaluate(self, fvals: Tensor) -> bool:
-        r"""Evaluate convergence criterion.
-
-        Args:
-            fvals: tensor containing function values for the current iteration.
-                If `fvals` contains more than one element, then the relative
-                tolerance criterion is evaluated element-wise and True is returned
-                if all elements have converged.
-
-        TODO: add support for utilizing gradient information
-
-        Returns:
-            bool: convergence indicator
-        """
-        self.iter += 1
-        if self.iter == self.maxiter:
-            return True
-        elif self.prev_fvals is not None:
-            fmax = torch.stack(
-                [self.prev_fvals.abs(), fvals.abs(), torch.ones_like(fvals)], dim=0
-            ).max(dim=0)[0]
-            f_delta = (self.prev_fvals - fvals).div(fmax)
-            if not self.minimize:
-                f_delta *= -1
-            if torch.all(f_delta <= self.ftol):
-                return True
-        self.prev_fvals = fvals
-        return False
-
-
 def columnwise_clamp(
     X: Tensor,
     lower: Optional[Union[float, Tensor]] = None,

--- a/sphinx/source/optim.rst
+++ b/sphinx/source/optim.rst
@@ -26,6 +26,11 @@ Initialization Helpers
 .. automodule:: botorch.optim.initializers
     :members:
 
+Stopping Criteria
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.optim.stopping
+    :members:
+
 
 Utilities
 -------------------------------------------

--- a/test/optim/test_stopping.py
+++ b/test/optim/test_stopping.py
@@ -1,0 +1,60 @@
+#! /usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import torch
+from botorch.optim.stopping import ExpMAStoppingCriterion, StoppingCriterion
+from botorch.utils.testing import BotorchTestCase
+
+
+class TestStoppingCriterion(BotorchTestCase):
+    def test_abstract_raises(self):
+        with self.assertRaises(TypeError):
+            StoppingCriterion()
+
+    def test_exponential_moving_average(self):
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"device": self.device, "dtype": dtype}
+
+            # test max iter
+            sc = ExpMAStoppingCriterion(maxiter=2)
+            self.assertEqual(sc.maxiter, 2)
+            self.assertEqual(sc.n_window, 10)
+            self.assertEqual(sc.rel_tol, 1e-5)
+            self.assertFalse(sc.evaluate(fvals=torch.ones(1, **tkwargs)))
+            self.assertTrue(sc.evaluate(fvals=torch.zeros(1, **tkwargs)))
+
+            # test convergence
+            n_window = 4
+            for minimize in (True, False):
+                # test basic
+                sc = ExpMAStoppingCriterion(
+                    minimize=minimize, n_window=n_window, rel_tol=0.0375
+                )
+                self.assertEqual(sc.rel_tol, 0.0375)
+                self.assertIsNone(sc._prev_fvals)
+                weights_exp = torch.tensor([0.1416, 0.1976, 0.2758, 0.3849])
+                self.assertTrue(torch.allclose(sc.weights, weights_exp, atol=1e-4))
+                f_vals = 1 + torch.linspace(1, 0, 25) ** 2
+                if not minimize:
+                    f_vals = -f_vals
+                for i, fval in enumerate(f_vals):
+                    if sc.evaluate(fval):
+                        self.assertEqual(i, 10)
+                        break
+                # test multiple components
+                sc = ExpMAStoppingCriterion(
+                    minimize=minimize, n_window=n_window, rel_tol=0.0375
+                )
+                df = torch.linspace(0, 0.1, 25)
+                if not minimize:
+                    df = -df
+                f_vals = torch.stack([f_vals, f_vals + df], dim=-1)
+                for i, fval in enumerate(f_vals):
+                    if sc.evaluate(fval):
+                        self.assertEqual(i, 10)
+                        break

--- a/test/optim/test_utils.py
+++ b/test/optim/test_utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import warnings
 from copy import deepcopy
 
@@ -12,7 +14,6 @@ from botorch import settings
 from botorch.exceptions import BotorchError
 from botorch.models import ModelListGP, SingleTaskGP
 from botorch.optim.utils import (
-    ConvergenceCriterion,
     _expand_bounds,
     _get_extra_mll_args,
     columnwise_clamp,
@@ -27,45 +28,6 @@ from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
 from gpytorch.priors.smoothed_box_prior import SmoothedBoxPrior
 from gpytorch.priors.torch_priors import GammaPrior
-
-
-class TestConvergenceCriterion(BotorchTestCase):
-    def test_convergence_criterion(self, cuda=False):
-        for dtype in (torch.float, torch.double):
-            tkwargs = {"device": self.device, "dtype": dtype}
-
-            # test max iter
-            max_iter_convergence_criterion = ConvergenceCriterion(maxiter=2)
-
-            self.assertFalse(
-                max_iter_convergence_criterion.evaluate(fvals=torch.ones(1, **tkwargs))
-            )
-            self.assertTrue(
-                max_iter_convergence_criterion.evaluate(fvals=torch.zeros(1, **tkwargs))
-            )
-            # test ftol
-            for minimize in (True, False):
-                ftol_convergence_criterion = ConvergenceCriterion(
-                    ftol=1.0, minimize=minimize
-                )
-                exp = 0 if minimize else 1
-                self.assertFalse(
-                    ftol_convergence_criterion.evaluate(
-                        fvals=(-1) ** exp * torch.tensor([2.0, 2.0], **tkwargs)
-                    )
-                )
-                # case 1: one element has converged and one has not
-                self.assertFalse(
-                    ftol_convergence_criterion.evaluate(
-                        fvals=(-1) ** exp * torch.tensor([0.0, -0.5], **tkwargs)
-                    )
-                )
-                # both converged
-                self.assertTrue(
-                    ftol_convergence_criterion.evaluate(
-                        fvals=(-1) ** exp * torch.tensor([0.0, -0.5], **tkwargs)
-                    )
-                )
 
 
 class TestColumnWiseClamp(BotorchTestCase):


### PR DESCRIPTION
The current `ConvergenceCriterion` assumes that the optimization is using a descent method. That's not true for stochastic optimization, so using this in `gen_candidates_torch` will very often prematurely terminate optimization. This diff adds a basic version of an exponential moving average smoothing of the losses to avoid this.

Since convergence is generally kind of fuzzy in stochastic optimization, this also renames `ConvergenceCriterion` to `StoppingCriterion`. It introduces an abstract base class, and moves this functionality to the `botorch.optim.stopping` submodule. 