### PR TITLE
Modify cuda tests to work with other test runners

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -34,6 +34,9 @@ def run_cuda_tests(tests: Union[unittest.TestCase, unittest.TestSuite]) -> bool:
     if isinstance(tests, BotorchTestCase):
         tests.device = torch.device("cuda")
         test_result = tests.run()
+        if test_result is None:
+            # some test runners may return None on skipped tests
+            return True
         passed = test_result.wasSuccessful()
         if not passed:
             # print test name


### PR DESCRIPTION
Summary:
Certain alternate test runners modify the behavior from the standard one and may return `None` from `TestCase.run` (if the test is skipped).

Without this change, that behavior breaks the current `test_cuda` test.

Reviewed By: thatch

Differential Revision: D25524086

