### PR TITLE
Fix TestSampleAllPriors unit test after SmoothedBoxPrior update

### DIFF
--- a/test/optim/test_utils.py
+++ b/test/optim/test_utils.py
@@ -33,7 +33,7 @@ from gpytorch.priors.torch_priors import GammaPrior
 class DummyPrior(Prior):
     arg_constraints = {}
 
-    def rsample(self, sample_shape=torch.Size()):
+    def rsample(self, sample_shape=torch.Size()):  # noqa: B008
         raise NotImplementedError
 
 


### PR DESCRIPTION
https://github.com/cornellius-gp/gpytorch/pull/1546 added `rsample` to `SmoothedBoxPrior`, so we need to adjust our test here.