### PR TITLE
`TrainingData.Yvars` should not be `Optional`

### DIFF
--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -296,8 +296,6 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         cls, training_data: TrainingData, **kwargs: Any
     ) -> Dict[str, Any]:
         r"""Standardize kwargs of the model constructor."""
-        if training_data.Yvars is None:
-            raise ValueError(f"Yvars required for {cls.__name__}.")
         Xs = training_data.Xs
         Ys = training_data.Ys
         Yvars = training_data.Yvars

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -221,8 +221,6 @@ class FixedNoiseMultiFidelityGP(FixedNoiseGP):
     @classmethod
     def construct_inputs(cls, training_data: TrainingData, **kwargs) -> Dict[str, Any]:
         r"""Standardize kwargs of the model constructor."""
-        if training_data.Yvars is None:
-            raise ValueError(f"Yvars required for {cls.__name__}.")
         Xs = training_data.Xs
         Ys = training_data.Ys
         Yvars = training_data.Yvars

--- a/botorch/utils/containers.py
+++ b/botorch/utils/containers.py
@@ -8,7 +8,7 @@ r"""
 Containers to standardize inputs into models and acquisition functions.
 """
 
-from typing import List, NamedTuple, Optional
+from typing import List, NamedTuple
 
 from torch import Tensor
 
@@ -18,4 +18,4 @@ class TrainingData(NamedTuple):
 
     Xs: List[Tensor]
     Ys: List[Tensor]
-    Yvars: Optional[List[Tensor]] = None
+    Yvars: List[Tensor]

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -282,7 +282,9 @@ class TestSingleTaskGP(BotorchTestCase):
             )
             # len(Xs) == len(Ys) == 1
             training_data = TrainingData(
-                Xs=[model_kwargs["train_X"][0]], Ys=[model_kwargs["train_Y"][0]]
+                Xs=[model_kwargs["train_X"][0]],
+                Ys=[model_kwargs["train_Y"][0]],
+                Yvars=[torch.full_like(model_kwargs["train_Y"][0], 0.01)],
             )
             data_dict = model.construct_inputs(training_data)
             self.assertTrue(
@@ -295,6 +297,7 @@ class TestSingleTaskGP(BotorchTestCase):
             training_data = TrainingData(
                 Xs=[model_kwargs["train_X"], model_kwargs["train_X"]],
                 Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
+                Yvars=[torch.full_like(model_kwargs["train_Y"], 0.01)],
             )
             data_dict = model.construct_inputs(training_data)
             self.assertTrue(torch.equal(data_dict["train_X"], model_kwargs["train_X"]))
@@ -306,13 +309,6 @@ class TestSingleTaskGP(BotorchTestCase):
                     ),
                 )
             )
-            # unexpected data format
-            training_data = TrainingData(
-                Xs=[model_kwargs["train_X"], torch.add(model_kwargs["train_X"], 1)],
-                Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
-            )
-            with self.assertRaises(ValueError):
-                model.construct_inputs(training_data)
             # make sure Yvar is not added to dict
             training_data = TrainingData(
                 Xs=[model_kwargs["train_X"]],
@@ -378,12 +374,6 @@ class TestFixedNoiseGP(TestSingleTaskGP):
             self.assertTrue(
                 torch.equal(data_dict["train_Yvar"], model_kwargs["train_Yvar"][0])
             )
-            # if Yvars is missing, then raise error
-            training_data = TrainingData(
-                Xs=model_kwargs["train_X"], Ys=model_kwargs["train_Y"]
-            )
-            with self.assertRaises(ValueError):
-                model.construct_inputs(training_data)
 
             # len(Xs) == len(Ys) == 1
             training_data = TrainingData(

--- a/test/models/test_gp_regression_fidelity.py
+++ b/test/models/test_gp_regression_fidelity.py
@@ -370,6 +370,7 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
                 training_data = TrainingData(
                     Xs=[model_kwargs["train_X"], model_kwargs["train_X"]],
                     Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
+                    Yvars=[torch.full_like(model_kwargs["train_Y"], 0.01)],
                 )
                 data_dict = model.construct_inputs(training_data, fidelity_features=[1])
                 self.assertTrue(
@@ -383,13 +384,6 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
                         ),
                     )
                 )
-                # unexpected data format
-                training_data = TrainingData(
-                    Xs=[model_kwargs["train_X"], torch.add(model_kwargs["train_X"], 1)],
-                    Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
-                )
-                with self.assertRaises(ValueError):
-                    model.construct_inputs(training_data, fidelity_features=[1])
 
 
 class TestFixedNoiseMultiFidelityGP(TestSingleTaskMultiFidelityGP):
@@ -473,17 +467,11 @@ class TestFixedNoiseMultiFidelityGP(TestSingleTaskMultiFidelityGP):
                     lin_truncated=lin_trunc,
                     **tkwargs,
                 )
-                training_data = TrainingData(
-                    Xs=[model_kwargs["train_X"][0]], Ys=[model_kwargs["train_Y"][0]]
-                )
-                # missing Yvars
-                with self.assertRaises(ValueError):
-                    model.construct_inputs(training_data, fidelity_features=[1])
                 # len(Xs) == len(Ys) == 1
                 training_data = TrainingData(
                     Xs=[model_kwargs["train_X"][0]],
                     Ys=[model_kwargs["train_Y"][0]],
-                    Yvars=[torch.full_like(model_kwargs["train_Y"], 0.01)[0]],
+                    Yvars=[model_kwargs["train_Yvar"][0]],
                 )
                 # missing fidelity features
                 with self.assertRaises(ValueError):

--- a/test/utils/test_containers.py
+++ b/test/utils/test_containers.py
@@ -15,11 +15,6 @@ class TestConstructContainers(BotorchTestCase):
         Ys = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
         Yvars = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
 
-        training_data = TrainingData(Xs, Ys)
-        self.assertTrue(torch.equal(training_data.Xs, Xs))
-        self.assertTrue(torch.equal(training_data.Ys, Ys))
-        self.assertEqual(training_data.Yvars, None)
-
         training_data = TrainingData(Xs, Ys, Yvars)
         self.assertTrue(torch.equal(training_data.Xs, Xs))
         self.assertTrue(torch.equal(training_data.Ys, Ys))


### PR DESCRIPTION
Summary:
`Yvars` does not need to be declared as an `Optional` variable since it is passed directly from the `ArrayModelBridge` on the Ax side.

**Previously:**
```
class TrainingData(NamedTuple):
    Xs: List[Tensor]
    Ys: List[Tensor]
    Yvars: Optional[List[Tensor]] = None
```
**Now:**
```
class TrainingData(NamedTuple):
    Xs: List[Tensor]
    Ys: List[Tensor]
    Yvars: List[Tensor]
```

Differential Revision: D22833487

