### PR TITLE
Add setuptools_scm to conda meta.yml

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -14,6 +14,7 @@ build:
 requirements:
   host:
     - python>=3.7
+    - setuptools_scm
   run:
     - pytorch>=1.6
     - gpytorch>=1.2


### PR DESCRIPTION
This is required for `conda build` after https://github.com/pytorch/botorch/pull/539
