### PR TITLE
Fix build issues with sphinx 3.0.0

### DIFF
--- a/botorch/sampling/samplers.py
+++ b/botorch/sampling/samplers.py
@@ -29,7 +29,6 @@ class MCSampler(Module, ABC):
     Subclasses must implement the `_construct_base_samples` method.
 
     Attributes:
-        sample_shape: The shape of each sample.
         resample: If `True`, re-draw samples in each `forward` evaluation -
             this results in stochastic acquisition functions (and thus should
             not be used with deterministic optimization algorithms).

--- a/sphinx/source/sampling.rst
+++ b/sphinx/source/sampling.rst
@@ -7,12 +7,6 @@ botorch.sampling
 .. automodule:: botorch.sampling
 
 
-Monte-Carlo Sampler API
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. currentmodule:: botorch.sampling.samplers
-.. autoclass:: MCSampler
-    :members:
-
 Monte-Carlo Samplers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.sampling.samplers


### PR DESCRIPTION
sphinx 3.0.0 was just released with some modified behavior, which caused some issues with repeated defs. This fixes these issues and makes the spinx build pass on the current release.

sphinx now also spews a large number of additional deprecation warnings, but this is b/c sphinx-autodoc-typehints uses the deprecated api: https://github.com/agronholm/sphinx-autodoc-typehints/issues/133
