### PR TITLE
modify _expand_bounds() shape checks to work with >2-dim bounds.

### DIFF
--- a/botorch/optim/utils.py
+++ b/botorch/optim/utils.py
@@ -153,7 +153,11 @@ def _expand_bounds(
             ebounds = bounds.view(1, -1)
         else:
             ebounds = bounds
-        if ebounds.shape[1] != X.shape[-1]:
+        if (
+            ebounds.shape[-1] != X.shape[-1]
+            or ebounds.shape[-2] not in [1, X.shape[-2]]
+            or (ebounds.dim() > 2 and ebounds.shape[:-2] != X.shape[:-2])
+        ):
             raise RuntimeError(
                 "Bounds must either be a single value or the same dimension as X"
             )

--- a/botorch/optim/utils.py
+++ b/botorch/optim/utils.py
@@ -147,19 +147,11 @@ def _expand_bounds(
     if bounds is not None:
         if not torch.is_tensor(bounds):
             bounds = torch.tensor(bounds)
-        if len(bounds.shape) == 0:
-            ebounds = bounds.expand(1, X.shape[-1])
-        elif len(bounds.shape) == 1:
-            ebounds = bounds.view(1, -1)
-        else:
-            ebounds = bounds
-        if (
-            ebounds.shape[-1] != X.shape[-1]
-            or ebounds.shape[-2] not in [1, X.shape[-2]]
-            or (ebounds.dim() > 2 and ebounds.shape[:-2] != X.shape[:-2])
-        ):
+        try:
+            ebounds = bounds.expand_as(X)
+        except RuntimeError:
             raise RuntimeError(
-                "Bounds must either be a single value or the same dimension as X"
+                "Bounds must be broadcastable to X!"
             )
         return ebounds.to(dtype=X.dtype, device=X.device)
     else:

--- a/botorch/optim/utils.py
+++ b/botorch/optim/utils.py
@@ -132,17 +132,21 @@ def _expand_bounds(
 ) -> Optional[Tensor]:
     r"""Expands a tensor representing bounds.
 
-    Expand the dimension of bounds if necessary such that the last dimension of
-    bounds is the same as the last dimension of `X`.
+    Expand the dimension of bounds if necessary such that the dimension of bounds
+    is the same as the dimension of `X`.
 
     Args:
-        bounds: a bound (either upper or lower) of each column (last dimension)
-            of `X`. If this is a single float, then all columns have the same bound.
+        bounds: a bound (either upper or lower) of each entry of `X`. If this is a
+            single float, then all entries have the same bound. Different sizes of
+            tensors can be used to specify custom bounds. E.g., a `d`-dim tensor can
+            be used to specify bounds for each column (last dimension) of `X`, or a
+            tensor with same shape as `X` can be used to specify a different bound
+            for each entry of `X`.
         X: `... x d` tensor
 
     Returns:
-        A tensor of bounds expanded to be compatible with the size of `X` if
-        bounds is not None, and None if bounds is None.
+        A tensor of bounds expanded to the size of `X` if bounds is not None,
+        and None if bounds is None.
     """
     if bounds is not None:
         if not torch.is_tensor(bounds):
@@ -150,9 +154,7 @@ def _expand_bounds(
         try:
             ebounds = bounds.expand_as(X)
         except RuntimeError:
-            raise RuntimeError(
-                "Bounds must be broadcastable to X!"
-            )
+            raise RuntimeError("Bounds must be broadcastable to X!")
         return ebounds.to(dtype=X.dtype, device=X.device)
     else:
         return None

--- a/test/optim/test_utils.py
+++ b/test/optim/test_utils.py
@@ -65,6 +65,22 @@ class TestColumnWiseClamp(BotorchTestCase):
         X_clmp = columnwise_clamp(X, torch.tensor([-3, -3]), torch.tensor([3, 3]))
         self.assertTrue(torch.equal(X_clmp, X))
 
+    def test_column_wise_clamp_full_dim_tensors(self):
+        X = torch.tensor([[[-1, 2, 0.5], [0.5, 3, 1.5]], [[0.5, 1, 0], [2, -2, 3]]])
+        lower = torch.tensor([[[0, 0.5, 1], [0, 2, 2]], [[0, 2, 0], [1, -1, 0]]])
+        upper = torch.tensor([[[1, 1.5, 1], [1, 4, 3]], [[1, 3, 0.5], [3, 1, 2.5]]])
+        X_expected = torch.tensor(
+            [[[0, 1.5, 1], [0.5, 3, 2]], [[0.5, 2, 0], [2, -1, 2.5]]]
+        )
+        X_clmp = columnwise_clamp(X, lower, upper)
+        self.assertTrue(torch.equal(X_clmp, X_expected))
+        X_clmp = columnwise_clamp(X, lower - 5, upper + 5)
+        self.assertTrue(torch.equal(X_clmp, X))
+        with self.assertRaises(ValueError):
+            X_clmp = columnwise_clamp(X, torch.ones_like(X), torch.zeros_like(X))
+        with self.assertRaises(RuntimeError):
+            X_clmp = columnwise_clamp(X, lower.unsqueeze(-3), upper.unsqueeze(-3))
+
     def test_column_wise_clamp_raise_on_violation(self):
         X = self.X
         with self.assertRaises(BotorchError):
@@ -153,7 +169,7 @@ class TestGetExtraMllArgs(BotorchTestCase):
 
 class TestExpandBounds(BotorchTestCase):
     def test_expand_bounds(self):
-        X = torch.zeros(2, 3)
+        X = torch.zeros(4, 2, 3)
         expected_bounds = torch.zeros(1, 3)
         # bounds is float
         bounds = 0.0
@@ -167,10 +183,16 @@ class TestExpandBounds(BotorchTestCase):
         bounds = torch.zeros(3)
         expanded_bounds = _expand_bounds(bounds=bounds, X=X)
         self.assertTrue(torch.equal(expected_bounds, expanded_bounds))
-        # bounds is > 1-d
+        # bounds is 2-d
         bounds = torch.zeros(1, 3)
         expanded_bounds = _expand_bounds(bounds=bounds, X=X)
         self.assertTrue(torch.equal(expected_bounds, expanded_bounds))
+        # bounds is > 2-d
+        bounds = torch.zeros_like(X)
+        expanded_bounds = _expand_bounds(bounds=bounds, X=X)
+        self.assertTrue(torch.equal(expanded_bounds, bounds))
+        with self.assertRaises(RuntimeError):
+            expanded_bounds = _expand_bounds(bounds=bounds[1:], X=X)
         # bounds is None
         expanded_bounds = _expand_bounds(bounds=None, X=X)
         self.assertIsNone(expanded_bounds)

--- a/test/optim/test_utils.py
+++ b/test/optim/test_utils.py
@@ -169,8 +169,8 @@ class TestGetExtraMllArgs(BotorchTestCase):
 
 class TestExpandBounds(BotorchTestCase):
     def test_expand_bounds(self):
-        X = torch.zeros(4, 2, 3)
-        expected_bounds = torch.zeros(1, 3)
+        X = torch.zeros(2, 3)
+        expected_bounds = torch.zeros(2, 3)
         # bounds is float
         bounds = 0.0
         expanded_bounds = _expand_bounds(bounds=bounds, X=X)
@@ -188,11 +188,16 @@ class TestExpandBounds(BotorchTestCase):
         expanded_bounds = _expand_bounds(bounds=bounds, X=X)
         self.assertTrue(torch.equal(expected_bounds, expanded_bounds))
         # bounds is > 2-d
-        bounds = torch.zeros_like(X)
-        expanded_bounds = _expand_bounds(bounds=bounds, X=X)
-        self.assertTrue(torch.equal(expanded_bounds, bounds))
+        bounds = torch.zeros(1, 1, 3)
         with self.assertRaises(RuntimeError):
-            expanded_bounds = _expand_bounds(bounds=bounds[1:], X=X)
+            # X does not have a t-batch
+            expanded_bounds = _expand_bounds(bounds=bounds, X=X)
+        X = torch.zeros(4, 2, 3)
+        expanded_bounds = _expand_bounds(bounds=bounds, X=X)
+        self.assertTrue(torch.equal(expanded_bounds, torch.zeros_like(X)))
+        with self.assertRaises(RuntimeError):
+            # bounds is not broadcastable to X
+            expanded_bounds = _expand_bounds(bounds=torch.zeros(2, 1, 3), X=X)
         # bounds is None
         expanded_bounds = _expand_bounds(bounds=None, X=X)
         self.assertIsNone(expanded_bounds)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md
-->

## Motivation

`botorch.optim.utils._expand_bounds()` raises an error when used with `bounds` with more than 2 dimensions. This PR modifies the shape checks in `_expand_bounds()` to allow more general shapes, as long as `bounds` has the same t-batch shape as `X`.

This change extends the functionality of `gen_candidates_scipy` to allow optimization with a custom bound for each entry of `initial_conditions`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added unit tests.
