### PR TITLE
Use sphinx' built-in autodoc type hint handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
 
 TEST_REQUIRES = ["pytest", "pytest-cov"]
 
-DEV_REQUIRES = TEST_REQUIRES + ["black", "flake8", "sphinx", "sphinx-autodoc-typehints"]
+DEV_REQUIRES = TEST_REQUIRES + ["black", "flake8", "sphinx"]
 
 TUTORIALS_REQUIRES = [
     "ax-platform",

--- a/sphinx/README.md
+++ b/sphinx/README.md
@@ -6,10 +6,7 @@ This file describes the sphinx setup for auto-generating the botorch API referen
 ## Installation
 
 **Requirements**:
-- sphinx >= 2.0
-- sphinx_autodoc_typehints
-
-You can install these via `pip install sphinx sphinx_autodoc_typehints`.
+- sphinx >= 3.0  (Install via `pip install sphinx`)
 
 
 ## Building

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -37,7 +37,6 @@ version = get_distribution("botorch").version
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
-    "sphinx_autodoc_typehints",
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
@@ -73,6 +72,8 @@ autodoc_default_options = {
     "show-inheritance": True,
     "member-order": "bysource",
 }
+# show type hints in the method description
+autodoc_typehints = "description"
 
 # Inlcude init docstrings into body of autoclass directives
 autoclass_content = "both"


### PR DESCRIPTION
Since sphinx 3.0 the `autodoc_typehints` option has a setting "description" that essentially achieves the behavior of the `sphinx_autodoc_typehints` plugin with the "official" spinx autodoc plugin: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_typehints

The formatting is slightly different: While `sphinx_autodoc_typehints` would just use class names, the built-in one does include the full path to where the class is defined. Further, by default Spinx will resolve all type aliases. While sphinx allows to specify aliases, it seems that these have to be manually specified for all type aliases which appears quite cumbersome: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_type_aliases