### PR TITLE
Fix max_hv for C2DTLZ2 and make Hypervolume always return a float

### DIFF
--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -581,7 +581,8 @@ class C2DTLZ2(DTLZ2, ConstrainedBaseTestProblem):
 
     num_constraints = 1
     _r = 0.2
-    _max_hv = 5.439801376693978  # approximate from nsga-ii, TODO: replace with analytic
+    # approximate from nsga-ii, TODO: replace with analytic
+    _max_hv = 0.3996406303723544
 
     def evaluate_slack_true(self, X: Tensor) -> Tensor:
         if X.ndim > 2:

--- a/botorch/utils/multi_objective/hypervolume.py
+++ b/botorch/utils/multi_objective/hypervolume.py
@@ -110,14 +110,14 @@ class Hypervolume:
         Returns:
             The hypervolume.
         """
-        hvol = 0.0
+        hvol = torch.tensor(0.0, dtype=bounds.dtype, device=bounds.device)
         sentinel = self.list.sentinel
         if n_pareto == 0:
             # base case: one dimension
-            return hvol
+            return hvol.item()
         elif i == 0:
             # base case: one dimension
-            return -sentinel.next[0].data[0]
+            return -sentinel.next[0].data[0].item()
         elif i == 1:
             # two dimensions, end recursion
             q = sentinel.next[1]
@@ -130,7 +130,7 @@ class Hypervolume:
                 q = p
                 p = q.next[1]
             hvol += h * q.data[1]
-            return hvol
+            return hvol.item()
         else:
             p = sentinel
             q = p.prev[i]


### PR DESCRIPTION
Summary:
This ensures that Hypervolume.compute() always returns a float (previous it could return a scalar tensor).

This also fixed max_hv for C2DTLZ2

Differential Revision: D22742771

