### PR TITLE
Fix warning on deprecated nonzero() overload

### DIFF
--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -341,7 +341,7 @@ def initialize_q_batch_nonneg(
     if num_pos < n:
         # select all positive points and then fill remaining quota with randomly
         # selected points
-        remaining_indices = (~pos).nonzero().view(-1)
+        remaining_indices = (~pos).nonzero(as_tuple=False).view(-1)
         rand_indices = torch.randperm(remaining_indices.shape[0], device=Y.device)
         sampled_remaining_indices = remaining_indices[rand_indices[: n - num_pos]]
         pos[sampled_remaining_indices] = 1


### PR DESCRIPTION
Fixes the following warning (raised since pytorch 1.6)
```
UserWarning: This overload of nonzero is deprecated:
	nonzero()
Consider using one of the following signatures instead:
	nonzero(*, bool as_tuple) (Triggered internally at  /Users/distiller/project/conda/conda-bld/pytorch_1595629430416/work/torch/csrc/utils/python_arg_parser.cpp:766.)
```