### PR TITLE
Properly set SCM_NO_LOCAL_VERSION env var in validation step

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,10 +55,13 @@ jobs:
         pip install .[test]
         pip install --upgrade setuptools wheel
     - name: Build packages (wheel and source distribution)
+      env:
+        SCM_NO_LOCAL_VERSION: true
       run: |
-        export SCM_NO_LOCAL_VERSION=true
         python setup.py sdist bdist_wheel
     - name: Verify packages
+      env:
+        SCM_NO_LOCAL_VERSION: true
       run: |
         ./scripts/build_and_verify_py_packages.sh
     - name: Deploy to Test PyPI


### PR DESCRIPTION
Fixes a bug in #687 in which the `SCM_NO_LOCAL_VERSION` env var wasn't set correctly during the validation step.
