### PR TITLE
Allow conda build to use the setuptools_scm generated version number

### DIFF
--- a/.conda/build_conda.sh
+++ b/.conda/build_conda.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+BOTORCH_VERSION="$(python ../setup.py --version)"
+export BOTORCH_VERSION
+
+conda build .

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: {{ data.get("name")|lower }}
-  version: {{ data.get("version") }}
+  version: {{ data.get("version", environ["BOTORCH_VERSION"]) }}
 
 source:
   path: ..

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+[tool.setuptools_scm]
+
 [build-system]
 requires = ["setuptools>=34.4", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import sys
 
 from setuptools import find_packages, setup
@@ -32,8 +33,10 @@ DEV_REQUIRES = TEST_REQUIRES + ["black", "flake8", "sphinx", "sphinx-autodoc-typ
 
 TUTORIALS_REQUIRES = ["jupyter", "matplotlib", "cma", "torchvision"]
 
+root_dir = os.path.dirname(__file__)
+
 # read in README.md as the long description
-with open("README.md", "r") as fh:
+with open(os.path.join(root_dir, "README.md"), "r") as fh:
     long_description = fh.read()
 
 setup(
@@ -60,7 +63,11 @@ setup(
     long_description_content_type="text/markdown",
     python_requires=">=3.7",
     setup_requires=["setuptools_scm"],
-    use_scm_version={"write_to": "botorch/version.py"},
+    use_scm_version={
+        "root": ".",
+        "relative_to": __file__,
+        "write_to": os.path.join(root_dir, "botorch", "version.py"),
+    },
     install_requires=["torch>=1.6", "gpytorch>=1.2", "scipy"],
     packages=find_packages(),
     extras_require={


### PR DESCRIPTION
Unfortunately `conda build`'s `load_setup_py_data` does not properly resolve the version number from `setuptools_scm`.

The workaround implemented here is to export this version number to an env variable that we can then substitute in to the jinja template of the `meta.yaml` file. This PR adds a simple shell script to make that easier, now the conda build process just amounts to calling `/build_conda.sh` from the `.conda/` directory and the version number gets automatically added.

This also required some changes to `setup.py` to make sure the relative paths are properly resolved.