### PR TITLE
Enable gpytorch settings to override BoTorch defaults for fast_pred_var and debug

### DIFF
--- a/botorch/models/utils.py
+++ b/botorch/models/utils.py
@@ -254,8 +254,12 @@ def mod_batch_shape(module: Module, names: List[str], b: int) -> None:
 def gpt_posterior_settings():
     r"""Context manager for settings used for computing model posteriors."""
     with ExitStack() as es:
-        es.enter_context(gpt_settings.debug(False))
-        es.enter_context(gpt_settings.fast_pred_var())
+        gp_debug = gpt_settings.debug.is_default()
+        if gp_debug:
+            es.enter_context(gpt_settings.debug(False))
+        gp_fast_pred_var = gpt_settings.fast_pred_var.is_default()
+        if gp_fast_pred_var:
+            es.enter_context(gpt_settings.fast_pred_var())
         es.enter_context(
             gpt_settings.detach_test_caches(settings.propagate_grads.off())
         )

--- a/botorch/models/utils.py
+++ b/botorch/models/utils.py
@@ -254,11 +254,9 @@ def mod_batch_shape(module: Module, names: List[str], b: int) -> None:
 def gpt_posterior_settings():
     r"""Context manager for settings used for computing model posteriors."""
     with ExitStack() as es:
-        gp_debug = gpt_settings.debug.is_default()
-        if gp_debug:
+        if gpt_settings.debug.is_default():
             es.enter_context(gpt_settings.debug(False))
-        gp_fast_pred_var = gpt_settings.fast_pred_var.is_default()
-        if gp_fast_pred_var:
+        if gpt_settings.fast_pred_var.is_default():
             es.enter_context(gpt_settings.fast_pred_var())
         es.enter_context(
             gpt_settings.detach_test_caches(settings.propagate_grads.off())


### PR DESCRIPTION
A quick test to ensure that this works as intended:

```python
import torch
import botorch
import gpytorch
import time

# botorch defaults
torch.random.manual_seed(0)
train_x = torch.rand(5000, 18)
train_y = torch.randn(5000, 1)
test_x = torch.rand(1600, 18)
model = SingleTaskGP(train_x, train_y)

start = time.time()
post = model.posterior(test_x).rsample(torch.Size((100,)))
end = time.time()

# on a Mac with 32 GB of RAM about 1.5-2 seconds
print("Under botorch defaults: ", end - start)

# turning off lanczos
torch.random.manual_seed(0)
train_x = torch.rand(5000, 18)
train_y = torch.randn(5000, 1)
test_x = torch.rand(1600, 18)
model = SingleTaskGP(train_x, train_y)

with gpytorch.settings.fast_pred_var(False):
    start = time.time()
    post = model.posterior(test_x).rsample(torch.Size((100,)))
    end = time.time()

# about 12 seconds
print("Under gpytorch fast pred var = False: ", end - start)

# uses the gpytorch option fast_pred_var = True
torch.random.manual_seed(0)
train_x = torch.rand(5000, 18)
train_y = torch.randn(5000, 1)
test_x = torch.rand(1600, 18)
model = SingleTaskGP(train_x, train_y)

with gpytorch.settings.fast_pred_var(True):
    start = time.time()
    post = model.posterior(test_x).rsample(torch.Size((100,)))
    end = time.time()

# again, 1.5 - 2 seconds
print("Under gpytorch fast pred var = True: ", end - start)
```

## Motivation

I'd like to be able to override the botorch defaults for fast predictive variances in order to enable fair comparisons to bayesian optimization with cholesky predictive distributions, rather than the default lanczos decompositions (LOVE). There are probably other cases/acquisition functions when you might want cholesky predictive distributions, even if they're rare.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

See above, not entirely sure how to generate a unit test here.

## Related PRs

Uses gpytorch PR [#1347](https://github.com/cornellius-gp/gpytorch/issues/1347).
