### PR TITLE
Use release versions for pytorch/gpytorch in deployment workflow

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -20,9 +20,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install (auto-install dependencies)
       run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[test]
     - name: Unit tests and coverage
       run: |
@@ -48,7 +47,6 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[test]
         pip install --upgrade setuptools wheel
     - name: Build packages (wheel and source distribution)
@@ -82,7 +80,7 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        conda install -y -c pytorch-nightly pytorch cpuonly
+        conda install -y -c pytorch pytorch cpuonly
         conda install -y scipy sphinx pytest flake8
         conda install -y -c gpytorch gpytorch
         conda install -y conda-build anaconda-client
@@ -111,11 +109,12 @@ jobs:
       with:
         python-version: 3.7
     - name: Install dependencies
+      # there may not be a compatible Ax pip version, so we use master
       run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install -e .[dev]
+        pip install gpytorch
+        pip install .[dev]
         pip install git+https://github.com/facebook/Ax.git
-        pip install -e .[tutorials]
+        pip install .[tutorials]
         pip install beautifulsoup4 ipython "nbconvert<6.0"
     - name: Publish latest website
       run: |


### PR DESCRIPTION
We need to make sure the to-be-released version runs against available releases, not dev versions.