### PR TITLE
Introduce base_sample_shape property to Posterior objects

### DIFF
--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -269,12 +269,12 @@ def prune_inferior_points(
     with torch.no_grad():
         posterior = model.posterior(X=X)
     if sampler is None:
-        if posterior.event_shape.numel() > SobolEngine.MAXDIM:
+        if posterior.base_sample_shape.numel() > SobolEngine.MAXDIM:
             if settings.debug.on():
                 warnings.warn(
-                    f"Sample dimension q*m={posterior.event_shape.numel()} exceeding "
-                    f"Sobol max dimension ({SobolEngine.MAXDIM}). Using iid samples "
-                    "instead.",
+                    f"Sample dimension q*m={posterior.base_sample_shape.numel()} "
+                    f"exceeding Sobol max dimension ({SobolEngine.MAXDIM}). "
+                    "Using iid samples instead.",
                     SamplingWarning,
                 )
             sampler = IIDNormalSampler(num_samples=num_samples)

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -28,7 +28,11 @@ from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform, Standardize
 from botorch.models.utils import gpt_posterior_settings
-from botorch.posteriors import GPyTorchPosterior, TransformedPosterior
+from botorch.posteriors import (
+    GPyTorchPosterior,
+    HigherOrderGPPosterior,
+    TransformedPosterior,
+)
 from gpytorch.constraints import GreaterThan
 from gpytorch.distributions import MultivariateNormal
 from gpytorch.kernels import Kernel, MaternKernel
@@ -46,7 +50,7 @@ from gpytorch.likelihoods import (
 from gpytorch.models import ExactGP
 from gpytorch.priors.torch_priors import GammaPrior, MultivariateNormalPrior
 from gpytorch.settings import fast_pred_var, skip_posterior_variances
-from torch import Size, Tensor
+from torch import Tensor
 from torch.nn import ModuleList, Parameter, ParameterList
 
 
@@ -61,10 +65,13 @@ class FlattenedStandardize(Standardize):
     """
 
     def __init__(
-        self, output_shape: Size, batch_shape: Size = None, min_stdv: float = 1e-8
+        self,
+        output_shape: torch.Size,
+        batch_shape: torch.Size = None,
+        min_stdv: float = 1e-8,
     ):
         if batch_shape is None:
-            batch_shape = Size()
+            batch_shape = torch.Size()
 
         super(FlattenedStandardize, self).__init__(
             m=1, outputs=None, batch_shape=batch_shape, min_stdv=min_stdv
@@ -129,207 +136,6 @@ class FlattenedStandardize(Standardize):
                 self._stdvs_sq * self._squeeze_to_single_output(v)
             ),
         )
-
-
-class HigherOrderGPPosterior(GPyTorchPosterior):
-    r"""
-    Posterior class for a Higher order Gaussian process model [Zhe2019hogp]. Extends the
-    standard GPyTorch posterior class by overwriting the rsample method. The posterior
-    variance is handled internally by the HigherOrderGP model.
-    HOGP is a tensorized GP model so the posterior covariance grows to be extremely
-    large, but is highly structured, which means that we can exploit Kronecker
-    identities to sample from the posterior using Matheron's rule as described in
-    [Doucet2010sampl]_. In general, this posterior should ONLY be used for HOGP models
-    that have highly structured covariances. It should also only be used internally when
-    called from the HigherOrderGP.posterior(...) method.
-    """
-
-    def __init__(
-        self,
-        mvn: MultivariateNormal,
-        joint_covariance_matrix: LazyTensor,
-        train_train_covar: LazyTensor,
-        test_train_covar: LazyTensor,
-        train_targets: Tensor,
-        output_shape: Size,
-        num_outputs: int,
-    ) -> None:
-        r"""A Posterior for HigherOrderGP models.
-
-        Args:
-            mvn: Posterior multivariate normal distribution
-            joint_covariance_matrix: Joint test train covariance matrix over the entire
-                tensor
-            train_train_covar: covariance matrix of train points in the data space
-            test_train_covar: covariance matrix of test x train points in the data space
-            train_targets: training responses vectorized
-            output_shape: shape output training responses
-            num_outputs: batch shaping of model
-        """
-        super().__init__(mvn)
-        self.joint_covariance_matrix = joint_covariance_matrix
-        self.train_train_covar = train_train_covar
-        self.test_train_covar = test_train_covar
-        self.train_targets = train_targets
-        self.output_shape = output_shape
-        self._is_mt = True
-        self.num_outputs = num_outputs
-
-    @property
-    def event_shape(self):
-        # overwrites the standard event_shape call to inform samplers that
-        # n + 2 n_train samples need to be drawn rather than n samples
-        # TODO: Expose a sample shape property that is independent of the event shape
-        # and handle those transparently in the samplers.
-        batch_shape = self.joint_covariance_matrix.shape[:-2]
-        sampling_shape = (
-            self.joint_covariance_matrix.shape[-2] + self.train_train_covar.shape[-2]
-        )
-        return batch_shape + torch.Size((sampling_shape,))
-
-    def _prepare_base_samples(
-        self, sample_shape: torch.Size, base_samples: Tensor = None
-    ) -> Tensor:
-        covariance_matrix = self.joint_covariance_matrix
-        joint_size = covariance_matrix.shape[-1]
-        batch_shape = covariance_matrix.batch_shape
-
-        if base_samples is not None:
-            if base_samples.shape[: len(sample_shape)] != sample_shape:
-                raise RuntimeError("sample_shape disagrees with shape of base_samples.")
-
-            appended_shape = joint_size + self.train_train_covar.shape[-1]
-            if appended_shape != base_samples.shape[-1]:
-                # get base_samples to the correct shape by expanding as sample shape,
-                # batch shape, then rest of dimensions. We have to add first the sample
-                # shape, then the batch shape of the model, and then finally the shape
-                # of the test data points squeezed into a single dimension, accessed
-                # from the test_train_covar.
-                base_sample_shapes = (
-                    sample_shape + batch_shape + self.test_train_covar.shape[-2:-1]
-                )
-                if base_samples.nelement() == base_sample_shapes.numel():
-                    base_samples = base_samples.reshape(base_sample_shapes)
-
-                    new_base_samples = torch.randn(
-                        *sample_shape,
-                        *batch_shape,
-                        appended_shape - base_samples.shape[-1],
-                        device=base_samples.device,
-                        dtype=base_samples.dtype,
-                    )
-                    base_samples = torch.cat((base_samples, new_base_samples), dim=-1)
-                else:
-                    # nuke the base samples if we cannot use them.
-                    base_samples = None
-
-        if base_samples is None:
-            # TODO: Allow qMC sampling
-            base_samples = torch.randn(
-                *sample_shape,
-                *batch_shape,
-                joint_size,
-                device=covariance_matrix.device,
-                dtype=covariance_matrix.dtype,
-            )
-
-            noise_base_samples = torch.randn(
-                *sample_shape,
-                *batch_shape,
-                self.train_train_covar.shape[-1],
-                device=covariance_matrix.device,
-                dtype=covariance_matrix.dtype,
-            )
-        else:
-            # finally split up the base samples
-            noise_base_samples = base_samples[..., joint_size:]
-            base_samples = base_samples[..., :joint_size]
-
-        perm_list = [*range(1, base_samples.ndim), 0]
-        return base_samples.permute(*perm_list), noise_base_samples.permute(*perm_list)
-
-    def rsample(
-        self,
-        sample_shape: Optional[torch.Size] = None,
-        base_samples: Optional[Tensor] = None,
-    ) -> Tensor:
-        r"""Sample from the posterior (with gradients).
-
-        As the posterior covariance is difficult to draw from in this model,
-        we implement Matheron's rule as described in [Doucet2010sampl]. This may not
-        work entirely correctly for deterministic base samples unless base samples
-        are provided that are of shape `n + 2 * n_train` because the sampling method
-        draws `2 * n_train` samples as well as the standard `n`.
-        samples.
-
-        Args:
-            sample_shape: A `torch.Size` object specifying the sample shape. To
-                draw `n` samples, set to `torch.Size([n])`. To draw `b` batches
-                of `n` samples each, set to `torch.Size([b, n])`.
-            base_samples: An (optional) Tensor of `N(0, I)` base samples of
-                appropriate dimension, typically obtained from a `Sampler`.
-                This is used for deterministic optimization.
-
-        Returns:
-            A `sample_shape x event_shape`-dim Tensor of samples from the posterior.
-        """
-        if sample_shape is None:
-            sample_shape = torch.Size([1])
-
-        base_samples, noise_base_samples = self._prepare_base_samples(
-            sample_shape, base_samples
-        )
-
-        # base samples now have trailing sample dimension
-        covariance_matrix = self.joint_covariance_matrix
-        covar_root = covariance_matrix.root_decomposition().root
-        samples = covar_root.matmul(base_samples)
-
-        # now pluck out Y_x and X_x
-        noiseless_train_marginal_samples = samples[
-            ..., : self.train_train_covar.shape[-1], :
-        ]
-        test_marginal_samples = samples[..., self.train_train_covar.shape[-1] :, :]
-        # we need to add noise to the train_joint_samples
-        # THIS ASSUMES CONSTANT NOISE
-        noise_std = self.train_train_covar.lazy_tensors[1]._diag[..., 0] ** 0.5
-        # TODO: cleanup the reshaping here
-        # expands the noise to allow broadcasting against the noise base samples
-        # reshape_as or view_as don't work here because we need to expand to
-        # broadcast against `samples x batch_shape x output_shape` while noise_std
-        # is `batch_shape x 1`.
-        if self.num_outputs > 1 or noise_std.ndim > 1:
-            ntms_dims = [
-                i == noise_std.shape[0] for i in noiseless_train_marginal_samples.shape
-            ]
-            for matched in ntms_dims:
-                if not matched:
-                    noise_std = noise_std.unsqueeze(-1)
-
-        # we need to add noise into the noiseless samples
-        noise_marginal_samples = noise_std * noise_base_samples
-
-        train_marginal_samples = (
-            noiseless_train_marginal_samples + noise_marginal_samples
-        )
-
-        # compute y - Y_x
-        train_rhs = self.train_targets - train_marginal_samples
-
-        # K_{train, train}^{-1} (y - Y_x)
-        # internally, this solve is done using Kronecker algebra and is fast.
-        kinv_rhs = self.train_train_covar.inv_matmul(train_rhs)
-        # multiply by cross-covariance
-        test_updated_samples = self.test_train_covar.matmul(kinv_rhs)
-
-        # add samples
-        test_cond_samples = test_marginal_samples + test_updated_samples
-        test_cond_samples = test_cond_samples.permute(
-            test_cond_samples.ndim - 1, *range(0, test_cond_samples.ndim - 1)
-        )
-
-        # reshape samples to be the actual size of the train targets
-        return test_cond_samples.reshape(*sample_shape, *self.output_shape)
 
 
 class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
@@ -564,19 +370,20 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         self, X: Tensor, Y: Tensor, **kwargs: Any
     ) -> HigherOrderGP:
         r"""Condition the model on new observations.
+
         Args:
             X: A `batch_shape x n' x d`-dim Tensor, where `d` is the dimension of
-            the feature space, `m` is the number of points per batch, and
-            `batch_shape` is the batch shape (must be compatible with the
-            batch shape of the model).
-
+                the feature space, `m` is the number of points per batch, and
+                `batch_shape` is the batch shape (must be compatible with the
+                batch shape of the model).
             Y: A `batch_shape' x n' x m_d`-dim Tensor, where `m_d` is the shaping
-            of the model outputs, `n'` is the number of points per batch, and
-            `batch_shape'` is the batch shape of the observations.
-            `batch_shape'` must be broadcastable to `batch_shape` using
-            standard broadcasting semantics. If `Y` has fewer batch dimensions
-            than `X`, its is assumed that the missing batch dimensions are
-            the same for all `Y`.
+                of the model outputs, `n'` is the number of points per batch, and
+                `batch_shape'` is the batch shape of the observations.
+                `batch_shape'` must be broadcastable to `batch_shape` using
+                standard broadcasting semantics. If `Y` has fewer batch dimensions
+                than `X`, its is assumed that the missing batch dimensions are
+                the same for all `Y`.
+
         Returns:
             A `BatchedMultiOutputGPyTorchModel` object of the same type with
             `n + n'` training examples, representing the original model
@@ -693,12 +500,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                 train_train_covar=train_train_covar,
                 test_train_covar=test_train_covar,
                 joint_covariance_matrix=full_covar.clone(),
-                output_shape=Size(
-                    (
-                        *X.shape[:-1],
-                        *self.target_shape,
-                    )
-                ),
+                output_shape=X.shape[:-1] + self.target_shape,
                 num_outputs=self._num_outputs,
             )
             if hasattr(self, "outcome_transform"):

--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -4,6 +4,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+r"""
+Outcome transformations for automatically transforming and un-transforming
+model outputs. Outcome transformations are typically part of a Model and
+applied (i) within the model constructor to transform the train observations
+to the model space, and (ii) in the `Model.posterior` call to untransform
+the model posterior back to the original space.
+"""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/botorch/posteriors/__init__.py
+++ b/botorch/posteriors/__init__.py
@@ -6,6 +6,7 @@
 
 from botorch.posteriors.deterministic import DeterministicPosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
+from botorch.posteriors.higher_order import HigherOrderGPPosterior
 from botorch.posteriors.posterior import Posterior
 from botorch.posteriors.transformed import TransformedPosterior
 
@@ -13,6 +14,7 @@ from botorch.posteriors.transformed import TransformedPosterior
 __all__ = [
     "DeterministicPosterior",
     "GPyTorchPosterior",
+    "HigherOrderGPPosterior",
     "Posterior",
     "TransformedPosterior",
 ]

--- a/botorch/posteriors/gpytorch.py
+++ b/botorch/posteriors/gpytorch.py
@@ -36,6 +36,14 @@ class GPyTorchPosterior(Posterior):
         self._is_mt = isinstance(mvn, MultitaskMultivariateNormal)
 
     @property
+    def base_sample_shape(self) -> torch.Size:
+        r"""The shape of a base sample used for constructing posterior samples."""
+        shape = self.mvn.batch_shape + self.mvn.base_sample_shape
+        if not self._is_mt:
+            shape += torch.Size([1])
+        return shape
+
+    @property
     def device(self) -> torch.device:
         r"""The torch device of the posterior."""
         return self.mvn.loc.device

--- a/botorch/posteriors/higher_order.py
+++ b/botorch/posteriors/higher_order.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+from botorch.posteriors.gpytorch import GPyTorchPosterior
+from gpytorch.distributions import MultivariateNormal
+from gpytorch.lazy import LazyTensor
+from torch import Tensor
+
+
+class HigherOrderGPPosterior(GPyTorchPosterior):
+    r"""
+    Posterior class for a Higher order Gaussian process model [Zhe2019hogp]_. Extends
+    the standard GPyTorch posterior class by overwriting the rsample method.
+    The posterior variance is handled internally by the HigherOrderGP model.
+    HOGP is a tensorized GP model so the posterior covariance grows to be extremely
+    large, but is highly structured, which means that we can exploit Kronecker
+    identities to sample from the posterior using Matheron's rule as described in
+    [Doucet2010sampl]_. In general, this posterior should ONLY be used for HOGP models
+    that have highly structured covariances. It should also only be used internally when
+    called from the HigherOrderGP.posterior(...) method.
+    """
+
+    def __init__(
+        self,
+        mvn: MultivariateNormal,
+        joint_covariance_matrix: LazyTensor,
+        train_train_covar: LazyTensor,
+        test_train_covar: LazyTensor,
+        train_targets: Tensor,
+        output_shape: torch.Size,
+        num_outputs: int,
+    ) -> None:
+        r"""A Posterior for HigherOrderGP models.
+
+        Args:
+            mvn: Posterior multivariate normal distribution
+            joint_covariance_matrix: Joint test train covariance matrix over the entire
+                tensor
+            train_train_covar: covariance matrix of train points in the data space
+            test_train_covar: covariance matrix of test x train points in the data space
+            train_targets: training responses vectorized
+            output_shape: shape output training responses
+            num_outputs: batch shaping of model
+        """
+        super().__init__(mvn)
+        self.joint_covariance_matrix = joint_covariance_matrix
+        self.train_train_covar = train_train_covar
+        self.test_train_covar = test_train_covar
+        self.train_targets = train_targets
+        self.output_shape = output_shape
+        self._is_mt = True
+        self.num_outputs = num_outputs
+
+    @property
+    def base_sample_shape(self):
+        # overwrites the standard base_sample_shape call to inform samplers that
+        # n + 2 n_train samples need to be drawn rather than n samples
+        joint_covar = self.joint_covariance_matrix
+        batch_shape = joint_covar.shape[:-2]
+        sampling_shape = torch.Size(
+            [joint_covar.shape[-2] + self.train_train_covar.shape[-2]]
+        )
+        return batch_shape + sampling_shape
+
+    @property
+    def event_shape(self):
+        return self.output_shape
+
+    def _prepare_base_samples(
+        self, sample_shape: torch.Size, base_samples: Tensor = None
+    ) -> Tensor:
+        covariance_matrix = self.joint_covariance_matrix
+        joint_size = covariance_matrix.shape[-1]
+        batch_shape = covariance_matrix.batch_shape
+
+        if base_samples is not None:
+            if base_samples.shape[: len(sample_shape)] != sample_shape:
+                raise RuntimeError("sample_shape disagrees with shape of base_samples.")
+
+            appended_shape = joint_size + self.train_train_covar.shape[-1]
+            if appended_shape != base_samples.shape[-1]:
+                # get base_samples to the correct shape by expanding as sample shape,
+                # batch shape, then rest of dimensions. We have to add first the sample
+                # shape, then the batch shape of the model, and then finally the shape
+                # of the test data points squeezed into a single dimension, accessed
+                # from the test_train_covar.
+                base_sample_shapes = (
+                    sample_shape + batch_shape + self.test_train_covar.shape[-2:-1]
+                )
+                if base_samples.nelement() == base_sample_shapes.numel():
+                    base_samples = base_samples.reshape(base_sample_shapes)
+
+                    new_base_samples = torch.randn(
+                        *sample_shape,
+                        *batch_shape,
+                        appended_shape - base_samples.shape[-1],
+                        device=base_samples.device,
+                        dtype=base_samples.dtype,
+                    )
+                    base_samples = torch.cat((base_samples, new_base_samples), dim=-1)
+                else:
+                    # nuke the base samples if we cannot use them.
+                    base_samples = None
+
+        if base_samples is None:
+            # TODO: Allow qMC sampling
+            base_samples = torch.randn(
+                *sample_shape,
+                *batch_shape,
+                joint_size,
+                device=covariance_matrix.device,
+                dtype=covariance_matrix.dtype,
+            )
+
+            noise_base_samples = torch.randn(
+                *sample_shape,
+                *batch_shape,
+                self.train_train_covar.shape[-1],
+                device=covariance_matrix.device,
+                dtype=covariance_matrix.dtype,
+            )
+        else:
+            # finally split up the base samples
+            noise_base_samples = base_samples[..., joint_size:]
+            base_samples = base_samples[..., :joint_size]
+
+        perm_list = [*range(1, base_samples.ndim), 0]
+        return base_samples.permute(*perm_list), noise_base_samples.permute(*perm_list)
+
+    def rsample(
+        self,
+        sample_shape: Optional[torch.Size] = None,
+        base_samples: Optional[Tensor] = None,
+    ) -> Tensor:
+        r"""Sample from the posterior (with gradients).
+
+        As the posterior covariance is difficult to draw from in this model,
+        we implement Matheron's rule as described in [Doucet2010sampl]-. This may not
+        work entirely correctly for deterministic base samples unless base samples
+        are provided that are of shape `n + 2 * n_train` because the sampling method
+        draws `2 * n_train` samples as well as the standard `n`.
+        samples.
+
+        Args:
+            sample_shape: A `torch.Size` object specifying the sample shape. To
+                draw `n` samples, set to `torch.Size([n])`. To draw `b` batches
+                of `n` samples each, set to `torch.Size([b, n])`.
+            base_samples: An (optional) Tensor of `N(0, I)` base samples of
+                appropriate dimension, typically obtained from a `Sampler`.
+                This is used for deterministic optimization.
+
+        Returns:
+            A `sample_shape x event_shape`-dim Tensor of samples from the posterior.
+        """
+        if sample_shape is None:
+            sample_shape = torch.Size([1])
+
+        base_samples, noise_base_samples = self._prepare_base_samples(
+            sample_shape, base_samples
+        )
+
+        # base samples now have trailing sample dimension
+        covariance_matrix = self.joint_covariance_matrix
+        covar_root = covariance_matrix.root_decomposition().root
+        samples = covar_root.matmul(base_samples)
+
+        # now pluck out Y_x and X_x
+        noiseless_train_marginal_samples = samples[
+            ..., : self.train_train_covar.shape[-1], :
+        ]
+        test_marginal_samples = samples[..., self.train_train_covar.shape[-1] :, :]
+        # we need to add noise to the train_joint_samples
+        # THIS ASSUMES CONSTANT NOISE
+        noise_std = self.train_train_covar.lazy_tensors[1]._diag[..., 0] ** 0.5
+        # TODO: cleanup the reshaping here
+        # expands the noise to allow broadcasting against the noise base samples
+        # reshape_as or view_as don't work here because we need to expand to
+        # broadcast against `samples x batch_shape x output_shape` while noise_std
+        # is `batch_shape x 1`.
+        if self.num_outputs > 1 or noise_std.ndim > 1:
+            ntms_dims = [
+                i == noise_std.shape[0] for i in noiseless_train_marginal_samples.shape
+            ]
+            for matched in ntms_dims:
+                if not matched:
+                    noise_std = noise_std.unsqueeze(-1)
+
+        # we need to add noise into the noiseless samples
+        noise_marginal_samples = noise_std * noise_base_samples
+
+        train_marginal_samples = (
+            noiseless_train_marginal_samples + noise_marginal_samples
+        )
+
+        # compute y - Y_x
+        train_rhs = self.train_targets - train_marginal_samples
+
+        # K_{train, train}^{-1} (y - Y_x)
+        # internally, this solve is done using Kronecker algebra and is fast.
+        kinv_rhs = self.train_train_covar.inv_matmul(train_rhs)
+        # multiply by cross-covariance
+        test_updated_samples = self.test_train_covar.matmul(kinv_rhs)
+
+        # add samples
+        test_cond_samples = test_marginal_samples + test_updated_samples
+        test_cond_samples = test_cond_samples.permute(
+            test_cond_samples.ndim - 1, *range(0, test_cond_samples.ndim - 1)
+        )
+
+        # reshape samples to be the actual size of the train targets
+        return test_cond_samples.reshape(*sample_shape, *self.output_shape)

--- a/botorch/posteriors/posterior.py
+++ b/botorch/posteriors/posterior.py
@@ -20,6 +20,16 @@ from torch import Tensor
 class Posterior(ABC):
     r"""Abstract base class for botorch posteriors."""
 
+    @property
+    def base_sample_shape(self) -> torch.Size:
+        r"""The shape of a base sample used for constructing posterior samples.
+
+        This function may be overwritten by subclasses in case `base_sample_shape`
+        and `event_shape` do not agree (e.g. if the posterior is a Multivariate
+        Gaussian that is not full rank).
+        """
+        return self.event_shape
+
     @abstractproperty
     def device(self) -> torch.device:
         r"""The torch device of the posterior."""

--- a/botorch/posteriors/transformed.py
+++ b/botorch/posteriors/transformed.py
@@ -44,6 +44,11 @@ class TransformedPosterior(Posterior):
         self._variance_transform = variance_transform
 
     @property
+    def base_sample_shape(self) -> torch.Size:
+        r"""The shape of a base sample used for constructing posterior samples."""
+        return self._posterior.base_sample_shape
+
+    @property
     def device(self) -> torch.device:
         r"""The torch device of the posterior."""
         return self._posterior.device

--- a/botorch/utils/gp_sampling.py
+++ b/botorch/utils/gp_sampling.py
@@ -73,9 +73,9 @@ class GPDraw(Module):
         else:
             X_eval = torch.cat([self.Xs, X], dim=-2)
         posterior = self._model.posterior(X=X_eval)
-        event_shape = posterior.event_shape
+        base_sample_shape = posterior.base_sample_shape
         # re-use old samples
-        bs_shape = event_shape[:-2] + X.shape[-2:-1] + event_shape[-1:]
+        bs_shape = base_sample_shape[:-2] + X.shape[-2:-1] + base_sample_shape[-1:]
         with manual_seed(seed=int(self._seed)):
             new_base_samples = torch.randn(bs_shape, device=X.device, dtype=X.dtype)
         seed = self._seed + 1

--- a/sphinx/source/posteriors.rst
+++ b/sphinx/source/posteriors.rst
@@ -29,6 +29,11 @@ Determinstic Posterior
 .. automodule:: botorch.posteriors.deterministic
     :members:
 
+Higher Order GP Posterior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.posteriors.higher_order
+    :members:
+
 Transformed Posterior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.posteriors.transformed

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -485,7 +485,7 @@ class TestPruneInferiorPoints(BotorchTestCase):
             with ExitStack() as es:
                 mock_event_shape = es.enter_context(
                     mock.patch(
-                        "botorch.utils.testing.MockPosterior.event_shape",
+                        "botorch.utils.testing.MockPosterior.base_sample_shape",
                         new_callable=mock.PropertyMock,
                     )
                 )

--- a/test/models/test_higher_order_gp.py
+++ b/test/models/test_higher_order_gp.py
@@ -4,9 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 import itertools
 
+import torch
 from botorch.models import HigherOrderGP
 from botorch.models.higher_order_gp import FlattenedStandardize
 from botorch.models.transforms.input import Normalize
@@ -19,18 +19,15 @@ from gpytorch.kernels import RBFKernel
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.mlls import ExactMarginalLogLikelihood
 from gpytorch.settings import skip_posterior_variances
-from numpy import prod
-from torch import Size, allclose, rand, randn
-from torch.random import manual_seed
 
 
 class TestHigherOrderGP(BotorchTestCase):
     def setUp(self):
         super().setUp()
-        manual_seed(0)
+        torch.random.manual_seed(0)
 
-        train_x = rand(2, 10, 1, device=self.device)
-        train_y = randn(2, 10, 3, 5, device=self.device)
+        train_x = torch.rand(2, 10, 1, device=self.device)
+        train_y = torch.randn(2, 10, 3, 5, device=self.device)
 
         self.model = HigherOrderGP(train_x, train_y)
 
@@ -47,30 +44,30 @@ class TestHigherOrderGP(BotorchTestCase):
             fit_gpytorch_torch(mll, options={"maxiter": 1, "disp": False})
 
     def test_num_output_dims(self):
-        train_x = rand(2, 10, 1, device=self.device)
-        train_y = randn(2, 10, 3, 5, device=self.device)
+        train_x = torch.rand(2, 10, 1, device=self.device)
+        train_y = torch.randn(2, 10, 3, 5, device=self.device)
         model = HigherOrderGP(train_x, train_y)
 
         # check that it correctly inferred that this is a batched model
         self.assertEqual(model._num_outputs, 2)
 
-        train_x = rand(10, 1, device=self.device)
-        train_y = randn(10, 3, 5, 2, device=self.device)
+        train_x = torch.rand(10, 1, device=self.device)
+        train_y = torch.randn(10, 3, 5, 2, device=self.device)
         model = HigherOrderGP(train_x, train_y)
 
         # non-batched case
         self.assertEqual(model._num_outputs, 1)
 
-        train_x = rand(3, 2, 10, 1, device=self.device)
-        train_y = randn(3, 2, 10, 3, 5, device=self.device)
+        train_x = torch.rand(3, 2, 10, 1, device=self.device)
+        train_y = torch.randn(3, 2, 10, 3, 5, device=self.device)
 
         # check the error when using multi-dim batch_shape
         with self.assertRaises(NotImplementedError):
             model = HigherOrderGP(train_x, train_y)
 
     def test_posterior(self):
-        manual_seed(0)
-        test_x = rand(2, 30, 1).to(device=self.device)
+        torch.random.manual_seed(0)
+        test_x = torch.rand(2, 30, 1).to(device=self.device)
 
         # test the posterior works
         posterior = self.model.posterior(test_x)
@@ -88,8 +85,8 @@ class TestHigherOrderGP(BotorchTestCase):
             self.assertLessEqual(posterior.variance.max(), 1e-6)
 
     def test_transforms(self):
-        train_x = rand(10, 3, device=self.device)
-        train_y = randn(10, 4, 5, device=self.device)
+        train_x = torch.rand(10, 3, device=self.device)
+        train_y = torch.randn(10, 4, 5, device=self.device)
 
         # test handling of Standardize
         with self.assertWarns(RuntimeWarning):
@@ -98,7 +95,7 @@ class TestHigherOrderGP(BotorchTestCase):
             )
         self.assertIsInstance(model.outcome_transform, FlattenedStandardize)
         self.assertEqual(model.outcome_transform.output_shape, train_y.shape[1:])
