### PR TITLE
Fixes a broken link in docs/batching

### DIFF
--- a/docs/batching.md
+++ b/docs/batching.md
@@ -100,7 +100,7 @@ of the form $b_1 \times \cdots \times b_k$.
 
 ##### Batched Models
 GPyTorch models can also be
-[fit on batched training points](https://github.com/cornellius-gp/gpytorch/blob/master/examples/01_Simple_GP_Regression/Simple_Batch_Mode_GP_Regression.ipynb)
+[fit on batched training points](https://github.com/cornellius-gp/gpytorch/blob/master/examples/08_Advanced_Usage/Simple_Batch_Mode_GP_Regression.ipynb)
 with shape $\textit{batch_shape} \times n \times d$. Here, each batch is modeled
 independently (i.e., each batch has its own hyperparameters).
 For example, if the training points have shape $b_1 \times b_2 \times n \times d$


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md
-->

## Motivation

Came across a broken link for "fitting batch models" in docs and fixed it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Verified that docs are building and the link is working.

