### PR TITLE
normalize before clamping in input warping transform

### DIFF
--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -216,7 +216,10 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
         )
         if prune_baseline:
             X_baseline = prune_inferior_points(
-                model=model, X=X_baseline, objective=objective
+                model=model,
+                X=X_baseline,
+                objective=objective,
+                marginalize_dim=kwargs.get("marginalize_dim"),
             )
         self.register_buffer("X_baseline", X_baseline)
 
@@ -241,7 +244,7 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
         posterior = self.model.posterior(X_full)
         samples = self.sampler(posterior)
         obj = self.objective(samples, X=X_full)
-        diffs = obj[:, :, :q].max(dim=-1)[0] - obj[:, :, q:].max(dim=-1)[0]
+        diffs = obj[..., :q].max(dim=-1).values - obj[..., q:].max(dim=-1).values
         return diffs.clamp_min(0).mean(dim=0)
 
 

--- a/botorch/utils/transforms.py
+++ b/botorch/utils/transforms.py
@@ -152,6 +152,11 @@ def _verify_output_shape(acqf: Any, X: Tensor, output: Tensor) -> bool:
             output.shape == X.shape[:-2]
             or (output.shape == torch.Size() and X.shape[:-2] == torch.Size([1]))
             or output.shape == acqf.model.batch_shape
+            # for a batched model, we may unsqueeze a batch dimension in X
+            # corresponding to the model's batch dim. In that case the
+            # acquisition function output should replace the right-most
+            # batch dim of X with the model's batch shape.
+            or output.shape == X.shape[:-3] + acqf.model.batch_shape
         )
     except (AttributeError, NotImplementedError):
         # acqf does not have model or acqf.model does not define `batch_shape`
@@ -210,6 +215,7 @@ def t_batch_mode_transform(
                     f"Expected X to be `batch_shape x q={expected_q} x d`, but"
                     f" got X with shape {X.shape}."
                 )
+            # add t-batch dim
             X = X if X.dim() > 2 else X.unsqueeze(0)
             output = method(acqf, X, *args, **kwargs)
             if assert_output_shape and not _verify_output_shape(

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -363,6 +363,15 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
                     )
                 mock_prune.assert_called_once()
                 self.assertTrue(torch.equal(acqf.X_baseline, X_pruned))
+                with mock.patch(prune, return_value=X_pruned) as mock_prune:
+                    acqf = qNoisyExpectedImprovement(
+                        model=mm,
+                        X_baseline=X_baseline,
+                        prune_baseline=True,
+                        marginalize_dim=-3,
+                    )
+                    _, kwargs = mock_prune.call_args
+                    self.assertEqual(kwargs["marginalize_dim"], -3)
 
     # TODO: Test different objectives (incl. constraints)
 

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -449,9 +449,7 @@ class TestInputTransforms(BotorchTestCase):
                     X, batch_shape=warp_tf.batch_shape
                 )
                 expected_X_tf[..., indices] = k.cdf(
-                    expected_X_tf[..., indices]
-                    .clamp_min(warp_tf.eps)
-                    .clamp_max(1 - warp_tf.eps)
+                    expected_X_tf[..., indices] * warp_tf._X_range + warp_tf._X_min
                 )
 
                 self.assertTrue(torch.equal(expected_X_tf, X_tf))

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -18,6 +18,7 @@ from botorch.models.transforms.input import (
     Normalize,
     Round,
 )
+from botorch.models.transforms.utils import expand_and_copy_tensor
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.priors import LogNormalPrior
 from torch.nn import Module
@@ -25,8 +26,13 @@ from torch.nn import Module
 
 def get_test_warp(indices, **kwargs):
     warp_tf = Warp(indices=indices, **kwargs)
-    warp_tf._set_concentration(0, torch.tensor([1.0, 2.0]))
-    warp_tf._set_concentration(1, torch.tensor([2.0, 3.0]))
+    c0 = torch.tensor([1.0, 2.0])[: len(indices)]
+    c1 = torch.tensor([2.0, 3.0])[: len(indices)]
+    batch_shape = kwargs.get("batch_shape", torch.Size([]))
+    c0 = c0.expand(batch_shape + c0.shape)
+    c1 = c1.expand(batch_shape + c1.shape)
+    warp_tf._set_concentration(0, c0)
+    warp_tf._set_concentration(1, c1)
     return warp_tf
 
 
@@ -416,107 +422,133 @@ class TestInputTransforms(BotorchTestCase):
                 self.assertTrue(torch.equal(log_tf.preprocess_transform(X), X_tf))
 
     def test_warp_transform(self):
-        for dtype in (torch.float, torch.double):
+        for dtype, batch_shape, warp_batch_shape in itertools.product(
+            (torch.float, torch.double),
+            (torch.Size(), torch.Size([3])),
+            (torch.Size(), torch.Size([2])),
+        ):
             tkwargs = {"device": self.device, "dtype": dtype}
 
             # basic init
             indices = [0, 2]
