### PR TITLE
add equals method to InputTransform

### DIFF
--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -119,7 +119,57 @@ class ChainedInputTransform(InputTransform, ModuleDict):
         return X
 
 
-class Normalize(InputTransform):
+class ReversibleTransform(InputTransform, ABC):
+    reverse: bool
+
+    def transform(self, X: Tensor) -> Tensor:
+        r"""Transform the inputs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of transformed inputs.
+        """
+        return self._untransform(X) if self.reverse else self._transform(X)
+
+    def untransform(self, X: Tensor) -> Tensor:
+        r"""Un-transform the inputs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of un-transformed inputs.
+        """
+        return self._transform(X) if self.reverse else self._untransform(X)
+
+    @abstractmethod
+    def _transform(self, X: Tensor) -> Tensor:
+        r"""Forward transform the inputs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of transformed inputs.
+        """
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def _untransform(self, X: Tensor) -> Tensor:
+        r"""Reverse transform the inputs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of transformed inputs.
+        """
+        pass  # pragma: no cover
+
+
+class Normalize(ReversibleTransform):
     r"""Normalize the inputs to the unit cube.
 
     If no explicit bounds are provided this module is stateful: If in train mode,
@@ -135,6 +185,7 @@ class Normalize(InputTransform):
         batch_shape: torch.Size = torch.Size(),  # noqa: B008
         transform_on_train: bool = True,
         transform_on_eval: bool = True,
+        reverse: bool = False,
     ) -> None:
         r"""Normalize the inputs to the unit cube.
 
@@ -149,6 +200,8 @@ class Normalize(InputTransform):
                 transforms in train() mode. Default: True
             transform_on_eval: A boolean indicating whether to apply the
                 transform in eval() mode. Default: True
+            reverse: A boolean indicating whether the forward pass should untransform
+                the inputs.
         """
         super().__init__()
         if bounds is not None:
@@ -168,8 +221,9 @@ class Normalize(InputTransform):
         self._d = d
         self.transform_on_train = transform_on_train
         self.transform_on_eval = transform_on_eval
+        self.reverse = reverse
 
-    def transform(self, X: Tensor) -> Tensor:
+    def _transform(self, X: Tensor) -> Tensor:
         r"""Normalize the inputs.
 
         If no explicit bounds are provided, this is stateful: In train mode,
@@ -194,7 +248,7 @@ class Normalize(InputTransform):
             self.ranges = X.max(dim=-2, keepdim=True)[0] - self.mins
         return (X - self.mins) / self.ranges
 
-    def untransform(self, X: Tensor) -> Tensor:
+    def _untransform(self, X: Tensor) -> Tensor:
         r"""Un-normalize the inputs.
 
         Args:

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 from typing import Optional
 
 import torch
@@ -63,6 +64,31 @@ class InputTransform(Module, ABC):
             f"{self.__class__.__name__} does not implement the `untransform` method"
         )
 
+    def equals(self, other: InputTransform) -> bool:
+        r"""Check if another input transform is equivalent.
+
+        Note: The reason that a custom equals method is definde rather than defining
+        an __eq__ method is because defining an __eq__ method sets the __hash__ method to None.
+        Hashing modules is currently used in pytorch.
+        See https://github.com/pytorch/pytorch/issues/7733.
+
+        Args:
+            other: Another input transform
+
+        Returns:
+            A boolean indicating if the other transform is equivalent.
+        """
+        other_state_dict = other.state_dict()
+        return (
+            type(self) == type(other)
+            and (self.transform_on_train == other.transform_on_train)
+            and (self.transform_on_eval == other.transform_on_eval)
+            and all(
+                torch.allclose(v, other_state_dict[k].to(v))
+                for k, v in self.state_dict().items()
+            )
+        )
+
 
 class ChainedInputTransform(InputTransform, ModuleDict):
     r"""An input transform representing the chaining of individual transforms"""
@@ -84,9 +110,9 @@ class ChainedInputTransform(InputTransform, ModuleDict):
                 kwargs are used as the keys for accessing the individual
                 transforms on the module.
         """
+        super().__init__(OrderedDict(transforms))
         self.transform_on_train = transform_on_train
         self.transform_on_eval = transform_on_eval
-        super().__init__(transforms)
 
     def transform(self, X: Tensor) -> Tensor:
         r"""Transform the inputs to a model.
@@ -117,6 +143,19 @@ class ChainedInputTransform(InputTransform, ModuleDict):
         for tf in reversed(self.values()):
             X = tf.untransform(X)
         return X
+
+    def equals(self, other: InputTransform) -> bool:
+        r"""Check if another input transform is equivalent.
+
+        Args:
+            other: Another input transform
+
+        Returns:
+            A boolean indicating if the other transform is equivalent.
+        """
+        return super().equals(other=other) and all(
+            t1 == t2 for t1, t2 in zip(self.values(), other.values())
+        )
 
 
 class ReversibleTransform(InputTransform, ABC):
@@ -167,6 +206,17 @@ class ReversibleTransform(InputTransform, ABC):
             A `batch_shape x n x d`-dim tensor of transformed inputs.
         """
         pass  # pragma: no cover
+
+    def equals(self, other: InputTransform) -> bool:
+        r"""Check if another input transform is equivalent.
+
+        Args:
+            other: Another input transform
+
+        Returns:
+            A boolean indicating if the other transform is equivalent.
+        """
+        return super().equals(other=other) and (self.reverse == other.reverse)
 
 
 class Normalize(ReversibleTransform):
@@ -263,3 +313,18 @@ class Normalize(ReversibleTransform):
     def bounds(self) -> Tensor:
         r"""The bounds used for normalizing the inputs."""
         return torch.cat([self.mins, self.mins + self.ranges], dim=-2)
+
+    def equals(self, other: InputTransform) -> bool:
+        r"""Check if another input transform is equivalent.
+
+        Args:
+            other: Another input transform
+
+        Returns:
+            A boolean indicating if the other transform is equivalent.
+        """
+        return (
+            super().equals(other=other)
+            and (self._d == other._d)
+            and (self.learn_bounds == other.learn_bounds)
+        )

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -155,6 +155,15 @@ class TestInputTransforms(BotorchTestCase):
                 X_unnlzd = nlz.untransform(X_nlzd)
                 self.assertTrue(torch.allclose(X, X_unnlzd, atol=1e-4, rtol=1e-4))
 
+                # test reverse
+                nlz = Normalize(
+                    d=2, bounds=bounds, batch_shape=batch_shape, reverse=True
+                )
+                X2 = nlz(X_nlzd)
+                self.assertTrue(torch.allclose(X2, X, atol=1e-4, rtol=1e-4))
+                X_nlzd2 = nlz.untransform(X2)
+                self.assertTrue(torch.allclose(X_nlzd, X_nlzd2, atol=1e-4, rtol=1e-4))
+
     def test_chained_input_transform(self):
 
         ds = (1, 2)


### PR DESCRIPTION
Summary: This is used in the next diff where we split batched models into model lists and vice versa.

Differential Revision: D23697874

