### PR TITLE
move Contextual GP to BoTorch OSS

### DIFF
--- a/botorch/models/contextual.py
+++ b/botorch/models/contextual.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, List, Optional
+
+from botorch.models.gp_regression import FixedNoiseGP
+from botorch.models.kernels.contextual_lcea import LCEAKernel
+from botorch.models.kernels.contextual_sac import SACKernel
+from torch import Tensor
+
+
+class SACGP(FixedNoiseGP):
+    """The GP uses Structural Additive Contextual(SAC) kernel.
+
+    Args:
+        train_X: (n x d) X training data.
+        train_Y: (n x 1) Y training data.
+        train_Yvar: (n x 1) Noise variances of each training Y.
+        decomposition: Keys are context names. Values are the indexes of
+            parameters belong to the context. The parameter indexes are in
+            the same order across contexts.
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        train_Yvar: Tensor,
+        decomposition: Dict[str, List[int]],
+    ) -> None:
+        super().__init__(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
+        self.covar_module = SACKernel(
+            decomposition=decomposition, batch_shape=self._aug_batch_shape
+        )
+        self.decomposition = decomposition
+        self.to(train_X)
+
+
+class LCEAGP(FixedNoiseGP):
+    r"""The GP with Latent Context Embedding Additive (LCE-A) Kernel.
+    Note that the model does not support batch training. Input training
+    data sets should have dim = 2.
+
+    Args:
+        train_X: (n x d) X training data.
+        train_Y: (n x 1) Y training data.
+        train_Yvar: (n x 1) Noise variance of Y.
+        decomposition: Keys are context names. Values are the indexes of
+            parameters belong to the context. The parameter indexes are in the
+            same order across contexts.
+        cat_feature_dict: Keys are context names and values are list of categorical
+            features i.e. {"context_name" : [cat_0, ..., cat_k]}. k equals to number
+            of categorical variables. If None, we use context names in the
+            decomposition as the only categorical feature i.e. k = 1
+        embs_feature_dict: Pre-trained continuous embedding features of each context.
+        embs_dim_list: Embedding dimension for each categorical variable. The length
+            equals to num of categorical features k. If None, emb dim is set to 1
+            for each categorical variable.
+        context_weight_dict: Known population Weights of each context.
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        train_Yvar: Tensor,
+        decomposition: Dict[str, List[int]],
+        train_embedding: bool = True,
+        cat_feature_dict: Optional[Dict] = None,
+        embs_feature_dict: Optional[Dict] = None,
+        embs_dim_list: Optional[List[int]] = None,
+        context_weight_dict: Optional[Dict] = None,
+    ) -> None:
+        super().__init__(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
+        self.covar_module = LCEAKernel(
+            decomposition=decomposition,
+            batch_shape=self._aug_batch_shape,
+            train_embedding=train_embedding,
+            cat_feature_dict=cat_feature_dict,
+            embs_feature_dict=embs_feature_dict,
+            embs_dim_list=embs_dim_list,
+            context_weight_dict=context_weight_dict,
+        )
+        self.decomposition = decomposition
+        self.to(train_X)

--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional
+
+import torch
+from botorch.models.multitask import MultiTaskGP
+from gpytorch.distributions.multivariate_normal import MultivariateNormal
+from gpytorch.kernels.rbf_kernel import RBFKernel
+from gpytorch.lazy import InterpolatedLazyTensor, LazyTensor
+from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
+from gpytorch.priors.torch_priors import UniformPrior
+from torch import Tensor
+from torch.nn import ModuleList
+
+
+class LCEMGP(MultiTaskGP):
+    r"""The Multi-Task GP with the latent context embedding multioutput
+    (LCE-M) kernel.
+
+    Args:
+        train_X: (n x d) X training data.
+        train_Y: (n x 1) Y training data.
+        task_feature: column index of train_X to get context indices.
+        context_cat_feature: (n_contexts x k) one-hot encoded context
+            features. Rows are ordered by context indices. k equals to
+            number of categorical variables. If None, task indices will
+            be used and k = 1
+        context_emb_feature: (n_contexts x m) pre-given continuous
+            embedding features. Rows are ordered by context indices.
+        embs_dim_list: Embedding dimension for each categorical variable.
+            The length equals to k. If None, emb dim is set to 1 for each
+            categorical variable.
+        output_tasks: A list of task indices for which to compute model
+            outputs for. If omitted, return outputs for all task indices.
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        task_feature: int,
+        context_cat_feature: Optional[Tensor] = None,
+        context_emb_feature: Optional[Tensor] = None,
+        embs_dim_list: Optional[List[int]] = None,
+        output_tasks: Optional[List[int]] = None,
+    ) -> None:
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            task_feature=task_feature,
+            output_tasks=output_tasks,
+        )
+        #  context indices
+        all_tasks = train_X[:, task_feature].unique()
+        self.all_tasks = all_tasks.to(dtype=torch.long).tolist()
+        self.all_tasks.sort()  # unique in python does automatic sort; add for safety
+
+        if context_cat_feature is None:
+            context_cat_feature = all_tasks.unsqueeze(-1)
+        self.context_cat_feature = context_cat_feature  # row indices = context indices
+        self.context_emb_feature = context_emb_feature
+
+        #  construct emb_dims based on categorical features
+        if embs_dim_list is None:
+            #  set embedding_dim = 1 for each categorical variable
+            embs_dim_list = [1 for _i in range(context_cat_feature.size(1))]
+        n_embs = sum(embs_dim_list)
+        self.emb_dims = [
+            (len(context_cat_feature[:, i].unique()), embs_dim_list[i])
+            for i in range(context_cat_feature.size(1))
+        ]
+        # contruct embedding layer: need to handle multiple categorical features
+        self.emb_layers = ModuleList(
+            [
+                torch.nn.Embedding(num_embeddings=x, embedding_dim=y, max_norm=1.0)
+                for x, y in self.emb_dims
+            ]
+        )
+        self.task_covar_module = RBFKernel(
+            ard_num_dims=n_embs, lengthscale_prior=UniformPrior(0.0, 2.0)
+        )
+        self.to(train_X)
+
+    def _eval_context_covar(self) -> LazyTensor:
+        """obtain context covariance matrix (num_contexts x num_contexts)"""
+        all_embs = self._task_embeddings()
+        return self.task_covar_module(all_embs)
+
+    def _task_embeddings(self) -> Tensor:
+        """generate embedding features for all contexts."""
+        embeddings = [
+            emb_layer(
+                self.context_cat_feature[:, i].to(dtype=torch.long)  # pyre-ignore
+            )
+            for i, emb_layer in enumerate(self.emb_layers)
+        ]
+        embeddings = torch.cat(embeddings, dim=1)
+
+        # add given embeddings if any
+        if self.context_emb_feature is not None:
+            embeddings = torch.cat(
+                [embeddings, self.context_emb_feature], dim=1  # pyre-ignore
+            )
+        return embeddings
+
+    def task_covar_matrix(self, task_idcs: Tensor) -> Tensor:
+        """compute covariance matrix of a list of given context
+
+        Args:
+            task_idcs: (n x 1) or (b x n x 1) task indices tensor
+        """
+        covar_matrix = self._eval_context_covar()
+        return InterpolatedLazyTensor(
+            base_lazy_tensor=covar_matrix,
+            left_interp_indices=task_idcs,
+            right_interp_indices=task_idcs,
+        ).evaluate()
+
+    def forward(self, x: Tensor) -> MultivariateNormal:
+        x_basic, task_idcs = self._split_inputs(x)
+        # Compute base mean and covariance
+        mean_x = self.mean_module(x_basic)
+        covar_x = self.covar_module(x_basic)
+        # Compute task covariances
+        covar_i = self.task_covar_matrix(task_idcs)
+        covar = covar_x.mul(covar_i)
+        return MultivariateNormal(mean_x, covar)
+
+
+class FixedNoiseLCEMGP(LCEMGP):
+    r"""The Multi-Task GP the latent context embedding multioutput
+    (LCE-M) kernel, with known observation noise.
+
+    Args:
+        train_X: (n x d) X training data.
+        train_Y: (n x 1) Y training data.
+        train_Yvar: (n x 1) Noise variances of each training Y.
+        task_feature: column index of train_X to get context indices.
+        context_cat_feature: (n_contexts x k) one-hot encoded context
+            features. Rows are ordered by context indices. k equals to
+            number of categorical variables. If None, task indices will
+            be used and k = 1.
+        context_emb_feature: (n_contexts x m) pre-given continuous
+            embedding features. Rows are ordered by context indices.
+        embs_dim_list: Embedding dimension for each categorical variable.
+            The length equals to k. If None, emb dim is set to 1 for each
+            categorical variable.
+        output_tasks: A list of task indices for which to compute model
+            outputs for. If omitted, return outputs for all task indices.
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        train_Yvar: Tensor,
+        task_feature: int,
+        context_cat_feature: Optional[Tensor] = None,
+        context_emb_feature: Optional[Tensor] = None,
+        embs_dim_list: Optional[List[int]] = None,
+        output_tasks: Optional[List[int]] = None,
+    ) -> None:
+        self._validate_tensor_args(X=train_X, Y=train_Y, Yvar=train_Yvar)
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            task_feature=task_feature,
+            context_cat_feature=context_cat_feature,
+            context_emb_feature=context_emb_feature,
+            embs_dim_list=embs_dim_list,
+            output_tasks=output_tasks,
+        )
+        self.likelihood = FixedNoiseGaussianLikelihood(noise=train_Yvar)
+        self.to(train_X)

