### PR TITLE
Multi-step look-ahead acquisition with generic stage costs

### DIFF
--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -158,7 +158,7 @@ class qExpectedImprovement(MCAcquisitionFunction):
         posterior = self.model.posterior(X)
         samples = self.sampler(posterior)
         obj = self.objective(samples)
-        obj = (obj - self.best_f).clamp_min(0)
+        obj = (obj - self.best_f.unsqueeze(-1)).clamp_min(0)
         q_ei = obj.max(dim=-1)[0].mean(dim=0)
         return q_ei
 
@@ -322,7 +322,8 @@ class qProbabilityOfImprovement(MCAcquisitionFunction):
         samples = self.sampler(posterior)
         obj = self.objective(samples)
         max_obj = obj.max(dim=-1)[0]
-        val = torch.sigmoid((max_obj - self.best_f) / self.tau).mean(dim=0)
+        impr = max_obj - self.best_f.unsqueeze(-1)
+        val = torch.sigmoid(impr / self.tau).mean(dim=0)
         return val
 
 

--- a/botorch/acquisition/multi_step_lookahead.py
+++ b/botorch/acquisition/multi_step_lookahead.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+
+import numpy as np
+import torch
+from torch import Size, Tensor
+from torch.distributions import Beta
+from torch.nn import ModuleList
+
+from ..exceptions.errors import UnsupportedError
+from ..exceptions.warnings import BotorchWarning
+from ..models.model import Model
+from ..optim.initializers import initialize_q_batch
+from ..sampling.samplers import MCSampler, SobolQMCNormalSampler
+from ..utils.transforms import match_batch_shape, t_batch_mode_transform, unnormalize
+from .acquisition import AcquisitionFunction, OneShotAcquisitionFunction
+from .analytic import AnalyticAcquisitionFunction, PosteriorMean
+from .monte_carlo import MCAcquisitionFunction
+from .objective import AcquisitionObjective, MCAcquisitionObjective, ScalarizedObjective
+
+
+TAcqfArgConstructor = Callable[[Model, Tensor], Dict[str, Any]]
+
+
+def make_best_f(model: Model, X: Tensor) -> Dict[str, Any]:
+    r"""Extract the best observed training input from the model."""
+    return {"best_f": model.train_targets.max(dim=-1).values}
+
+
+class qMultiStepLookahead(MCAcquisitionFunction, OneShotAcquisitionFunction):
+    r"""MC-based batch Multi-Step Look-Ahead (one-shot optimization)."""
+
+    def __init__(
+        self,
+        model: Model,
+        batch_sizes: List[int],
+        num_fantasies: Optional[List[int]] = None,
+        samplers: Optional[List[MCSampler]] = None,
+        valfunc_cls: Optional[List[Optional[Type[AcquisitionFunction]]]] = None,
+        valfunc_argfacs: Optional[List[Optional[TAcqfArgConstructor]]] = None,
+        objective: Optional[AcquisitionObjective] = None,
+        inner_mc_samples: Optional[List[int]] = None,
+        X_pending: Optional[Tensor] = None,
+    ) -> None:
+        r"""q-Multi-Step Look-Ahead (one-shot optimization).
+
+        Performs a `k`-step lookahead by means of repeated fantasizing.
+
+        Allows to specify the stage value functions by passing the respective class
+        objects via the `valfunc_cls` list. Optionally, `valfunc_argfacs` takes a list
+        of callables that generate additional kwargs for these constructors. By default,
+        `valfunc_cls` will be chosen as `[None, ..., None, PosteriorMean]`, which
+        corresponds to the (parallel) multi-step KnowledgeGradient. If, in addition,
+        `k=1` and `q_1 = 1`, this reduces to the classic Knowledge Gradient.
+
+        WARNING: The complexity of evaluating this function is exponential in the number
+        of lookahead steps!
+
+        Args:
+            model: A fitted model.
+            batch_sizes: A list `[q_1, ..., q_k]` containing the batch sizes for the
+                `k` look-ahead steps.
+            num_fantasies: A list `[f_1, ..., f_k]` containing the number of fantasy
+                points to use for the `k` look-ahead steps.
+            valfunc_cls: A list of `k + 1` acquisition function classes to be used as
+                the (stage + terminal) value functions. Each element (except for the
+                last one) can be `None`, in which case a zero stage value is assumed for
+                the respective stage. If `None`, this defaults to
+                `[None, ..., None, PosteriorMean]`
+            valfunc_argfacs: A list of `k + 1` "argument factories", i.e. callables that
+                map a `Model` and input tensor `X` to a dictionary of kwargs for the
+                respective stage value function constructor (e.g. `best_f` for
+                `ExpectedImprovement`). If None, only the standard (`model`, `sampler`
+                and `objective`) kwargs will be used.
+            objective: The objective under which the output is evaluated. If `None`, use
+                the model output (requires a single-output model). If a
+                `ScalarizedObjective` and `value_function_cls` is a subclass of
+                `AnalyticAcquisitonFunction`, then the analytic posterior mean is used.
+                Otherwise the objective is MC-evaluated (using `inner_sampler`).
+            inner_mc_samples: A list `[n_0, ..., n_k]` containing the number of MC
+                samples to be used for evaluating the stage value function. Ignored if
+                the objective is `None` or a `ScalarizedObjective`.
+            X_pending: A `m x d`-dim Tensor of `m` design points that have points that
+                have been submitted for function evaluation but have not yet been
+                evaluated. Concatenated into `X` upon forward call. Copied and set to
+                have no gradient.
+        """
+        super(MCAcquisitionFunction, self).__init__(model=model)
+        self.batch_sizes = batch_sizes
+        if not ((num_fantasies is None) ^ (samplers is None)):
+            raise UnsupportedError(
+                "qMultiStepLookahead requires exactly one of `num_fantasies` or "
+                "`samplers` as arguments."
+            )
+        if samplers is None:
+            samplers: List[MCSampler] = [
+                SobolQMCNormalSampler(
+                    num_samples=nf, resample=False, collapse_batch_dims=True
+                )
+                for nf in num_fantasies
+            ]
+        else:
+            num_fantasies = [sampler.sample_shape[0] for sampler in samplers]
+        self.num_fantasies = num_fantasies
+        # By default do not use stage values and use PosteriorMean as terminal value
+        # function (= multi-step KG)
+        if valfunc_cls is None:
+            valfunc_cls = [None for _ in num_fantasies] + [PosteriorMean]
+        if inner_mc_samples is None:
+            inner_mc_samples = [None] * (1 + len(num_fantasies))
+        # TODO: Allow passing in inner samplers directly
+        inner_samplers = _construct_inner_samplers(
+            batch_sizes=batch_sizes,
+            valfunc_cls=valfunc_cls,
+            objective=objective,
+            inner_mc_samples=inner_mc_samples,
+        )
+        if valfunc_argfacs is None:
+            valfunc_argfacs = [None] * (1 + len(batch_sizes))
+        self.objective = objective
+        self.set_X_pending(X_pending)
+        self.samplers = ModuleList(samplers)
+        self.inner_samplers = ModuleList(inner_samplers)
+        self._valfunc_cls = valfunc_cls
+        self._valfunc_argfacs = valfunc_argfacs
+
+    @t_batch_mode_transform()
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Evaluate qMultiStepLookahead on the candidate set X.
+
+        Args:
+            X: A `batch_shape x q' x d`-dim Tensor with `q'` design points for each
+                batch, where `q' = q_0 + f_1 q_1 + f_2 f_1 q_2 + ...`. Here `q_i`
+                is the number of candidates jointly considered in look-ahead step
+                `i`, and `f_i` is respective number of fantasies.
+
+        Returns:
+            The acquisition value for each batch as a tensor of shape `batch_shape`.
+        """
+        batch_shape, shapes, sizes = self.get_split_shapes(X=X)
+        # # Each X_i in Xsplit has shape batch_shape x qtilde x d with
+        # # qtilde = f_i * ... * f_1 * q_i
+        Xsplit = torch.split(X, sizes, dim=-2)
+        # now reshape (need to permute batch_shape and qtilde dimensions for i > 0)
+        perm = [-2] + list(range(len(batch_shape))) + [-1]
+        X0 = Xsplit[0].reshape(shapes[0])
+        Xother = [
+            X.permute(*perm).reshape(shape) for X, shape in zip(Xsplit[1:], shapes[1:])
+        ]
+        # concatenate in pending points
+        if self.X_pending is not None:
+            X0 = torch.cat([X0, match_batch_shape(self.X_pending, X0)], dim=-2)
+        return _step(
+            model=self.model,
+            Xs=[X0] + Xother,
+            samplers=self.samplers,
+            valfunc_cls=self._valfunc_cls,
+            valfunc_argfacs=self._valfunc_argfacs,
+            inner_samplers=self.inner_samplers,
+            objective=self.objective,
+            running_val=None,
+        )
+
+    @property
+    def _num_auxiliary(self) -> int:
+        r"""Number of auxiliary variables in the q-batch dimension.
+
+        Returns:
+             `q_aux` s.t. `q + q_aux = augmented_q_batch_size`
+        """
+        return np.dot(self.batch_sizes, np.cumprod(self.num_fantasies)).item()
+
+    def get_augmented_q_batch_size(self, q: int) -> int:
+        r"""Get augmented q batch size for one-shot optimzation.
+
+        Args:
+            q: The number of candidates to consider jointly.
+
+        Returns:
+            The augmented size for one-shot optimzation (including variables
+            parameterizing the fantasy solutions): `q_0 + f_1 q_1 + f_2 f_1 q_2 + ...`
+        """
+        return q + self._num_auxiliary
+
+    def get_split_shapes(self, X: Tensor) -> Tuple[Size, List[Size], List[int]]:
+        r"""
+
+        """
+        batch_shape, (q_aug, d) = X.shape[:-2], X.shape[-2:]
+        q = q_aug - self._num_auxiliary
+        batch_sizes = [q] + self.batch_sizes
+        # X_i needs to have shape f_i x .... x f_1 x batch_shape x q_i x d
+        shapes = [
+            torch.Size(self.num_fantasies[:i][::-1] + [*batch_shape, q_i, d])
+            for i, q_i in enumerate(batch_sizes)
+        ]
+        # Each X_i in Xsplit has shape batch_shape x qtilde x d with
+        # qtilde = f_i * ... * f_1 * q_i
+        sizes = [s[:-3].numel() * s[-2] for s in shapes]
+        return batch_shape, shapes, sizes
+
+    def extract_candidates(self, X_full: Tensor) -> Tensor:
+        r"""We only return X as the set of candidates post-optimization.
+
+        Args:
+            X_full: A `batch_shape x q' x d`-dim Tensor with `q'` design points for
+                each batch, where `q' = q + f_1 q_1 + f_2 f_1 q_2 + ...`.
+
+        Returns:
+            A `batch_shape x q x d`-dim Tensor with `q` design points for each batch.
+        """
+        return X_full[..., : -self._num_auxiliary, :]
+
+
+def _step(
+    model: Model,
+    Xs: List[Tensor],
+    samplers: List[Optional[MCSampler]],
+    valfunc_cls: List[Optional[Type[AcquisitionFunction]]],
+    valfunc_argfacs: List[Optional[TAcqfArgConstructor]],
+    inner_samplers: List[Optional[MCSampler]],
+    objective: AcquisitionObjective,
+    running_val: Optional[Tensor] = None,
+    sample_weights: Optional[Tensor] = None,
+    step_index: int = 0,
+) -> Tensor:
+    r"""Recursive multi-step look-ahead computation.
+
+    Helper function computing the "value-to-go" of a multi-step lookahead scheme.
+
+    Args:
+        model: A Model of appropriate batch size. Specifically, it must be possible to
+            evaluate the model's posterior at `Xs[0]`.
+        Xs: A list `[X_j, ..., X_k]` of tensors, where `X_i` has shape
+            `f_i x .... x f_1 x batch_shape x q_i x d`.
+        samplers: A list of `k - j` samplers, such that the number of samples of sampler
+            `i` is `f_i`. The last element of this list is considered the
+            "inner sampler", which is used for evaluating the objective in case it is an
+            MCAcquisitionObjective.
+        valfunc_cls: A list of acquisition function class to be used as the (stage +
+            terminal) value functions. Each element (except for the last one) can be
+            `None`, in which case a zero stage value is assumed for the respective
+            stage.
+        valfunc_argfacs: A list of callables that map a `Model` and input tensor `X` to
+            a dictionary of kwargs for the respective stage value function constructor.
+            If `None`, only the standard `model`, `sampler` and `objective` kwargs will
+            be used.
+        inner_samplers: A list of `MCSampler` objects, each to be used in the stage
+            value function at the corresponding index.
+        objective: The AcquisitionObjective under which the model output is evaluated.
+        running_val: As `batch_shape`-dim tensor containing the current running value.
+        sample_weights: A tensor of shape `f_i x .... x f_1 x batch_shape` when called
+            in the `i`-th step by which to weight the stage value samples. Used in
+            conjunction with Gauss-Hermite integration or importance sampling. Assumed
+            to be `None` in the initial step (when `step_index=0`).
+        step_index: The index of the look-ahead step. `step_index=0` indicates the
+            initial step.
+
+    Returns:
+        A `b`-dim tensor containing the multi-step value of the design `X`.
+    """
+    if len(Xs) != len(samplers) + 1:
+        raise ValueError("Must have as many samplers as look-ahead steps")
+
+    X = Xs[0]
+    if sample_weights is None:  # only happens in the initial step
+        sample_weights = torch.ones(*X.shape[:-2], device=X.device, dtype=X.dtype)
+
+    # compute stage value
+    stage_val = _compute_stage_value(
+        model=model,
+        valfunc_cls=valfunc_cls[0],
+        X=X,
+        objective=objective,
+        sample_weights=sample_weights,
+        num_batch_dims=X.ndim - (step_index + 2),
+        inner_sampler=inner_samplers[0],
+        arg_fac=valfunc_argfacs[0],
+    )
+    if stage_val is not None:  # update running value
+        running_val = stage_val if running_val is None else running_val + stage_val
+
+    # base case: no more fantasizing, return value
+    if len(Xs) == 1:
+        return running_val
+
+    # construct fantasy model (with batch shape f_{j+1} x ... x f_1 x batch_shape)
+    prop_grads = step_index > 0  # need to propagate gradients for steps > 0
+    fantasy_model = model.fantasize(
+        X=X, sampler=samplers[0], observation_noise=True, propagate_grads=prop_grads
+    )
+
+    # augment sample weights appropriately
+    sample_weights = _construct_sample_weights(
+        prev_weights=sample_weights, sampler=samplers[0]
+    )
+
+    return _step(
+        model=fantasy_model,
+        Xs=Xs[1:],
+        samplers=samplers[1:],
+        valfunc_cls=valfunc_cls[1:],
+        valfunc_argfacs=valfunc_argfacs[1:],
+        inner_samplers=inner_samplers[1:],
+        objective=objective,
+        sample_weights=sample_weights,
+        running_val=running_val,
+        step_index=step_index + 1,
+    )
+
+
+def _compute_stage_value(
+    model: Model,
+    valfunc_cls: Optional[Type[AcquisitionFunction]],
+    X: Tensor,
+    objective: AcquisitionObjective,
+    sample_weights: Tensor,
+    num_batch_dims: int,
+    inner_sampler: Optional[MCSampler] = None,
+    arg_fac: Optional[TAcqfArgConstructor] = None,
+) -> Optional[Tensor]:
+    r"""Compute the stage value of a multi-step look-ahead policy.
+
+    Args:
+        model: A Model of appropriate batch size. Specifically, it must be possible to
+            evaluate the model's posterior at `Xs[0]`.
+        valfunc_cls: The acquisition function class to be used as the stage value
+            functions. If `None`, a zero stage value is assumed (returns `None`)
+        X: A tensor with shape `f_i x .... x f_1 x batch_shape x q_i x d` when called in
+            the `i`-th step.
+        objective: The AcquisitionObjective under which the model output is evaluated.
+        sample_weights: A tensor of shape `f_i x .... x f_1 x batch_shape` when called
+            in the `i`-th step by which to weight the stage value samples. Used in
+            conjunction with Gauss-Hermite integration or importance sampling.
+        num_batch_dims: The number of batch dimensions (i.e. `len(batch_shape)`).
+        inner_sampler: An `MCSampler` object to be used in the stage value function. Can
+            be `None` for analytic acquisition funcitons or when using the default
+            sampler of the acquisition function class.
+        arg_fac: A callable mapping a `Model` and the input tensor `X` to a dictionary
+            of kwargs for the stage value function constructor. If `None`, only the
+            standard `model`, `sampler` and `objective` kwargs will be used.
+
+    Returns:
+        A `batch_shape`-dim tensor of stage values, or `None` (=zero stage value).
+    """
+    if valfunc_cls is None:
+        return None
+    common_kwargs: Dict[str, Any] = {"model": model, "objective": objective}
+    if issubclass(valfunc_cls, MCAcquisitionFunction):
+        common_kwargs["sampler"] = inner_sampler
+    kwargs = arg_fac(model=model, X=X) if arg_fac is not None else {}
+    stage_val_func = valfunc_cls(**common_kwargs, **kwargs)
+    stage_val = stage_val_func(X=X)
+    # shape of stage_val is (inner_mc_samples) x f_j x ... x f_1 x batch_shape
+    batch_shape = stage_val.shape[-num_batch_dims:]
+    if sample_weights.numel() > 0:
+        # if there are sample weights, we need to use them
+        # sample_weights must be of shape f_j x ... x f_1 x batch_shape
+        stage_val = (stage_val * sample_weights).view(-1, *batch_shape).sum(dim=0)
+    else:
+        # we average across all dimensions except for the batch dimension
+        stage_val = stage_val.view(-1, *batch_shape).mean(dim=0)
+    return stage_val
+
+
+def _construct_sample_weights(
+    prev_weights: Tensor, sampler: Optional[MCSampler]
+) -> Optional[Tensor]:
+    r"""Iteratively construct tensor of sample weifhts for multi-step look-ahead.
+
+    Args:
+        prev_weights: A `f_i x .... x f_1 x batch_shape` tensor of previous sample
+            weights.
+        sampler: A `MCSampler` that may have sample weights as the `base_weights`
+            attribute. If `None` or the sampler does not have a `base_weights`
+            attribute, samples are weighted uniformly.
+
+    Returns:
+        A `f_{i+1} x .... x f_1 x batch_shape` tensor of sample weights for the next
+        step.
+    """
+    new_weights = getattr(sampler, "base_weights", None)  # TODO: generalize this
+    if new_weights is None:
+        return prev_weights.unsqueeze(0)  # uses broadcasting
+    new_weights = new_weights.view(-1, *(1 for _ in prev_weights.shape))
+    return new_weights * prev_weights
+
+
+def _construct_inner_samplers(
+    batch_sizes: List[int],
+    valfunc_cls: List[Optional[Type[AcquisitionFunction]]],
+    inner_mc_samples: List[Optional[int]],
+    objective: Optional[AcquisitionObjective] = None,
+) -> List[Optional[MCSampler]]:
+    r"""Check validity of inputs and construct inner samplers.
+
+    Helper function to be used internally for constructing inner samplers.
+
+    Args:
+        batch_sizes: A list `[q_1, ..., q_k]` containing the batch sizes for the
+            `k` look-ahead steps.
+        valfunc_cls: A list of `k + 1` acquisition function classes to be used as the
+            (stage + terminal) value functions. Each element (except for the last one)
+            can be `None`, in which case a zero stage value is assumed for the
+            respective stage.
+        inner_mc_samples: A list `[n_0, ..., n_k]` containing the number of MC
+            samples to be used for evaluating the stage value function. Ignored if
+            the objective is `None` or a `ScalarizedObjective`.
+        objective: The objective under which the output is evaluated. If `None`, use
+            the model output (requires a single-output model). If a
+            `ScalarizedObjective` and `value_function_cls` is a subclass of
+            `AnalyticAcquisitonFunction`, then the analytic posterior mean is used.
+            Otherwise the objective is MC-evaluated (using `inner_sampler`).
+
+    Returns:
+        A list with `k + 1` elements that are either `MCSampler`s or `None.
+    """
+    inner_samplers = []
+    for q, vfc, mcs in zip([None] + batch_sizes, valfunc_cls, inner_mc_samples):
+        if vfc is None:
+            inner_samplers.append(None)
+        elif vfc == qMultiStepLookahead:
+            raise UnsupportedError(
+                "qMultiStepLookahead not supported as a value function "
+                "(I see what you did there, nice try...)."
+            )
+        elif issubclass(vfc, AnalyticAcquisitionFunction):
+            if objective is not None and not isinstance(objective, ScalarizedObjective):
+                raise UnsupportedError(
+                    "Only objectives of type ScalarizedObjective are supported "
+                    "for analytic value functions."
+                )
+            # At this point, we don't know the initial q-batch size here
+            if q is not None and q > 1:
+                raise UnsupportedError(
+                    "Only batch sizes of q=1 are supported for analytic value "
+                    "functions."
+                )
+            if q is not None and mcs is not None:
+                warnings.warn(
+                    "inner_mc_samples is ignored for analytic acquistion functions",
+                    BotorchWarning,
+                )
+            inner_samplers.append(None)
+        else:
+            if objective is not None and not isinstance(
+                objective, MCAcquisitionObjective
+            ):
+                raise UnsupportedError(
+                    "Only objectives of type MCAcquisitionObjective are supported "
+                    "for MC value functions."
+                )
+            if mcs is None:
+                # TODO: Default values for mc samples
+                raise NotImplementedError
+            inner_sampler = SobolQMCNormalSampler(
+                num_samples=mcs, resample=False, collapse_batch_dims=True
+            )
+            inner_samplers.append(inner_sampler)
+    return inner_samplers
+
+
+def warmstart_multistep(
+    acq_function: qMultiStepLookahead,
+    bounds: Tensor,
+    num_restarts: int,
+    raw_samples: int,
+    full_optimizer: Tensor,
+    **kwargs: Any,
+) -> Tensor:
+    r"""Warm-start initialization for multi-step look-ahead acquisition functions.
+
+    For now uses the same q as in `full_optimizer`. TODO: allow different values of `q`
+
+    Args:
+        acq_function: A qMultiStepLookahead acquisition function.
+        bounds: A `2 x d` tensor of lower and upper bounds for each column of features.
+        num_restarts: The number of starting points for multistart acquisition
+            function optimization.
+        raw_samples: The number of raw samples to consider in the initialization
+            heuristic.
+        full_optiizer: The full tree of optimizers of the previous iteration. Typically
+            obtained by passing `return_best_only=False` and `return_full_tree=True`
+            into `optimize_acqf`.
+        kwargs: Optimization kwargs.
+
+    This is a very simple initialization heuristic.
+    TODO: Use the observed values to identify the fantasy sub-tree that is closest to
+    the observed value.
+    """
+    batch_shape, shapes, sizes = acq_function.get_split_shapes(full_optimizer)
+    Xopts = torch.split(full_optimizer, sizes, dim=-2)
+    tkwargs = {"device": Xopts[0].device, "dtype": Xopts[0].dtype}
+
+    B = Beta(torch.ones(1, **tkwargs), 3 * torch.ones(1, **tkwargs))
+
+    def mixin_layer(X: Tensor, bounds: Tensor, eta: float) -> Tensor:
+        perturbations = unnormalize(B.sample(X.shape).squeeze(-1), bounds)
+        return (1 - eta) * X + eta * perturbations
+
+    def make_init_tree(Xopts: List[Tensor], bounds: Tensor, etas: Tensor) -> Tensor:
+        Xtrs = [mixin_layer(X=X, bounds=bounds, eta=eta) for eta, X in zip(etas, Xopts)]
+        return torch.cat(Xtrs, dim=-2)
+
+    def mixin_tree(T: Tensor, bounds: Tensor, alpha: float) -> Tensor:
+        return (1 - alpha) * T + alpha * unnormalize(torch.rand_like(T), bounds)
+
+    n_repeat = math.ceil(raw_samples / batch_shape[0])
+    alphas = torch.linspace(0, 0.75, n_repeat, **tkwargs)
+    etas = torch.linspace(0.1, 1.0, len(Xopts), **tkwargs)
+
+    X_full = torch.cat(
+        [
+            mixin_tree(
+                T=make_init_tree(Xopts=Xopts, bounds=bounds, etas=etas),
+                bounds=bounds,
+                alpha=alpha,
+            )
+            for alpha in alphas
+        ],
+        dim=0,
+    )
+
+    with torch.no_grad():
+        Y_full = acq_function(X_full)
+    X_init = initialize_q_batch(X=X_full, Y=Y_full, n=num_restarts, eta=1.0)
+    return X_init[:raw_samples]

--- a/botorch/sampling/samplers.py
+++ b/botorch/sampling/samplers.py
@@ -10,9 +10,11 @@ Sampler modules to be used with MC-evaluated acquisition functions.
 
 from __future__ import annotations
 
+import math
 from abc import ABC, abstractmethod
 from typing import Optional
 
+import numpy as np
 import torch
 from torch import Tensor
 from torch.nn import Module
@@ -243,6 +245,87 @@ class SobolQMCNormalSampler(MCSampler):
             self.seed += 1
             base_samples = base_samples.view(shape)
             self.register_buffer("base_samples", base_samples)
+        elif self.collapse_batch_dims and shape != posterior.event_shape:
+            self.base_samples = self.base_samples.view(shape)
+        if self.base_samples.device != posterior.device:
+            self.to(device=posterior.device)  # pragma: nocover
+        if self.base_samples.dtype != posterior.dtype:
+            self.to(dtype=posterior.dtype)
+
+
+class GaussHermiteSampler(MCSampler):
+    r"""Sampler for Gaussian hermite base samples.
+
+    Example:
+        >>> sampler = GaussHermiteSampler(1000, seed=1234)
+        >>> posterior = model.posterior(test_X)
+        >>> samples = sampler(posterior)
+    """
+
+    def __init__(
+        self,
+        num_samples: int,
+        resample: bool = False,
+        seed: Optional[int] = None,
+        collapse_batch_dims: bool = True,
+    ) -> None:
+        r"""Sampler for quasi-MC base samples using Sobol sequences.
+
+        Args:
+            num_samples: The number of samples to use.
+            resample: If `True`, re-draw samples in each `forward` evaluation -
+                this results in stochastic acquisition functions (and thus should
+                not be used with deterministic optimization algorithms).
+            seed: The seed for the RNG. If omitted, use a random seed.
+            collapse_batch_dims: If True, collapse the t-batch dimensions to
+                size 1. This is useful for preventing sampling variance across
+                t-batches.
+        """
+        super().__init__()
+        self._sample_shape = torch.Size([num_samples])
+        self.collapse_batch_dims = collapse_batch_dims
+        self.resample = resample
+        self.seed = seed if seed is not None else torch.randint(0, 1000000, (1,)).item()
+
+    def _construct_base_samples(self, posterior: Posterior, shape: torch.Size) -> None:
+        r"""Generate quasi-random Normal base samples (if necessary).
+
+        This function will generate a new set of base samples and set the
+        `base_samples` buffer if one of the following is true:
+        - `resample=True`
+        - the MCSampler has no `base_samples` attribute.
+        - `shape` is different than `self.base_samples.shape` (if
+          `collapse_batch_dims=True`, then batch dimensions of will be
+          automatically broadcasted as necessary)
+
+        Args:
+            posterior: The Posterior for which to generate base samples.
+            shape: The shape of the base samples to construct.
+        """
+        if (
+            self.resample
+            or not hasattr(self, "base_samples")
+            or self.base_samples.shape[-2:] != shape[-2:]
+            or (not self.collapse_batch_dims and shape != self.base_samples.shape)
+        ):
+            output_dim = shape[-2:].numel()
+            if output_dim != 1:
+                raise UnsupportedError(
+                    "Only output_dim=1 is supported by GaussHermiteSampler."
+                    f"Got output_dim={output_dim}."
+                )
+            n = shape[:-2].numel()
+            base_samples, base_weights = np.polynomial.hermite.hermgauss(n)
+            tkwargs = {"device": posterior.device, "dtype": posterior.dtype}
+            base_samples = torch.from_numpy(base_samples).to(**tkwargs)
+            base_samples = (base_samples * math.sqrt(2.0)).view(n, output_dim)
+            base_weights = torch.from_numpy(base_weights).to(**tkwargs)
+            base_weights = (base_weights / math.sqrt(math.pi)).view(-1, 1)
+            self.seed += 1
+            base_samples = base_samples.view(shape)
+            self.register_buffer("base_samples", base_samples)
+            self.register_buffer("base_weights", base_weights)
+
         elif self.collapse_batch_dims and shape != posterior.event_shape:
             self.base_samples = self.base_samples.view(shape)
         if self.base_samples.device != posterior.device:

--- a/sphinx/source/acquisition.rst
+++ b/sphinx/source/acquisition.rst
@@ -53,6 +53,11 @@ Entropy-Based Acquisition Functions
 .. automodule:: botorch.acquisition.max_value_entropy_search
     :members:
 
+Multi-Step Look-Ahead Acquisition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.acquisition.multi_step_lookahead
+    :members:
+
 Active Learning Acquisition Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.acquisition.active_learning

--- a/test/acquisition/test_multi_step_lookahead.py
+++ b/test/acquisition/test_multi_step_lookahead.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import mock
+
+import torch
+from botorch.acquisition.analytic import PosteriorMean
+from botorch.acquisition.cost_aware import GenericCostAwareUtility
+from botorch.acquisition.knowledge_gradient import (
+    _get_value_function,
+    _split_fantasy_points,
+    qKnowledgeGradient,
+    qMultiFidelityKnowledgeGradient,
+)
+from botorch.acquisition.monte_carlo import qSimpleRegret
+from botorch.acquisition.objective import GenericMCObjective, ScalarizedObjective
+from botorch.exceptions.errors import UnsupportedError
+from botorch.posteriors.gpytorch import GPyTorchPosterior
+from botorch.sampling.samplers import IIDNormalSampler, SobolQMCNormalSampler
+from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
+from gpytorch.distributions import MultitaskMultivariateNormal
+
+
+NO = "botorch.utils.testing.MockModel.num_outputs"
+
+
+class TestQMultiStepLookahead(BotorchTestCase):
+    def test_step(self):
+        raise NotImplementedError
+
+    def test_initialize_q_multi_step_lookahead(self):
+        raise NotImplementedError
+
+    def test_evaluate_q_multi_step_lookahead(self):
+        raise NotImplementedError


### PR DESCRIPTION
Summary:
This modifies the `qMultiStepLookahead` acquisition function to allow for general "stage" or "running" value functions. This is WIP and there is a lot more to do, including

- supporting batched inputs to acquisition functions, e.g. batched values `best_f` for qEI.
- proper testing w/ full test coverage
- empirical evaluation

Differential Revision: D20657699

