### PR TITLE
`Model.construct_inputs` expects a single `TrainingData` now –– BoTorch changes

### DIFF
--- a/botorch/acquisition/multi_objective/objective.py
+++ b/botorch/acquisition/multi_objective/objective.py
@@ -31,7 +31,8 @@ class MCMultiOutputObjective(AcquisitionObjective):
 
         Returns:
             A `sample_shape x batch_shape x q x m'`-dim Tensor of objective values with
-            `m'` the output dimension. This assumes maximization in each output dimension).
+            `m'` the output dimension. This assumes maximization in each output
+            dimension).
 
         This method is usually not called directly, but via the objectives
 

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -141,15 +141,14 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP):
     def construct_inputs(
         cls, training_data: TrainingData, **kwargs: Any
     ) -> Dict[str, Any]:
-        r"""Standardize kwargs of the model constructor."""
-        Xs = training_data.Xs
-        Ys = training_data.Ys
-        if len(Xs) == len(Ys) == 1:
-            return {"train_X": Xs[0], "train_Y": Ys[0]}
-        if all(torch.equal(Xs[0], X) for X in Xs[1:]):
-            # Use batched multioutput, single task GP.
-            return {"train_X": Xs[0], "train_Y": torch.cat(Ys, dim=-1)}
-        raise ValueError("Unexpected training data format.")
+        r"""Construct kwargs for the `Model` from `TrainingData`.
+
+        Args:
+            training_data: `TrainingData` container with data for single outcome
+                or for multiple outcomes for batched multi-output case.
+            **kwargs: None expected for this class.
+        """
+        return {"train_X": training_data.X, "train_Y": training_data.Y}
 
 
 class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
@@ -296,22 +295,20 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
     def construct_inputs(
         cls, training_data: TrainingData, **kwargs: Any
     ) -> Dict[str, Any]:
-        r"""Standardize kwargs of the model constructor."""
-        if training_data.Yvars is None:
-            raise ValueError(f"Yvars required for {cls.__name__}.")
-        Xs = training_data.Xs
-        Ys = training_data.Ys
-        Yvars = training_data.Yvars
-        if len(Xs) == len(Ys) == 1:
-            return {"train_X": Xs[0], "train_Y": Ys[0], "train_Yvar": Yvars[0]}
-        if all(torch.equal(Xs[0], X) for X in Xs[1:]):
-            # Use batched multioutput, single task GP.
-            return {
-                "train_X": Xs[0],
-                "train_Y": torch.cat(Ys, dim=-1),
-                "train_Yvar": torch.cat(Yvars, dim=-1),
-            }
-        raise ValueError("Unexpected training data format.")
+        r"""Construct kwargs for the `Model` from `TrainingData`.
+
+        Args:
+            training_data: `TrainingData` container with data for single outcome
+                or for multiple outcomes for batched multi-output case.
+            **kwargs: None expected for this class.
+        """
+        if training_data.Yvar is None:
+            raise ValueError(f"Yvar required for {cls.__name__}.")
+        return {
+            "train_X": training_data.X,
+            "train_Y": training_data.Y,
+            "train_Yvar": training_data.Yvar,
+        }
 
 
 class HeteroskedasticSingleTaskGP(SingleTaskGP):

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -117,26 +117,23 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
 
     @classmethod
     def construct_inputs(cls, training_data: TrainingData, **kwargs) -> Dict[str, Any]:
-        r"""Standardize kwargs of the model constructor."""
+        r"""Construct kwargs for the `Model` from `TrainingData`.
+
+        Args:
+            training_data: `TrainingData` container with data for single outcome
+                or for multiple outcomes for batched multi-output case.
+            **kwargs: Options, expected for this class:
+                - fidelity_features: List of columns of X that are fidelity parameters.
+        """
         fidelity_features = kwargs.get("fidelity_features")
         if fidelity_features is None:
             raise ValueError(f"Fidelity features required for {cls.__name__}.")
