### PR TITLE
Use setuptools_scm for version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,9 @@ ENV/
 # cython-generated C-code
 botorch/qmc/sobol.c*
 
+# version file
+botorch/version.py
+
 # Sphinx documentation
 sphinx/build/
 

--- a/botorch/__init__.py
+++ b/botorch/__init__.py
@@ -23,7 +23,10 @@ from botorch.generation.gen import (
 from botorch.utils import manual_seed
 
 
-__version__ = "0.3.0"
+try:
+    from botorch.version import version as __version__
+except Exception:  # pragma: no cover
+    __version__ = "Unknown"  # pragma: no cover
 
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=34.4", "wheel", "setuptools_scm"]
+build-backend = "setuptools.build_meta"

--- a/scripts/validate_sphinx.py
+++ b/scripts/validate_sphinx.py
@@ -21,7 +21,7 @@ BOTORCH_LIBRARY_PATH = "botorch"
 AUTOMODULE_REGEX = re.compile(r"\.\. automodule:: ([\.\w]*)")
 
 # The top-level modules in botorch not to be validated
-EXCLUDED_MODULES = {}
+EXCLUDED_MODULES = {"version"}
 
 
 def parse_rst(rst_filename: str) -> Set[str]:

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
-import re
 import sys
 
 from setuptools import find_packages, setup
@@ -34,17 +32,12 @@ DEV_REQUIRES = TEST_REQUIRES + ["black", "flake8", "sphinx", "sphinx-autodoc-typ
 
 TUTORIALS_REQUIRES = ["jupyter", "matplotlib", "cma", "torchvision"]
 
-# get version string from module
-with open(os.path.join(os.path.dirname(__file__), "botorch/__init__.py"), "r") as f:
-    version = re.search(r"__version__ = ['\"]([^'\"]*)['\"]", f.read(), re.M).group(1)
-
 # read in README.md as the long description
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
     name="botorch",
-    version=version,
     description="Bayesian Optimization in PyTorch",
     author="Facebook, Inc.",
     license="MIT",
@@ -66,6 +59,8 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">=3.7",
+    setup_requires=["setuptools_scm"],
+    use_scm_version={"write_to": "botorch/version.py"},
     install_requires=["torch>=1.6", "gpytorch>=1.2", "scipy"],
     packages=find_packages(),
     extras_require={

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -12,8 +12,9 @@
 # -- Path setup --------------------------------------------------------------
 
 import os
-import re
 import sys
+
+from pkg_resources import get_distribution
 
 
 base_path = os.path.abspath(os.path.join(__file__, "..", "..", "..", "botorch"))
@@ -26,16 +27,8 @@ project = "BoTorch"
 copyright = "2019, Facebook, Inc."
 author = "Facebook, Inc."
 
-
-# get version string from setup.py
-with open(os.path.join(base_path, "__init__.py"), "r") as f:
-    match = re.search(r"__version__ = ['\"]([^'\"]*)['\"]", f.read(), re.M)
-
-# The full version (of the form X.Y.ZaW or X.Y.Z.pW)
-release = match.group(1)
-# The short X.Y.Z version
-splits = release.split(".")
-version = ".".join(splits[:2] + [splits[2][:1]])  # TODO: be smarter here
+# get version string
+version = get_distribution("botorch").version
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Uses setuptools_scm to do versioning. This will automatically generate the version numbers from the tags, including dev installs if off a particular tag. Mostly copied over from https://github.com/facebook/Ax/pull/359/files

Adresses #517 

Test Plan:
`python setup.py --version`

`pip install -e .`

```
import botorch
botorch.__version__
```