### PR TITLE
add seperate init_batch_limit option for generating initial_conditions

### DIFF
--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -48,7 +48,10 @@ def gen_batch_initial_conditions(
             `initialize_q_batch` and `initialize_q_batch_nonneg`. If `options`
             contains a `nonnegative=True` entry, then `acq_function` is
             assumed to be non-negative (useful when using custom acquisition
-            functions).
+            functions). In addition, an "init_batch_limit" option can be passed
+            to specify the batch limit for the initialization. This is useful
+            for avoiding memory limits when computing the batch posterior over
+            raw samples.
 
     Returns:
         A `num_restarts x q x d` tensor of initial conditions.
@@ -62,7 +65,9 @@ def gen_batch_initial_conditions(
     """
     options = options or {}
     seed: Optional[int] = options.get("seed")
-    batch_limit: Optional[int] = options.get("batch_limit")
+    batch_limit: Optional[int] = options.get(
+        "init_batch_limit", options.get("batch_limit")
+    )
     batch_initial_arms: Tensor
     factor, max_factor = 1, 5
     init_kwargs = {}

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -172,7 +172,7 @@ def optimize_acqf(
             options={
                 k: v
                 for k, v in options.items()
-                if k not in ("batch_limit", "nonnegative")
+                if k not in ("init_batch_limit", "batch_limit", "nonnegative")
             },
             inequality_constraints=inequality_constraints,
             equality_constraints=equality_constraints,


### PR DESCRIPTION
Summary: If batch_limit is too high, this can cause memory issues. However, batch_limit is used in optimize_acqf to limit the number of random restarts that we jointly optimize with LBFGS, which we often want to be low to reduce the dimension of the optimization problem. Using a super low batch_limit can make generating initial conditions unnecessarily slow.

Reviewed By: danielrjiang

Differential Revision: D24311761

