### PR TITLE
clone().detach() -> detach().clone()

### DIFF
--- a/botorch/acquisition/acquisition.py
+++ b/botorch/acquisition/acquisition.py
@@ -46,7 +46,7 @@ class AcquisitionFunction(Module, ABC):
                     " will not provide a gradient to these points.",
                     BotorchWarning,
                 )
-            self.X_pending = X_pending.clone().detach()
+            self.X_pending = X_pending.detach().clone()
         else:
             self.X_pending = X_pending
 

--- a/botorch/acquisition/fixed_feature.py
+++ b/botorch/acquisition/fixed_feature.py
@@ -56,7 +56,7 @@ class FixedFeatureAcquisitionFunction(AcquisitionFunction):
         Module.__init__(self)
         self.acq_func = acq_function
         self.d = d
-        values = torch.as_tensor(values).clone().detach()
+        values = torch.as_tensor(values).detach().clone()
         self.register_buffer("values", values)
         # build selector for _construct_X_full
         self._selector = []


### PR DESCRIPTION
Summary: Makes more sense to detach and clone, rather than copying the graph and then throwing it away.

Differential Revision: D22179882

