### PR TITLE
Apply transform to constrain RBFKernel lengthscale in LCEMGP

### DIFF
--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -86,8 +86,9 @@ class LCEMGP(MultiTaskGP):
         unif = Uniform(0.0, 2.0)
         self.task_covar_module = RBFKernel(
             ard_num_dims=n_embs,
-            lengthscale_prior=UniformPrior(unif.low, unif.high,
-                                           transform=biject_to(unif.support)),
+            lengthscale_prior=UniformPrior(
+                unif.low, unif.high, transform=biject_to(unif.support)
+            ),
         )
         self.to(train_X)
 

--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -13,9 +13,7 @@ from gpytorch.distributions.multivariate_normal import MultivariateNormal
 from gpytorch.kernels.rbf_kernel import RBFKernel
 from gpytorch.lazy import InterpolatedLazyTensor, LazyTensor
 from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
-from gpytorch.priors.torch_priors import UniformPrior
 from torch import Tensor
-from torch.distributions import Uniform, biject_to
 from torch.nn import ModuleList
 
 

--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 
 import torch
 from botorch.models.multitask import MultiTaskGP
+from gpytorch.constraints import Interval
 from gpytorch.distributions.multivariate_normal import MultivariateNormal
 from gpytorch.kernels.rbf_kernel import RBFKernel
 from gpytorch.lazy import InterpolatedLazyTensor, LazyTensor
@@ -81,13 +82,10 @@ class LCEMGP(MultiTaskGP):
                 for x, y in self.emb_dims
             ]
         )
-        # TODO: Ideally, the transform should be applied automatically within
-        # gpytorch.priors
-        unif = Uniform(0.0, 2.0)
         self.task_covar_module = RBFKernel(
             ard_num_dims=n_embs,
-            lengthscale_prior=UniformPrior(
-                unif.low, unif.high, transform=biject_to(unif.support)
+            lengthscale_constraint=Interval(
+                0.0, 2.0, transform=None, initial_value=1.0
             ),
         )
         self.to(train_X)

--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -14,6 +14,7 @@ from gpytorch.lazy import InterpolatedLazyTensor, LazyTensor
 from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
 from gpytorch.priors.torch_priors import UniformPrior
 from torch import Tensor
+from torch.distributions import Uniform, biject_to
 from torch.nn import ModuleList
 
 
@@ -80,8 +81,13 @@ class LCEMGP(MultiTaskGP):
                 for x, y in self.emb_dims
             ]
         )
+        # TODO: Ideally, the transform should be applied automatically within
+        # gpytorch.priors
+        unif = Uniform(0.0, 2.0)
         self.task_covar_module = RBFKernel(
-            ard_num_dims=n_embs, lengthscale_prior=UniformPrior(0.0, 2.0)
+            ard_num_dims=n_embs,
+            lengthscale_prior=UniformPrior(unif.low, unif.high,
+                                           transform=biject_to(unif.support)),
         )
         self.to(train_X)
 

--- a/test/models/test_contextual_multioutput.py
+++ b/test/models/test_contextual_multioutput.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from torch.distributions import Distribution
 from botorch import fit_gpytorch_model
 from botorch.models.contextual_multioutput import LCEMGP, FixedNoiseLCEMGP
 from botorch.models.multitask import MultiTaskGP
@@ -15,9 +14,6 @@ from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNorm
 from gpytorch.lazy import LazyTensor
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from torch import Tensor
-
-
-Distribution.set_default_validate_args(True)
 
 
 class ContextualMultiOutputTest(BotorchTestCase):

--- a/test/models/test_contextual_multioutput.py
+++ b/test/models/test_contextual_multioutput.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+from torch.distributions import Distribution
 from botorch import fit_gpytorch_model
 from botorch.models.contextual_multioutput import LCEMGP, FixedNoiseLCEMGP
 from botorch.models.multitask import MultiTaskGP
@@ -16,8 +17,12 @@ from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikeliho
 from torch import Tensor
 
 
+Distribution.set_default_validate_args(True)
+
+
 class ContextualMultiOutputTest(BotorchTestCase):
     def testLCEMGP(self):
+        torch.manual_seed(2)
         d = 1
         train_x = torch.rand(10, d)
         train_y = torch.cos(train_x)
@@ -35,7 +40,7 @@ class ContextualMultiOutputTest(BotorchTestCase):
         self.assertEqual(model.emb_dims, [(2, 1)])
 
         mll = ExactMarginalLogLikelihood(model.likelihood, model)
-        fit_gpytorch_model(mll, options={"maxiter": 1})
+        fit_gpytorch_model(mll, options={"maxiter": 4})
 
         context_covar = model._eval_context_covar()
         self.assertIsInstance(context_covar, LazyTensor)

--- a/test/models/test_contextual_multioutput.py
+++ b/test/models/test_contextual_multioutput.py
@@ -18,7 +18,6 @@ from torch import Tensor
 
 class ContextualMultiOutputTest(BotorchTestCase):
     def testLCEMGP(self):
-        torch.manual_seed(2)
         d = 1
         train_x = torch.rand(10, d)
         train_y = torch.cos(train_x)
@@ -36,7 +35,7 @@ class ContextualMultiOutputTest(BotorchTestCase):
         self.assertEqual(model.emb_dims, [(2, 1)])
 
         mll = ExactMarginalLogLikelihood(model.likelihood, model)
-        fit_gpytorch_model(mll, options={"maxiter": 4})
+        fit_gpytorch_model(mll, options={"maxiter": 1})
 
         context_covar = model._eval_context_covar()
         self.assertIsInstance(context_covar, LazyTensor)


### PR DESCRIPTION
## Motivation

This adds a transform to `UniformPrior` in `LCEMGP` class to convert real values to constrained values in `[0, 2]`. Otherwise, with distribution validation enabled (which will be the default once https://github.com/pytorch/pytorch/pull/48743 is merged), this throws an error in `Uniform.log_prob` method. We were facing this issue in an internal FB test that uses botorch.

While this fixes the specific issue, my thinking is that this transform should ideally be applied automatically within `gpytorch.priors`. That said, my understanding of the codebase is very limited, so would love to hear others' thoughts on this.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Turned `Distribution.set_default_validate_args(True)` and succesffully ran `test_contextual_multioutput.py: ContextualMultiOutputTest.testLCEMGP` with a fixed seed and increased `maxiter` (this test fails without the fix).

cc @Balandat