--- a/botorch/models/kernels/contextual_lcea.py
+++ b/botorch/models/kernels/contextual_lcea.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, List, Optional
+
+import torch
+from gpytorch.constraints import Positive
+from gpytorch.kernels.kernel import Kernel
+from gpytorch.kernels.matern_kernel import MaternKernel
+from gpytorch.lazy.sum_lazy_tensor import SumLazyTensor
+from gpytorch.priors.torch_priors import GammaPrior
+from torch import Tensor
+from torch.nn import ModuleList
+
+
+class LCEAKernel(Kernel):
+    r"""The Latent Context Embedding Additive (LCE-A) Kernel.
+
+    This kernel is similar to the SACKernel, and is used when context breakdowns are
+    unbserverable. It assumes the same additive structure and a spatial kernel shared
+    across contexts. Rather than assuming independence, LCEAKernel models the
+    correlation in the latent functions for each context through learning context
+    embeddings.
+
+    Args:
+        decomposition: Keys index context names. Values are the indexes of parameters
+            belong to the context. The parameter indexes are in the same order across
+            contexts.
+        batch_shape: Batch shape as usual for gpytorch kernels. Model does not support
+            batch training. When batch_shape is non-empty, it is used for loading
+            hyper-parameter values generated from MCMC sampling.
+        train_embedding: A boolean indictor of whether to learn context embeddings
+        cat_feature_dict: Keys are context names and values are list of categorical
+            features i.e. {"context_name" : [cat_0, ..., cat_k]}. k equals to number
+            of categorical variables. If None, we use context names in the
+            decomposition as the only categorical feature i.e. k = 1
+        embs_feature_dict: Pre-trained continuous embedding features of each context.
+        embs_dim_list: Embedding dimension for each categorical variable. The length
+            equals to num of categorical features k. If None, emb dim is set to 1
+            for each categorical variable.
+        context_weight_dict: Known population Weights of each context.
+    """
+
+    def __init__(
+        self,
+        decomposition: Dict[str, List[int]],
+        batch_shape: torch.Size,
+        train_embedding: bool = True,
+        cat_feature_dict: Optional[Dict] = None,
+        embs_feature_dict: Optional[Dict] = None,
+        embs_dim_list: Optional[List[int]] = None,
+        context_weight_dict: Optional[Dict] = None,
+    ) -> None:
+
+        super().__init__(batch_shape=batch_shape)
+        self.decomposition = decomposition
+        self.batch_shape = batch_shape
+        self.train_embedding = train_embedding
+
+        num_param = len(next(iter(decomposition.values())))
+        self.context_list = list(decomposition.keys())
+        self.num_contexts = len(self.context_list)
+
+        # get parameter space decomposition
+        for active_parameters in decomposition.values():
+            # check number of parameters are same in each decomp
+            if len(active_parameters) != num_param:
+                raise ValueError(
+                    "num of parameters needs to be same across all contexts"
+                )
+        self._indexers = {
+            context: torch.tensor(active_params)
+            for context, active_params in self.decomposition.items()
+        }
+        # get context features and set emb dim
+        self.context_cat_feature = None
+        self.context_emb_feature = None
+        self.n_embs = 0
+        self.emb_weight_matrix_list = None
+        self.emb_dims = None
+        self._set_context_features(
+            cat_feature_dict=cat_feature_dict,
+            embs_feature_dict=embs_feature_dict,
+            embs_dim_list=embs_dim_list,
+        )
+        # contruct embedding layer
+        if train_embedding:
+            self._set_emb_layers()
+        # task covariance matrix
+        self.task_covar_module = MaternKernel(
+            nu=2.5,
+            ard_num_dims=self.n_embs,
+            batch_shape=batch_shape,
+            lengthscale_prior=GammaPrior(3.0, 6.0),
+        )
+        # base kernel
+        self.base_kernel = MaternKernel(
+            nu=2.5,
+            ard_num_dims=num_param,
+            batch_shape=batch_shape,
+            lengthscale_prior=GammaPrior(3.0, 6.0),
+        )
+        # outputscales for each context (note this is like sqrt of outputscale)
+        self.context_weight = None
+        if context_weight_dict is None:
+            outputscale_list = torch.zeros(*batch_shape, self.num_contexts)
+        else:
+            outputscale_list = torch.zeros(*batch_shape, 1)
+            self.context_weight = torch.tensor(
+                [context_weight_dict[c] for c in self.context_list]
+            )
+        self.register_parameter(
+            name="raw_outputscale_list", parameter=torch.nn.Parameter(outputscale_list)
+        )
+        self.register_prior(
+            "outputscale_list_prior",
+            GammaPrior(2.0, 15.0),
+            lambda: self.outputscale_list,
+            lambda v: self._set_outputscale_list(v),
+        )
+        self.register_constraint("raw_outputscale_list", Positive())
+
+    @property
+    def outputscale_list(self) -> Tensor:
+        return self.raw_outputscale_list_constraint.transform(self.raw_outputscale_list)
+
+    @outputscale_list.setter
+    def outputscale_list(self, value: Tensor) -> None:
+        self._set_outputscale_list(value)
+
+    def _set_outputscale_list(self, value: Tensor) -> None:
+        if not torch.is_tensor(value):
+            value = torch.as_tensor(value).to(self.raw_outputscale_list)
+        self.initialize(
+            raw_outputscale_list=self.raw_outputscale_list_constraint.inverse_transform(
+                value
+            )
+        )
+
+    def _set_context_features(
+        self,
+        cat_feature_dict: Optional[Dict] = None,
+        embs_feature_dict: Optional[Dict] = None,
+        embs_dim_list: Optional[List[int]] = None,
+    ) -> None:
+        """Set context categorical features and continuous embedding features.
+        If cat_feature_dict is None, context indices will be used; If embs_dim_list
+        is None, we use 1-d embedding for each categorical features.
+        """
+        # get context categorical features
+        if cat_feature_dict is None:
+            self.context_cat_feature = torch.arange(self.num_contexts).unsqueeze(-1)
+        else:
+            self.context_cat_feature = torch.tensor(
+                [cat_feature_dict[c] for c in self.context_list]
+            )
+        #  construct emb_dims based on categorical features
+        if embs_dim_list is None:
+            #  set embedding_dim = 1 for each categorical variable
+            embs_dim_list = [1 for _i in range(self.context_cat_feature.size(1))]
+        self.emb_dims = [
+            (len(self.context_cat_feature[:, i].unique()), embs_dim_list[i])
+            for i in range(self.context_cat_feature.size(1))
+        ]
+        if self.train_embedding:
+            self.n_embs = sum(embs_dim_list)  # total num of emb features
+        # get context embedding features
+        if embs_feature_dict is not None:
+            self.context_emb_feature = torch.tensor(
+                [embs_feature_dict[c] for c in self.context_list]
+            )
+            self.n_embs += self.context_emb_feature.size(1)
+
+    def _set_emb_layers(self) -> None:
+        """Construct embedding layers.
+        If model is non-batch, we use nn.Embedding to learn emb weights. If model is
+        batched (sef.batch_shape is non-empty), we load emb weights posterior samples
+        and construct a parameter list that each parameter is the emb weight of each
+        layer. The shape of weight matrices are ns x num_contexts x emb_dim.
+        """
+        self.emb_layers = ModuleList(
+            [
+                torch.nn.Embedding(num_embeddings=x, embedding_dim=y, max_norm=1.0)
+                for x, y in self.emb_dims
+            ]
+        )
+        # use posterior of emb weights
+        if len(self.batch_shape) > 0:
+            self.emb_weight_matrix_list = torch.nn.ParameterList(
+                [
+                    torch.nn.Parameter(
+                        torch.zeros(self.batch_shape + emb_layer.weight.shape)
+                    )
+                    for emb_layer in self.emb_layers
+                ]
+            )
+
+    def _eval_context_covar(self) -> Tensor:
+        """Compute context covariance matrix.
+
+        Returns:
+            A (ns) x num_contexts x num_contexts tensor.
+        """
+        if len(self.batch_shape) > 0:
+            # broadcast - (ns x num_contexts x k)
+            all_embs = self._task_embeddings_batch()
+        else:
+            all_embs = self._task_embeddings()  # no broadcast - (num_contexts x k)
+
+        context_covar = self.task_covar_module(all_embs).evaluate()
+        if self.context_weight is None:
+            context_outputscales = self.outputscale_list
+        else:
+            context_outputscales = self.outputscale_list * self.context_weight
+        context_covar = (
+            (context_outputscales.unsqueeze(-2))  # (ns) x 1 x num_contexts
+            .mul(context_covar)
+            .mul(context_outputscales.unsqueeze(-1))  # (ns) x num_contexts x 1
+        )
+        return context_covar
+
+    def _task_embeddings(self) -> Tensor:
+        """Generate embedding features of contexts when model is non-batch.
+
+        Returns:
+            a (num_contexts x n_embs) tensor. n_embs is the sum of embedding
+            dimensions i.e. sum(embs_dim_list)
+        """
+        if self.train_embedding is False:
+            return self.context_emb_feature  # use pre-trained embedding only
+        context_features = torch.stack(
+            [self.context_cat_feature[i, :] for i in range(self.num_contexts)], dim=0
+        )
+        embeddings = [
+            emb_layer(context_features[:, i].to(dtype=torch.long))
+            for i, emb_layer in enumerate(self.emb_layers)
+        ]
+        embeddings = torch.cat(embeddings, dim=1)
+        # add given embeddings if any
+        if self.context_emb_feature is not None:
+            embeddings = torch.cat([embeddings, self.context_emb_feature], dim=1)
+        return embeddings
+
+    def _task_embeddings_batch(self) -> Tensor:
+        """Generate embedding features of contexts when model has multiple batches.
+
+        Returns:
+            a (ns) x num_contexts x n_embs tensor. ns is the batch size i.e num of
+            posterior samples; n_embs is the sum of embedding dimensions i.e.
+            sum(embs_dim_list).
+        """
+        context_features = torch.cat(
+            [
+                self.context_cat_feature[i, :].unsqueeze(0)
+                for i in range(self.num_contexts)
+            ]
+        )
+        embeddings = []
+        for b in range(self.batch_shape.numel()):  # pyre-ignore
+            for i in range(len(self.emb_weight_matrix_list)):
+                # loop over emb layer and concat embs from each layer
+                embeddings.append(
+                    torch.cat(
+                        [
+                            torch.nn.functional.embedding(
+                                context_features[:, 0].to(dtype=torch.long),
+                                self.emb_weight_matrix_list[i][b, :],
+                            ).unsqueeze(0)
+                        ],
+                        dim=1,
+                    )
+                )
+        embeddings = torch.cat(embeddings, dim=0)
+        # add given embeddings if any
+        if self.context_emb_feature is not None:
+            embeddings = torch.cat(
+                [
+                    embeddings,
+                    self.context_emb_feature.expand(
+                        *self.batch_shape + self.context_emb_feature.shape
+                    ),
+                ],
+                dim=-1,
+            )
+        return embeddings
+
+    def forward(
+        self,
+        x1: Tensor,
+        x2: Tensor,
+        diag: bool = False,
+        last_dim_is_batch: bool = False,
+        **params: Any,
+    ) -> Tensor:
+        """Iterate across each partition of parameter space and sum the
+        covariance matrices together
+        """
+        # context covar matrix
+        context_covar = self._eval_context_covar()
+        # check input batch size if b x ns x n x d: expand context_covar to
+        # b x ns x num_context x num_context
+        if x1.dim() > context_covar.dim():
+            context_covar = context_covar.expand(*x1.shape[:1] + context_covar.shape)
+        covars = []
+        # TODO: speed computation of covariance matrix
+        for i in range(self.num_contexts):
+            for j in range(self.num_contexts):
+                context1 = self.context_list[i]
+                context2 = self.context_list[j]
+                active_params1 = self._indexers[context1]
+                active_params2 = self._indexers[context2]
+                covars.append(
+                    (
+                        context_covar.index_select(  # pyre-ignore
+                            -1, torch.tensor([j])
+                        ).index_select(
+                            -2, torch.tensor([i])
+                        )  # b x ns x 1 x 1
+                    )
+                    * self.base_kernel(
+                        x1=x1.index_select(-1, active_params1),
+                        x2=x2.index_select(-1, active_params2),
+                        diag=diag,
+                    )
+                )
+        if diag:
+            res = sum(covars)
+        else:
+            res = SumLazyTensor(*covars)
+        return res

