### PR TITLE
Allow batched best_f in qEI/qPI.

### DIFF
--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -61,11 +61,7 @@ class TestQExpectedImprovement(BotorchTestCase):
             res = acqf(X)
             self.assertEqual(res.item(), 1.0)
 
-            # test size verification of best_f
-            with self.assertRaises(ValueError):
-                qExpectedImprovement(
-                    model=mm, best_f=torch.zeros(2, device=self.device, dtype=dtype)
-                )
+            # TODO: Test batched best_f, batched model, batched evaluation
 
             # basic test, no resample
             sampler = IIDNormalSampler(num_samples=2, seed=12345)


### PR DESCRIPTION
Summary:
This is useful when working with batched models (e.g. fantasized models in look-ahead strategies).

Also updates a bunch of docstrings to be more clear about the functionality and use consistent notation.
I noticed that test coverage w.r.t. batched models / batched evaluation is limited, we will want to improve this going forward.

Reviewed By: sdaulton

Differential Revision: D20823404

