### PR TITLE
Memory Fixes to Higher Order GP Model

### DIFF
--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -413,7 +413,9 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
             self._is_custom_likelihood = True
 
         super().__init__(
-            train_X, train_Y.view(*self._aug_batch_shape, -1), likelihood=likelihood,
+            train_X, 
+            train_Y.view(*self._aug_batch_shape, -1), 
+            likelihood=likelihood,
         )
 
         if covar_modules is not None:
@@ -485,12 +487,17 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                 ).add_jitter(1e-4)
                 latent_dist = MultivariateNormal(
                     torch.zeros(
-                        self.target_shape[dim_num], device=device, dtype=dtype,
+                        self.target_shape[dim_num], 
+                        device=device, 
+                        dtype=dtype,
                     ),
                     latent_covar,
                 )
                 sample_shape = torch.Size(
-                    (*self._aug_batch_shape, num_latent_dims[dim_num],)
+                    (
+                        *self._aug_batch_shape, 
+                        num_latent_dims[dim_num],
+                    )
                 )
                 latent_sample = latent_dist.sample(sample_shape=sample_shape)
                 latent_sample = latent_sample.reshape(
@@ -499,7 +506,10 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                     num_latent_dims[dim_num],
                 )
                 self.latent_parameters.append(
-                    Parameter(latent_sample, requires_grad=learn_latent_pars,)
+                    Parameter(
+                        latent_sample, 
+                        requires_grad=learn_latent_pars,
+                    )
                 )
                 self.register_prior(
                     "latent_parameters_" + str(dim_num),
@@ -678,7 +688,12 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                 train_train_covar=train_train_covar,
                 test_train_covar=test_train_covar,
                 joint_covariance_matrix=full_covar.clone(),
-                output_shape=Size((*X.shape[:-1], *self.target_shape,)),
+                output_shape=Size(
+                    (
+                        *X.shape[:-1], 
+                        *self.target_shape,
+                    )
+                ),
                 num_outputs=self._num_outputs,
             )
             if hasattr(self, "outcome_transform"):

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -670,7 +670,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
             mvn = MultivariateNormal(new_mean, new_variance)
 
             train_train_covar = self.prediction_strategy.lik_train_train_covar.detach()
-            
+
             # return a specialized Posterior to allow for sampling
             posterior = HigherOrderGPPosterior(
                 mvn=mvn,

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -413,8 +413,8 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
             self._is_custom_likelihood = True
 
         super().__init__(
-            train_X, 
-            train_Y.view(*self._aug_batch_shape, -1), 
+            train_X,
+            train_Y.view(*self._aug_batch_shape, -1),
             likelihood=likelihood,
         )
 
@@ -487,15 +487,15 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                 ).add_jitter(1e-4)
                 latent_dist = MultivariateNormal(
                     torch.zeros(
-                        self.target_shape[dim_num], 
-                        device=device, 
+                        self.target_shape[dim_num],
+                        device=device,
                         dtype=dtype,
                     ),
                     latent_covar,
                 )
                 sample_shape = torch.Size(
                     (
-                        *self._aug_batch_shape, 
+                        *self._aug_batch_shape,
                         num_latent_dims[dim_num],
                     )
                 )
@@ -507,7 +507,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                 )
                 self.latent_parameters.append(
                     Parameter(
-                        latent_sample, 
+                        latent_sample,
                         requires_grad=learn_latent_pars,
                     )
                 )
@@ -690,7 +690,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                 joint_covariance_matrix=full_covar.clone(),
                 output_shape=Size(
                     (
-                        *X.shape[:-1], 
+                        *X.shape[:-1],
                         *self.target_shape,
                     )
                 ),

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -498,6 +498,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                         *self._aug_batch_shape,
                         num_latent_dims[dim_num],
                     )
+                )
                 latent_sample = latent_dist.sample(sample_shape=sample_shape)
                 latent_sample = latent_sample.reshape(
                     *self._aug_batch_shape,

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -526,7 +526,11 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         covariance_list.append(self.covar_modules[0](X))
 
         for cm, param in zip(self.covar_modules[1:], self.latent_parameters):
-            covariance_list.append(cm(param))
+            if not self.training:
+                with torch.no_grad():
+                    covariance_list.append(cm(param))
+            else:
+                covariance_list.append(cm(param))
 
         # check batch_shapes
         if covariance_list[0].batch_shape != covariance_list[1].batch_shape:
@@ -650,7 +654,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                 pred_variance = self.make_posterior_variances(joint_covar)
 
                 full_covar = KroneckerProductLazyTensor(
-                    full_covar, *joint_covar.lazy_tensors[1:]
+                    full_covar, *[x.detach() for x in joint_covar.lazy_tensors[1:]]
                 )
 
             joint_covar_list = [self.covar_modules[0](X, train_inputs)]
@@ -659,7 +663,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                 covar = cm(param)
                 if covar.batch_shape != batch_shape:
                     covar = BatchRepeatLazyTensor(covar, batch_shape)
-                joint_covar_list.append(covar)
+                joint_covar_list.append(covar.detach())
 
             test_train_covar = KroneckerProductLazyTensor(*joint_covar_list)
 
@@ -679,9 +683,9 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
             posterior = HigherOrderGPPosterior(
                 mvn=mvn,
                 train_targets=self.train_targets.unsqueeze(-1),
-                train_train_covar=self.prediction_strategy.lik_train_train_covar,
+                train_train_covar=self.prediction_strategy.lik_train_train_covar.detach(),
                 test_train_covar=test_train_covar,
-                joint_covariance_matrix=full_covar,
+                joint_covariance_matrix=full_covar.clone(),
                 output_shape=Size(
                     (
                         *X.shape[:-1],

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -510,6 +510,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                         latent_sample,
                         requires_grad=learn_latent_pars,
                     )
+                )
                 self.register_prior(
                     "latent_parameters_" + str(dim_num),
                     MultivariateNormalPrior(


### PR DESCRIPTION
Detaching the latent dimensions of the HOGP should reduce the memory overhead a bit as we don't need to keep the computation graphs around.

Also fixes a small bug where the full joint covariance was not picking up the computation graph; resolved by cloning the lazy tensor here.

## Motivation

Reduce memory overhead.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

yes.

## Test Plan

unit tests.

## Related PRs

n/a.
