### PR TITLE
Fix HigherOrderGP dtype bug

### DIFF
--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -242,7 +242,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         if num_latent_dims is None:
             num_latent_dims = [1] * (self._num_dimensions - 1)
 
-        self.to(train_X.device)
+        self.to(train_X)
 
         self._initialize_latents(
             latent_init=latent_init,

--- a/test/models/test_higher_order_gp.py
+++ b/test/models/test_higher_order_gp.py
@@ -181,7 +181,9 @@ class TestHigherOrderGP(BotorchTestCase):
             _ = self.model.posterior(test_x)
             fantasy_model = self.model.fantasize(test_x, sampler=sampler)
             self.assertIsInstance(fantasy_model, HigherOrderGP)
-            self.assertEqual(fantasy_model.train_inputs[0].shape[:2], torch.Size((32, 2)))
+            self.assertEqual(
+                fantasy_model.train_inputs[0].shape[:2], torch.Size((32, 2))
+            )
 
     def test_initialize_latents(self):
         for dtype in [torch.float, torch.double]:
@@ -208,4 +210,3 @@ class TestHigherOrderGP(BotorchTestCase):
                     self.model.latent_parameters[1].shape,
                     torch.Size((5, latent_dim_sizes[1])),
                 )
-

--- a/test/models/test_higher_order_gp.py
+++ b/test/models/test_higher_order_gp.py
@@ -44,82 +44,90 @@ class TestHigherOrderGP(BotorchTestCase):
             fit_gpytorch_torch(mll, options={"maxiter": 1, "disp": False})
 
     def test_num_output_dims(self):
-        train_x = torch.rand(2, 10, 1, device=self.device)
-        train_y = torch.randn(2, 10, 3, 5, device=self.device)
-        model = HigherOrderGP(train_x, train_y)
-
-        # check that it correctly inferred that this is a batched model
-        self.assertEqual(model._num_outputs, 2)
-
-        train_x = torch.rand(10, 1, device=self.device)
-        train_y = torch.randn(10, 3, 5, 2, device=self.device)
-        model = HigherOrderGP(train_x, train_y)
-
-        # non-batched case
-        self.assertEqual(model._num_outputs, 1)
-
-        train_x = torch.rand(3, 2, 10, 1, device=self.device)
-        train_y = torch.randn(3, 2, 10, 3, 5, device=self.device)
-
-        # check the error when using multi-dim batch_shape
-        with self.assertRaises(NotImplementedError):
+        for dtype in [torch.float, torch.double]:
+            train_x = torch.rand(2, 10, 1, device=self.device, dtype=dtype)
+            train_y = torch.randn(2, 10, 3, 5, device=self.device, dtype=dtype)
             model = HigherOrderGP(train_x, train_y)
 
+            # check that it correctly inferred that this is a batched model
+            self.assertEqual(model._num_outputs, 2)
+
+            train_x = torch.rand(10, 1, device=self.device, dtype=dtype)
+            train_y = torch.randn(10, 3, 5, 2, device=self.device, dtype=dtype)
+            model = HigherOrderGP(train_x, train_y)
+
+            # non-batched case
+            self.assertEqual(model._num_outputs, 1)
+
+            train_x = torch.rand(3, 2, 10, 1, device=self.device, dtype=dtype)
+            train_y = torch.randn(3, 2, 10, 3, 5, device=self.device, dtype=dtype)
+
+            # check the error when using multi-dim batch_shape
+            with self.assertRaises(NotImplementedError):
+                model = HigherOrderGP(train_x, train_y)
+
     def test_posterior(self):
-        torch.random.manual_seed(0)
-        test_x = torch.rand(2, 30, 1).to(device=self.device)
+        for dtype in [torch.float, torch.double]:
+            torch.random.manual_seed(0)
+            test_x = torch.rand(2, 30, 1).to(device=self.device, dtype=dtype)
 
-        # test the posterior works
-        posterior = self.model.posterior(test_x)
-        self.assertIsInstance(posterior, GPyTorchPosterior)
-
-        # test the posterior works with observation noise
-        posterior = self.model.posterior(test_x, observation_noise=True)
-        self.assertIsInstance(posterior, GPyTorchPosterior)
-
-        # test the posterior works with no variances
-        # some funkiness in MVNs registration so the variance is non-zero.
-        with skip_posterior_variances():
+            self.model.to(dtype)
+            if dtype == torch.double:
+                # need to clear float caches
+                self.model.train()
+                self.model.eval()
+            # test the posterior works
             posterior = self.model.posterior(test_x)
             self.assertIsInstance(posterior, GPyTorchPosterior)
