### PR TITLE
Shortcutting 'sequential' in optimize_acqf

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -95,7 +95,7 @@ def optimize_acqf(
             >>> )
 
     """
-    if sequential:
+    if sequential and q > 1:
         if not return_best_only:
             raise NotImplementedError(
                 "return_best_only=False only supported for joint optimization"


### PR DESCRIPTION
Summary: When only one candidate is going to be generated, we can skip 'sequential' in optimize_acqf. This will alleviate an error raising when calling optimize_acqf on PenalizedAcquisitionFunction through .gen method in TorchModelBridge.

Reviewed By: Balandat

Differential Revision: D21738029

