### PR TITLE
Check for NaN in gen_candidates_scipy

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -115,15 +115,13 @@ def gen_candidates_scipy(
         # compute gradient w.r.t. the inputs (does not accumulate in leaves)
         gradf = _arrayify(torch.autograd.grad(loss, X)[0].contiguous().view(-1))
         if np.isnan(gradf).any():
-            raise RuntimeError(
+            msg = (
                 f"{np.isnan(gradf).sum()} elements of the {x.shape} gradient tensor "
-                "`gradf` are NaN."
-                + (
-                    "Consider using `dtype=torch.double`."
-                    if initial_conditions.dtype != torch.double
-                    else ""
-                )
+                "`gradf` are NaN. This often indicates numerical issues."
             )
+            if initial_conditions.dtype != torch.double:
+                msg += " Consider using `dtype=torch.double`."
+            raise RuntimeError(msg)
         fval = loss.item()
         return fval, gradf
 

--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -101,7 +101,8 @@ def gen_candidates_scipy(
     def f(x):
         if np.isnan(x).any():
             raise RuntimeError(
-                f"{np.isnan(x).sum()} elements of the {x.shape} tensor `x` are NaN."
+                f"{np.isnan(x).sum()} elements of the {x.size} element array "
+                f"`x` are NaN."
             )
         X = (
             torch.from_numpy(x)
@@ -116,8 +117,8 @@ def gen_candidates_scipy(
         gradf = _arrayify(torch.autograd.grad(loss, X)[0].contiguous().view(-1))
         if np.isnan(gradf).any():
             msg = (
-                f"{np.isnan(gradf).sum()} elements of the {x.shape} gradient tensor "
-                "`gradf` are NaN. This often indicates numerical issues."
+                f"{np.isnan(gradf).sum()} elements of the {x.size} element "
+                "gradient array `gradf` are NaN. This often indicates numerical issues."
             )
             if initial_conditions.dtype != torch.double:
                 msg += " Consider using `dtype=torch.double`."

--- a/test/generation/test_gen.py
+++ b/test/generation/test_gen.py
@@ -142,7 +142,7 @@ class TestGenCandidates(TestBaseCandidateGeneration):
     def test_gen_candidates_scipy_nan_handling(self):
         for dtype, expected_regex in [
             (torch.float, "Consider using"),
-            (torch.double, "gradient tensor"),
+            (torch.double, "gradient array"),
         ]:
             ckwargs = {"dtype": dtype, "device": self.device}
 
@@ -158,7 +158,7 @@ class TestGenCandidates(TestBaseCandidateGeneration):
 
             # test NaN in `x`
             test_ics = torch.tensor([0.0, 0.0, float("nan")], **ckwargs)
-            with self.assertRaisesRegex(RuntimeError, "tensor `x` are NaN."):
+            with self.assertRaisesRegex(RuntimeError, "array `x` are NaN."):
                 gen_candidates_scipy(
                     initial_conditions=test_ics,
                     acquisition_function=mock.Mock(),

--- a/test/generation/test_gen.py
+++ b/test/generation/test_gen.py
@@ -157,7 +157,7 @@ class TestGenCandidates(TestBaseCandidateGeneration):
                     )
 
             # test NaN in `x`
-            test_ics[-1] = torch.tensor(float("nan"))
+            test_ics = torch.tensor([0.0, 0.0, float("nan")], **ckwargs)
             with self.assertRaisesRegex(RuntimeError, "tensor `x` are NaN."):
                 _ = gen_candidates_scipy(
                     initial_conditions=test_ics,

--- a/test/generation/test_gen.py
+++ b/test/generation/test_gen.py
@@ -151,7 +151,7 @@ class TestGenCandidates(TestBaseCandidateGeneration):
             # test NaN in grad
             with mock.patch("torch.autograd.grad", return_value=[test_grad]):
                 with self.assertRaisesRegex(RuntimeError, expected_regex):
-                    _ = gen_candidates_scipy(
+                    gen_candidates_scipy(
                         initial_conditions=test_ics,
                         acquisition_function=mock.Mock(return_value=test_ics),
                     )
@@ -159,7 +159,7 @@ class TestGenCandidates(TestBaseCandidateGeneration):
             # test NaN in `x`
             test_ics = torch.tensor([0.0, 0.0, float("nan")], **ckwargs)
             with self.assertRaisesRegex(RuntimeError, "tensor `x` are NaN."):
-                _ = gen_candidates_scipy(
+                gen_candidates_scipy(
                     initial_conditions=test_ics,
                     acquisition_function=mock.Mock(),
                 )


### PR DESCRIPTION
## Motivation

Closes #685. Implements simple checks in `gen_candidates_scipy` to catch `NaN` inputs and gradients, making debugging easier.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added unit tests.

