### PR TITLE
Properly escape nbconvert version pinning in pip install

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install -e .[test]
+        pip install .[test]
     - name: Unit tests and coverage
       run: |
         pytest -ra --cov=. --cov-report term-missing
@@ -115,7 +115,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install -e .[dev]
+        pip install .[dev]
         pip install git+https://github.com/facebook/Ax.git
         pip install beautifulsoup4 ipython "nbconvert<6.0"
     - name: Unit tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -117,7 +117,7 @@ jobs:
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install -e .[dev]
         pip install git+https://github.com/facebook/Ax.git
-        pip install jupyter nbconvert<6.0
+        pip install beautifulsoup4 ipython "nbconvert<6.0"
     - name: Unit tests
       run: |
         pytest -ra


### PR DESCRIPTION
Previously this would fail with `6.0: No such file or directory`

Also avoids installing all or jupyter, and instead only ipython. Also installs beautifulsoup4 for tutorial parsing.