-        Xs = training_data.Xs
-        Ys = training_data.Ys
-        if len(Xs) == len(Ys) == 1:
-            return {
-                "train_X": Xs[0],
-                "train_Y": Ys[0],
-                "data_fidelity": fidelity_features[0],
-            }
-        if all(torch.equal(Xs[0], X) for X in Xs[1:]):
-            # Use batched multioutput, single task GP.
-            return {
-                "train_X": Xs[0],
-                "train_Y": torch.cat(Ys, dim=-1),
-                "data_fidelity": fidelity_features[0],
-            }
-        raise ValueError("Unexpected training data format.")
+
+        return {
+            "train_X": training_data.X,
+            "train_Y": training_data.Y,
+            "data_fidelity": fidelity_features[0],
+        }
 
 
 class FixedNoiseMultiFidelityGP(FixedNoiseGP):
@@ -220,31 +217,26 @@ class FixedNoiseMultiFidelityGP(FixedNoiseGP):
 
     @classmethod
     def construct_inputs(cls, training_data: TrainingData, **kwargs) -> Dict[str, Any]:
-        r"""Standardize kwargs of the model constructor."""
-        if training_data.Yvars is None:
-            raise ValueError(f"Yvars required for {cls.__name__}.")
-        Xs = training_data.Xs
-        Ys = training_data.Ys
-        Yvars = training_data.Yvars
+        r"""Construct kwargs for the `Model` from `TrainingData`.
+
+        Args:
+            training_data: `TrainingData` container with data for single outcome
+                or for multiple outcomes for batched multi-output case.
+            **kwargs: Options, expected for this class:
+                - fidelity_features: List of columns of X that are fidelity parameters.
+        """
         fidelity_features = kwargs.get("fidelity_features")
         if fidelity_features is None:
             raise ValueError(f"Fidelity features required for {cls.__name__}.")
-        if len(Xs) == len(Ys) == 1:
-            return {
-                "train_X": Xs[0],
-                "train_Y": Ys[0],
-                "train_Yvar": Yvars[0],
-                "data_fidelity": fidelity_features[0],
-            }
-        if all(torch.equal(Xs[0], X) for X in Xs[1:]):
-            # Use batched multioutput, single task GP.
-            return {
-                "train_X": Xs[0],
-                "train_Y": torch.cat(Ys, dim=-1),
-                "train_Yvar": torch.cat(Yvars, dim=-1),
-                "data_fidelity": fidelity_features[0],
-            }
-        raise ValueError("Unexpected training data format.")
+        if training_data.Yvar is None:
+            raise ValueError(f"Yvar required for {cls.__name__}.")
+
+        return {
+            "train_X": training_data.X,
+            "train_Y": training_data.Y,
+            "train_Yvar": training_data.Yvar,
+            "data_fidelity": fidelity_features[0],
+        }
 
 
 def _setup_multifidelity_covar_module(

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -129,7 +129,7 @@ class Model(Module, ABC):
     def construct_inputs(
         cls, training_data: TrainingData, **kwargs: Any
     ) -> Dict[str, Any]:
-        r"""Standardize kwargs of the model constructor."""
+        r"""Construct kwargs for the `Model` from `TrainingData`."""
         raise NotImplementedError(
             f"`construct_inputs` not implemented for {cls.__name__}."
         )

--- a/botorch/utils/containers.py
+++ b/botorch/utils/containers.py
@@ -8,14 +8,14 @@ r"""
 Containers to standardize inputs into models and acquisition functions.
 """
 
-from typing import List, NamedTuple, Optional
+from typing import NamedTuple, Optional
 
 from torch import Tensor
 
 
 class TrainingData(NamedTuple):
-    r"""Standardized struct of model training data."""
+    r"""Standardized struct of model training data for a single outcome."""
 
-    Xs: List[Tensor]
-    Ys: List[Tensor]
-    Yvars: Optional[List[Tensor]] = None
+    X: Tensor
+    Y: Tensor
+    Yvar: Optional[Tensor] = None

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -280,47 +280,12 @@ class TestSingleTaskGP(BotorchTestCase):
             model, model_kwargs = self._get_model_and_data(
                 batch_shape=batch_shape, m=2, **tkwargs
             )
-            # len(Xs) == len(Ys) == 1
             training_data = TrainingData(
-                Xs=[model_kwargs["train_X"][0]], Ys=[model_kwargs["train_Y"][0]]
-            )
-            data_dict = model.construct_inputs(training_data)
-            self.assertTrue(
-                torch.equal(data_dict["train_X"], model_kwargs["train_X"][0])
-            )
-            self.assertTrue(
-                torch.equal(data_dict["train_Y"], model_kwargs["train_Y"][0])
-            )
-            # all X's are equal
-            training_data = TrainingData(
-                Xs=[model_kwargs["train_X"], model_kwargs["train_X"]],
-                Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
+                X=model_kwargs["train_X"], Y=model_kwargs["train_Y"]
             )
             data_dict = model.construct_inputs(training_data)
             self.assertTrue(torch.equal(data_dict["train_X"], model_kwargs["train_X"]))
-            self.assertTrue(
-                torch.equal(
-                    data_dict["train_Y"],
-                    torch.cat(
-                        [model_kwargs["train_Y"], model_kwargs["train_Y"]], dim=-1
-                    ),
-                )
-            )
-            # unexpected data format
-            training_data = TrainingData(
-                Xs=[model_kwargs["train_X"], torch.add(model_kwargs["train_X"], 1)],
-                Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
-            )
-            with self.assertRaises(ValueError):
-                model.construct_inputs(training_data)
-            # make sure Yvar is not added to dict
-            training_data = TrainingData(
-                Xs=[model_kwargs["train_X"]],
-                Ys=[model_kwargs["train_Y"]],
-                Yvars=[torch.full_like(model_kwargs["train_Y"], 0.01)],
-            )
-            data_dict = model.construct_inputs(training_data)
-            self.assertTrue("train_Yvar" not in data_dict)
+            self.assertTrue(torch.equal(data_dict["train_Y"], model_kwargs["train_Y"]))
 
 
 class TestFixedNoiseGP(TestSingleTaskGP):
@@ -363,73 +328,20 @@ class TestFixedNoiseGP(TestSingleTaskGP):
                 batch_shape=batch_shape, m=2, **tkwargs
             )
             training_data = TrainingData(
-                Xs=[model_kwargs["train_X"][0]],
-                Ys=[model_kwargs["train_Y"][0]],
-                Yvars=[model_kwargs["train_Yvar"][0]],
+                X=model_kwargs["train_X"],
+                Y=model_kwargs["train_Y"],
+                Yvar=model_kwargs["train_Yvar"],
             )
             data_dict = model.construct_inputs(training_data)
             self.assertTrue("train_Yvar" in data_dict)
