### PR TITLE
Refactor Max Value Entropy Search Methods

### DIFF
--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -192,7 +192,7 @@ class DiscreteMaxValueBase(MaxValueBase):
         self,
         model: Model,
         candidate_set: Tensor,
-        num_mv_samples: int,
+        num_mv_samples: int = 10,
         use_gumbel: bool = True,
         maximize: bool = True,
         X_pending: Optional[Tensor] = None,


### PR DESCRIPTION
Further abstracts `MaxValueBase` into a base class with `_compute_information_gain` and `_sample_max_values` abstract methods, allowing generic sampling of posterior max values rather than the existing joint and Gumbel sampling methods (e.g. one could optimize RFF draws or use decoupled sampling).

- `DiscreteMaxValueBase` now implements the core functionality for sampling max values from a discrete candidate set.
- `qMaxValueEntropy` and `qLowerBoundMaxValueEntropy` now derive from `DiscreteMaxValueBase`, though going forward we could of course have those use other sampling as well.
- Also cleans up a bunch of ad-hoc treatment of `X_pending` and `_sample_max_values()` calls in the code, using superclass constructors to a much larger extent.
- Cleanup docstrings
- Bring code coverage back up to 100%

This is a step towards making it easier to implement other (e.g. Multi-Objective) entropy-based methods going forward.

