### PR TITLE
Hit and run sampler for uniform sampling from a polytope (#591)

### DIFF
--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import warnings
 from contextlib import contextmanager
-from typing import Generator, Iterable, Optional
+from typing import Generator, Iterable, Optional, Tuple
 
+import numpy as np
+import scipy
 import torch
 from botorch.exceptions.warnings import SamplingWarning
 from botorch.posteriors.posterior import Posterior
@@ -340,3 +342,206 @@ def batched_multinomial(
         out=None if out is None else out.view(-1, num_samples),
     )
     return flat_samples.view(*batch_shape, num_samples)
+
+
+class PolytopeSampler:
+    r"""
+    Sampling points from a polytope described via a set of inequality and
+    equality constraints.
+    """
+
+    def __init__(
+        self,
+        inequality_constraints: Tuple[Tensor, Tensor],
+        n_burnin: int = 0,
+        equality_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        initial_point: Optional[Tensor] = None,
+    ) -> None:
+        r"""
+        Args:
+            inequality_constraints: Tensors (A, b) describing inequality
+                constraints: A*x<=b, where A is (n_ineq_con, d_sample)-dim Tensor
+                and b is (n_ineq_con, 1)-dim Tensor with n_ineq_con
+                being the number of inequalities and d_sample the dimension
+                of the sample space.
+            n_burnin: The number of burn in samples.
+            equality_constraints: Tensors (C, d) describing the equality
+                constraints: C*x=d, where C is (n_eq_con, d_sample)-dim Tensor and
+                d is (n_eq_con-dim, 1) Tensor with n_eq_con
+                being the number of equalities.
+            initial_point: An (d_sample, 1)-dim Tensor presenting an inital point of
+                the chain satisfying all the conditions.
+                Determined automatically (by solving an LP) if not provided.
+        """
+        self.A, self.b = inequality_constraints
+        self.n_burnin = n_burnin
+        self.equality_constraints = equality_constraints
+
+        if equality_constraints is not None:
+            self.C, self.d = equality_constraints
+            U, S, V = torch.svd(self.C, some=False)
+            r = torch.nonzero(S).size(0)  # rank of matrix C
+            self.nullC = V[:, r:]  # orthonormal null space of C, satisfying
+            # C @ nullC = 0 and nullC.T @ nullC = I
+            # using the change of variables x=x0+nullC*y,
+            # sample y satisfies A*nullC*y<=b-A*x0.
+            # the linear constraint is automatically satisfied as x0 satisfies it.
+        else:
+            self.C = None
+            self.d = None
+            self.nullC = torch.eye(
+                self.A.size(-1), dtype=self.A.dtype, device=self.A.device
+            )
+
+        self.new_A = self.A @ self.nullC  # doesn't depend on the initial point
+
+        # initial point for the original, not transformed, problem
+        if initial_point is not None:
+            if self.feasible(initial_point):
+                self.x0 = initial_point
+            else:
+                raise ValueError("The given input point is not feasible.")
+        else:
+            self.x0 = self.find_initial_point()
+
+    def feasible(self, x: Tensor) -> bool:
+        ineq = (self.A @ x - self.b <= 0).all()
+        if self.equality_constraints is not None:
+            eq = (self.C @ x - self.d == 0).all()
+            return ineq & eq
+        return ineq
+
+    def find_initial_point(self):
+        r"""
+        Finds a feasible point of the original problem.
+        Details: Solves the following LP:
+        min -s such that Ax<=b-2*s, s>=0, plus equality constraints.
+        The number of inequality constrains in LP: nrow(A) + 1.
+        LP solution dimension: dim(x) + dim(s) = dim(x) + 1.
+        """
+        # inequality constraints: A_ub * (x, s) <= b_ub
+        ncon = self.A.size(0) + 1
+        dim = self.A.size(-1) + 1
+        c = np.zeros(dim)
+        c[-1] = -1
+        b_ub = np.zeros(ncon)
+        b_ub[:-1] = self.b.cpu().squeeze(-1).numpy()
+        A_ub = np.zeros((ncon, dim))
+        A_ub[:-1, :-1] = self.A.cpu().numpy()
+        A_ub[:, -1] = 2.0
+        A_ub[-1, -1] = -1.0
+
+        if self.equality_constraints:
+            # equality constraints: A_eq * (x, s) = b_eq
+            A_eq = np.zeros((self.C.size(0), self.C.size(-1) + 1))
+            A_eq[:, :-1] = self.C.cpu().numpy()
+            b_eq = self.d.cpu().numpy()
+        else:
+            A_eq = None
+            b_eq = None
+
+        result = scipy.optimize.linprog(  # solving LP
+            c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq
+        )
+
+        if result.status == 2:
+            raise ValueError(
+                "No feasible point found. Constraint polytope appears empty. "
+                + "Check your constraints."
+            )
+        elif result.status > 0:
+            raise ValueError(
+                "Problem checking constraint specification. "
+                + "linprog status: {}".format(result.message)
+            )
+
+        x0 = (
+            torch.from_numpy(result.x[:-1])
+            .to(dtype=self.A.dtype, device=self.A.device)
+            .unsqueeze(-1)
+        )
+
+        return x0
+
+    def draw(self, n: int = 1, seed: Optional[int] = None) -> Tensor:
+
+        transformed_samples = sample_polytope(
+            A=self.new_A,
+            b=self.b - self.A @ self.x0,
+            x0=torch.zeros(
+                (self.nullC.size(1), 1), dtype=self.A.dtype, device=self.A.device
+            ),
+            n=n,
+            n0=self.n_burnin,
+            seed=seed,
+        )
+
+        init_shift = self.x0.transpose(-1, -2)
+        samples = init_shift + transformed_samples @ self.nullC.transpose(-1, -2)
+
+        # keep the last element of the resulting chain as
+        # the beginning of the next chain
+        self.x0 = samples[samples.size(-1)]
+        # next time the sampling is called there won't be any burn-in
+        self.n_burnin = 0
+        return samples
+
+
+def sample_polytope(
+    A: Tensor,
+    b: Tensor,
+    x0: Tensor,
+    n: int = 10000,
+    n0: int = 100,
+    seed: Optional[int] = None,
+) -> Tensor:
+    r"""
+    Hit and run sampler from uniform sampling points from a polytope,
+    described via inequality constraints A*x<=b.
+
+    Args:
+        A: A Tensor describing inequality constraints
+            so that all samples satisfy Ax<=b.
+        b: A Tensor describing the inequality constraints
+            so that all samples satisfy Ax<=b.
+        x0: d dim Tensor representing a starting point of the chain
+            satisfying the constraints.
+        n: The number of resulting samples kept in the output.
+        n0: The number of burn-in samples. The chain will produce
+            n+n0 samples but the first n0 samples are not saved.
+        seed: The seed for the sampler. If omitted, use a random seed.
+
+    Returns:
+        (n, d) dim Tensor containing the resulting samples.
+    """
+    n_tot = n + n0
+    seed = seed if seed is not None else torch.randint(0, 1000000, (1,)).item()
+    with manual_seed(seed=seed):
+        rands = torch.rand(n_tot, dtype=A.dtype, device=A.device)
+
+    # pre-sample samples from hypersphere
+    d = x0.size(0)
+    # uniform samples from unit ball in d dims
+    Rs = sample_hypersphere(d=d, n=n_tot, dtype=A.dtype, device=A.device).unsqueeze(-1)
+
+    # compute matprods in batch
+    ARs = (A @ Rs).squeeze(-1)
+    out = torch.empty(n, A.size(-1), dtype=A.dtype, device=A.device)
+    x = x0.clone()
+    for i, (ar, r, rnd) in enumerate(zip(ARs, Rs, rands)):
+        # given x, the next point in the chain is x+alpha*r
+        # it also satisfies A(x+alpha*r)<=b which implies A*alpha*r<=b-Ax
+        # so alpha<=(b-Ax)/ar for ar>0, and alpha>=(b-Ax)/ar for ar<0.
+        w = (b - A @ x).squeeze() / ar  # b - A @ x is always >= 0
+        pos = w >= 0
+        alpha_max = w[pos].min()
+        # important to include equality here in cases x is at the boundary
+        # of the polytope
+        neg = w <= 0
+        alpha_min = w[neg].max()
+        # alpha~Unif[alpha_min, alpha_max]
+        alpha = alpha_min + rnd * (alpha_max - alpha_min)
+        x = x + alpha * r
+        if i >= n0:  # save samples after burn-in period
+            out[i - n0] = x.squeeze()
+    return out

--- a/test/utils/test_sampling.py
+++ b/test/utils/test_sampling.py
@@ -6,12 +6,14 @@
 
 import itertools
 import warnings
+from unittest import mock
 
 import torch
 from botorch import settings
 from botorch.exceptions.warnings import SamplingWarning
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.utils.sampling import (
+    PolytopeSampler,
     batched_multinomial,
     construct_base_samples,
     construct_base_samples_from_posterior,
@@ -231,3 +233,96 @@ class TestSampleUtils(BotorchTestCase):
             if not replacement:
                 for s in samples.view(-1, num_samples):
                     self.assertTrue(torch.unique(s).size(0), num_samples)
+
+
+class PolytopeSamplerTestCase(BotorchTestCase):
+    def test_sample_polytope(self):
+        for dtype in (torch.float, torch.double):
+            A = torch.tensor(
+                [[0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [0.0, 4.0, 1.0]],
+                device=self.device,
+                dtype=dtype,
+            )
+            b = torch.tensor([[0.0], [0.0], [1.0]], device=self.device, dtype=dtype)
+
+            x0 = torch.tensor(
+                [0.1, 0.1, 0.1], device=self.device, dtype=dtype
+            ).unsqueeze(-1)
+
+            for initial_point in [x0, None]:
+
+                sampler = PolytopeSampler(
+                    inequality_constraints=(A, b),
+                    initial_point=initial_point,
+                    n_burnin=0,
+                )
+
+                samples = sampler.draw(n=10, seed=1)
+
+                inequality_satisfied = ((A @ samples.t() - b) > 0).sum().item() == 0
+
+                self.assertTrue(inequality_satisfied)
+
+    def test_sample_polytope_with_constraints(self):
+        for dtype in (torch.float, torch.double):
+            A = torch.tensor(
+                [[0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [0.0, 4.0, 1.0]],
+                device=self.device,
+                dtype=dtype,
+            )
+            b = torch.tensor([[0.0], [0.0], [1.0]], device=self.device, dtype=dtype)
+            C = torch.tensor([1.0, -1, 0.0], device=self.device, dtype=dtype).reshape(
+                (1, 3)
+            )
+            d = torch.tensor([0.0], device=self.device, dtype=dtype).reshape((1, 1))
+
+            x0 = torch.tensor(
+                [0.1, 0.1, 0.1], device=self.device, dtype=dtype
+            ).unsqueeze(-1)
+
+            for initial_point in [x0, None]:
+                sampler = PolytopeSampler(
+                    inequality_constraints=(A, b),
+                    equality_constraints=(C, d),
+                    initial_point=initial_point,
+                    n_burnin=0,
+                )
+
+                samples = sampler.draw(n=10, seed=1)
+
+                inequality_satisfied = ((A @ samples.t() - b) > 0).sum().item() == 0
+                equality_satisfied = (C @ samples.t() - d).abs().sum().item() < 10e-6
+
+                self.assertTrue(inequality_satisfied)
+                self.assertTrue(equality_satisfied)
+
+    def test_intial_point(self):
+        for dtype in (torch.float, torch.double):
+            A = torch.tensor(
+                [[0.0, -1.0, 0.0], [0.0, -1.0, 0.0], [0.0, 4.0, 0.0]],
+                device=self.device,
+                dtype=dtype,
+            )
+            b = torch.tensor([[0.0], [-1.0], [1.0]], device=self.device, dtype=dtype)
+
+            x0 = torch.tensor(
+                [0.1, 0.1, 0.1], device=self.device, dtype=dtype
+            ).unsqueeze(-1)
+
+            # testing for infeasibility of the initial point and
+            # infeasibility of the original LP (status 2 of the linprog output).
+            for initial_point in [x0, None]:
+                with self.assertRaises(ValueError):
+                    PolytopeSampler(
+                        inequality_constraints=(A, b), initial_point=initial_point
+                    )
+
+            class Result:
+                status = 1
+                message = "mock status 1"
+
+            # testing for only status 1 of the LP
+            with mock.patch("scipy.optimize.linprog") as mock_linprog:
+                mock_linprog.return_value = Result()
+                with self.assertRaises(ValueError):
+                    PolytopeSampler(inequality_constraints=(A, b))


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/botorch/pull/591

Hit and run sampler for uniform sampling from a constrained set described with a set of inequalities and possibly a set of equalities.

Reviewed By: Balandat

Differential Revision: D23145190

