### PR TITLE
Add ufmt check to CI and docs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         pip install ufmt
     - name: ufmt
+      # TODO: Show mismatches in logs: https://github.com/omnilib/ufmt/issues/2
       run: |
         ufmt check .
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,3 +45,22 @@ jobs:
     - name: Flake8
       run: |
         flake8
+
+  usort:
+    name: Import sorting with usort
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        pip install musort
+    - name: usort
+      run: |
+        usort diff botorch
+        usort diff test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,9 +25,8 @@ jobs:
       run: |
         pip install ufmt
     - name: ufmt
-      # TODO: Show mismatches in logs: https://github.com/omnilib/ufmt/issues/2
       run: |
-        ufmt check .
+        ufmt diff .
 
   flake8:
     name: Lint with flake8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,8 +59,7 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: |
-        pip install musort
+        pip install usort
     - name: usort
       run: |
-        usort diff botorch
-        usort diff test
+        usort check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,8 @@ on:
 
 jobs:
 
-  black:
-    name: Lint with black
+  ufmt:
+    name: Code formatting and sorting with ufmt
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -23,10 +23,10 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: |
-        pip install black
-    - name: Black
+        pip install ufmt
+    - name: ufmt
       run: |
-        black --check --diff .
+        ufmt check .
 
   flake8:
     name: Lint with flake8
@@ -45,21 +45,3 @@ jobs:
     - name: Flake8
       run: |
         flake8
-
-  usort:
-    name: Import sorting with usort
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-        pip install usort
-    - name: usort
-      run: |
-        usort check .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,20 +28,20 @@ from the repository root. No additional configuration should be needed (see the
 [black documentation](https://black.readthedocs.io/en/stable/installation_and_usage.html#usage)
 for advanced usage).
 
-We feel strongly that having a consistent code style is extremely important, so
-Travis will fail on your PR if it does not adhere to the black formatting style.
-
 
 #### Import Sorting
 
-BoTorch uses [usort](https://github.com/facebookexperimental/usort) for consistent
-sorting of imports across the codebase. Install via `pip install usort`, and auto-
-sort with
+BoTorch uses [ufmt]https://github.com/omnilib/ufmt library for consistent
+sorting of imports across the codebase. Install via `pip install ufmt`, and
+auto-sort with
 ```bash
-usort format .
+ufmt format .
 ```
-from the repository root. You can also create a diff or just validate sorting following
-the instructions [here](https://github.com/facebookexperimental/usort#usage).
+from the repository root.
+
+We feel strongly that having a consistent code style and imports is important,
+so CI will fail on your PR if it does not pass ufmt muster (note: under the
+hood ufmt also checks black code style).
 
 
 #### Type Hints

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,18 @@ We feel strongly that having a consistent code style is extremely important, so
 Travis will fail on your PR if it does not adhere to the black formatting style.
 
 
+#### Import Sorting
+
+BoTorch uses [usort](https://github.com/facebookexperimental/usort) for consistent
+sorting of imports across the codebase. Install via `pip install usort`, and auto-
+sort with
+```bash
+usort format .
+```
+from the repository root. You can also create a diff or just validate sorting following
+the instructions [here](https://github.com/facebookexperimental/usort#usage).
+
+
 #### Type Hints
 
 BoTorch is fully typed using python 3.7+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,6 @@
 [build-system]
 requires = ["setuptools>=34.4", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.usort]
+first_party_detection = false

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
 
 TEST_REQUIRES = ["pytest", "pytest-cov"]
 
-DEV_REQUIRES = TEST_REQUIRES + ["black", "flake8", "sphinx<4.0"]
+DEV_REQUIRES = TEST_REQUIRES + ["black", "flake8", "sphinx<4.0", "usort"]
 
 TUTORIALS_REQUIRES = [
     "ax-platform",


### PR DESCRIPTION
Going forward, we will use `ufmt` to sort imports. `ufmt` includes both `black` and `usort` and runs the formatting in a single step (which will ensure there is consistency with FB-internal codeformatting tools).  