### PR TITLE
fix formatting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ If you use BoTorch, please cite the following paper:
 }
 ```
 
-If you use $q$-Expected Hypervolume Improvement, $q$-ParEGO, or analytic Expected Hypervolume Improvement with auto-differentiation, please also cite the following paper:
+If you use q-Expected Hypervolume Improvement, q-ParEGO, or analytic Expected Hypervolume Improvement with auto-differentiation, please also cite the following paper:
 > [S. Daulton, M. Balandat, E. Bakshy. Differentiable Expected Hypervolume Improvement for Parallel Multi-Objective Bayesian Optimization. ArXiv e-prints, 2020.](http://arxiv.org/abs/1910.06403)
 
 ```


### PR DESCRIPTION
Summary: mathtype `q` doesn't render properly in github homepage

Differential Revision: D22387109

