### PR TITLE
Version 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 The release log for BoTorch.
 
 
+## [0.2.4] - May 12, 2020
+
+Bugfix Release
+
+#### Bug fixes
+* There was a mysterious issue with the 0.2.3 wheel on pypi, where part of the
+  `botorch/optim/utils.py` file was not included, which resulted in an `ImportError` for
+  many central components of the code. Interestingly, the source dist (built with the
+  same command) did not have this issue.
+* Preserve order in ChainedOutcomeTransform (#440).
+
+#### New Features
+* Utilities for estimating the feasible volume under outcome constraints (#437).
+
+
 ## [0.2.3] - Apr 27, 2020
 
 Pairwise GP for Preference Learning, Sampling Strategies.

--- a/botorch/__init__.py
+++ b/botorch/__init__.py
@@ -23,7 +23,7 @@ from .generation.gen import (
 from .utils import manual_seed
 
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 
 __all__ = [

--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -77,7 +77,7 @@ class AnalyticAcquisitionFunction(AcquisitionFunction, ABC):
 
     def set_X_pending(self, X_pending: Optional[Tensor] = None) -> None:
         raise UnsupportedError(
-            f"Analytic acquisition functions do not account for X_pending yet."
+            "Analytic acquisition functions do not account for X_pending yet."
         )
 
 

--- a/scripts/update_versions_html.py
+++ b/scripts/update_versions_html.py
@@ -44,8 +44,8 @@ def updateVersionHTML(base_path, base_url=BASE_URL):
 
         # nav
         nav_links = soup.find("nav").findAll("a")
-        for l in nav_links:
-            l.attrs["href"] = prepend_url(l, base_url, v)
+        for nl in nav_links:
+            nl.attrs["href"] = prepend_url(nl, base_url, v)
 
         # version link
         t = soup.find("h2", {"class": "headerTitleWithLogo"}).find_next("a")
@@ -55,8 +55,8 @@ def updateVersionHTML(base_path, base_url=BASE_URL):
 
         # footer
         nav_links = soup.find("footer").findAll("a")
-        for l in nav_links:
-            l.attrs["href"] = prepend_url(l, base_url, v)
+        for nl in nav_links:
+            nl.attrs["href"] = prepend_url(nl, base_url, v)
 
         # output files
         with open(base_path + "/new-site/v/{}/versions.html".format(v), "w") as outfile:


### PR DESCRIPTION
This is a bump mainly to fix a mysterious issue with the python wheel on pypi being broken. Specifically, in that wheel the `botorch/optim/utils.py` file was not included, which resulted in an `ImportError` for many central components of the code. Interestingly, the source dist (built with the same command) did not have this issue.