### PR TITLE
Add "Test against stable" workflow.

### DIFF
--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -1,0 +1,26 @@
+name: Test against stable
+
+on:
+  workflow_dispatch:
+
+  tests-and-coverage:
+    name: Tests and coverage (pip, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: [3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install gpytorch
+        pip install .[test]
+    - name: Unit tests and coverage
+      run: |
+        pytest -ra --cov=. --cov-report term-missing


### PR DESCRIPTION
This workflow tests against current releases of gpytorch/pytorch. Since these will generally fail it is not set up to execute automatically, only on manual dispatch.

This workflow is primarily intended to be used prior to releasing a new version to check compatibility with current releases (and without executing the full deployment workflow that pushes packages and the website).

Ideally we'd run this at a nightly cadence as well, but it appears that GHA currently has some limitations w.r.t. marking a flow as "not required" or "experimental", and we don't want this top clobber the CI status.