### PR TITLE
Faster indexing

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -426,7 +426,7 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
         ):
             if full_name in subset_batch_dict:
                 idx = subset_batch_dict[full_name]
-                new_data = p.index_select(idx, tidxr)
+                new_data = p.index_select(dim=idx, index=tidxr)
                 if m == 1:
                     new_data = new_data.squeeze(idx)
                 p.data = new_data

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -120,8 +120,8 @@ class Normalize(InputTransform):
                 raise BotorchTensorDimensionError(
                     "Incompatible dimensions of provided bounds"
                 )
-            mins = bounds[..., [0], :]
-            ranges = bounds[..., [1], :] - mins
+            mins = bounds[..., 0:1, :]
+            ranges = bounds[..., 1:2, :] - mins
             self.learn_bounds = False
         else:
             mins = torch.zeros(*batch_shape, 1, d)

--- a/botorch/sampling/samplers.py
+++ b/botorch/sampling/samplers.py
@@ -29,7 +29,6 @@ class MCSampler(Module, ABC):
     Subclasses must implement the `_construct_base_samples` method.
 
     Attributes:
-        sample_shape: The shape of each sample.
         resample: If `True`, re-draw samples in each `forward` evaluation -
             this results in stochastic acquisition functions (and thus should
             not be used with deterministic optimization algorithms).

--- a/botorch/test_functions/multi_fidelity.py
+++ b/botorch/test_functions/multi_fidelity.py
@@ -137,6 +137,6 @@ class AugmentedRosenbrock(SyntheticTestFunction):
     def evaluate_true(self, X: Tensor) -> Tensor:
         X_curr = X[..., :-3]
         X_next = X[..., 1:-2]
-        t1 = 100 * (X_next - X_curr ** 2 + 0.1 * (1 - X[..., [-2]])) ** 2
-        t2 = (X_curr - 1 + 0.1 * (1 - X[..., [-1]]) ** 2) ** 2
+        t1 = 100 * (X_next - X_curr ** 2 + 0.1 * (1 - X[..., -2:-1])) ** 2
+        t2 = (X_curr - 1 + 0.1 * (1 - X[..., -1:]) ** 2) ** 2
         return -(t1 + t2).sum(dim=-1)

--- a/sphinx/source/sampling.rst
+++ b/sphinx/source/sampling.rst
@@ -7,12 +7,6 @@ botorch.sampling
 .. automodule:: botorch.sampling
 
 
-Monte-Carlo Sampler API
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. currentmodule:: botorch.sampling.samplers
-.. autoclass:: MCSampler
-    :members:
-
 Monte-Carlo Samplers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.sampling.samplers

--- a/test/models/test_cost.py
+++ b/test/models/test_cost.py
@@ -22,7 +22,7 @@ class TestCostModels(BotorchTestCase):
                 self.assertEqual(model.fidelity_dims, [-1])
                 self.assertEqual(model.fixed_cost, 0.01)
                 cost = model(X)
-                cost_exp = 0.01 + X[..., [-1]]
+                cost_exp = 0.01 + X[..., -1:]
                 self.assertTrue(torch.allclose(cost, cost_exp))
                 # test custom parameters
                 fw = {2: 2.0, 0: 1.0}
@@ -31,5 +31,5 @@ class TestCostModels(BotorchTestCase):
                 self.assertEqual(model.fidelity_dims, [0, 2])
                 self.assertEqual(model.fixed_cost, fc)
                 cost = model(X)
-                cost_exp = fc + sum(v * X[..., [i]] for i, v in fw.items())
+                cost_exp = fc + sum(v * X[..., i : i + 1] for i, v in fw.items())
                 self.assertTrue(torch.allclose(cost, cost_exp))

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -53,9 +53,9 @@ class TestInputTransforms(BotorchTestCase):
             self.assertFalse(nlz.learn_bounds)
             self.assertTrue(nlz.training)
             self.assertEqual(nlz._d, 2)
-            self.assertTrue(torch.equal(nlz.mins, bounds[..., [0], :]))
+            self.assertTrue(torch.equal(nlz.mins, bounds[..., 0:1, :]))
             self.assertTrue(
-                torch.equal(nlz.mins, bounds[..., [1], :] - bounds[..., [0], :])
+                torch.equal(nlz.mins, bounds[..., 1:2, :] - bounds[..., 0:1, :])
             )
             # test .to
             other_dtype = torch.float if dtype == torch.double else torch.double


### PR DESCRIPTION
Summary: sdaulton figured out in D20860736  that advanced indexing with lists can be a lot slower than with scalars. Also `index_select` seems to be much faster.

Reviewed By: sdaulton

Differential Revision: D20861106

