### PR TITLE
Allow telling setuptools_scm to not use local version via envvar

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,6 @@ jobs:
       run: |
         bash <(curl -s https://codecov.io/bash)
 
-
   package-test-deploy-pypi:
     name: Package and test deployment to test.pypi.org
     runs-on: ubuntu-latest
@@ -57,6 +56,7 @@ jobs:
         pip install --upgrade setuptools wheel
     - name: Build packages (wheel and source distribution)
       run: |
+        export SCM_NO_LOCAL_VERSION=true
         python setup.py sdist bdist_wheel
     - name: Verify packages
       run: |
@@ -68,7 +68,7 @@ jobs:
         password: ${{ secrets.TEST_PYPI_PASSWORD }}
         repository_url: https://test.pypi.org/legacy/
         skip_existing: true
-
+        verbose: true
 
   package-conda:
     name: Test conda build
@@ -96,7 +96,6 @@ jobs:
       shell: bash -l {0}
       run: |
         ./scripts/build_and_verify_conda_package.sh
-
 
   publish-latest-website:
     name: Publish latest website

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,10 @@ setup(
         "root": ".",
         "relative_to": __file__,
         "write_to": os.path.join(root_dir, "botorch", "version.py"),
+        "local_scheme": (
+            "no-local-version" if os.environ.get("SCM_NO_LOCAL_VERSION", False)
+            else "node-and-date"
+        ),
     },
     install_requires=["torch>=1.7.1", "gpytorch>=1.3", "scipy"],
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ setup(
         "relative_to": __file__,
         "write_to": os.path.join(root_dir, "botorch", "version.py"),
         "local_scheme": (
-            "no-local-version" if os.environ.get("SCM_NO_LOCAL_VERSION", False)
+            "no-local-version"
+            if os.environ.get("SCM_NO_LOCAL_VERSION", False)
             else "node-and-date"
         ),
     },


### PR DESCRIPTION
Configures `setuptools_scm` to not use a local version number if the `SCM_NO_LOCAL_VERSION` env var is set to "true".
This is useful to be able to build a version that can be uploaded to test.pypi.org as part of CI testing.