### PR TITLE
Add ability manually kick off workflows

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types: [created]
 
+
 jobs:
 
   tests-and-coverage-pip:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+
 
 jobs:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+
 
 jobs:
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     # 2:30 PST
     - cron:  '30 10 * * *'
-  # allow this to be scheduled manually in addition to cron
   workflow_dispatch:
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+
 
 jobs:
 

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+
 
 jobs:
 


### PR DESCRIPTION
Now we can manually kick off all workflows (except for the deployment workflow). This is useful for debugging (e.g. against upstream changes in pytorch/gpytorch)