+            self.assertTrue(torch.equal(data_dict["train_X"], model_kwargs["train_X"]))
+            self.assertTrue(torch.equal(data_dict["train_Y"], model_kwargs["train_Y"]))
             self.assertTrue(
-                torch.equal(data_dict["train_X"], model_kwargs["train_X"][0])
-            )
-            self.assertTrue(
-                torch.equal(data_dict["train_Y"], model_kwargs["train_Y"][0])
-            )
-            self.assertTrue(
-                torch.equal(data_dict["train_Yvar"], model_kwargs["train_Yvar"][0])
+                torch.equal(data_dict["train_Yvar"], model_kwargs["train_Yvar"])
             )
             # if Yvars is missing, then raise error
             training_data = TrainingData(
-                Xs=model_kwargs["train_X"], Ys=model_kwargs["train_Y"]
-            )
-            with self.assertRaises(ValueError):
-                model.construct_inputs(training_data)
-
-            # len(Xs) == len(Ys) == 1
-            training_data = TrainingData(
-                Xs=[model_kwargs["train_X"][0]],
-                Ys=[model_kwargs["train_Y"][0]],
-                Yvars=[model_kwargs["train_Yvar"][0]],
-            )
-            data_dict = model.construct_inputs(training_data)
-            self.assertTrue(
-                torch.equal(data_dict["train_X"], model_kwargs["train_X"][0])
-            )
-            self.assertTrue(
-                torch.equal(data_dict["train_Y"], model_kwargs["train_Y"][0])
-            )
-            self.assertTrue(
-                torch.equal(data_dict["train_Yvar"], model_kwargs["train_Yvar"][0])
-            )
-            # all X's are equal
-            training_data = TrainingData(
-                Xs=[model_kwargs["train_X"], model_kwargs["train_X"]],
-                Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
-                Yvars=[model_kwargs["train_Yvar"], model_kwargs["train_Yvar"]],
-            )
-            data_dict = model.construct_inputs(training_data)
-            self.assertTrue(torch.equal(data_dict["train_X"], model_kwargs["train_X"]))
-            self.assertTrue(
-                torch.equal(
-                    data_dict["train_Y"],
-                    torch.cat(
-                        [model_kwargs["train_Y"], model_kwargs["train_Y"]], dim=-1
-                    ),
-                )
-            )
-            self.assertTrue(
-                torch.equal(
-                    data_dict["train_Yvar"],
-                    torch.cat(
-                        [model_kwargs["train_Yvar"], model_kwargs["train_Yvar"]], dim=-1
-                    ),
-                )
-            )
-            # unexpected data format
-            training_data = TrainingData(
-                Xs=[model_kwargs["train_X"], torch.add(model_kwargs["train_X"], 1)],
-                Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
-                Yvars=[model_kwargs["train_Yvar"]],
+                X=model_kwargs["train_X"], Y=model_kwargs["train_Y"]
             )
             with self.assertRaises(ValueError):
                 model.construct_inputs(training_data)

