### PR TITLE
Add packaging tests to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,12 +98,19 @@ commands:
           name: "Upload coverage report"
           command: bash <(curl -s https://codecov.io/bash)
 
+  test_packaging:
+    description: "Test packaging (python sdist and wheel, conda package)"
+    steps:
+       - run:
+          name: "Build pacakges"
+          command: ./scripts/test_packaging.sh
+
 
 jobs:
 
   lint_test_py38_pip:
     docker:
-      - image: circleci/python:3.8.1
+      - image: circleci/python:3.8
     resource_class: large
     steps:
       - checkout
@@ -133,7 +140,7 @@ jobs:
 
   run_tutorials_py38_pip:
     docker:
-      - image: circleci/python:3.8.1
+      - image: circleci/python:3.8
     resource_class: large
     steps:
       - checkout
@@ -143,7 +150,7 @@ jobs:
 
   auto_deploy_site:
     docker:
-      - image: circleci/python:3.8.1-node
+      - image: circleci/python:3.8-node
     steps:
       - checkout
       - pip_install:
@@ -154,6 +161,14 @@ jobs:
       - sphinx
       - configure_docusaurus_bot
       - deploy_site
+
+  package:
+    docker:
+      - image: continuumio/miniconda3
+    resource_class: large
+    steps:
+      - checkout
+      - test_packaging
 
 
 aliases:
@@ -176,6 +191,17 @@ workflows:
       - run_tutorials_py38_pip:
           filters: *exclude_ghpages_fbconfig
 
+  package:
+    triggers:
+      - schedule:
+          cron: "0 9 * * *" # UTC
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - package
+          
   auto_deploy_site:
     triggers:
       - schedule:

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -17,9 +17,6 @@ while getopts 'n' flag; do
 # update conda
 conda update -y -n base -c defaults conda
 
-# required to use conda develop
-conda install -y conda-build
-
 if [[ $PYTORCH_NIGHTLY == true ]]; then
   # install CPU version for much smaller download
   conda install -y -c pytorch-nightly pytorch cpuonly

--- a/scripts/test_packaging.sh
+++ b/scripts/test_packaging.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# update conda
+conda update -y -n base -c defaults conda
+
+# install pip into conda
+conda install -y pip
+
+# install python packaging deps
+pip install --upgrade setuptools wheel twine
+
+# install conda-build
+conda install -y conda-build
+
+# test python packaging
+python setup.py sdist bdist_wheel
+
+# test conda packaging
+conda config --show
+conda config --add channels pytorch
+conda config --add channels gpytorch
+cd .conda || exit
+./build_conda.sh


### PR DESCRIPTION
This adds a nightly workflow to CircleCI that verifies that packaging works for the followoing:
- python sdist
- python wheel
- conda package
