### PR TITLE
Handle case when nb metada has no kernelspec attribute in tutorial parsing

### DIFF
--- a/scripts/parse_tutorials.py
+++ b/scripts/parse_tutorials.py
@@ -89,8 +89,11 @@ def gen_tutorials(repo_dir: str) -> None:
             nb_str = infile.read()
             nb = nbformat.reads(nb_str, nbformat.NO_CONVERT)
 
+        metadata = nb["metadata"]
+        if "kernelspec" not in metadata:
+            metadata["kernelspec"] = {"language": "python", "name": "python3"}
         # displayname is absent from notebook metadata
-        nb["metadata"]["kernelspec"]["display_name"] = "python3"
+        metadata["kernelspec"]["display_name"] = "python3"
 
         exporter = HTMLExporter()
         html, meta = exporter.from_notebook_node(nb)


### PR DESCRIPTION
This allows notebook parsing to succeed even if kernelspec is not defined in the source metadata (this is the case e.g. for `multi_fidelity_bo.ipynb`, not sure why).