### PR TITLE
Modifies qMFKG.evaluate() to work with project, expand and cost aware utility

### DIFF
--- a/botorch/acquisition/__init__.py
+++ b/botorch/acquisition/__init__.py
@@ -23,7 +23,10 @@ from botorch.acquisition.cost_aware import (
     InverseCostWeightedUtility,
 )
 from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
-from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
+from botorch.acquisition.knowledge_gradient import (
+    qKnowledgeGradient,
+    qMultiFidelityKnowledgeGradient,
+)
 from botorch.acquisition.max_value_entropy_search import (
     qMaxValueEntropy,
     qMultiFidelityMaxValueEntropy,
@@ -62,6 +65,7 @@ __all__ = [
     "UpperConfidenceBound",
     "qExpectedImprovement",
     "qKnowledgeGradient",
+    "qMultiFidelityKnowledgeGradient",
     "qMaxValueEntropy",
     "qMultiFidelityMaxValueEntropy",
     "qNoisyExpectedImprovement",

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -16,7 +16,6 @@ from botorch.acquisition.knowledge_gradient import (
     _get_value_function,
     qKnowledgeGradient,
 )
-from botorch.acquisition.monte_carlo import MCAcquisitionFunction
 from botorch.acquisition.utils import is_nonnegative
 from botorch.exceptions.warnings import BadInitialCandidatesWarning, SamplingWarning
 from botorch.models.model import Model
@@ -210,6 +209,7 @@ def gen_one_shot_kg_initial_conditions(
         model=acq_function.model,
         objective=acq_function.objective,
         sampler=acq_function.inner_sampler,
+        project=getattr(acq_function, "project", None),
     )
     from botorch.optim.optimize import optimize_acqf
 
@@ -304,9 +304,8 @@ def gen_value_function_initial_conditions(
     value_function = _get_value_function(
         model=current_model,
         objective=acq_function.objective,
-        sampler=acq_function.sampler
-        if isinstance(acq_function, MCAcquisitionFunction)
-        else None,
+        sampler=getattr(acq_function, "sampler", None),
+        project=getattr(acq_function, "project", None),
     )
     from botorch.optim.optimize import optimize_acqf
 

--- a/test/acquisition/test_knowledge_gradient.py
+++ b/test/acquisition/test_knowledge_gradient.py
@@ -445,9 +445,10 @@ class TestQMultiFidelityKnowledgeGradient(BotorchTestCase):
                                 raw_samples=1,
                             )
                     patch_f.asset_called_once()
+                    cargs, ckwargs = patch_f.call_args
                     self.assertTrue(
                         (
-                            patch_f.call_args.kwargs["X"]
+                            ckwargs["X"]
                             == torch.ones(2, 1, 1, device=self.device, dtype=dtype)
                         ).all()
                     )

--- a/test/acquisition/test_knowledge_gradient.py
+++ b/test/acquisition/test_knowledge_gradient.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+
 from contextlib import ExitStack
 from unittest import mock
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md
-->

## Motivation

Modifies `qMFKG.evaluate()` to work with `project`, `expand` and `cost_aware_utility`. Partially fixes #587. 

- Introduces a `ProjectedValueFunction` that wraps the `value_function` and applies the `project` operator on the `forward` call.
- Changes `evaluate()` signature to use `X` instead of `X_actual`. Current implementation raises an exception with the decorators when called with `evaluate(X_actual=...)`.

Note: The treatment of `cost_aware_utility` assumes that it is monotone non-decreasing in `deltas`. Otherwise, optimizing the inner problem and passing through `cost_aware_utility` may not produce the correct output.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added mock unit tests. Verified the expected behavior in additional offline tests. 