--- a/botorch/models/kernels/contextual_sac.py
+++ b/botorch/models/kernels/contextual_sac.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, List
+
+import torch
+from gpytorch.kernels.kernel import Kernel
+from gpytorch.kernels.matern_kernel import MaternKernel
+from gpytorch.kernels.scale_kernel import ScaleKernel
+from gpytorch.lazy.sum_lazy_tensor import SumLazyTensor
+from gpytorch.priors.torch_priors import GammaPrior
+from torch import Tensor
+from torch.nn import ModuleDict  # pyre-ignore
+
+
+class SACKernel(Kernel):
+    r"""The structural additive contextual(SAC) kernel.
+
+    The kernel is used for contextual BO without oberseving context breakdowns.
+    There are d parameters and M contexts. In total, the dimension of parameter space
+    is d*M and input x can be written as
+    x=[x_11, ..., x_1d, x_21, ..., x_2d, ...,  x_M1, ..., x_Md].
+
+    The kernel uses the parameter decomposition and assumes an additive structure
+    across contexts. Each context compponent is assumed to be independent.
+
+    .. math::
+       \begin{equation*}
+          k(\mathbf{x}, \mathbf{x'}) = k_1(\mathbf{x_(1)}, \mathbf{x'_(1)}) + \cdots
+          + k_M(\mathbf{x_(M)}, \mathbf{x'_(M)})
+       \end{equation*}
+
+    where
+    * :math: M is the number of partitions of parameter space. Each partition contains
+    same number of parameters d. Each kernel `k_i` acts only on d parameters of ith
+    partition i.e. `\mathbf{x}_(i)`. Each kernel `k_i` is a scaled Matern kernel
+    with same lengthscales but different outputscales.
+
+    Args:
+        decomposition: Keys are context names. Values are the indexes of parameters
+            belong to the context. The parameter indexes are in the same order across
+            contexts.
+        batch_shape: Batch shape as usual for gpytorch kernels.
+    """
+
+    def __init__(
+        self, decomposition: Dict[str, List[int]], batch_shape: torch.Size
+    ) -> None:
+        super().__init__(batch_shape=batch_shape)
+        self.decomposition = decomposition
+
+        num_param = len(next(iter(decomposition.values())))
+        for active_parameters in decomposition.values():
+            # check number of parameters are same in each decomp
+            if len(active_parameters) != num_param:
+                raise ValueError(
+                    "num of parameters needs to be same across all contexts"
+                )
+
+        self._indexers = {
+            context: torch.tensor(active_params)
+            for context, active_params in self.decomposition.items()
+        }
+
+        self.base_kernel = MaternKernel(
+            nu=2.5,
+            ard_num_dims=num_param,
+            batch_shape=batch_shape,
+            lengthscale_prior=GammaPrior(3.0, 6.0),
+        )
+
+        self.kernel_dict = {}  # scaled kernel for each parameter space partition
+        for context in list(decomposition.keys()):
+            self.kernel_dict[context] = ScaleKernel(
+                base_kernel=self.base_kernel, outputscale_prior=GammaPrior(2.0, 15.0)
+            )
+        self.kernel_dict = ModuleDict(self.kernel_dict)
+
+    def forward(
+        self,
+        x1: Tensor,
+        x2: Tensor,
+        diag: bool = False,
+        last_dim_is_batch: bool = False,
+        **params: Any,
+    ) -> Tensor:
+        """
+        iterate across each partition of parameter space and sum the
+        covariance matrices together
+        """
+        # same lengthscale for all the components
+        covars = [
+            self.kernel_dict[context](
+                x1=x1.index_select(dim=-1, index=active_params),  # pyre-ignore
+                x2=x2.index_select(dim=-1, index=active_params),
+                diag=diag,
+            )
+            for context, active_params in self._indexers.items()
+        ]
+
+        if diag:
+            res = sum(covars)
+        else:
+            res = SumLazyTensor(*covars)
+        return res

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -59,6 +59,16 @@ Pairwise GP Models
 .. automodule:: botorch.models.pairwise_gp
     :members:
 
