### PR TITLE
tutorials: Use PythonExporter instead of ScriptExporter

### DIFF
--- a/scripts/parse_tutorials.py
+++ b/scripts/parse_tutorials.py
@@ -12,7 +12,7 @@ import os
 
 import nbformat
 from bs4 import BeautifulSoup
-from nbconvert import HTMLExporter, ScriptExporter
+from nbconvert import HTMLExporter, PythonExporter
 
 
 TEMPLATE = """const CWD = process.cwd();
@@ -92,8 +92,10 @@ def gen_tutorials(repo_dir: str) -> None:
         )
         with open(ipynb_out_path, "w") as ipynb_outfile:
             ipynb_outfile.write(nb_str)
-        exporter = ScriptExporter()
+        exporter = PythonExporter()
         script, meta = exporter.from_notebook_node(nb)
+        # make sure to use python3 shebang
+        script = script.replace("#!/usr/bin/env python", "#!/usr/bin/env python3")
         py_out_path = os.path.join(
             repo_dir, "website", "static", "files", "{}.py".format(tid)
         )


### PR DESCRIPTION
We want to export python, so this is what we should do. Also, this replaces the default `#!/usr/bin/env python` shebang in the generated .py files with `#!/usr/bin/env python3`.
