### PR TITLE
Resolve sampling memory inefficiencies for HigherOrderGP

### DIFF
--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -197,12 +197,8 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
             if base_samples.shape[: len(sample_shape)] != sample_shape:
                 raise RuntimeError("sample_shape disagrees with shape of base_samples.")
 
-            if base_samples.shape[-1] != 1:
-                base_samples = base_samples.unsqueeze(-1)
-            unsqueezed_dim = -2
-
             appended_shape = joint_size + self.train_train_covar.shape[-1]
-            if appended_shape != base_samples.shape[unsqueezed_dim]:
+            if appended_shape != base_samples.shape[-1]:
                 # get base_samples to the correct shape by expanding as sample shape,
                 # batch shape, then rest of dimensions. We have to add first the sample
                 # shape, then the batch shape of the model, and then finally the shape
@@ -214,10 +210,6 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
                 if base_samples.nelement() == base_sample_shapes.numel():
                     base_samples = base_samples.reshape(base_sample_shapes)
 
-                    # remove output dimension in single output case
-                    if not self.num_outputs > 1:
-                        base_samples = base_samples.squeeze(-1)
-
                     new_base_samples = torch.randn(
                         *sample_shape,
                         *batch_shape,
@@ -226,9 +218,6 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
                         dtype=base_samples.dtype,
                     )
                     base_samples = torch.cat((base_samples, new_base_samples), dim=-1)
-
-                    # if self.num_outputs > 1:
-                    base_samples = base_samples.unsqueeze(-1)
                 else:
                     # nuke the base samples if we cannot use them.
                     base_samples = None
@@ -239,7 +228,6 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
                 *sample_shape,
                 *batch_shape,
                 joint_size,
-                1,
                 device=covariance_matrix.device,
                 dtype=covariance_matrix.dtype,
             )
@@ -248,16 +236,16 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
                 *sample_shape,
                 *batch_shape,
                 self.train_train_covar.shape[-1],
-                1,
                 device=covariance_matrix.device,
                 dtype=covariance_matrix.dtype,
             )
         else:
             # finally split up the base samples
-            noise_base_samples = base_samples[..., joint_size:, :]
-            base_samples = base_samples[..., :joint_size, :]
+            noise_base_samples = base_samples[..., joint_size:]
+            base_samples = base_samples[..., :joint_size]
 
-        return base_samples, noise_base_samples
+        perm_list = [*range(1, base_samples.ndim), 0]
+        return base_samples.permute(*perm_list), noise_base_samples.permute(*perm_list)
 
     def rsample(
         self,
@@ -291,8 +279,9 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
             sample_shape, base_samples
         )
 
+        # base samples now have trailing sample dimension
         covariance_matrix = self.joint_covariance_matrix
-        covar_root = covariance_matrix.root_decomposition(method="symeig").root
+        covar_root = covariance_matrix.root_decomposition().root
         samples = covar_root.matmul(base_samples)
 
         # now pluck out Y_x and X_x
@@ -300,7 +289,7 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
             ..., : self.train_train_covar.shape[-1], :
         ]
         test_marginal_samples = samples[..., self.train_train_covar.shape[-1] :, :]
-
+                
         # we need to add noise to the train_joint_samples
         # THIS ASSUMES CONSTANT NOISE
         noise_std = self.train_train_covar.lazy_tensors[1]._diag[..., 0] ** 0.5
@@ -341,7 +330,7 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
 
         # add samples
         test_cond_samples = test_marginal_samples + test_updated_samples
-        test_cond_samples = test_cond_samples.transpose(-1, -2)
+        test_cond_samples = test_cond_samples.permute(test_cond_samples.ndim-1, *range(0, test_cond_samples.ndim-1))
 
         # reshape samples to be the actual size of the train targets
         return test_cond_samples.reshape(*sample_shape, *self.output_shape)

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -289,7 +289,7 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
             ..., : self.train_train_covar.shape[-1], :
         ]
         test_marginal_samples = samples[..., self.train_train_covar.shape[-1] :, :]
-                
+        
         # we need to add noise to the train_joint_samples
         # THIS ASSUMES CONSTANT NOISE
         noise_std = self.train_train_covar.lazy_tensors[1]._diag[..., 0] ** 0.5
@@ -330,7 +330,9 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
 
         # add samples
         test_cond_samples = test_marginal_samples + test_updated_samples
-        test_cond_samples = test_cond_samples.permute(test_cond_samples.ndim-1, *range(0, test_cond_samples.ndim-1))
+        test_cond_samples = test_cond_samples.permute(
+            test_cond_samples.ndim - 1, *range(0, test_cond_samples.ndim-1)
+        )
 
         # reshape samples to be the actual size of the train targets
         return test_cond_samples.reshape(*sample_shape, *self.output_shape)

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -331,7 +331,7 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
         # add samples
         test_cond_samples = test_marginal_samples + test_updated_samples
         test_cond_samples = test_cond_samples.permute(
-            test_cond_samples.ndim - 1, *range(0, test_cond_samples.ndim-1)
+            test_cond_samples.ndim - 1, *range(0, test_cond_samples.ndim - 1)
         )
 
         # reshape samples to be the actual size of the train targets

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -301,16 +301,9 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
             ntms_dims = [
                 i == noise_std.shape[0] for i in noiseless_train_marginal_samples.shape
             ]
