### PR TITLE
Add batch_shape property to models

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
+import torch
 from botorch import settings
 from botorch.posteriors import Posterior
 from botorch.sampling.samplers import MCSampler
@@ -50,6 +51,19 @@ class Model(Module, ABC):
             over `q` points and `m` outputs each.
         """
         pass  # pragma: no cover
+
+    @property
+    def batch_shape(self) -> torch.Size:
+        r"""The batch shape of the model.
+
+        This is a batch shape from an I/O perspective, independent of the internal
+        representation of the model (as e.g. in BatchedMultiOutputGPyTorchModel).
+        For a model with `m` outputs, a `test_batch_shape x q x d`-shaped input `X`
+        to the `posterior` method returns a Posterior object over an output of
+        shape `broadcast(test_batch_shape, model.batch_shape) x q x m`.
+        """
+        cls_name = self.__class__.__name__
+        raise NotImplementedError(f"{cls_name} does not define batch_shape property")
 
     @property
     def num_outputs(self) -> int:

--- a/botorch/models/pairwise_gp.py
+++ b/botorch/models/pairwise_gp.py
@@ -190,11 +190,6 @@ class PairwiseGP(Model, GP):
             self.__deepcopy__ = dcp
             return new_model
 
-    @property
-    def num_outputs(self) -> int:
-        r"""The number of outputs of the model."""
-        return self._num_outputs
-
     def _has_no_data(self):
         r"""Return true if the model does not have both datapoints and comparisons"""
         return (
@@ -645,6 +640,23 @@ class PairwiseGP(Model, GP):
         return x
 
     # ============== public APIs ==============
+
+    @property
+    def num_outputs(self) -> int:
+        r"""The number of outputs of the model."""
+        return self._num_outputs
+
+    @property
+    def batch_shape(self) -> torch.Size:
+        r"""The batch shape of the model.
+
+        This is a batch shape from an I/O perspective, independent of the internal
+        representation of the model (as e.g. in BatchedMultiOutputGPyTorchModel).
+        For a model with `m` outputs, a `test_batch_shape x q x d`-shaped input `X`
+        to the `posterior` method returns a Posterior object over an output of
+        shape `broadcast(test_batch_shape, model.batch_shape) x q x m`.
+        """
+        return self.datapoints.shape[:-2]
 
     def set_train_data(
         self, datapoints: Tensor, comparisons: Tensor, update_model: bool = True

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -279,8 +279,8 @@ def gen_value_function_initial_conditions(
 
     Returns:
         A `num_restarts x batch_shape x q x d` tensor that can be used as initial
-        conditions for `optimize_acqf()`. Here `batch_shape` is the
-        `_input_batch_shape` of value function model.
+        conditions for `optimize_acqf()`. Here `batch_shape` is the batch shape
+        of value function model.
 
     Example:
         >>> fant_X = torch.rand(5, 1, 2)
@@ -325,7 +325,7 @@ def gen_value_function_initial_conditions(
         },
     )
 
-    batch_shape = acq_function.model._input_batch_shape
+    batch_shape = acq_function.model.batch_shape
     # sampling from the optimizers
     n_value = int((1 - frac_random) * raw_samples)  # number of non-random ICs
     if n_value > 0:

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -86,6 +86,7 @@ class TestGPyTorchModel(BotorchTestCase):
             # basic test
             model = SimpleGPyTorchModel(train_X, train_Y, octf)
             self.assertEqual(model.num_outputs, 1)
+            self.assertEqual(model.batch_shape, torch.Size())
             test_X = torch.rand(2, 1, **tkwargs)
             posterior = model.posterior(test_X)
             self.assertIsInstance(posterior, GPyTorchPosterior)
@@ -181,6 +182,7 @@ class TestBatchedMultiOutputGPyTorchModel(BotorchTestCase):
             # basic test
             model = SimpleBatchedMultiOutputGPyTorchModel(train_X, train_Y)
             self.assertEqual(model.num_outputs, 2)
+            self.assertEqual(model.batch_shape, torch.Size())
             test_X = torch.rand(2, 1, **tkwargs)
             posterior = model.posterior(test_X)
             self.assertIsInstance(posterior, GPyTorchPosterior)
@@ -257,6 +259,8 @@ class TestModelListGPyTorchModel(BotorchTestCase):
             m2 = SimpleGPyTorchModel(train_X2, train_Y2)
             model = SimpleModelListGPyTorchModel(m1, m2)
             self.assertEqual(model.num_outputs, 2)
+            with self.assertRaises(NotImplementedError):
+                model.batch_shape
             test_X = torch.rand(2, 1, **tkwargs)
             posterior = model.posterior(test_X)
             self.assertIsInstance(posterior, GPyTorchPosterior)

--- a/test/models/test_model.py
+++ b/test/models/test_model.py
@@ -25,6 +25,8 @@ class TestBaseModel(BotorchTestCase):
         with self.assertRaises(NotImplementedError):
             model.num_outputs
         with self.assertRaises(NotImplementedError):
+            model.batch_shape
+        with self.assertRaises(NotImplementedError):
             model.subset_output([0])
         with self.assertRaises(NotImplementedError):
             model.construct_inputs(None)

--- a/test/models/test_pairwise_gp.py
+++ b/test/models/test_pairwise_gp.py
@@ -90,6 +90,7 @@ class TestPairwiseGP(BotorchTestCase):
                 model.covar_module.outputscale_prior, SmoothedBoxPrior
             )
             self.assertEqual(model.num_outputs, 1)
+            self.assertEqual(model.batch_shape, batch_shape)
 
             # test custom models
             custom_m = PairwiseGP(**model_kwargs, covar_module=LinearKernel())


### PR DESCRIPTION
A consistent API like this will be useful and avoid ad-hoc inferring of batch shapes. See #587 for more context.
