### PR TITLE
Model Input Standardization Using `TrainingData`

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -11,11 +11,12 @@ Abstract base module for all BoTorch models.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from botorch import settings
 from botorch.posteriors import Posterior
 from botorch.sampling.samplers import MCSampler
+from botorch.utils.containers import TrainingData
 from torch import Tensor
 from torch.nn import Module
 
@@ -123,3 +124,10 @@ class Model(Module, ABC):
             post_X = self.posterior(X, observation_noise=observation_noise)
         Y_fantasized = sampler(post_X)  # num_fantasies x batch_shape x n' x m
         return self.condition_on_observations(X=X, Y=Y_fantasized, **kwargs)
+
+    @classmethod
+    def construct_inputs(cls, training_data: TrainingData) -> Dict[str, Any]:
+        r"""Standardize kwargs of the model constructor."""
+        raise NotImplementedError(
+            f"`construct_inputs` not implemented for {cls.__name__}."
+        )

--- a/botorch/utils/containers.py
+++ b/botorch/utils/containers.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+Containers to standardize inputs into models and acquisition functions.
+"""
+
+from typing import List, NamedTuple, Optional
+
+from torch import Tensor
+
+
+class TrainingData(NamedTuple):
+    r"""Standardized struct of model training data."""
+
+    Xs: List[Tensor]
+    Ys: List[Tensor]
+    Yvars: Optional[List[Tensor]] = None

--- a/sphinx/source/utils.rst
+++ b/sphinx/source/utils.rst
@@ -12,6 +12,11 @@ Constraints
 .. automodule:: botorch.utils.constraints
 		:members:
 
+Containers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.utils.containers
+		:members:
+
 Objective
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.utils.objective

--- a/test/models/test_model.py
+++ b/test/models/test_model.py
@@ -26,3 +26,5 @@ class TestBaseModel(BotorchTestCase):
             model.num_outputs
         with self.assertRaises(NotImplementedError):
             model.subset_output([0])
+        with self.assertRaises(NotImplementedError):
+            model.construct_inputs(None)

--- a/test/utils/test_containers.py
+++ b/test/utils/test_containers.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from botorch.utils.containers import TrainingData
+from botorch.utils.testing import BotorchTestCase
+
+
+class TestConstructContainers(BotorchTestCase):
+    def test_TrainingData(self):
+        Xs = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
+        Ys = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
+        Yvars = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
+
+        training_data = TrainingData(Xs, Ys)
+        self.assertTrue(torch.equal(training_data.Xs, Xs))
+        self.assertTrue(torch.equal(training_data.Ys, Ys))
+        self.assertEqual(training_data.Yvars, None)
+
+        training_data = TrainingData(Xs, Ys, Yvars)
+        self.assertTrue(torch.equal(training_data.Xs, Xs))
+        self.assertTrue(torch.equal(training_data.Ys, Ys))
+        self.assertTrue(torch.equal(training_data.Yvars, Yvars))


### PR DESCRIPTION
Summary: Different GP models take different kwargs as inputs into their constructors. To standardize the inputs, we create a `TrainingData` dataclass in conjunction with a classmethod `construct_inputs()`.

Differential Revision: D22395030