-        self.assertEqual(model.outcome_transform.batch_shape, Size())
+        self.assertEqual(model.outcome_transform.batch_shape, torch.Size())
 
         model = HigherOrderGP(
             train_X=train_x,
@@ -109,8 +106,8 @@ class TestHigherOrderGP(BotorchTestCase):
         mll = ExactMarginalLogLikelihood(model.likelihood, model)
         fit_gpytorch_torch(mll, options={"maxiter": 1, "disp": False})
 
-        test_x = rand(2, 5, 3, device=self.device)
-        test_y = randn(2, 5, 4, 5, device=self.device)
+        test_x = torch.rand(2, 5, 3, device=self.device)
+        test_y = torch.randn(2, 5, 4, 5, device=self.device)
         posterior = model.posterior(test_x)
         self.assertIsInstance(posterior, TransformedPosterior)
 
@@ -121,35 +118,35 @@ class TestHigherOrderGP(BotorchTestCase):
         self.check_transform_untransform(model)
 
     def check_transform_forward(self, model):
-        train_y = randn(2, 10, 4, 5, device=self.device)
-        train_y_var = rand(2, 10, 4, 5, device=self.device)
+        train_y = torch.randn(2, 10, 4, 5, device=self.device)
+        train_y_var = torch.rand(2, 10, 4, 5, device=self.device)
 
         output, output_var = model.outcome_transform.forward(train_y)
-        self.assertEqual(output.shape, Size((2, 10, 4, 5)))
+        self.assertEqual(output.shape, torch.Size((2, 10, 4, 5)))
         self.assertEqual(output_var, None)
 
         output, output_var = model.outcome_transform.forward(train_y, train_y_var)
-        self.assertEqual(output.shape, Size((2, 10, 4, 5)))
-        self.assertEqual(output_var.shape, Size((2, 10, 4, 5)))
+        self.assertEqual(output.shape, torch.Size((2, 10, 4, 5)))
+        self.assertEqual(output_var.shape, torch.Size((2, 10, 4, 5)))
 
     def check_transform_untransform(self, model):
         output, output_var = model.outcome_transform.untransform(
-            randn(2, 2, 4, 5, device=self.device)
+            torch.randn(2, 2, 4, 5, device=self.device)
         )
-        self.assertEqual(output.shape, Size((2, 2, 4, 5)))
+        self.assertEqual(output.shape, torch.Size((2, 2, 4, 5)))
         self.assertEqual(output_var, None)
 
         output, output_var = model.outcome_transform.untransform(
-            randn(2, 2, 4, 5, device=self.device),
-            rand(2, 2, 4, 5, device=self.device),
+            torch.randn(2, 2, 4, 5, device=self.device),
+            torch.rand(2, 2, 4, 5, device=self.device),
         )
-        self.assertEqual(output.shape, Size((2, 2, 4, 5)))
-        self.assertEqual(output_var.shape, Size((2, 2, 4, 5)))
+        self.assertEqual(output.shape, torch.Size((2, 2, 4, 5)))
+        self.assertEqual(output_var.shape, torch.Size((2, 2, 4, 5)))
 
     def test_condition_on_observations(self):
-        manual_seed(0)
-        test_x = rand(2, 5, 1, device=self.device)
-        test_y = randn(2, 5, 3, 5, device=self.device)
+        torch.random.manual_seed(0)
+        test_x = torch.rand(2, 5, 1, device=self.device)
+        test_y = torch.randn(2, 5, 3, 5, device=self.device)
 
         # dummy call to ensure caches have been computed
         _ = self.model.posterior(test_x)
@@ -157,20 +154,20 @@ class TestHigherOrderGP(BotorchTestCase):
         self.assertIsInstance(conditioned_model, HigherOrderGP)
 
     def test_fantasize(self):
-        manual_seed(0)
-        test_x = rand(2, 5, 1, device=self.device)
+        torch.random.manual_seed(0)
+        test_x = torch.rand(2, 5, 1, device=self.device)
         sampler = IIDNormalSampler(num_samples=32).to(self.device)
 
         _ = self.model.posterior(test_x)
         fantasy_model = self.model.fantasize(test_x, sampler=sampler)
         self.assertIsInstance(fantasy_model, HigherOrderGP)
-        self.assertEqual(fantasy_model.train_inputs[0].shape[:2], Size((32, 2)))
+        self.assertEqual(fantasy_model.train_inputs[0].shape[:2], torch.Size((32, 2)))
 
     def test_initialize_latents(self):
-        manual_seed(0)
+        torch.random.manual_seed(0)
 
-        train_x = rand(10, 1, device=self.device)
-        train_y = randn(10, 3, 5, device=self.device)
+        train_x = torch.rand(10, 1, device=self.device)
+        train_y = torch.randn(10, 3, 5, device=self.device)
 
         for latent_dim_sizes, latent_init in itertools.product(
             [[1, 1], [2, 3]],
@@ -184,112 +181,9 @@ class TestHigherOrderGP(BotorchTestCase):
             )
             self.assertEqual(
                 self.model.latent_parameters[0].shape,
-                Size((3, latent_dim_sizes[0])),
+                torch.Size((3, latent_dim_sizes[0])),
             )
             self.assertEqual(
                 self.model.latent_parameters[1].shape,
-                Size((5, latent_dim_sizes[1])),
-            )
-
-
-class TestHigherOrderGPPosterior(BotorchTestCase):
-    def setUp(self):
-        super().setUp()
-        manual_seed(0)
-
-        train_x = rand(2, 10, 1, device=self.device)
-        train_y = randn(2, 10, 3, 5, device=self.device)
-
-        m1 = HigherOrderGP(train_x, train_y)
-        m2 = HigherOrderGP(train_x[0], train_y[0])
-
-        manual_seed(0)
-        test_x = rand(2, 5, 1, device=self.device)
-
-        posterior1 = m1.posterior(test_x)
-        posterior2 = m2.posterior(test_x[0])
-        posterior3 = m2.posterior(test_x)
-
-        self.post_list = [
-            [m1, test_x, posterior1],
-            [m2, test_x[0], posterior2],
-            [m2, test_x, posterior3],
-        ]
-
-    def test_posterior(self):
-        # test the posterior works
-        sample_shaping = [5, 3, 5]
-
-        for post_collection in self.post_list:
-            model, test_x, posterior = post_collection
-
-            self.assertIsInstance(posterior, GPyTorchPosterior)
-
-            correct_shape = [2] if test_x.shape[0] == 2 else []
-            [correct_shape.append(s) for s in sample_shaping]
-
-            # test providing no base samples
-            samples_0 = posterior.rsample()
-            self.assertEqual(samples_0.shape, Size((1, *correct_shape)))
-
-            # test that providing all base samples produces non-random results
-            if test_x.shape[0] == 2:
-                base_samples = randn(8, 2, (5 + 10 + 10) * 3 * 5, device=self.device)
-            else:
-                base_samples = randn(8, (5 + 10 + 10) * 3 * 5, device=self.device)
-
-            samples_1 = posterior.rsample(
-                base_samples=base_samples, sample_shape=Size((8,))
-            )
-            samples_2 = posterior.rsample(
-                base_samples=base_samples, sample_shape=Size((8,))
-            )
-            self.assertTrue(allclose(samples_1, samples_2))
-
-            # test that botorch.sampler picks up the correct shapes
-            sampler = IIDNormalSampler(num_samples=5)
-            samples_det_shape = sampler(posterior).shape
-            self.assertEqual(samples_det_shape, Size([5, *correct_shape]))
-
-            # test that providing only some base samples is okay
-            base_samples = randn(8, prod(correct_shape), device=self.device)
-            samples_3 = posterior.rsample(
-                base_samples=base_samples, sample_shape=Size((8,))
-            )
-            self.assertEqual(samples_3.shape, Size([8, *correct_shape]))
-
-            # test that providing the wrong number base samples is okay
-            base_samples = randn(8, 50 * 2 * 3 * 5, device=self.device)
-            samples_4 = posterior.rsample(
-                base_samples=base_samples, sample_shape=Size((8,))
-            )
-            self.assertEqual(samples_4.shape, Size([8, *correct_shape]))
-
-            # test that providing the wrong shapes of base samples fails
-            base_samples = randn(8, 5 * 2 * 3 * 5, device=self.device)
-            with self.assertRaises(RuntimeError):
-                samples_4 = posterior.rsample(
-                    base_samples=base_samples, sample_shape=Size((4,))
-                )
-
-            # finally we check the quality of the variances and the samples
-            # test that the posterior variances are the same as the evaluation variance
-            posterior_variance = posterior.variance
-
-            model.eval()
-            eval_mode_variance = model(test_x).variance.reshape_as(posterior_variance)
-            self.assertLess(
-                (posterior_variance - eval_mode_variance).norm()
-                / eval_mode_variance.norm(),
-                4e-2,
-            )
-
-            # and finally test that sampling with no base samples is okay
-            samples_3 = posterior.rsample(sample_shape=Size((5000,)))
-            sampled_variance = samples_3.var(dim=0).view(-1)
-            posterior_variance = posterior_variance.view(-1)
-            self.assertLess(
-                (posterior_variance - sampled_variance).norm()
-                / posterior_variance.norm(),
-                5e-2,
+                torch.Size((5, latent_dim_sizes[1])),
             )

--- a/test/posteriors/test_higher_order.py
+++ b/test/posteriors/test_higher_order.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import numpy as np
+import torch
+from botorch.models.higher_order_gp import HigherOrderGP
+from botorch.posteriors.higher_order import HigherOrderGPPosterior
+from botorch.sampling import IIDNormalSampler
+from botorch.utils.testing import BotorchTestCase
+
+
+class TestHigherOrderGPPosterior(BotorchTestCase):
+    def setUp(self):
+        super().setUp()
+        torch.random.manual_seed(0)
+
+        train_x = torch.rand(2, 10, 1, device=self.device)
+        train_y = torch.randn(2, 10, 3, 5, device=self.device)
+
+        m1 = HigherOrderGP(train_x, train_y)
+        m2 = HigherOrderGP(train_x[0], train_y[0])
+
+        torch.random.manual_seed(0)
+        test_x = torch.rand(2, 5, 1, device=self.device)
+
+        posterior1 = m1.posterior(test_x)
+        posterior2 = m2.posterior(test_x[0])
+        posterior3 = m2.posterior(test_x)
+
+        self.post_list = [
+            [m1, test_x, posterior1],
+            [m2, test_x[0], posterior2],
+            [m2, test_x, posterior3],
+        ]
+
+    def test_HigherOrderGPPosterior(self):
+        sample_shaping = torch.Size([5, 3, 5])
+
+        for post_collection in self.post_list:
+            model, test_x, posterior = post_collection
+
+            self.assertIsInstance(posterior, HigherOrderGPPosterior)
+
+            batch_shape = test_x.shape[:-2]
+            # expected_event_shape = batch_shape + sample_shaping[-2:]
+            expected_event_shape = batch_shape + sample_shaping
+
+            self.assertEqual(posterior.event_shape, expected_event_shape)
+
+            # test providing no base samples
+            samples_0 = posterior.rsample()
+            self.assertEqual(samples_0.shape, torch.Size((1, *expected_event_shape)))
+
+            # test that providing all base samples produces non-torch.random results
+            if len(batch_shape) > 0:
+                base_sample_shape = (8, 2, (5 + 10 + 10) * 3 * 5)
+            else:
+                base_sample_shape = (8, (5 + 10 + 10) * 3 * 5)
+            base_samples = torch.randn(*base_sample_shape, device=self.device)
+
+            samples_1 = posterior.rsample(
+                base_samples=base_samples, sample_shape=torch.Size((8,))
+            )
+            samples_2 = posterior.rsample(
+                base_samples=base_samples, sample_shape=torch.Size((8,))
+            )
+            self.assertTrue(torch.allclose(samples_1, samples_2))
+
+            # test that botorch.sampler picks up the correct shapes
+            sampler = IIDNormalSampler(num_samples=5)
+            samples_det_shape = sampler(posterior).shape
+            self.assertEqual(samples_det_shape, torch.Size([5, *expected_event_shape]))
+
+            # test that providing only some base samples is okay
+            base_samples = torch.randn(
+                8, np.prod(expected_event_shape), device=self.device
+            )
+            samples_3 = posterior.rsample(
+                base_samples=base_samples, sample_shape=torch.Size((8,))
+            )
+            self.assertEqual(samples_3.shape, torch.Size([8, *expected_event_shape]))
+
+            # test that providing the wrong number base samples is okay
+            base_samples = torch.randn(8, 50 * 2 * 3 * 5, device=self.device)
+            samples_4 = posterior.rsample(
+                base_samples=base_samples, sample_shape=torch.Size((8,))
+            )
+            self.assertEqual(samples_4.shape, torch.Size([8, *expected_event_shape]))
+
+            # test that providing the wrong shapes of base samples fails
+            base_samples = torch.randn(8, 5 * 2 * 3 * 5, device=self.device)
+            with self.assertRaises(RuntimeError):
+                samples_4 = posterior.rsample(
+                    base_samples=base_samples, sample_shape=torch.Size((4,))
+                )
+
+            # finally we check the quality of the variances and the samples
+            # test that the posterior variances are the same as the evaluation variance
+            posterior_variance = posterior.variance
+
+            model.eval()
+            eval_mode_variance = model(test_x).variance.reshape_as(posterior_variance)
+            self.assertLess(
+                (posterior_variance - eval_mode_variance).norm()
+                / eval_mode_variance.norm(),
+                4e-2,
+            )
+
+            # and finally test that sampling with no base samples is okay
+            samples_3 = posterior.rsample(sample_shape=torch.Size((5000,)))
+            sampled_variance = samples_3.var(dim=0).view(-1)
+            posterior_variance = posterior_variance.view(-1)
+            self.assertLess(
+                (posterior_variance - sampled_variance).norm()
+                / posterior_variance.norm(),
+                5e-2,
+            )

--- a/test/posteriors/test_transformed.py
+++ b/test/posteriors/test_transformed.py
@@ -36,6 +36,7 @@ class TestTransformedPosterior(BotorchTestCase):
                 self.assertEqual(p_tf.device.type, self.device.type)
                 self.assertTrue(p_tf.dtype == dtype)
                 self.assertEqual(p_tf.event_shape, shape)
+                self.assertEqual(p_tf.base_sample_shape, shape)
                 self.assertTrue(torch.equal(p_tf.mean, 2 * mean + variance))
                 self.assertTrue(torch.equal(p_tf.variance, mean + 2 * variance))
                 # rsample


### PR DESCRIPTION
This allows base sample shapes that are different from the posterior's `event_shape`. This is relevant e.g if for GPyTorch MVN posteriors the covariance is singular, or if a low-rank approximation of the root decomposition is used. 
See the corresponding GPyTorch PR here: https://github.com/cornellius-gp/gpytorch/pull/1502

Also does some cleanup and moves the `HigherOrderGPPosterior` into the `posteriors` module.