### PR TITLE
Add Ax tutorial back into CI runs

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -28,7 +28,6 @@ IGNORE = {
     "preference_bo.ipynb",
     # some others may require setting paths to local data
     "vae_mnist.ipynb",
-    "custom_botorch_model_in_ax.ipynb",  # TODO: Remove after next Ax release
 }
 
 


### PR DESCRIPTION
Summary: Undo D23609515 (https://github.com/pytorch/botorch/commit/7258e569d57651916eab78747f81cfc045d17b77)

Reviewed By: lena-kashtelyan

Differential Revision: D23609513

