### PR TITLE
MultiFidelityGP Model Input Standardization

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -126,7 +126,9 @@ class Model(Module, ABC):
         return self.condition_on_observations(X=X, Y=Y_fantasized, **kwargs)
 
     @classmethod
-    def construct_inputs(cls, training_data: TrainingData) -> Dict[str, Any]:
+    def construct_inputs(
+        cls, training_data: TrainingData, **kwargs: Any
+    ) -> Dict[str, Any]:
         r"""Standardize kwargs of the model constructor."""
         raise NotImplementedError(
             f"`construct_inputs` not implemented for {cls.__name__}."

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -280,10 +280,44 @@ class TestSingleTaskGP(BotorchTestCase):
             model, model_kwargs = self._get_model_and_data(
                 batch_shape=batch_shape, m=2, **tkwargs
             )
+            # len(Xs) == len(Ys) == 1
             training_data = TrainingData(
-                Xs=model_kwargs["train_X"],
-                Ys=model_kwargs["train_Y"],
-                Yvars=torch.full_like(model_kwargs["train_Y"], 0.01),
+                Xs=[model_kwargs["train_X"][0]], Ys=[model_kwargs["train_Y"][0]]
+            )
+            data_dict = model.construct_inputs(training_data)
+            self.assertTrue(
+                torch.equal(data_dict["train_X"], model_kwargs["train_X"][0])
+            )
+            self.assertTrue(
+                torch.equal(data_dict["train_Y"], model_kwargs["train_Y"][0])
+            )
+            # all X's are equal
+            training_data = TrainingData(
+                Xs=[model_kwargs["train_X"], model_kwargs["train_X"]],
+                Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
+            )
+            data_dict = model.construct_inputs(training_data)
+            self.assertTrue(torch.equal(data_dict["train_X"], model_kwargs["train_X"]))
+            self.assertTrue(
+                torch.equal(
+                    data_dict["train_Y"],
+                    torch.cat(
+                        [model_kwargs["train_Y"], model_kwargs["train_Y"]], dim=-1
+                    ),
+                )
+            )
+            # unexpected data format
+            training_data = TrainingData(
+                Xs=[model_kwargs["train_X"], torch.add(model_kwargs["train_X"], 1)],
+                Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
+            )
+            with self.assertRaises(ValueError):
+                model.construct_inputs(training_data)
+            # make sure Yvar is not added to dict
+            training_data = TrainingData(
+                Xs=[model_kwargs["train_X"]],
+                Ys=[model_kwargs["train_Y"]],
+                Yvars=[torch.full_like(model_kwargs["train_Y"], 0.01)],
             )
             data_dict = model.construct_inputs(training_data)
             self.assertTrue("train_Yvar" not in data_dict)
@@ -329,15 +363,73 @@ class TestFixedNoiseGP(TestSingleTaskGP):
                 batch_shape=batch_shape, m=2, **tkwargs
             )
             training_data = TrainingData(
-                Xs=model_kwargs["train_X"],
-                Ys=model_kwargs["train_Y"],
-                Yvars=model_kwargs["train_Yvar"],
+                Xs=[model_kwargs["train_X"][0]],
+                Ys=[model_kwargs["train_Y"][0]],
+                Yvars=[model_kwargs["train_Yvar"][0]],
             )
             data_dict = model.construct_inputs(training_data)
             self.assertTrue("train_Yvar" in data_dict)
+            self.assertTrue(
+                torch.equal(data_dict["train_X"], model_kwargs["train_X"][0])
+            )
+            self.assertTrue(
+                torch.equal(data_dict["train_Y"], model_kwargs["train_Y"][0])
+            )
+            self.assertTrue(
+                torch.equal(data_dict["train_Yvar"], model_kwargs["train_Yvar"][0])
+            )
             # if Yvars is missing, then raise error
             training_data = TrainingData(
                 Xs=model_kwargs["train_X"], Ys=model_kwargs["train_Y"]
+            )
+            with self.assertRaises(ValueError):
+                model.construct_inputs(training_data)
+
+            # len(Xs) == len(Ys) == 1
+            training_data = TrainingData(
+                Xs=[model_kwargs["train_X"][0]],
+                Ys=[model_kwargs["train_Y"][0]],
+                Yvars=[model_kwargs["train_Yvar"][0]],
+            )
+            data_dict = model.construct_inputs(training_data)
+            self.assertTrue(
+                torch.equal(data_dict["train_X"], model_kwargs["train_X"][0])
+            )
+            self.assertTrue(
+                torch.equal(data_dict["train_Y"], model_kwargs["train_Y"][0])
+            )
+            self.assertTrue(
+                torch.equal(data_dict["train_Yvar"], model_kwargs["train_Yvar"][0])
+            )
+            # all X's are equal
+            training_data = TrainingData(
+                Xs=[model_kwargs["train_X"], model_kwargs["train_X"]],
+                Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
+                Yvars=[model_kwargs["train_Yvar"], model_kwargs["train_Yvar"]],
+            )
+            data_dict = model.construct_inputs(training_data)
+            self.assertTrue(torch.equal(data_dict["train_X"], model_kwargs["train_X"]))
+            self.assertTrue(
+                torch.equal(
+                    data_dict["train_Y"],
+                    torch.cat(
+                        [model_kwargs["train_Y"], model_kwargs["train_Y"]], dim=-1
+                    ),
+                )
+            )
+            self.assertTrue(
+                torch.equal(
+                    data_dict["train_Yvar"],
+                    torch.cat(
+                        [model_kwargs["train_Yvar"], model_kwargs["train_Yvar"]], dim=-1
+                    ),
+                )
+            )
+            # unexpected data format
+            training_data = TrainingData(
+                Xs=[model_kwargs["train_X"], torch.add(model_kwargs["train_X"], 1)],
+                Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
+                Yvars=[model_kwargs["train_Yvar"]],
             )
             with self.assertRaises(ValueError):
                 model.construct_inputs(training_data)


### PR DESCRIPTION
Summary:
We want to extend model input standardization to include multi fidelity models.

Previously, we finalized input standardization for `SingleTaskGP` and `FixedNoiseGP`. These two models only required `TrainingData` as inputs to `construct_inputs()`. However, the `...MultiFidelityGP` classes require `fidelity_features` on top of `TrainingData` as inputs.

To accomplish this, we:
- modify `construct_inputs` in `models/model.py` to include `fidelity_features` as a kwarg
- pass `fidelity_features` into `construct_inputs` for `SingleTaskGP` and `FixedNoiseGP`, but do not use the kwarg
- implement `construct_inputs` for the `...MultiFidelityGP` classes

Reviewed By: lena-kashtelyan

Differential Revision: D22467526

