### PR TITLE
Fix matrix multiplication in scalarize_posterior

### DIFF
--- a/botorch/posteriors/gpytorch.py
+++ b/botorch/posteriors/gpytorch.py
@@ -149,7 +149,7 @@ def scalarize_posterior(
     new_mean = offset + (mean @ weights).view(*batch_shape, q)
 
     if q == 1:
-        new_cov = ((cov @ weights) @ weights).view(*batch_shape, q, q)
+        new_cov = weights.unsqueeze(-2) @ (cov @ weights.unsqueeze(-1))
     else:
         # we need to handle potentially different representations of the multi-task mvn
         if mvn._interleaved:


### PR DESCRIPTION
This was doing the right thing, but it would cause issues when back-propagating through the posterior covariance of a model evaluated in batch mode with a single test point in each batch (b/c of how things are handled on the GPyTorch end).