+Contextual GP Models with Aggregate Rewards
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.contextual
+    :members:
+
+Contextual GP Models with Context Rewards
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.contextual_multioutput
+    :members:
+
 
 Model Components
 -------------------------------------------
@@ -73,6 +83,12 @@ Kernels
 
 .. automodule:: botorch.models.kernels.linear_truncated_fidelity
 .. autoclass:: LinearTruncatedFidelityKernel
+
+.. automodule:: botorch.models.kernels.contextual_lcea
+.. autoclass:: LCEAKernel
+
+.. automodule:: botorch.models.kernels.contextual_sac
+.. autoclass:: SACKernel
 
 
 Transforms

--- a/test/models/kernels/test_contextual.py
+++ b/test/models/kernels/test_contextual.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from botorch.models.kernels.contextual_lcea import LCEAKernel
+from botorch.models.kernels.contextual_sac import SACKernel
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.kernels.matern_kernel import MaternKernel
+from torch import Tensor
+from torch.nn import ModuleDict
+
+
+class ContextualKernelTest(BotorchTestCase):
+    def test_SACKernel(self):
+        decomposition = {"1": [0, 3], "2": [1, 2]}
+        kernel = SACKernel(decomposition=decomposition, batch_shape=torch.Size([]))
+
+        self.assertIsInstance(kernel.kernel_dict, ModuleDict)
+        self.assertIsInstance(kernel.base_kernel, MaternKernel)
+        self.assertDictEqual(kernel.decomposition, decomposition)
+
+        # test diag works well for lazy tensor
+        x1 = torch.rand(5, 4)
+        x2 = torch.rand(5, 4)
+        res = kernel(x1, x2).evaluate()
+        res_diag = kernel(x1, x2, diag=True)
+        self.assertLess(torch.norm(res_diag - res.diag()), 1e-4)
+
+        # test raise of ValueError
+        with self.assertRaises(ValueError):
+            SACKernel(decomposition={"1": [0, 3], "2": [1]}, batch_shape=torch.Size([]))
+
+    def testLCEAKernel(self):
+        decomposition = {"1": [0, 3], "2": [1, 2]}
+        num_contexts = len(decomposition)
+
+        kernel = LCEAKernel(decomposition=decomposition, batch_shape=torch.Size([]))
+        # test init
+        self.assertListEqual(kernel.context_list, ["1", "2"])
+        self.assertDictEqual(kernel.decomposition, decomposition)
+
+        self.assertIsInstance(kernel.base_kernel, MaternKernel)
+        self.assertIsInstance(kernel.task_covar_module, MaternKernel)
+
+        # test raise of ValueError
+        with self.assertRaises(ValueError):
+            LCEAKernel(
+                decomposition={"1": [0, 3], "2": [1]}, batch_shape=torch.Size([])
+            )
+
+        # test set_outputscale_list
+        kernel.initialize(outputscale_list=[0.5, 0.5])
+        actual_value = torch.tensor([0.5, 0.5]).view_as(kernel.outputscale_list)
+        self.assertLess(torch.norm(kernel.outputscale_list - actual_value), 1e-5)
+
+        self.assertTrue(kernel.train_embedding)
+        self.assertEqual(kernel.num_contexts, num_contexts)
+        self.assertEqual(kernel.n_embs, 1)
+        self.assertIsNone(kernel.context_emb_feature)
+        self.assertIsInstance(kernel.context_cat_feature, Tensor)
+        self.assertEqual(len(kernel.emb_layers), 1)
+        self.assertListEqual(kernel.emb_dims, [(num_contexts, 1)])
+
+        context_covar = kernel._eval_context_covar()
+        self.assertIsInstance(context_covar, Tensor)
+        self.assertEqual(context_covar.shape, torch.Size([num_contexts, num_contexts]))
+
+        embeddings = kernel._task_embeddings()
+        self.assertIsInstance(embeddings, Tensor)
+        self.assertEqual(embeddings.shape, torch.Size([num_contexts, 1]))
+
+        self.assertIsInstance(kernel.outputscale_list, Tensor)
+        self.assertEqual(kernel.outputscale_list.shape, torch.Size([num_contexts]))
+
+        # test diag works well for lazy tensor
+        x1 = torch.rand(5, 4)
+        x2 = torch.rand(5, 4)
+        res = kernel(x1, x2).evaluate()
+        res_diag = kernel(x1, x2, diag=True)
+        self.assertLess(torch.norm(res_diag - res.diag()), 1e-4)
+
+        # test batch evaluation
+        x1 = torch.rand(3, 5, 4)
+        x2 = torch.rand(3, 5, 4)
+        res = kernel(x1, x2).evaluate()
+        self.assertEqual(res.shape, torch.Size([3, 5, 5]))
+
+        # test input context_weight,
+        # test input embs_dim_list (one categorical feature)
+        # test input context_cat_feature
+        embs_dim_list = [2]
+        kernel2 = LCEAKernel(
+            decomposition=decomposition,
+            context_weight_dict={"1": 0.5, "2": 0.8},
+            cat_feature_dict={"1": [0], "2": [1]},
+            embs_dim_list=embs_dim_list,  # increase dim from 1 to 2
+            batch_shape=torch.Size([]),
+        )
+
+        self.assertEqual(kernel2.num_contexts, num_contexts)
+        self.assertEqual(kernel2.n_embs, 2)
+        self.assertIsNone(kernel2.context_emb_feature)
+        self.assertIsInstance(kernel2.context_cat_feature, Tensor)
+        self.assertEqual(
+            kernel2.context_cat_feature.shape, torch.Size([num_contexts, 1])
+        )
+        self.assertEqual(len(kernel2.emb_layers), 1)
+        self.assertListEqual(kernel2.emb_dims, [(num_contexts, embs_dim_list[0])])
+
+        context_covar2 = kernel2._eval_context_covar()
+        self.assertIsInstance(context_covar2, Tensor)
+        self.assertEqual(context_covar2.shape, torch.Size([num_contexts, num_contexts]))
+
+        # test input pre-trained embedding
+        kernel3 = LCEAKernel(
+            decomposition=decomposition,
+            embs_feature_dict={"1": [0.2], "2": [0.5]},
+            batch_shape=torch.Size([]),
+        )
+        self.assertEqual(kernel3.num_contexts, num_contexts)
+        self.assertEqual(kernel3.n_embs, 2)
+        self.assertIsNotNone(kernel3.context_emb_feature)
+        self.assertIsInstance(kernel3.context_emb_feature, Tensor)
+        self.assertIsInstance(kernel3.context_cat_feature, Tensor)
+        self.assertEqual(
+            kernel3.context_cat_feature.shape, torch.Size([num_contexts, 1])
+        )
+        self.assertListEqual(kernel3.emb_dims, [(num_contexts, 1)])
+        embeddings3 = kernel3._task_embeddings()
+        self.assertEqual(embeddings3.shape, torch.Size([num_contexts, 2]))
+
+        # test only use pre-trained embedding
+        kernel4 = LCEAKernel(
+            decomposition=decomposition,
+            train_embedding=False,
+            embs_feature_dict={"1": [0.2], "2": [0.5]},
+            batch_shape=torch.Size([]),
+        )
+        self.assertEqual(kernel4.n_embs, 1)
+        self.assertIsNotNone(kernel4.context_emb_feature)
+        self.assertIsInstance(kernel4.context_emb_feature, Tensor)
+        self.assertIsInstance(kernel4.context_cat_feature, Tensor)
+        embeddings4 = kernel4._task_embeddings()
+        self.assertEqual(embeddings4.shape, torch.Size([num_contexts, 1]))
+
+        # test batch
+        kernel5 = LCEAKernel(decomposition=decomposition, batch_shape=torch.Size([3]))
+        self.assertEqual(kernel5.n_embs, 1)  # one dim cat
+        self.assertListEqual(kernel5.emb_dims, [(num_contexts, 1)])
+
+        embeddings_batch = kernel5._task_embeddings_batch()
+        self.assertIsInstance(embeddings_batch, Tensor)
+        self.assertEqual(embeddings_batch.shape, torch.Size([3, num_contexts, 1]))
+
+        context_covar5 = kernel5._eval_context_covar()
+        self.assertIsInstance(context_covar5, Tensor)
+        self.assertEqual(
+            context_covar5.shape, torch.Size([3, num_contexts, num_contexts])
+        )
+
+        # test batch with pre-trained features
+        kernel6 = LCEAKernel(
+            decomposition=decomposition,
+            batch_shape=torch.Size([3]),
+            embs_feature_dict={"1": [0.2], "2": [0.5]},
+        )
+        self.assertEqual(kernel6.n_embs, 2)  # one dim cat + one dim pre-train
+        self.assertListEqual(kernel6.emb_dims, [(num_contexts, 1)])  # one dim for cat
+
+        embeddings_batch = kernel6._task_embeddings_batch()
+        self.assertIsInstance(embeddings_batch, Tensor)
+        self.assertEqual(
+            embeddings_batch.shape, torch.Size([3, num_contexts, num_contexts])
+        )
+
+        context_covar6 = kernel6._eval_context_covar()
+        self.assertIsInstance(context_covar6, Tensor)
+        self.assertEqual(
+            context_covar6.shape, torch.Size([3, num_contexts, num_contexts])
+        )

