### PR TITLE
make contextual kernel device-aware

### DIFF
--- a/botorch/models/contextual.py
+++ b/botorch/models/contextual.py
@@ -33,7 +33,9 @@ class SACGP(FixedNoiseGP):
     ) -> None:
         super().__init__(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
         self.covar_module = SACKernel(
-            decomposition=decomposition, batch_shape=self._aug_batch_shape
+            decomposition=decomposition,
+            batch_shape=self._aug_batch_shape,
+            device=train_X.device,
         )
         self.decomposition = decomposition
         self.to(train_X)
@@ -83,6 +85,7 @@ class LCEAGP(FixedNoiseGP):
             embs_feature_dict=embs_feature_dict,
             embs_dim_list=embs_dim_list,
             context_weight_dict=context_weight_dict,
+            device=train_X.device,
         )
         self.decomposition = decomposition
         self.to(train_X)

--- a/botorch/models/kernels/contextual_sac.py
+++ b/botorch/models/kernels/contextual_sac.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import torch
 from gpytorch.kernels.kernel import Kernel
@@ -47,10 +47,14 @@ class SACKernel(Kernel):
     """
 
     def __init__(
-        self, decomposition: Dict[str, List[int]], batch_shape: torch.Size
+        self,
+        decomposition: Dict[str, List[int]],
+        batch_shape: torch.Size,
+        device: Optional[torch.device] = None,
     ) -> None:
         super().__init__(batch_shape=batch_shape)
         self.decomposition = decomposition
+        self.device = device
 
         num_param = len(next(iter(decomposition.values())))
         for active_parameters in decomposition.values():
@@ -61,7 +65,7 @@ class SACKernel(Kernel):
                 )
 
         self._indexers = {
-            context: torch.tensor(active_params)
+            context: torch.tensor(active_params, device=self.device)
             for context, active_params in self.decomposition.items()
         }
 

--- a/test/models/test_contextual_multioutput.py
+++ b/test/models/test_contextual_multioutput.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+
 import torch
 from botorch import fit_gpytorch_model
 from botorch.models.contextual_multioutput import LCEMGP, FixedNoiseLCEMGP
@@ -19,77 +20,100 @@ from torch import Tensor
 class ContextualMultiOutputTest(BotorchTestCase):
     def testLCEMGP(self):
         d = 1
-        train_x = torch.rand(10, d)
-        train_y = torch.cos(train_x)
-        # 2 contexts here
-        task_indices = torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0])
-        train_x = torch.cat([train_x, task_indices.unsqueeze(-1)], axis=1)
+        for dtype in (torch.float, torch.double):
+            train_x = torch.rand(10, d, device=self.device, dtype=dtype)
+            train_y = torch.cos(train_x)
+            # 2 contexts here
+            task_indices = torch.tensor(
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                device=self.device,
+                dtype=dtype,
+            )
+            train_x = torch.cat([train_x, task_indices.unsqueeze(-1)], axis=1)
 
-        model = LCEMGP(train_X=train_x, train_Y=train_y, task_feature=d)
-        self.assertIsInstance(model, LCEMGP)
-        self.assertIsInstance(model, MultiTaskGP)
-        self.assertIsNone(model.context_emb_feature)
-        self.assertIsInstance(model.context_cat_feature, Tensor)
-        self.assertEqual(model.context_cat_feature.shape, torch.Size([2, 1]))
-        self.assertEqual(len(model.emb_layers), 1)
-        self.assertEqual(model.emb_dims, [(2, 1)])
+            model = LCEMGP(train_X=train_x, train_Y=train_y, task_feature=d)
+            self.assertIsInstance(model, LCEMGP)
+            self.assertIsInstance(model, MultiTaskGP)
+            self.assertIsNone(model.context_emb_feature)
+            self.assertIsInstance(model.context_cat_feature, Tensor)
+            self.assertEqual(model.context_cat_feature.shape, torch.Size([2, 1]))
+            self.assertEqual(len(model.emb_layers), 1)
+            self.assertEqual(model.emb_dims, [(2, 1)])
 
-        mll = ExactMarginalLogLikelihood(model.likelihood, model)
-        fit_gpytorch_model(mll, options={"maxiter": 1})
+            mll = ExactMarginalLogLikelihood(model.likelihood, model)
+            fit_gpytorch_model(mll, options={"maxiter": 1})
 
-        context_covar = model._eval_context_covar()
-        self.assertIsInstance(context_covar, LazyTensor)
-        self.assertEqual(context_covar.shape, torch.Size([2, 2]))
+            context_covar = model._eval_context_covar()
+            self.assertIsInstance(context_covar, LazyTensor)
+            self.assertEqual(context_covar.shape, torch.Size([2, 2]))
 
-        embeddings = model._task_embeddings()
-        self.assertIsInstance(embeddings, Tensor)
-        self.assertEqual(embeddings.shape, torch.Size([2, 1]))
+            embeddings = model._task_embeddings()
+            self.assertIsInstance(embeddings, Tensor)
+            self.assertEqual(embeddings.shape, torch.Size([2, 1]))
 
-        test_x = torch.rand(5, d)
-        task_indices = torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0])
-        test_x = torch.cat([test_x, task_indices.unsqueeze(-1)], axis=1)
-        self.assertIsInstance(model(test_x), MultivariateNormal)
+            test_x = torch.rand(5, d, device=self.device, dtype=dtype)
+            task_indices = torch.tensor(
+                [0.0, 0.0, 0.0, 0.0, 0.0], device=self.device, dtype=dtype
+            )
+            test_x = torch.cat([test_x, task_indices.unsqueeze(-1)], axis=1)
+            self.assertIsInstance(model(test_x), MultivariateNormal)
 
-        # test posterior
-        posterior_f = model.posterior(test_x[:, :d])
-        self.assertIsInstance(posterior_f, GPyTorchPosterior)
-        self.assertIsInstance(posterior_f.mvn, MultitaskMultivariateNormal)
+            # test posterior
+            posterior_f = model.posterior(test_x[:, :d])
+            self.assertIsInstance(posterior_f, GPyTorchPosterior)
+            self.assertIsInstance(posterior_f.mvn, MultitaskMultivariateNormal)
 
-        # test posterior w/ single output index
-        posterior_f = model.posterior(test_x[:, :d], output_indices=[0])
-        self.assertIsInstance(posterior_f, GPyTorchPosterior)
-        self.assertIsInstance(posterior_f.mvn, MultivariateNormal)
+            # test posterior w/ single output index
+            posterior_f = model.posterior(test_x[:, :d], output_indices=[0])
+            self.assertIsInstance(posterior_f, GPyTorchPosterior)
+            self.assertIsInstance(posterior_f.mvn, MultivariateNormal)
 
-        # test input embs_dim_list (one categorical feature)
-        # test input pre-trained emb context_emb_feature
-        model2 = LCEMGP(
-            train_X=train_x,
-            train_Y=train_y,
-            task_feature=d,
-            embs_dim_list=[2],  # increase dim from 1 to 2
-            context_emb_feature=torch.Tensor([[0.2], [0.3]]),
-        )
-        self.assertIsInstance(model2, LCEMGP)
-        self.assertIsInstance(model2, MultiTaskGP)
-        self.assertIsNotNone(model2.context_emb_feature)
-        self.assertIsInstance(model2.context_cat_feature, Tensor)
-        self.assertEqual(model2.context_cat_feature.shape, torch.Size([2, 1]))
-        self.assertEqual(len(model2.emb_layers), 1)
-        self.assertEqual(model2.emb_dims, [(2, 2)])
+            # test input embs_dim_list (one categorical feature)
+            # test input pre-trained emb context_emb_feature
+            model2 = LCEMGP(
+                train_X=train_x,
+                train_Y=train_y,
+                task_feature=d,
+                embs_dim_list=[2],  # increase dim from 1 to 2
+                context_emb_feature=torch.Tensor([[0.2], [0.3]]),
+            )
+            self.assertIsInstance(model2, LCEMGP)
+            self.assertIsInstance(model2, MultiTaskGP)
+            self.assertIsNotNone(model2.context_emb_feature)
+            self.assertIsInstance(model2.context_cat_feature, Tensor)
+            self.assertEqual(model2.context_cat_feature.shape, torch.Size([2, 1]))
+            self.assertEqual(len(model2.emb_layers), 1)
+            self.assertEqual(model2.emb_dims, [(2, 2)])
 
-        embeddings2 = model2._task_embeddings()
-        self.assertIsInstance(embeddings2, Tensor)
-        self.assertEqual(embeddings2.shape, torch.Size([2, 3]))
+            embeddings2 = model2._task_embeddings()
+            self.assertIsInstance(embeddings2, Tensor)
+            self.assertEqual(embeddings2.shape, torch.Size([2, 3]))
 
     def testFixedNoiseLCEMGP(self):
         d = 1
-        train_x = torch.rand(10, d)
-        train_y = torch.cos(train_x)
-        task_indices = torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0])
-        train_x = torch.cat([train_x, task_indices.unsqueeze(-1)], axis=1)
-        train_yvar = torch.ones(10, 1) * 0.01
+        for dtype in (torch.float, torch.double):
+            train_x = torch.rand(10, d, device=self.device, dtype=dtype)
+            train_y = torch.cos(train_x)
+            task_indices = torch.tensor(
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0], device=self.device
+            )
+            train_x = torch.cat([train_x, task_indices.unsqueeze(-1)], axis=1)
+            train_yvar = torch.ones(10, 1, device=self.device, dtype=dtype) * 0.01
 
-        model = FixedNoiseLCEMGP(
-            train_X=train_x, train_Y=train_y, train_Yvar=train_yvar, task_feature=d
-        )
-        self.assertIsInstance(model, FixedNoiseLCEMGP)
+            model = FixedNoiseLCEMGP(
+                train_X=train_x, train_Y=train_y, train_Yvar=train_yvar, task_feature=d
+            )
+            mll = ExactMarginalLogLikelihood(model.likelihood, model)
+            fit_gpytorch_model(mll, options={"maxiter": 1})
+
+            self.assertIsInstance(model, FixedNoiseLCEMGP)
+
+            test_x = torch.rand(5, d, device=self.device, dtype=dtype)
+            task_indices = torch.tensor(
+                [0.0, 0.0, 0.0, 0.0, 0.0], device=self.device, dtype=dtype
+            )
+            test_x = torch.cat(
+                [test_x, task_indices.unsqueeze(-1)],
+                axis=1,
+            )
+            self.assertIsInstance(model(test_x), MultivariateNormal)


### PR DESCRIPTION
Summary:
CBO was not device-aware as raised and resolved in D25133408. The changes were made in code lives in ax/fb. This diff patches the change of LCEA into OSS, makes LCEM and SAC device-aware, and adds the unit test.

Note: the prior change in LCEM was copied from D25699129 (https://github.com/pytorch/botorch/commit/17ad4fe55bae04fc590ca183ec7404c53f41926c). I will clean it up after the diff lands.

Reviewed By: sdsingh

Differential Revision: D25715108