--- a/test/models/test_gp_regression_fidelity.py
+++ b/test/models/test_gp_regression_fidelity.py
@@ -348,9 +348,9 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
                 )
                 # len(Xs) == len(Ys) == 1
                 training_data = TrainingData(
-                    Xs=[model_kwargs["train_X"][0]],
-                    Ys=[model_kwargs["train_Y"][0]],
-                    Yvars=[torch.full_like(model_kwargs["train_Y"], 0.01)[0]],
+                    X=model_kwargs["train_X"],
+                    Y=model_kwargs["train_Y"],
+                    Yvar=torch.full_like(model_kwargs["train_Y"], 0.01),
                 )
                 # missing fidelity features
                 with self.assertRaises(ValueError):
@@ -361,35 +361,11 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
                 self.assertEqual(data_dict["data_fidelity"], 1)
                 data_dict = model.construct_inputs(training_data, fidelity_features=[1])
                 self.assertTrue(
-                    torch.equal(data_dict["train_X"], model_kwargs["train_X"][0])
-                )
-                self.assertTrue(
-                    torch.equal(data_dict["train_Y"], model_kwargs["train_Y"][0])
-                )
-                # all X's are equal
-                training_data = TrainingData(
-                    Xs=[model_kwargs["train_X"], model_kwargs["train_X"]],
-                    Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
-                )
-                data_dict = model.construct_inputs(training_data, fidelity_features=[1])
-                self.assertTrue(
                     torch.equal(data_dict["train_X"], model_kwargs["train_X"])
                 )
                 self.assertTrue(
-                    torch.equal(
-                        data_dict["train_Y"],
-                        torch.cat(
-                            [model_kwargs["train_Y"], model_kwargs["train_Y"]], dim=-1
-                        ),
-                    )
+                    torch.equal(data_dict["train_Y"], model_kwargs["train_Y"])
                 )
-                # unexpected data format
-                training_data = TrainingData(
-                    Xs=[model_kwargs["train_X"], torch.add(model_kwargs["train_X"], 1)],
-                    Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
-                )
-                with self.assertRaises(ValueError):
-                    model.construct_inputs(training_data, fidelity_features=[1])
 
 
 class TestFixedNoiseMultiFidelityGP(TestSingleTaskMultiFidelityGP):
@@ -474,16 +450,16 @@ class TestFixedNoiseMultiFidelityGP(TestSingleTaskMultiFidelityGP):
                     **tkwargs,
                 )
                 training_data = TrainingData(
-                    Xs=[model_kwargs["train_X"][0]], Ys=[model_kwargs["train_Y"][0]]
+                    X=model_kwargs["train_X"], Y=model_kwargs["train_Y"]
                 )
                 # missing Yvars
                 with self.assertRaises(ValueError):
                     model.construct_inputs(training_data, fidelity_features=[1])
                 # len(Xs) == len(Ys) == 1
                 training_data = TrainingData(
-                    Xs=[model_kwargs["train_X"][0]],
-                    Ys=[model_kwargs["train_Y"][0]],
-                    Yvars=[torch.full_like(model_kwargs["train_Y"], 0.01)[0]],
+                    X=model_kwargs["train_X"],
+                    Y=model_kwargs["train_Y"],
+                    Yvar=torch.full_like(model_kwargs["train_Y"], 0.01),
                 )
                 # missing fidelity features
                 with self.assertRaises(ValueError):