--- a/test/models/test_contextual.py
+++ b/test/models/test_contextual.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+from botorch import fit_gpytorch_model
+from botorch.models.contextual import LCEAGP, SACGP
+from botorch.models.gp_regression import FixedNoiseGP
+from botorch.models.kernels.contextual_lcea import LCEAKernel
+from botorch.models.kernels.contextual_sac import SACKernel
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.distributions.multivariate_normal import MultivariateNormal
+from gpytorch.means import ConstantMean
+from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+
+
+class ContextualGPTest(BotorchTestCase):
+    def test_SACGP(self):
+        train_X = torch.tensor(
+            [[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]]
+        )
+        train_Y = torch.tensor([[1.0], [2.0], [3.0]])
+        train_Yvar = 0.01 * torch.ones(3, 1, dtype=torch.double)
+        self.decomposition = {"1": [0, 3], "2": [1, 2]}
+
+        self.model = SACGP(train_X, train_Y, train_Yvar, self.decomposition)
+        mll = ExactMarginalLogLikelihood(self.model.likelihood, self.model)
+        fit_gpytorch_model(mll, options={"maxiter": 1})
+
+        self.assertIsInstance(self.model, FixedNoiseGP)
+        self.assertDictEqual(self.model.decomposition, self.decomposition)
+        self.assertIsInstance(self.model.mean_module, ConstantMean)
+        self.assertIsInstance(self.model.covar_module, SACKernel)
+
+        # test number of named parameters
+        num_of_mean = 0
+        num_of_lengthscales = 0
+        num_of_outputscales = 0
+        for param_name, param in self.model.named_parameters():
+            if param_name == "mean_module.constant":
+                num_of_mean += param.data.shape.numel()
+            elif "raw_lengthscale" in param_name:
+                num_of_lengthscales += param.data.shape.numel()
+            elif "raw_outputscale" in param_name:
+                num_of_outputscales += param.data.shape.numel()
+        self.assertEqual(num_of_mean, 1)
+        self.assertEqual(num_of_lengthscales, 2)
+        self.assertEqual(num_of_outputscales, 2)
+
+        test_x = torch.rand(5, 4)
+        posterior = self.model(test_x)
+        self.assertIsInstance(posterior, MultivariateNormal)
+
+    def testLCEAGP(self):
+        train_X = torch.tensor(
+            [[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]]
+        )
+        train_Y = torch.tensor([[1.0], [2.0], [3.0]])
+        train_Yvar = 0.01 * torch.ones(3, 1, dtype=torch.double)
+        # Test setting attributes
+        decomposition = {"1": [0, 1], "2": [2, 3]}
+
+        # test instantiate model
+        model = LCEAGP(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            decomposition=decomposition,
+        )
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        fit_gpytorch_model(mll, options={"maxiter": 1})
+
+        self.assertIsInstance(model, LCEAGP)
+        self.assertIsInstance(model.covar_module, LCEAKernel)
+        self.assertDictEqual(model.decomposition, decomposition)

