### PR TITLE
Reversible input transform

### DIFF
--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -119,7 +119,57 @@ class ChainedInputTransform(InputTransform, ModuleDict):
         return X
 
 
-class Normalize(InputTransform):
+class ReversibleTransform(InputTransform, ABC):
+    reverse: bool
+
+    def transform(self, X: Tensor) -> Tensor:
+        r"""Transform the inputs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of transformed inputs.
+        """
+        return self._untransform(X) if self.reverse else self._transform(X)
+
+    def untransform(self, X: Tensor) -> Tensor:
+        r"""Un-transform the inputs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of un-transformed inputs.
+        """
+        return self._transform(X) if self.reverse else self._untransform(X)
+
+    @abstractmethod
+    def _transform(self, X: Tensor) -> Tensor:
+        r"""Forward transform the inputs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of transformed inputs.
+        """
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def _untransform(self, X: Tensor) -> Tensor:
+        r"""Reverse transform the inputs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of transformed inputs.
+        """
+        pass  # pragma: no cover
+
+
+class Normalize(ReversibleTransform):
     r"""Normalize the inputs to the unit cube.
 
     If no explicit bounds are provided this module is stateful: If in train mode,
@@ -135,6 +185,7 @@ class Normalize(InputTransform):
         batch_shape: torch.Size = torch.Size(),  # noqa: B008
         transform_on_train: bool = True,
         transform_on_eval: bool = True,
+        reverse: bool = False,
     ) -> None:
         r"""Normalize the inputs to the unit cube.
 
@@ -149,6 +200,8 @@ class Normalize(InputTransform):
                 transforms in train() mode. Default: True
             transform_on_eval: A boolean indicating whether to apply the
                 transform in eval() mode. Default: True
+            reverse: A boolean indicating whether the forward pass should untransform
+                the inputs.
         """
         super().__init__()
         if bounds is not None:
@@ -168,8 +221,9 @@ class Normalize(InputTransform):
         self._d = d
         self.transform_on_train = transform_on_train
         self.transform_on_eval = transform_on_eval
+        self.reverse = reverse
 
-    def transform(self, X: Tensor) -> Tensor:
+    def _transform(self, X: Tensor) -> Tensor:
         r"""Normalize the inputs.
 
         If no explicit bounds are provided, this is stateful: In train mode,
@@ -194,7 +248,7 @@ class Normalize(InputTransform):
             self.ranges = X.max(dim=-2, keepdim=True)[0] - self.mins
         return (X - self.mins) / self.ranges
 
-    def untransform(self, X: Tensor) -> Tensor:
+    def _untransform(self, X: Tensor) -> Tensor:
         r"""Un-normalize the inputs.
 
         Args:

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -155,6 +155,15 @@ class TestInputTransforms(BotorchTestCase):
                 X_unnlzd = nlz.untransform(X_nlzd)
                 self.assertTrue(torch.allclose(X, X_unnlzd, atol=1e-4, rtol=1e-4))
 
+                # test reverse
+                nlz = Normalize(
+                    d=2, bounds=bounds, batch_shape=batch_shape, reverse=True
+                )
+                X2 = nlz(X_nlzd)
+                self.assertTrue(torch.allclose(X2, X, atol=1e-4, rtol=1e-4))
+                X_nlzd2 = nlz.untransform(X2)
+                self.assertTrue(torch.allclose(X_nlzd, X_nlzd2, atol=1e-4, rtol=1e-4))
+
     def test_chained_input_transform(self):
 
         ds = (1, 2)


### PR DESCRIPTION
Summary: Create a reversible input tranform to reverse for example normalization and log transformation input transform by swapping the original functionality of transform and untransform

Differential Revision: D23650686

