### PR TITLE
Add list of papers using BoTorch to docs

### DIFF
--- a/docs/papers.md
+++ b/docs/papers.md
@@ -1,0 +1,30 @@
+---
+id: papers
+title: Papers using BoTorch
+---
+
+The main reference for BoTorch is
+
+[BoTorch: A Framework for Efficient Monte-Carlo Bayesian Optimization](https://proceedings.neurips.cc/paper/2020/hash/f5b1b89d98b7286673128a5fb112cb9a-Abstract.html):
+
+    @inproceedings{balandat2020botorch,
+        title = {{BoTorch: A Framework for Efficient Monte-Carlo Bayesian Optimization}},
+        author = {Balandat, Maximilian and Karrer, Brian and Jiang, Daniel R. and Daulton, Samuel and Letham, Benjamin and Wilson, Andrew Gordon and Bakshy, Eytan},
+        booktitle = {Advances in Neural Information Processing Systems 33},
+        year = 2020,
+        url = {https://proceedings.neurips.cc/paper/2020/hash/f5b1b89d98b7286673128a5fb112cb9a-Abstract.html}
+    }
+
+
+Here is an incomplete selection of peer-reviewed Bayesian optimization papers that build off of BoTorch:
+
+- [Differentiable Expected Hypervolume Improvement for Parallel Multi-Objective Bayesian Optimization](https://proceedings.neurips.cc/paper/2020/hash/6fec24eac8f18ed793f5eaad3dd7977c-Abstract.html). Sam Daulton, Maximilian Balandat, Eytan Bakshy. NeurIPS 2020.
+- [Bayesian Optimization of Risk Measures
+](https://proceedings.neurips.cc/paper/2020/hash/e8f2779682fd11fa2067beffc27a9192-Abstract.html). Sait Cakmak, Raul Astudillo Marban, Peter Frazier, Enlu Zhou. NeurIPS 2020.
+- [High-Dimensional Contextual Policy Search with Unknown Context Rewards using Bayesian Optimization
+](https://proceedings.neurips.cc/paper/2020/hash/faff959d885ec0ecf70741a846c34d1d-Abstract.html). Qing Feng, Benjamin Letham, Hongzi Mao, Eytan Bakshy. NeurIPS 2020.
+- [High-Dimensional Bayesian Optimization via Nested Riemannian Manifolds](https://proceedings.neurips.cc/paper/2020/hash/f05da679342107f92111ad9d65959cd3-Abstract.html). Noémie Jaquier, Leonel Rozo. NeurIPS 2020.
+- [Efficient Nonmyopic Bayesian Optimization via One-Shot Multi-Step Trees](https://proceedings.neurips.cc/paper/2020/hash/d1d5923fc822531bbfd9d87d4760914b-Abstract.html). Shali Jiang, Daniel Jiang, Maximilian Balandat, Brian Karrer, Jacob Gardner, Roman Garnett. NeurIPS 2020.
+- [Re-Examining Linear Embeddings for High-Dimensional Bayesian Optimization](https://proceedings.neurips.cc/paper/2020/hash/10fb6cfa4c990d2bad5ddef4f70e8ba2-Abstract.html). Ben Letham, Roberto Calandra, Akshara Rai, Eytan Bakshy. NeurIPS 2020.
+- [PareCO: Pareto-aware Channel Optimization for Slimmable Neural Networks
+](https://arxiv.org/abs/2007.11752). Ting-Wu Chin, Ari S. Morcos, Diana Marculescu. ICML 2020 Workshop on Real World Experiment Design and Active Learning.

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -153,16 +153,6 @@ candidate  # tensor([0.4887, 0.5063])
   url = {http://arxiv.org/abs/1910.06403}
 }
   `;
-  const ehvi_papertitle = `Differentiable Expected Hypervolume Improvement for Parallel Multi-Objective Bayesian Optimization`
-  const ehvi_paper_bibtex = `${pre}plaintext
-  @inproceedings{daulton2020ehvi,
-    title = {{Differentiable Expected Hypervolume Improvement for Parallel Multi-Objective Bayesian Optimization}},
-    author = {Daulton, Samuel and Balandat, Maximilian and Bakshy, Eytan},
-    booktitle = {Advances in Neural Information Processing Systems 33},
-    year = 2020,
-    url = {https://arxiv.org/abs/2006.05078}
-  }
-  `;
     //
     const QuickStart = () => (
       <div
@@ -236,8 +226,7 @@ candidate  # tensor([0.4887, 0.5063])
         <Container>
           <a href={`https://arxiv.org/abs/1910.06403`}>{papertitle}</a>
           <MarkdownBlock>{paper_bibtex}</MarkdownBlock>
-          <a href={`https://arxiv.org/abs/2006.05078`}>{ehvi_papertitle}</a>
-          <MarkdownBlock>{ehvi_paper_bibtex}</MarkdownBlock>
+          Check out some <a href={`${baseUrl}docs/papers`}>other papers using BoTorch</a>.
         </Container>
       </div>
     );

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,6 +1,6 @@
 {
   "docs": {
-    "About": ["introduction", "design_philosophy", "botorch_and_ax"],
+    "About": ["introduction", "design_philosophy", "botorch_and_ax", "papers"],
     "General": ["getting_started"],
     "Basic Concepts": ["overview", "models", "posteriors", "acquisition", "optimization"],
     "Advanced Topics": ["batching", "objectives", "samplers"],

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -40,6 +40,7 @@ const siteConfig = {
     {doc: 'introduction', label: 'Docs'},
     {href: `${baseUrl}tutorials/`, label: 'Tutorials'},
     {href: `${baseUrl}api/`, label: 'API Reference'},
+    {href: `${baseUrl}docs/papers`, label: 'Papers'},
     {href: 'https://github.com/pytorch/botorch', label: 'GitHub'},
   ],
 


### PR DESCRIPTION
This adds a selection of papers that do interesting things with BoTorch (rather than just use the vanilla BO loop). We can curate this going forward.

Also adds a link to this page to the landing page.