### PR TITLE
Do not use an `MCSampler` in `MaxPosteriorSampling`

### DIFF
--- a/botorch/generation/sampling.py
+++ b/botorch/generation/sampling.py
@@ -28,7 +28,6 @@ from botorch.acquisition.objective import (
 )
 from botorch.generation.utils import _flip_sub_unique
 from botorch.models.model import Model
-from botorch.sampling.samplers import IIDNormalSampler
 from botorch.utils.sampling import batched_multinomial
 from botorch.utils.transforms import standardize
 from torch import Tensor

--- a/botorch/generation/sampling.py
+++ b/botorch/generation/sampling.py
@@ -106,10 +106,8 @@ class MaxPosteriorSampling(SamplingStrategy):
         if isinstance(self.objective, ScalarizedObjective):
             posterior = self.objective(posterior)
 
-        sampler = IIDNormalSampler(
-            num_samples=num_samples, collapse_batch_dims=False, resample=True
-        )
-        samples = sampler(posterior)  # num_samples x batch_shape x N x m
+        # num_samples x batch_shape x N x m
+        samples = posterior.rsample(sample_shape=torch.Size([num_samples]))
         if isinstance(self.objective, ScalarizedObjective):
             obj = samples.squeeze(-1)  # num_samples x batch_shape x N
         else:


### PR DESCRIPTION
By using a sampler, we always end up passing `base_samples` to downstream GPyTorch's `MultivariateNormal`, which means that this always used the `root_decomposition` to correlate base samples, rather than `zero_mean_mvn_samples`. This resulted in CIQ never being used.