### PR TITLE
Some fixes to website deployment setup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,6 +112,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
+    - name: Fetch all history for all tags and branches
+      run: git fetch --prune --unshallow
     - name: Install dependencies
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
@@ -122,5 +124,7 @@ jobs:
       run: |
         pytest -ra
     - name: Publish latest website
+      env:
+        DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}
       run: |
         ./scripts/publish_site.sh -d

--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -50,9 +50,9 @@ cd "${WORK_DIR}" || exit
 
 if [[ $DOCUSAURUS_BOT == true ]]; then
   # Assumes docusaurus bot credentials have been stored in ~/.netrc, e.g. via
-  # git config --global user.email "docusaurus-bot@users.noreply.github.com"
-  # git config --global user.name "BoTorch website deployment script"
-  # echo "machine github.com login docusaurus-bot password ${DOCUSAURUS_PUBLISH_TOKEN}" > ~/.netrc
+  git config --global user.email "docusaurus-bot@users.noreply.github.com"
+  git config --global user.name "BoTorch website deployment script"
+  echo "machine github.com login docusaurus-bot password ${DOCUSAURUS_PUBLISH_TOKEN}" > ~/.netrc
 
   # Clone both master & gh-pages branches
   git clone https://docusaurus-bot@github.com/pytorch/botorch.git botorch-master
@@ -133,7 +133,6 @@ if [[ $VERSION == false ]]; then
   # versions.html goes both in top-level and under en/ (default language)
   cp versions.html botorch-gh-pages/v/latest/versions.html
   cp versions.html botorch-gh-pages/v/latest/en/versions.html
-  cp -R botorch-master/.circleci botorch-gh-pages/
 
   # Push changes to gh-pages
   cd botorch-gh-pages || exit
@@ -209,7 +208,6 @@ else
   # needs to be updated when a new version is built.
   cd "${WORK_DIR}" || exit
   python3 botorch-master/scripts/update_versions_html.py -p "${WORK_DIR}"
-  cp -R botorch-master/.circleci new-site/
 
   # move contents of newsite to botorch-gh-pages, preserving commit history
   rm -rfv ./botorch-gh-pages/*


### PR DESCRIPTION
- Need to fetch github tags so `setuptools_scm` generates the right version number and the BoTorch install deosn't get uninstalled by Ax
- Need to set up docusaurus bot correctly (git credentials and point to the publish token)