### PR TITLE
Fix HolderTable synthetic function bounds

### DIFF
--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -346,7 +346,7 @@ class HolderTable(SyntheticTestFunction):
     """
 
     dim = 2
-    _bounds = [(-10.0, 10.0)]
+    _bounds = [(-10.0, 10.0), (-10.0, 10.0)]
     _optimal_value = -19.2085
     _optimizers = [
         (8.05502, 9.66459),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md
-->

## Motivation

The 2D synthetic test function HolderTable had bounds that didn't match with its dimensionality, like every other test function does.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

It's just an internal attribute change, so no test here.

(CircleCI failed tests unrelated)
