### PR TITLE
Add conda tests to the "Test against stable" workflow

### DIFF
--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
 
-  tests-and-coverage:
+  tests-and-coverage-pip-stable:
     name: Tests and coverage (pip, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -26,3 +26,30 @@ jobs:
     - name: Unit tests and coverage
       run: |
         pytest -ra --cov=. --cov-report term-missing
+
+  tests-conda-stable:
+    name: Tests (conda, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.7", "3.8"]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        miniconda-version: "latest"
+        activate-environment: test
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      shell: bash -l {0}
+      run: |
+        conda install -y -c pytorch pytorch cpuonly
+        conda install -y pip scipy pytest
+        conda install -y -c gpytorch gpytorch
+        pip install .[test]
+    - name: Unit tests
+      shell: bash -l {0}
+      run: |
+        pytest -ra


### PR DESCRIPTION
Makes it easier to automatically verify that comda packages for deps are available and updated to the latest version.