-            self.assertLessEqual(posterior.variance.max(), 1e-6)
+
+            # test the posterior works with observation noise
+            posterior = self.model.posterior(test_x, observation_noise=True)
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+
+            # test the posterior works with no variances
+            # some funkiness in MVNs registration so the variance is non-zero.
+            with skip_posterior_variances():
+                posterior = self.model.posterior(test_x)
+                self.assertIsInstance(posterior, GPyTorchPosterior)
+                self.assertLessEqual(posterior.variance.max(), 1e-6)
 
     def test_transforms(self):
-        train_x = torch.rand(10, 3, device=self.device)
-        train_y = torch.randn(10, 4, 5, device=self.device)
+        for dtype in [torch.float, torch.double]:
+            train_x = torch.rand(10, 3, device=self.device, dtype=dtype)
+            train_y = torch.randn(10, 4, 5, device=self.device, dtype=dtype)
 
-        # test handling of Standardize
-        with self.assertWarns(RuntimeWarning):
+            # test handling of Standardize
+            with self.assertWarns(RuntimeWarning):
+                model = HigherOrderGP(
+                    train_X=train_x, train_Y=train_y, outcome_transform=Standardize(m=5)
+                )
+            self.assertIsInstance(model.outcome_transform, FlattenedStandardize)
+            self.assertEqual(model.outcome_transform.output_shape, train_y.shape[1:])
+            self.assertEqual(model.outcome_transform.batch_shape, torch.Size())
+
             model = HigherOrderGP(
-                train_X=train_x, train_Y=train_y, outcome_transform=Standardize(m=5)
+                train_X=train_x,
+                train_Y=train_y,
+                input_transform=Normalize(d=3),
+                outcome_transform=FlattenedStandardize(train_y.shape[1:]),
             )
-        self.assertIsInstance(model.outcome_transform, FlattenedStandardize)
-        self.assertEqual(model.outcome_transform.output_shape, train_y.shape[1:])
-        self.assertEqual(model.outcome_transform.batch_shape, torch.Size())
+            mll = ExactMarginalLogLikelihood(model.likelihood, model)
+            fit_gpytorch_torch(mll, options={"maxiter": 1, "disp": False})
 
-        model = HigherOrderGP(
-            train_X=train_x,
-            train_Y=train_y,
-            input_transform=Normalize(d=3),
-            outcome_transform=FlattenedStandardize(train_y.shape[1:]),
-        )
-        mll = ExactMarginalLogLikelihood(model.likelihood, model)
-        fit_gpytorch_torch(mll, options={"maxiter": 1, "disp": False})
+            test_x = torch.rand(2, 5, 3, device=self.device, dtype=dtype)
+            test_y = torch.randn(2, 5, 4, 5, device=self.device, dtype=dtype)
+            posterior = model.posterior(test_x)
+            self.assertIsInstance(posterior, TransformedPosterior)
 
-        test_x = torch.rand(2, 5, 3, device=self.device)
-        test_y = torch.randn(2, 5, 4, 5, device=self.device)
-        posterior = model.posterior(test_x)
-        self.assertIsInstance(posterior, TransformedPosterior)
+            conditioned_model = model.condition_on_observations(test_x, test_y)
+            self.assertIsInstance(conditioned_model, HigherOrderGP)
 
-        conditioned_model = model.condition_on_observations(test_x, test_y)
-        self.assertIsInstance(conditioned_model, HigherOrderGP)
+            self.check_transform_forward(model, dtype)
+            self.check_transform_untransform(model, dtype)
 
-        self.check_transform_forward(model)
-        self.check_transform_untransform(model)
-
-    def check_transform_forward(self, model):
-        train_y = torch.randn(2, 10, 4, 5, device=self.device)
-        train_y_var = torch.rand(2, 10, 4, 5, device=self.device)
+    def check_transform_forward(self, model, dtype):
+        train_y = torch.randn(2, 10, 4, 5, device=self.device, dtype=dtype)
+        train_y_var = torch.rand(2, 10, 4, 5, device=self.device, dtype=dtype)
 
         output, output_var = model.outcome_transform.forward(train_y)
         self.assertEqual(output.shape, torch.Size((2, 10, 4, 5)))
@@ -129,61 +137,75 @@ class TestHigherOrderGP(BotorchTestCase):
         self.assertEqual(output.shape, torch.Size((2, 10, 4, 5)))
         self.assertEqual(output_var.shape, torch.Size((2, 10, 4, 5)))
 
-    def check_transform_untransform(self, model):
+    def check_transform_untransform(self, model, dtype):
         output, output_var = model.outcome_transform.untransform(
-            torch.randn(2, 2, 4, 5, device=self.device)
+            torch.randn(2, 2, 4, 5, device=self.device, dtype=dtype)
         )
         self.assertEqual(output.shape, torch.Size((2, 2, 4, 5)))
         self.assertEqual(output_var, None)
 
         output, output_var = model.outcome_transform.untransform(
-            torch.randn(2, 2, 4, 5, device=self.device),
-            torch.rand(2, 2, 4, 5, device=self.device),
+            torch.randn(2, 2, 4, 5, device=self.device, dtype=dtype),
+            torch.rand(2, 2, 4, 5, device=self.device, dtype=dtype),
         )
         self.assertEqual(output.shape, torch.Size((2, 2, 4, 5)))
         self.assertEqual(output_var.shape, torch.Size((2, 2, 4, 5)))
 
     def test_condition_on_observations(self):
