### PR TITLE
Fix custom_acquisition tutorial

### DIFF
--- a/tutorials/custom_acquisition.ipynb
+++ b/tutorials/custom_acquisition.ipynb
@@ -39,9 +39,10 @@
     "from typing import Optional\n",
     "\n",
     "from botorch.acquisition import MCAcquisitionObjective\n",
+    "from botorch.acquisition.acquisition import AcquisitionFunction\n",
     "from botorch.acquisition.monte_carlo import MCAcquisitionFunction\n",
     "from botorch.models.model import Model\n",
-    "from botorch.sampling.samplers import MCSampler\n",
+    "from botorch.sampling.samplers import MCSampler, SobolQMCNormalSampler\n",
     "from botorch.utils import t_batch_mode_transform\n",
     "\n",
     "\n",
@@ -52,9 +53,13 @@
     "        beta: Tensor,\n",
     "        weights: Tensor,\n",
     "        sampler: Optional[MCSampler] = None,\n",
-    "        objective: Optional[MCAcquisitionObjective] = None,\n",
     "    ) -> None:\n",
-    "        super().__init__(model=model, sampler=sampler, objective=objective)\n",
+    "        # we use the AcquisitionFunction constructor, since that of \n",
+    "        # MCAcquisitionFunction performs some validity checks that we don't want here\n",
+    "        super(MCAcquisitionFunction, self).__init__(model=model)\n",
+    "        if sampler is None:\n",
+    "            sampler = SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)\n",
+    "        self.sampler = sampler\n",
     "        self.register_buffer(\"beta\", torch.as_tensor(beta))\n",
     "        self.register_buffer(\"weights\", torch.as_tensor(weights))\n",
     "\n",
@@ -109,11 +114,14 @@
     "\n",
     "from botorch.fit import fit_gpytorch_model\n",
     "from botorch.models import SingleTaskGP\n",
+    "from botorch.utils import standardize\n",
     "from gpytorch.mlls import ExactMarginalLogLikelihood\n",
+    "\n",
     "\n",
     "# generate synthetic data\n",
     "X = torch.rand(20, 2)\n",
     "Y = torch.stack([torch.sin(X[:, 0]), torch.cos(X[:, 1])], -1)\n",
+    "Y = standardize(Y)  # standardize to zero mean unit variance\n",
     "\n",
     "# construct and fit the multi-output model\n",
     "gp = SingleTaskGP(X, Y)\n",
@@ -132,7 +140,7 @@
     {
      "data": {
       "text/plain": [
-       "tensor([0.4938], grad_fn=<MeanBackward2>)"
+       "tensor([-0.1354], grad_fn=<MeanBackward1>)"
       ]
      },
      "execution_count": 3,
@@ -155,7 +163,7 @@
     {
      "data": {
       "text/plain": [
-       "tensor([0.5833, 0.5478], grad_fn=<MeanBackward2>)"
+       "tensor([-0.0566,  0.2893], grad_fn=<MeanBackward1>)"
       ]
      },
      "execution_count": 4,
@@ -176,7 +184,9 @@
    "source": [
     "### A scalarized version of analytic UCB (`q=1` only)\n",
     "\n",
-    "We can also write an *analytic* version of UCB for a multi-output model, assuming a multivariate normal posterior and `q=1`. The new class `ScalarizedUpperConfidenceBound` subclasses `AnalyticAcquisitionFunction` instead of `MCAcquisitionFunction`. In contrast to the MC version, instead of using the weights on the MC samples, we directly scalarize the mean vector $\\mu$ and covariance matrix $\\Sigma$ and apply standard UCB on the univariate normal distribution, which has mean $w^T \\mu$ and variance $w^T \\Sigma w$. In addition to the `@t_batch_transform` decorator, here we are also using `expected_q=1` to ensure the input `X` has a `q=1`."
+    "We can also write an *analytic* version of UCB for a multi-output model, assuming a multivariate normal posterior and `q=1`. The new class `ScalarizedUpperConfidenceBound` subclasses `AnalyticAcquisitionFunction` instead of `MCAcquisitionFunction`. In contrast to the MC version, instead of using the weights on the MC samples, we directly scalarize the mean vector $\\mu$ and covariance matrix $\\Sigma$ and apply standard UCB on the univariate normal distribution, which has mean $w^T \\mu$ and variance $w^T \\Sigma w$. In addition to the `@t_batch_transform` decorator, here we are also using `expected_q=1` to ensure the input `X` has a `q=1`.\n",
+    "\n",
+    "*Note:* BoTorch also provides a `ScalarizedObjective` abstraction that can be used with any existing analytic acqusition functions and automatically performs the scalarization we implement manually below. See the end of this tutorial for a usage example."
    ]
   },
   {
@@ -196,7 +206,9 @@
     "        weights: Tensor,\n",
     "        maximize: bool = True,\n",
     "    ) -> None:\n",
-    "        super().__init__(model=model)\n",
+    "        # we use the AcquisitionFunction constructor, since that of \n",
+    "        # AnalyticAcquisitionFunction performs some validity checks that we don't want here\n",
+    "        super(AnalyticAcquisitionFunction, self).__init__(model)\n",
     "        self.maximize = maximize\n",
     "        self.register_buffer(\"beta\", torch.as_tensor(beta))\n",
     "        self.register_buffer(\"weights\", torch.as_tensor(weights))\n",
@@ -259,7 +271,7 @@
     {
      "data": {
       "text/plain": [
-       "tensor([0.3583], grad_fn=<AddBackward0>)"
+       "tensor([0.3753], grad_fn=<AddBackward0>)"
       ]
      },
      "execution_count": 7,
@@ -280,7 +292,7 @@
     {
      "data": {
       "text/plain": [
-       "tensor([0.3743, 0.5131, 0.3595], grad_fn=<AddBackward0>)"
+       "tensor([-0.2374, -0.0187,  0.0905], grad_fn=<AddBackward0>)"
       ]
      },
      "execution_count": 8,
@@ -330,6 +342,28 @@
    "source": [
     "By following the example shown in the [custom botorch model in ax](./custom_botorch_model_in_ax) tutorial, a `BotorchModel` can be instantiated with `get_scalarized_UCB` and then run in Ax."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using `ScalarizedObjective`\n",
+    "\n",
+    "Using the `ScalarizedObjective` abstraction, the funcitonality of `ScalarizedUpperConfidenceBound` implemented above can be easily achieved in just a few lines of code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from botorch.acquisition.objective import ScalarizedObjective\n",
+    "from botorch.acquisition.analytic import UpperConfidenceBound\n",
+    "\n",
+    "obj = ScalarizedObjective(weights=torch.tensor([0.1, 0.5]))\n",
+    "SUCB = UpperConfidenceBound(gp, beta=0.1, objective=obj)"
+   ]
   }
  ],
  "metadata": {
@@ -348,7 +382,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Addresses #395. Also adds how to achieve the `ScalarizedUpperConfidenceBound` functionality  in a much easier fashion using the `ScalarizedObjective` module.