@@ -494,34 +470,8 @@ class TestFixedNoiseMultiFidelityGP(TestSingleTaskMultiFidelityGP):
                 self.assertEqual(data_dict["data_fidelity"], 1)
                 data_dict = model.construct_inputs(training_data, fidelity_features=[1])
                 self.assertTrue(
-                    torch.equal(data_dict["train_X"], model_kwargs["train_X"][0])
-                )
-                self.assertTrue(
-                    torch.equal(data_dict["train_Y"], model_kwargs["train_Y"][0])
-                )
-                # all X's are equal
-                training_data = TrainingData(
-                    Xs=[model_kwargs["train_X"], model_kwargs["train_X"]],
-                    Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
-                    Yvars=[model_kwargs["train_Yvar"], model_kwargs["train_Yvar"]],
-                )
-                data_dict = model.construct_inputs(training_data, fidelity_features=[1])
-                self.assertTrue(
                     torch.equal(data_dict["train_X"], model_kwargs["train_X"])
                 )
                 self.assertTrue(
-                    torch.equal(
-                        data_dict["train_Y"],
-                        torch.cat(
-                            [model_kwargs["train_Y"], model_kwargs["train_Y"]], dim=-1
-                        ),
-                    )
+                    torch.equal(data_dict["train_Y"], model_kwargs["train_Y"])
                 )
-                # unexpected data format
-                training_data = TrainingData(
-                    Xs=[model_kwargs["train_X"], torch.add(model_kwargs["train_X"], 1)],
-                    Ys=[model_kwargs["train_Y"], model_kwargs["train_Y"]],
-                    Yvars=[model_kwargs["train_Yvar"], model_kwargs["train_Yvar"]],
-                )
-                with self.assertRaises(ValueError):
-                    model.construct_inputs(training_data, fidelity_features=[1])

--- a/test/utils/test_containers.py
+++ b/test/utils/test_containers.py
@@ -11,16 +11,16 @@ from botorch.utils.testing import BotorchTestCase
 
 class TestConstructContainers(BotorchTestCase):
     def test_TrainingData(self):
-        Xs = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
-        Ys = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
-        Yvars = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
+        X = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
+        Y = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
+        Yvar = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
 
-        training_data = TrainingData(Xs, Ys)
-        self.assertTrue(torch.equal(training_data.Xs, Xs))
-        self.assertTrue(torch.equal(training_data.Ys, Ys))
-        self.assertEqual(training_data.Yvars, None)
+        training_data = TrainingData(X, Y)
+        self.assertTrue(torch.equal(training_data.X, X))
+        self.assertTrue(torch.equal(training_data.Y, Y))
+        self.assertEqual(training_data.Yvar, None)
 
-        training_data = TrainingData(Xs, Ys, Yvars)
-        self.assertTrue(torch.equal(training_data.Xs, Xs))
-        self.assertTrue(torch.equal(training_data.Ys, Ys))
-        self.assertTrue(torch.equal(training_data.Yvars, Yvars))
+        training_data = TrainingData(X, Y, Yvar)
+        self.assertTrue(torch.equal(training_data.X, X))
+        self.assertTrue(torch.equal(training_data.Y, Y))
+        self.assertTrue(torch.equal(training_data.Yvar, Yvar))


### PR DESCRIPTION
Summary:
Change the structure of `TrainingData` and `construct_inputs` in BoTorch.

**Previously:**
```
class TrainingData:
    Xs: List[Tensor]
    Ys: List[Tensor]
    Yvars: Optional[List[Tensor]] = None

training_data: TrainingData
```
**Now:**
```
class TrainingData:
    X: Tensor
    Y: Tensor
    Yvar: Optional[Tensor] = None

training_data: Dict[str, TrainingData]
```

Reviewed By: Balandat

Differential Revision: D23380460

