### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/botorch/test_functions/base.py
+++ b/botorch/test_functions/base.py
@@ -28,7 +28,7 @@ class BaseTestProblem(Module, ABC):
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
         r"""Base constructor for test functions.
 
-        Arguments:
+        Args:
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
         """
@@ -144,7 +144,7 @@ class MultiObjectiveTestProblem(BaseTestProblem):
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
         r"""Base constructor for multi-objective test functions.
 
-        Arguments:
+        Args:
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the objectives.
         """

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -86,7 +86,7 @@ class BraninCurrin(MultiObjectiveTestProblem):
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
         r"""Constructor for Branin-Currin.
 
-        Arguments:
+        Args:
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the objectives.
         """

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -29,7 +29,7 @@ class SyntheticTestFunction(BaseTestProblem):
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
         r"""Base constructor for synthetic test functions.
 
-        Arguments:
+        Args:
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
         """

--- a/botorch/utils/torch.py
+++ b/botorch/utils/torch.py
@@ -33,7 +33,7 @@ class BufferDict(Module):
     types (e.g., Python's plain ``dict``) does not preserve the order of the
     merged mapping.
 
-    Arguments:
+    Args:
         buffers (iterable, optional): a mapping (dictionary) of
             (string : :class:`~torch.Tensor`) or an iterable of key-value pairs
             of type (string, :class:`~torch.Tensor`)
@@ -83,7 +83,7 @@ class BufferDict(Module):
     def pop(self, key):
         r"""Remove key from the BufferDict and return its buffer.
 
-        Arguments:
+        Args:
             key (string): key to pop from the BufferDict
         """
         v = self[key]
@@ -111,7 +111,7 @@ class BufferDict(Module):
             or an iterable of key-value pairs, the order of new elements in it is
             preserved.
 
-        Arguments:
+        Args:
             buffers (iterable): a mapping (dictionary) from string to
                 :class:`~torch.Tensor`, or an iterable of
                 key-value pairs of type (string, :class:`~torch.Tensor`)


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue when I was parsing/generating from the TensorFlow—and now PyTorch—codebases: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see pytorch/pytorch/pull/49736