### PR TITLE
Extract callback option and pass as positional argument to SciPy minimize

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -133,7 +133,8 @@ def gen_candidates_scipy(
         jac=True,
         bounds=bounds,
         constraints=constraints,
-        options={k: v for k, v in options.items() if k != "method"},
+        callback=options.get("callback", None),
+        options={k: v for k, v in options.items() if k not in ["method", "callback"]},
     )
     candidates = fix_features(
         X=torch.from_numpy(res.x).to(initial_conditions).view(shapeX).contiguous(),


### PR DESCRIPTION
## Motivation

We do not have the functionality to retrieve the intermediate steps from the SciPy minimize operation generating candidates. From SciPy's end, this is made possible using the `callback` option. However, SciPy passes the `callback` argument explicitly, which means that passing `callback` in the `options` dictionary leads to the following error:

```_minimize_lbfgsb() got multiple values for keyword argument 'callback'``` 

## Test Plan

This code change should not affect any existing tests.