### PR TITLE
Add **kwargs to MC and KG Acquisition Function Constructors

### DIFF
--- a/botorch/acquisition/knowledge_gradient.py
+++ b/botorch/acquisition/knowledge_gradient.py
@@ -27,7 +27,7 @@ and [Wu2016parallelkg]_.
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Callable, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 import torch
 from botorch import settings
@@ -71,6 +71,7 @@ class qKnowledgeGradient(MCAcquisitionFunction, OneShotAcquisitionFunction):
         inner_sampler: Optional[MCSampler] = None,
         X_pending: Optional[Tensor] = None,
         current_value: Optional[Tensor] = None,
+        **kwargs: Any,
     ) -> None:
         r"""q-Knowledge Gradient (one-shot optimization).
 
@@ -227,6 +228,7 @@ class qMultiFidelityKnowledgeGradient(qKnowledgeGradient):
         cost_aware_utility: Optional[CostAwareUtility] = None,
         project: Callable[[Tensor], Tensor] = lambda X: X,
         expand: Callable[[Tensor], Tensor] = lambda X: X,
+        **kwargs: Any,
     ) -> None:
         r"""Multi-Fidelity q-Knowledge Gradient (one-shot optimization).
 

--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import torch
 from botorch.acquisition.acquisition import AcquisitionFunction
@@ -116,6 +116,7 @@ class qExpectedImprovement(MCAcquisitionFunction):
         sampler: Optional[MCSampler] = None,
         objective: Optional[MCAcquisitionObjective] = None,
         X_pending: Optional[Tensor] = None,
+        **kwargs: Any,
     ) -> None:
         r"""q-Expected Improvement.
 
@@ -188,6 +189,7 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
         objective: Optional[MCAcquisitionObjective] = None,
         X_pending: Optional[Tensor] = None,
         prune_baseline: bool = False,
+        **kwargs: Any,
     ) -> None:
         r"""q-Noisy Expected Improvement.
 


### PR DESCRIPTION
Summary: Different acquisition functions take different kwargs as inputs into their constructors. To standardize the inputs, we add `**kwargs` to the constructors, specifically for `qEI`, `qNEI`, `qKG`, and `qMFKG`.

Differential Revision: D22416290

