### PR TITLE
handle empty pareto set in is_non_dominated

### DIFF
--- a/botorch/utils/multi_objective/pareto.py
+++ b/botorch/utils/multi_objective/pareto.py
@@ -24,6 +24,8 @@ def is_non_dominated(Y: Tensor, deduplicate: bool = True) -> Tensor:
         A `(batch_shape) x n`-dim boolean tensor indicating whether
         each point is non-dominated.
     """
+    if Y.shape[-2] == 0:
+        return torch.zeros(Y.shape[:-1], dtype=torch.bool, device=Y.device)
     Y1 = Y.unsqueeze(-3)
     Y2 = Y.unsqueeze(-2)
     dominates = (Y1 >= Y2).all(dim=-1) & (Y1 > Y2).any(dim=-1)

--- a/test/utils/multi_objective/test_pareto.py
+++ b/test/utils/multi_objective/test_pareto.py
@@ -122,3 +122,13 @@ class TestPareto(BotorchTestCase):
             self.assertTrue(
                 torch.equal(batch_Y3[1][nondom_mask3[1]], expected_nondom_Y3b_no_dedup)
             )
+
+            # test empty pareto
+            mask = is_non_dominated(Y3[:0])
+            expected_mask = torch.zeros(0, dtype=torch.bool, device=Y3.device)
+            self.assertTrue(torch.equal(expected_mask, mask))
+            mask = is_non_dominated(batch_Y3[:, :0])
+            expected_mask = torch.zeros(
+                *batch_Y3.shape[:-2], 0, dtype=torch.bool, device=Y3.device
+            )
+            self.assertTrue(torch.equal(expected_mask, mask))


### PR DESCRIPTION
Summary: see title. We have previously dealt with this outside of this function, but it's better to have this function do something reasonable with an empty pareto set.

Differential Revision: D27024248

