### PR TITLE
modify X_pending behavior in multi-objective acqfs

### DIFF
--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -74,7 +74,9 @@ class MultiObjectiveMCAcquisitionFunction(AcquisitionFunction):
                 "Multi-Objective MC acquisition functions."
             )
         self.add_module("objective", objective)
-        self.set_X_pending(X_pending)
+        self.X_pending = None
+        if X_pending is not None:
+            self.set_X_pending(X_pending)
 
     @abstractmethod
     def forward(self, X: Tensor) -> Tensor:


### PR DESCRIPTION
Summary: Slight modification so that set_X_pending is only called in __init__ when X_pending is not None. This helps with inheritance, where acquisition functions may handle pending points in a different ways

Differential Revision: D27106477