-        torch.random.manual_seed(0)
-        test_x = torch.rand(2, 5, 1, device=self.device)
-        test_y = torch.randn(2, 5, 3, 5, device=self.device)
+        for dtype in [torch.float, torch.double]:
+            torch.random.manual_seed(0)
+            test_x = torch.rand(2, 5, 1, device=self.device, dtype=dtype)
+            test_y = torch.randn(2, 5, 3, 5, device=self.device, dtype=dtype)
 
-        # dummy call to ensure caches have been computed
-        _ = self.model.posterior(test_x)
-        conditioned_model = self.model.condition_on_observations(test_x, test_y)
-        self.assertIsInstance(conditioned_model, HigherOrderGP)
+            self.model.to(dtype)
+            if dtype == torch.double:
+                # need to clear float caches
+                self.model.train()
+                self.model.eval()
+            # dummy call to ensure caches have been computed
+            _ = self.model.posterior(test_x)
+            conditioned_model = self.model.condition_on_observations(test_x, test_y)
+            self.assertIsInstance(conditioned_model, HigherOrderGP)
 
     def test_fantasize(self):
-        torch.random.manual_seed(0)
-        test_x = torch.rand(2, 5, 1, device=self.device)
-        sampler = IIDNormalSampler(num_samples=32).to(self.device)
+        for dtype in [torch.float, torch.double]:
+            torch.random.manual_seed(0)
+            test_x = torch.rand(2, 5, 1, device=self.device, dtype=dtype)
+            sampler = IIDNormalSampler(num_samples=32)
 
-        _ = self.model.posterior(test_x)
-        fantasy_model = self.model.fantasize(test_x, sampler=sampler)
-        self.assertIsInstance(fantasy_model, HigherOrderGP)
-        self.assertEqual(fantasy_model.train_inputs[0].shape[:2], torch.Size((32, 2)))
+            self.model.to(dtype)
+            if dtype == torch.double:
+                # need to clear float caches
+                self.model.train()
+                self.model.eval()
+            _ = self.model.posterior(test_x)
+            fantasy_model = self.model.fantasize(test_x, sampler=sampler)
+            self.assertIsInstance(fantasy_model, HigherOrderGP)
+            self.assertEqual(fantasy_model.train_inputs[0].shape[:2], torch.Size((32, 2)))
 
     def test_initialize_latents(self):
-        torch.random.manual_seed(0)
+        for dtype in [torch.float, torch.double]:
+            torch.random.manual_seed(0)
 
-        train_x = torch.rand(10, 1, device=self.device)
-        train_y = torch.randn(10, 3, 5, device=self.device)
+            train_x = torch.rand(10, 1, device=self.device, dtype=dtype)
+            train_y = torch.randn(10, 3, 5, device=self.device, dtype=dtype)
 
-        for latent_dim_sizes, latent_init in itertools.product(
-            [[1, 1], [2, 3]],
-            ["gp", "default"],
-        ):
-            self.model = HigherOrderGP(
-                train_x,
-                train_y,
-                num_latent_dims=latent_dim_sizes,
-                latent_init=latent_init,
-            )
-            self.assertEqual(
-                self.model.latent_parameters[0].shape,
-                torch.Size((3, latent_dim_sizes[0])),
-            )
-            self.assertEqual(
-                self.model.latent_parameters[1].shape,
-                torch.Size((5, latent_dim_sizes[1])),
-            )
+            for latent_dim_sizes, latent_init in itertools.product(
+                [[1, 1], [2, 3]],
+                ["gp", "default"],
+            ):
+                self.model = HigherOrderGP(
+                    train_x,
+                    train_y,
+                    num_latent_dims=latent_dim_sizes,
+                    latent_init=latent_init,
+                )
+                self.assertEqual(
+                    self.model.latent_parameters[0].shape,
+                    torch.Size((3, latent_dim_sizes[0])),
+                )
+                self.assertEqual(
+                    self.model.latent_parameters[1].shape,
+                    torch.Size((5, latent_dim_sizes[1])),
+                )
+


### PR DESCRIPTION
## Motivation

HigherOrderGP would raise `RuntimeError: expected scalar type Float but found Double` when used with double. This fixes the bug by setting the model `to(train_X)` (instead of `train_X.device`).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Updated unit tests. Updated tests would fail without the change.
