### PR TITLE
Run tutorials in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,13 @@ commands:
           name: "Validate sphinx coverage"
           command: python scripts/validate_sphinx.py -p "$(pwd)"
 
+  run_tutorials:
+    description: "Run tutorials"
+    steps:
+      - run:
+          name: "Run tutorials"
+          command: python scripts/run_tutorials.py -p "$(pwd)"
+
   configure_docusaurus_bot:
     description: "Configure Docusaurus GitHub bot"
     steps:
@@ -122,6 +129,15 @@ jobs:
       - sphinx_coverage
       - upload_coverage
 
+  run_tutorials_py38_pip:
+    docker:
+      - image: circleci/python:3.8.1
+    steps:
+      - checkout
+      - pip_install:
+          args: "-n -d -t"
+      - run_tutorials
+
   auto_deploy_site:
     docker:
       - image: circleci/python:3.8.1-node
@@ -153,6 +169,8 @@ workflows:
       - lint_test_py38_pip:
           filters: *exclude_ghpages_fbconfig
       - lint_test_py37_conda:
+          filters: *exclude_ghpages_fbconfig
+      - run_tutorials_py38_pip:
           filters: *exclude_ghpages_fbconfig
 
   auto_deploy_site:

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -6,11 +6,13 @@
 
 PYTORCH_NIGHLTY=false
 DEPLOY=false
+TUTORIAL_DEPS=false
 
-while getopts 'nd' flag; do
+while getopts 'ndt' flag; do
   case "${flag}" in
     n) PYTORCH_NIGHLTY=true ;;
     d) DEPLOY=true ;;
+    t) TUTORIAL_DEPS=true ;;
     *) echo "usage: $0 [-n] [-d]" >&2
        exit 1 ;;
     esac
@@ -37,6 +39,11 @@ sudo pip install --progress-bar off git+https://github.com/cornellius-gp/gpytorc
 
 # install botorch + dev deps
 sudo pip install -e .[dev]
+
+if [[ $TUTORIAL_DEPS == true ]]; then
+  sudo pip install --progress-bar off cma matplotlib ipykernel
+  sudo pip install --progress-bar off git+https://github.com/facebook/Ax.git
+fi
 
 if [[ $DEPLOY == true ]]; then
   sudo pip install --progress-bar off beautifulsoup4 ipython nbconvert

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from subprocess import CalledProcessError
+
+import nbformat
+from nbconvert import PythonExporter
+
+
+IGNORE = {
+    # some nbs take quite a while, don't run by default
+    "closed_loop_botorch_only.ipynb",
+    # some others may require setting paths to local data
+    "vae_mnist.ipynb",
+}
+
+
+def parse_ipynb(file: Path) -> str:
+    with open(file, "r") as nb_file:
+        nb_str = nb_file.read()
+    nb = nbformat.reads(nb_str, nbformat.NO_CONVERT)
+    exporter = PythonExporter()
+    script, _ = exporter.from_notebook_node(nb)
+    return script
+
+
+def run_script(script: str) -> None:
+    # need to keep the file around & close it so subprocess does not run into I/O issues
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+        tf_name = tf.name
+        with open(tf_name, "w") as tmp_script:
+            tmp_script.write(script)
+    run_out = subprocess.run(["ipython", tf_name], capture_output=True, text=True)
+    os.remove(tf_name)
+    return run_out
+
+
+def run_tutorial(tutorial: Path) -> None:
+    script = parse_ipynb(tutorial)
+    tic = time.time()
+    print(f"Running tutorial {tutorial.name}.")
+    run_out = run_script(script)
+    try:
+        run_out.check_returncode()
+    except CalledProcessError:
+        raise RuntimeError(
+            "\n".join(
+                [
+                    f"Encountered error running tutorial {tutorial.name}:",
+                    "stdout:",
+                    run_out.stdout,
+                    "stderr:",
+                    run_out.stderr,
+                ]
+            )
+        )
+    runtime = time.time() - tic
+    print(f"Running tutorial {tutorial.name} took {runtime:.2f} seconds.")
+
+
+def run_tutorials(repo_dir: str) -> None:
+    tutorial_dir = Path(repo_dir).joinpath("tutorials")
+    for tutorial in tutorial_dir.iterdir():
+        if not tutorial.is_file or tutorial.suffix != ".ipynb":
+            continue
+        if tutorial.name in IGNORE:
+            print(f"Ignoring tutorial {tutorial.name}.")
+            continue
+        run_tutorial(tutorial)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run the tutorials.")
+    parser.add_argument(
+        "-p", "--path", metavar="path", required=True, help="botorch repo directory."
+    )
+    args = parser.parse_args()
+    run_tutorials(args.path)


### PR DESCRIPTION
Failing tutorials have been a blind spot for a while - this adds a check to CircleCI to run the tutorials against the current changes on each PR, which will avoid this issue.

Right now there are a couple of tutorials failing, I'll fix those in separate PRs and then merge this one in after. 
