### PR TITLE
Add osy test problem

### DIFF
--- a/botorch/test_functions/__init__.py
+++ b/botorch/test_functions/__init__.py
@@ -15,6 +15,7 @@ from botorch.test_functions.multi_objective import (
     CONSTR,
     DTLZ1,
     DTLZ2,
+    OSY,
     SRN,
     ZDT1,
     ZDT2,

--- a/botorch/test_functions/__init__.py
+++ b/botorch/test_functions/__init__.py
@@ -73,6 +73,7 @@ __all__ = [
     "HolderTable",
     "Levy",
     "Michalewicz",
+    "OSY",
     "Powell",
     "Rastrigin",
     "Rosenbrock",

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -30,7 +30,7 @@ References
     A. Osyczka, S. Kundu. 1995. A new method to solve generalized multicriteria 
     optimization problems using the simple genetic algorithm. In Structural
     Optimization 10. 94–99.
-    
+
 .. [Tanabe2020]
     Ryoji Tanabe, Hisao Ishibuchi, An easy-to-use real-world multi-objective
     optimization problem suite, Applied Soft Computing,Volume 89, 2020.
@@ -606,19 +606,22 @@ class C2DTLZ2(DTLZ2, ConstrainedBaseTestProblem):
         min1 = (term1 + term2).min(dim=-1).values
         min2 = ((f_X - 1 / math.sqrt(f_X.shape[-1])).pow(2) - self._r ** 2).sum(dim=-1)
         return -torch.min(min1, min2).unsqueeze(-1)
-    
+
+
 class OSY(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     r""" 
-    The OSY test problem from [Oszycka1995]. 
-    Implementation from https://github.com/msu-coinlab/pymoo/blob/master/pymoo/problems/multi/osy.py
-    
+    The OSY test problem from [Oszycka1995]_. 
+    Implementation from 
+    https://github.com/msu-coinlab/pymoo/blob/master/pymoo/problems/multi/osy.py
     Note that this implementation assumes minimization, so please choose negate=True.
     """
     
     dim = 6
     num_constraints = 6
     num_objectives = 2
-    _bounds = [(0.0, 10.0), (0.0, 10.0), (1.0, 5.0), (0.0, 6.0), (1.0, 5.0), (0.0, 10.0)]
+    _bounds = [
+        (0.0, 10.0), (0.0, 10.0), (1.0, 5.0), (0.0, 6.0), (1.0, 5.0), (0.0, 10.0)
+    ]
     _ref_point = [-75.0, 75.0]
     
     def __init__(
@@ -631,11 +634,11 @@ class OSY(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
         super().__init__(noise_std=noise_std, negate=negate)
         
     def evaluate_true(self, X: Tensor) -> Tensor:
-        f1 = - (25 * (X[..., 0] - 2) ** 2 + (X[..., 1] - 2) ** 2 + (X[..., 2] - 1) ** 2 + (X[..., 3] - 4) ** 2 + (
-                    X[..., 4] - 1) ** 2)
+        f1 = - (25 * (X[..., 0] - 2) ** 2 + (X[..., 1] - 2) ** 2 + (X[..., 2] - 1) ** 2 + \
+            (X[..., 3] - 4) ** 2 + (X[..., 4] - 1) ** 2)
         f2 = (X**2).sum(-1)
         return torch.stack([f1, f2], dim=-1)
-
+        
     def evaluate_slack_true(self, X: Tensor) -> Tensor:
         g1 = (X[..., 0] + X[..., 1] - 2.0)
         g2 = (6.0 - X[..., 0] - X[..., 1])

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -629,15 +629,6 @@ class OSY(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     ]
     _ref_point = [-75.0, 75.0]
 
-    def __init__(
-        self,
-        dim: int = 6,
-        num_objectives: int = 2,
-        noise_std: Optional[float] = None,
-        negate: bool = False,
-    ) -> None:
-        super().__init__(noise_std=noise_std, negate=negate)
-
     def evaluate_true(self, X: Tensor) -> Tensor:
         f1 = -(
             25 * (X[..., 0] - 2) ** 2

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -612,7 +612,7 @@ class OSY(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     The OSY test problem from [Oszycka1995]. 
     Implementation from https://github.com/msu-coinlab/pymoo/blob/master/pymoo/problems/multi/osy.py
     
-    This implementation assumes minimization.
+    Note that this implementation assumes minimization, so please choose negate=True.
     """
     
     dim = 6
@@ -626,7 +626,7 @@ class OSY(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
         dim: int = 6,
         num_objectives: int = 2,
         noise_std: Optional[float] = None,
-        negate: bool = True,
+        negate: bool = False,
     ) -> None:
         super().__init__(noise_std=noise_std, negate=negate)
         

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -26,6 +26,11 @@ References
     Conference on Uncertainty in Artificial Intelligence (UAI’14).
     AUAI Press, Arlington, Virginia, USA, 250–259.
 
+.. [Oszycka1995]
+    A. Osyczka, S. Kundu. 1995. A new method to solve generalized multicriteria 
+    optimization problems using the simple genetic algorithm. In Structural
+    Optimization 10. 94–99.
+    
 .. [Tanabe2020]
     Ryoji Tanabe, Hisao Ishibuchi, An easy-to-use real-world multi-objective
     optimization problem suite, Applied Soft Computing,Volume 89, 2020.
@@ -601,3 +606,41 @@ class C2DTLZ2(DTLZ2, ConstrainedBaseTestProblem):
         min1 = (term1 + term2).min(dim=-1).values
         min2 = ((f_X - 1 / math.sqrt(f_X.shape[-1])).pow(2) - self._r ** 2).sum(dim=-1)
         return -torch.min(min1, min2).unsqueeze(-1)
+    
+class OSY(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
+    r""" 
+    The OSY test problem from [Oszycka1995]. 
+    Implementation from https://github.com/msu-coinlab/pymoo/blob/master/pymoo/problems/multi/osy.py
+    
+    This implementation assumes minimization.
+    """
+    
+    dim = 6
+    num_constraints = 6
+    num_objectives = 2
+    _bounds = [(0.0, 10.0), (0.0, 10.0), (1.0, 5.0), (0.0, 6.0), (1.0, 5.0), (0.0, 10.0)]
+    _ref_point = [-75.0, 75.0]
+    
+    def __init__(
+        self,
+        dim: int = 6,
+        num_objectives: int = 2,
+        noise_std: Optional[float] = None,
+        negate: bool = True,
+    ) -> None:
+        super().__init__(noise_std=noise_std, negate=negate)
+        
+    def evaluate_true(self, X: Tensor) -> Tensor:
+        f1 = - (25 * (X[..., 0] - 2) ** 2 + (X[..., 1] - 2) ** 2 + (X[..., 2] - 1) ** 2 + (X[..., 3] - 4) ** 2 + (
+                    X[..., 4] - 1) ** 2)
+        f2 = (X**2).sum(-1)
+        return torch.stack([f1, f2], dim=-1)
+
+    def evaluate_slack_true(self, X: Tensor) -> Tensor:
+        g1 = (X[..., 0] + X[..., 1] - 2.0)
+        g2 = (6.0 - X[..., 0] - X[..., 1])
+        g3 = (2.0 - X[..., 1] + X[..., 0])
+        g4 = (2.0 - X[..., 0] + 3.0 * X[..., 1])
+        g5 = (4.0 - (X[..., 2] - 3.0) ** 2 - X[..., 3])
+        g6 = ((X[..., 4] - 3.0) ** 2 + X[..., 5] - 4.0)
+        return torch.stack([g1, g2, g3, g4, g5, g6], dim=-1)

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -615,15 +615,20 @@ class OSY(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     https://github.com/msu-coinlab/pymoo/blob/master/pymoo/problems/multi/osy.py
     Note that this implementation assumes minimization, so please choose negate=True.
     """
-    
+
     dim = 6
     num_constraints = 6
     num_objectives = 2
     _bounds = [
-        (0.0, 10.0), (0.0, 10.0), (1.0, 5.0), (0.0, 6.0), (1.0, 5.0), (0.0, 10.0)
+        (0.0, 10.0),
+        (0.0, 10.0),
+        (1.0, 5.0),
+        (0.0, 6.0),
+        (1.0, 5.0),
+        (0.0, 10.0),
     ]
     _ref_point = [-75.0, 75.0]
-    
+
     def __init__(
         self,
         dim: int = 6,
@@ -632,18 +637,23 @@ class OSY(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
         negate: bool = False,
     ) -> None:
         super().__init__(noise_std=noise_std, negate=negate)
-        
+
     def evaluate_true(self, X: Tensor) -> Tensor:
-        f1 = - (25 * (X[..., 0] - 2) ** 2 + (X[..., 1] - 2) ** 2 + (X[..., 2] - 1) ** 2 + \
-            (X[..., 3] - 4) ** 2 + (X[..., 4] - 1) ** 2)
-        f2 = (X**2).sum(-1)
+        f1 = -(
+            25 * (X[..., 0] - 2) ** 2
+            + (X[..., 1] - 2) ** 2
+            + (X[..., 2] - 1) ** 2
+            + (X[..., 3] - 4) ** 2
+            + (X[..., 4] - 1) ** 2
+        )
+        f2 = (X ** 2).sum(-1)
         return torch.stack([f1, f2], dim=-1)
-        
+
     def evaluate_slack_true(self, X: Tensor) -> Tensor:
-        g1 = (X[..., 0] + X[..., 1] - 2.0)
-        g2 = (6.0 - X[..., 0] - X[..., 1])
-        g3 = (2.0 - X[..., 1] + X[..., 0])
-        g4 = (2.0 - X[..., 0] + 3.0 * X[..., 1])
-        g5 = (4.0 - (X[..., 2] - 3.0) ** 2 - X[..., 3])
-        g6 = ((X[..., 4] - 3.0) ** 2 + X[..., 5] - 4.0)
+        g1 = X[..., 0] + X[..., 1] - 2.0
+        g2 = 6.0 - X[..., 0] - X[..., 1]
+        g3 = 2.0 - X[..., 1] + X[..., 0]
+        g4 = 2.0 - X[..., 0] + 3.0 * X[..., 1]
+        g5 = 4.0 - (X[..., 2] - 3.0) ** 2 - X[..., 3]
+        g6 = (X[..., 4] - 3.0) ** 2 + X[..., 5] - 4.0
         return torch.stack([g1, g2, g3, g4, g5, g6], dim=-1)

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -27,7 +27,7 @@ References
     AUAI Press, Arlington, Virginia, USA, 250–259.
 
 .. [Oszycka1995]
-    A. Osyczka, S. Kundu. 1995. A new method to solve generalized multicriteria 
+    A. Osyczka, S. Kundu. 1995. A new method to solve generalized multicriteria
     optimization problems using the simple genetic algorithm. In Structural
     Optimization 10. 94–99.
 
@@ -609,9 +609,9 @@ class C2DTLZ2(DTLZ2, ConstrainedBaseTestProblem):
 
 
 class OSY(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
-    r""" 
-    The OSY test problem from [Oszycka1995]_. 
-    Implementation from 
+    r"""
+    The OSY test problem from [Oszycka1995]_.
+    Implementation from
     https://github.com/msu-coinlab/pymoo/blob/master/pymoo/problems/multi/osy.py
     Note that this implementation assumes minimization, so please choose negate=True.
     """

--- a/test/test_functions/test_multi_objective.py
+++ b/test/test_functions/test_multi_objective.py
@@ -21,6 +21,7 @@ from botorch.test_functions.multi_objective import (
     ConstrainedBraninCurrin,
     MultiObjectiveTestProblem,
     VehicleSafety,
+    OSY,
 )
 from botorch.utils.testing import (
     BotorchTestCase,
@@ -195,6 +196,7 @@ class TestConstrainedMultiObjectiveProblems(
         CONSTR(),
         ConstrainedBraninCurrin(),
         C2DTLZ2(dim=3, num_objectives=2),
+        OSY(),
     ]
 
     def test_c2dtlz2_batch_exception(self):


### PR DESCRIPTION
This PR adds the OSY multi-objective test problem (two objectives, six constraints, six dimensions).

## Motivation

It's a higher dimensional output multi-objective test problem that is useful for testing out MTGPs for constrained multi-objective bayes opt.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

yes.

## Test Plan

unit tests. osy is added.

## Related PRs

N/A. Pulled out of https://github.com/wjmaddox/botorch.
