### PR TITLE
skip test on custom botorch model in ax tutorial

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -24,6 +24,8 @@ IGNORE = {
     "bo_with_warped_gp.ipynb",
     "closed_loop_botorch_only.ipynb",
     "constrained_multi_objective_bo.ipynb",
+    # this tutorial has an ax dependency
+    "custom_botorch_model_in_ax.ipynb",
     "multi_fidelity_bo.ipynb",
     "meta_learning_with_rgpe.ipynb",
     "multi_objective_bo.ipynb",


### PR DESCRIPTION
Summary: This tutorial has an ax dependency and currently fails in the github actions test

Differential Revision: D26315127