-            warp_tf = get_test_warp(indices).to(**tkwargs)
+            warp_tf = get_test_warp(indices, batch_shape=warp_batch_shape).to(**tkwargs)
             self.assertTrue(warp_tf.training)
 
             k = Kumaraswamy(warp_tf.concentration1, warp_tf.concentration0)
 
             self.assertEqual(warp_tf.indices.tolist(), indices)
 
-            # basic usage
-            for batch_shape in (torch.Size(), torch.Size([3])):
-                X = torch.rand(*batch_shape, 4, 3, **tkwargs)
-                with torch.no_grad():
-                    warp_tf = get_test_warp(indices=indices).to(**tkwargs)
-                    X_tf = warp_tf(X)
-                    expected_X_tf = X.clone()
-                    expected_X_tf[..., indices] = k.cdf(
-                        expected_X_tf[..., indices]
-                        .clamp_min(warp_tf.eps)
-                        .clamp_max(1 - warp_tf.eps)
-                    )
-                    # check non-integers parameters are unchanged
-                    self.assertTrue(torch.equal(expected_X_tf, X_tf))
-
-                    # test untransform
-                    untransformed_X = warp_tf.untransform(X_tf)
-                    self.assertTrue(
-                        torch.allclose(
-                            untransformed_X,
-                            X,
-                            rtol=1e-3,
-                            atol=1e-3 if self.device == torch.device("cpu") else 1e-2,
-                        )
-                    )
-
-                    # test no transform on eval
-                    warp_tf = get_test_warp(indices, transform_on_eval=False).to(
-                        **tkwargs
-                    )
-                    X_tf = warp_tf(X)
-                    self.assertFalse(torch.equal(X, X_tf))
-                    warp_tf.eval()
-                    X_tf = warp_tf(X)
-                    self.assertTrue(torch.equal(X, X_tf))
-
-                    # test no transform on train
-                    warp_tf = get_test_warp(
-                        indices=indices, transform_on_train=False
-                    ).to(**tkwargs)
-                    X_tf = warp_tf(X)
-                    self.assertTrue(torch.equal(X, X_tf))
-                    warp_tf.eval()
-                    X_tf = warp_tf(X)
-                    self.assertFalse(torch.equal(X, X_tf))
-
-                    # test equals
-                    warp_tf2 = get_test_warp(
-                        indices=indices, transform_on_train=False
-                    ).to(**tkwargs)
-                    self.assertTrue(warp_tf.equals(warp_tf2))
-                    # test different transform_on_train
-                    warp_tf2 = get_test_warp(indices=indices)
-                    self.assertFalse(warp_tf.equals(warp_tf2))
-                    # test different indices
-                    warp_tf2 = get_test_warp(
-                        indices=[0, 1], transform_on_train=False
-                    ).to(**tkwargs)
-                    self.assertFalse(warp_tf.equals(warp_tf2))
-
-                    # test preprocess_transform
-                    self.assertTrue(torch.equal(warp_tf.preprocess_transform(X), X))
-                    warp_tf.transform_on_preprocess = True
-                    self.assertTrue(torch.equal(warp_tf.preprocess_transform(X), X_tf))
-
-                    # test _set_concentration
-                    warp_tf._set_concentration(0, warp_tf.concentration0.shape)
-                    warp_tf._set_concentration(1, warp_tf.concentration1.shape)
-
-                    # test concentration prior
-                    prior0 = LogNormalPrior(0.0, 0.75).to(**tkwargs)
-                    prior1 = LogNormalPrior(0.0, 0.5).to(**tkwargs)
-                    warp_tf = get_test_warp(
-                        indices=[0, 1],
-                        concentration0_prior=prior0,
-                        concentration1_prior=prior1,
-                    )
-                    for i, (name, module, p, _, _) in enumerate(warp_tf.named_priors()):
-                        self.assertEqual(name, f"concentration{i}_prior")
-                        self.assertIsInstance(p, LogNormalPrior)
-                        self.assertEqual(p.base_dist.scale, 0.75 if i == 0 else 0.5)
-
-                # test gradients
-                X = 1 + 5 * torch.rand(*batch_shape, 4, 3, **tkwargs)
-                warp_tf = get_test_warp(indices=indices).to(**tkwargs)
+            X = torch.rand(*batch_shape, 4, 3, **tkwargs)
+            X = X.unsqueeze(-3) if len(warp_batch_shape) > 0 else X
+            with torch.no_grad():
+                warp_tf = get_test_warp(
+                    indices=indices, batch_shape=warp_batch_shape
+                ).to(**tkwargs)
                 X_tf = warp_tf(X)
