### PR TITLE
Use torch/gpytorch nightlies in nightly testing workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
 
-  tests-and-coverage-pip:
+  tests-and-coverage-nightly:
     name: Tests and coverage (pip, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -26,6 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[test]
     - name: Unit tests and coverage
@@ -51,6 +52,7 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: |
+        pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[test]
         pip install --upgrade setuptools wheel
@@ -89,12 +91,13 @@ jobs:
       run: git fetch --prune --unshallow
     - name: Install dependencies
       shell: bash -l {0}
+      # Don't need deps for conda build, but need them for testing
       run: |
-        conda install -y -c pytorch-nightly pytorch cpuonly
-        conda install -y scipy sphinx pytest flake8
-        conda install -y -c gpytorch gpytorch
         conda install -y conda-build
         conda config --set anaconda_upload no
+        conda install -y -c pytorch-nightly pytorch cpuonly
+        conda install -y scipy
+        pip install git+https://github.com/cornellius-gp/gpytorch.git
     - name: Build and verify conda package
       shell: bash -l {0}
       run: |
@@ -103,7 +106,7 @@ jobs:
   publish-latest-website:
     name: Publish latest website
     runs-on: ubuntu-latest
-    needs: [tests-and-coverage-pip, package-test-deploy-pypi, package-conda]
+    needs: [tests-and-coverage-nightly, package-test-deploy-pypi, package-conda]
     strategy:
       fail-fast: true
     steps:


### PR DESCRIPTION
We may well fail against the latest release on master, this makes sure tests are run against nightlies instead. For testing against the latest releases, use the "Test against stable" workflow from #706.