### PR TITLE
Properly source shell in anaconda deployment workflow step

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -91,6 +91,7 @@ jobs:
       run: |
         ./scripts/build_and_verify_conda_package.sh
     - name: Deploy to anaconda.org
+      shell: bash -l {0}
       run: |
         botorch_version=$(python setup.py --version)
         build_dir="$(pwd)/.conda/conda_build/noarch"


### PR DESCRIPTION
I believe this should fix the following failure: https://github.com/pytorch/botorch/runs/1965071028?check_suite_focus=true