--- a/test/models/test_contextual_multioutput.py
+++ b/test/models/test_contextual_multioutput.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from botorch import fit_gpytorch_model
+from botorch.models.contextual_multioutput import LCEMGP, FixedNoiseLCEMGP
+from botorch.models.multitask import MultiTaskGP
+from botorch.posteriors import GPyTorchPosterior
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
+from gpytorch.lazy import LazyTensor
+from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+from torch import Tensor
+
+
+class ContextualMultiOutputTest(BotorchTestCase):
+    def testLCEMGP(self):
+        d = 1
+        train_x = torch.rand(10, d)
+        train_y = torch.cos(train_x)
+        # 2 contexts here
+        task_indices = torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+        train_x = torch.cat([train_x, task_indices.unsqueeze(-1)], axis=1)
+
+        model = LCEMGP(train_X=train_x, train_Y=train_y, task_feature=d)
+        self.assertIsInstance(model, LCEMGP)
+        self.assertIsInstance(model, MultiTaskGP)
+        self.assertIsNone(model.context_emb_feature)
+        self.assertIsInstance(model.context_cat_feature, Tensor)
+        self.assertEqual(model.context_cat_feature.shape, torch.Size([2, 1]))
+        self.assertEqual(len(model.emb_layers), 1)
+        self.assertEqual(model.emb_dims, [(2, 1)])
+
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        fit_gpytorch_model(mll, options={"maxiter": 1})
+
+        context_covar = model._eval_context_covar()
+        self.assertIsInstance(context_covar, LazyTensor)
+        self.assertEqual(context_covar.shape, torch.Size([2, 2]))
+
+        embeddings = model._task_embeddings()
+        self.assertIsInstance(embeddings, Tensor)
+        self.assertEqual(embeddings.shape, torch.Size([2, 1]))
+
+        test_x = torch.rand(5, d)
+        task_indices = torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0])
+        test_x = torch.cat([test_x, task_indices.unsqueeze(-1)], axis=1)
+        self.assertIsInstance(model(test_x), MultivariateNormal)
+
+        # test posterior
+        posterior_f = model.posterior(test_x[:, :d])
+        self.assertIsInstance(posterior_f, GPyTorchPosterior)
+        self.assertIsInstance(posterior_f.mvn, MultitaskMultivariateNormal)
+
+        # test posterior w/ single output index
+        posterior_f = model.posterior(test_x[:, :d], output_indices=[0])
+        self.assertIsInstance(posterior_f, GPyTorchPosterior)
+        self.assertIsInstance(posterior_f.mvn, MultivariateNormal)
+
+        # test input embs_dim_list (one categorical feature)
+        # test input pre-trained emb context_emb_feature
+        model2 = LCEMGP(
+            train_X=train_x,
+            train_Y=train_y,
+            task_feature=d,
+            embs_dim_list=[2],  # increase dim from 1 to 2
+            context_emb_feature=torch.Tensor([[0.2], [0.3]]),
+        )
+        self.assertIsInstance(model2, LCEMGP)
+        self.assertIsInstance(model2, MultiTaskGP)
+        self.assertIsNotNone(model2.context_emb_feature)
+        self.assertIsInstance(model2.context_cat_feature, Tensor)
+        self.assertEqual(model2.context_cat_feature.shape, torch.Size([2, 1]))
+        self.assertEqual(len(model2.emb_layers), 1)
+        self.assertEqual(model2.emb_dims, [(2, 2)])
+
+        embeddings2 = model2._task_embeddings()
+        self.assertIsInstance(embeddings2, Tensor)
+        self.assertEqual(embeddings2.shape, torch.Size([2, 3]))
+
+    def testFixedNoiseLCEMGP(self):
+        d = 1
+        train_x = torch.rand(10, d)
+        train_y = torch.cos(train_x)
+        task_indices = torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+        train_x = torch.cat([train_x, task_indices.unsqueeze(-1)], axis=1)
+        train_yvar = torch.ones(10, 1) * 0.01
+
+        model = FixedNoiseLCEMGP(
+            train_X=train_x, train_Y=train_y, train_Yvar=train_yvar, task_feature=d
+        )
+        self.assertIsInstance(model, FixedNoiseLCEMGP)


### PR DESCRIPTION
Summary: move SAC, LCE-A, LCE-M GP to BoTorch OSS

Differential Revision: D24194236

