### PR TITLE
Pin nbconvert version to <6.0 in CI

### DIFF
--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -46,5 +46,5 @@ if [[ $TUTORIAL_DEPS == true ]]; then
 fi
 
 if [[ $DEPLOY == true ]]; then
-  sudo pip install --progress-bar off beautifulsoup4 ipython nbconvert
+  sudo pip install --progress-bar off beautifulsoup4 ipython "nbconvert<6.0"
 fi


### PR DESCRIPTION
Mitigates #556. Ultimately we will want to change the tutorial parsing script to properly use the new nbconvert html template.