### PR TITLE
utility for converting batched mo models into batched so models

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -568,10 +568,9 @@ class ModelListGPyTorchModel(GPyTorchModel, ABC):
         # return result as a GPyTorchPosteriors
         if len(mvns) == 1:
             return GPyTorchPosterior(mvn=mvns[0])
-        else:
-            return GPyTorchPosterior(
-                mvn=MultitaskMultivariateNormal.from_independent_mvns(mvns=mvns)
-            )
+        return GPyTorchPosterior(
+            mvn=MultitaskMultivariateNormal.from_independent_mvns(mvns=mvns)
+        )
 
     def condition_on_observations(
         self, X: Tensor, Y: Tensor, **kwargs: Any


### PR DESCRIPTION
Summary: This is helpful for several entropy acquisition functions in the works. This is also useful because it allows you to compute a batched independent MVN (with a covariance matrix of shape m x n x n) rather than the full MTMVN (with a covariance of shape mn x mn), which is far more memory efficient.

Differential Revision: D25816540

