### PR TITLE
Skip custom_botorch_model_in_ax tutorial

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -27,6 +27,7 @@ IGNORE = {
     "preference_bo.ipynb",
     # some others may require setting paths to local data
     "vae_mnist.ipynb",
+    "custom_botorch_model_in_ax.ipynb",  # TODO: Remove after next Ax release
 }
 
 

--- a/tutorials/compare_mc_analytic_acquisition.ipynb
+++ b/tutorials/compare_mc_analytic_acquisition.ipynb
@@ -212,7 +212,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from botorch.gen import get_best_candidates, gen_candidates_torch\n",
+    "from botorch.generation import get_best_candidates, gen_candidates_torch\n",
     "from botorch.optim import gen_batch_initial_conditions\n",
     "\n",
     "resampler = SobolQMCNormalSampler(num_samples=500, seed=0, resample=True)        \n",


### PR DESCRIPTION
Summary:
This breaks our CI b/c of prematurely landing changes to a tutorial
depending on a new Ax release

Differential Revision: D23609515

