### PR TITLE
set X_pending in get_acquisition_function in qEHVI

### DIFF
--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -149,6 +149,7 @@ def get_acquisition_function(
             sampler=sampler,
             objective=objective,
             constraints=constraints,
+            X_pending=X_pending,
         )
     raise NotImplementedError(
         f"Unknown acquisition function {acquisition_function_name}"

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -344,6 +344,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
             ref_point=self.ref_point,
             partitioning=mock.ANY,
             sampler=mock.ANY,
+            X_pending=self.X_pending,
         )
         args, kwargs = mock_acqf.call_args
         self.assertEqual(args, ())


### PR DESCRIPTION
Summary: see title

Differential Revision: D25891439