-            print("ntms_dims", ntms_dims)
-            has_matched = False
             for matched in ntms_dims:
-                if matched:
-                    has_matched = True
-                else:
-                    # if has_matched:
+                if not matched:
                     noise_std = noise_std.unsqueeze(-1)
-                    # else:
-                    #    noise_std = noise_std.unsqueeze(0)
 
         # we need to add noise into the noiseless samples
         noise_marginal_samples = noise_std * noise_base_samples

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -506,7 +506,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                     MultivariateNormalPrior(
                         latent_dist.loc, latent_dist.covariance_matrix.detach().clone()
                     ),
-                    lambda dim_num=dim_num: self.latent_parameters[dim_num],
+                    lambda module, dim_num=dim_num: self.latent_parameters[dim_num],
                 )
 
     def forward(self, X: Tensor) -> MultivariateNormal:

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -302,15 +302,16 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
             ntms_dims = [
                 i == noise_std.shape[0] for i in noiseless_train_marginal_samples.shape
             ]
+            print("ntms_dims", ntms_dims)
             has_matched = False
             for matched in ntms_dims:
                 if matched:
                     has_matched = True
                 else:
-                    if has_matched:
-                        noise_std = noise_std.unsqueeze(-1)
-                    else:
-                        noise_std = noise_std.unsqueeze(0)
+                    # if has_matched:
+                    noise_std = noise_std.unsqueeze(-1)
+                    # else:
+                    #    noise_std = noise_std.unsqueeze(0)
 
         # we need to add noise into the noiseless samples
         noise_marginal_samples = noise_std * noise_base_samples

--- a/test/models/test_higher_order_gp.py
+++ b/test/models/test_higher_order_gp.py
@@ -257,19 +257,10 @@ class TestHigherOrderGPPosterior(BotorchTestCase):
 
             # and finally test that sampling with no base samples is okay
             samples_3 = posterior.rsample(sample_shape=Size((5000,)))
-            sampled_variance = (samples_3.std(dim=0) ** 2).view(-1)
+            sampled_variance = samples_3.var(dim=0).view(-1)
             posterior_variance = posterior_variance.view(-1)
             self.assertLess(
                 (posterior_variance - sampled_variance).norm()
                 / posterior_variance.norm(),
                 5e-2,
             )
-
-
-# def TestFlattenedStandardize(BotorchTestCase):
-#     def setUp(self):
-#         super().setUp()
-
-#         self.train_y = randn(2, 10, 4, 5, device=self.device)
-#         self.train_y_var = rand(2, 10, 4, 5, device=self.device)
-#         self.model = FlattenedStandardize(Size((4, 5)), Size((2,)), min_stdv=1e-4)


### PR DESCRIPTION
Resolves some of the sampling memory inefficiences for the HigherOrderGP. I'd originally implemented the posterior sampling with a trailing batch dimension so that the base samples were being stored as `num_samples x batch x dim x 1`. Surprisingly, this is somewhat less memory efficient than the gpytorch way of storing base samples `batch x dim x num_samples`. This PR resolves that issue and cleans up some of the funkiness associated with that trailing dimension. I think it'll make backpropagation through the rsample somewhat faster as well.

Example that now works:
```python
import torch
from torch import Tensor
from botorch import fit_gpytorch_model
from botorch.acquisition import MCAcquisitionObjective, qExpectedImprovement
from botorch.models.higher_order_gp import HigherOrderGP, FlattenedStandardize
from botorch.models import SingleTaskGP
from botorch.optim import optimize_acqf
from botorch.sampling import IIDNormalSampler
import gpytorch
from gpytorch import ExactMarginalLogLikelihood

device = "cuda" if torch.cuda.is_available() else "cpu"

train_X = torch.rand(100, 2, device=device)
train_Y = torch.rand(100, num_outputs, device=device)
model = HigherOrderGP(
    train_X,
    train_Y,
    # outcome_transform=FlattenedStandardize(output_shape=torch.Size([num_outputs]))
)
mll = ExactMarginalLogLikelihood(model.likelihood, model)
_ = fit_gpytorch_model(mll)

class SumSquaresObjective(MCAcquisitionObjective):
    def forward(self, samples: Tensor) -> Tensor:
        return samples.pow(2).sum(dim=-1)


f_star = SumSquaresObjective()(train_Y).max()

acqf = qExpectedImprovement(
    model=model,
    best_f=f_star,
    objective=SumSquaresObjective(),
    sampler=IIDNormalSampler(512),
)

sol, _ = optimize_acqf(
    acq_function=acqf,
    bounds=torch.tensor([[0.], [1.]]).repeat(1, 2).to(device=device),
    q=1,
    num_restarts=10,
    raw_samples=40,
)
```

## Motivation

Provides a partial resolution to #644. Thanks for pointing this issue out! cc @saitcakmak @Balandat 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests pass.

## Related PRs

#646