-                X_tf.sum().backward()
-                for grad in (warp_tf.concentration0.grad, warp_tf.concentration1.grad):
-                    self.assertIsNotNone(grad)
-                    self.assertFalse(torch.isnan(grad).any())
-                    self.assertFalse(torch.isinf(grad).any())
-                    self.assertFalse((grad == 0).all())
+                expected_X_tf = expand_and_copy_tensor(
+                    X, batch_shape=warp_tf.batch_shape
+                )
+                expected_X_tf[..., indices] = k.cdf(
+                    expected_X_tf[..., indices]
+                    .clamp_min(warp_tf.eps)
+                    .clamp_max(1 - warp_tf.eps)
+                )
+
+                self.assertTrue(torch.equal(expected_X_tf, X_tf))
+
+                # test untransform
+                untransformed_X = warp_tf.untransform(X_tf)
+                self.assertTrue(
+                    torch.allclose(
+                        untransformed_X,
+                        expand_and_copy_tensor(X, batch_shape=warp_tf.batch_shape),
+                        rtol=1e-3,
+                        atol=1e-3 if self.device == torch.device("cpu") else 1e-2,
+                    )
+                )
+                if len(warp_batch_shape) > 0:
+                    with self.assertRaises(BotorchTensorDimensionError):
+                        warp_tf.untransform(X_tf.unsqueeze(-3))
+
+                # test no transform on eval
+                warp_tf = get_test_warp(
+                    indices, transform_on_eval=False, batch_shape=warp_batch_shape
+                ).to(**tkwargs)
+                X_tf = warp_tf(X)
+                self.assertFalse(torch.equal(X, X_tf))
+                warp_tf.eval()
+                X_tf = warp_tf(X)
+                self.assertTrue(torch.equal(X, X_tf))
+
+                # test no transform on train
+                warp_tf = get_test_warp(
+                    indices=indices,
+                    transform_on_train=False,
+                    batch_shape=warp_batch_shape,
+                ).to(**tkwargs)
+                X_tf = warp_tf(X)
+                self.assertTrue(torch.equal(X, X_tf))
+                warp_tf.eval()
+                X_tf = warp_tf(X)
+                self.assertFalse(torch.equal(X, X_tf))
+
+                # test equals
+                warp_tf2 = get_test_warp(
+                    indices=indices,
+                    transform_on_train=False,
+                    batch_shape=warp_batch_shape,
+                ).to(**tkwargs)
+                self.assertTrue(warp_tf.equals(warp_tf2))
+                # test different transform_on_train
+                warp_tf2 = get_test_warp(indices=indices, batch_shape=warp_batch_shape)
+                self.assertFalse(warp_tf.equals(warp_tf2))
+                # test different indices
+                warp_tf2 = get_test_warp(
+                    indices=[0, 1],
+                    transform_on_train=False,
+                    batch_shape=warp_batch_shape,
+                ).to(**tkwargs)
+                self.assertFalse(warp_tf.equals(warp_tf2))
+
+                # test preprocess_transform
+                self.assertTrue(torch.equal(warp_tf.preprocess_transform(X), X))
+                warp_tf.transform_on_preprocess = True
+                self.assertTrue(torch.equal(warp_tf.preprocess_transform(X), X_tf))
+
+                # test _set_concentration
+                warp_tf._set_concentration(0, warp_tf.concentration0)
+                warp_tf._set_concentration(1, warp_tf.concentration1)
+
+                # test concentration prior
+                prior0 = LogNormalPrior(0.0, 0.75).to(**tkwargs)
+                prior1 = LogNormalPrior(0.0, 0.5).to(**tkwargs)
+                warp_tf = get_test_warp(
+                    indices=[0, 1],
+                    concentration0_prior=prior0,
+                    concentration1_prior=prior1,
+                    batch_shape=warp_batch_shape,
+                )
+                for i, (name, _, p, _, _) in enumerate(warp_tf.named_priors()):
+                    self.assertEqual(name, f"concentration{i}_prior")
+                    self.assertIsInstance(p, LogNormalPrior)
+                    self.assertEqual(p.base_dist.scale, 0.75 if i == 0 else 0.5)
+
+            # test gradients
+            X = 1 + 5 * torch.rand(*batch_shape, 4, 3, **tkwargs)
+            X = X.unsqueeze(-3) if len(warp_batch_shape) > 0 else X
+            warp_tf = get_test_warp(indices=indices, batch_shape=warp_batch_shape).to(
+                **tkwargs
+            )
+            X_tf = warp_tf(X)
+            X_tf.sum().backward()
+            for grad in (warp_tf.concentration0.grad, warp_tf.concentration1.grad):
+                self.assertIsNotNone(grad)
+                self.assertFalse(torch.isnan(grad).any())
+                self.assertFalse(torch.isinf(grad).any())
+                self.assertFalse((grad == 0).all())
+
+            # test set with scalar
+            warp_tf._set_concentration(i=0, value=2.0)
+            self.assertTrue((warp_tf.concentration0 == 2.0).all())
+            warp_tf._set_concentration(i=1, value=3.0)
+            self.assertTrue((warp_tf.concentration1 == 3.0).all())


### PR DESCRIPTION
Summary: see title. This avoids clipping the ends of the search space

Differential Revision: D26636473

