### PR TITLE
Implement construct_inputs for acquisition functions

### DIFF
--- a/botorch/acquisition/acquisition.py
+++ b/botorch/acquisition/acquisition.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import warnings
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Dict, Optional
 
+from botorch.acquisition.objective import AcquisitionObjective
 from botorch.exceptions import BotorchWarning
 from botorch.models.model import Model
+from botorch.utils.containers import TrainingData
 from torch import Tensor
 from torch.nn import Module
 
@@ -63,6 +65,37 @@ class AcquisitionFunction(Module, ABC):
             design points `X`.
         """
         pass  # pragma: no cover
+
+    @classmethod
+    def construct_inputs(
+        cls,
+        model: Model,
+        training_data: TrainingData,
+        objective: Optional[AcquisitionObjective] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
+        r"""Construct kwargs for the `AcquisitionFunction` constructor.
+
+        Args:
+            model: The model to be used in the acquisition function.
+            training_data: A TrainingData object contraining the model's
+                training data. Used e.g. to extract inputs such as `best_f`
+                for expected improvement acquisition functions.
+            objective: The objective to in the acquisition function.
+
+        Returns:
+            A dict mapping kwarg names of the constructor to values.
+
+        This functionality is optional and useful for programmatically constructing
+        acquistion function objects using a consistent top-level interface.
+
+        Example:
+            >>> kwargs = ExpectedImprovement.construct_inputs(
+                    model, training_data,
+                )
+            >>> EI = ExpectedImprovement(**kwargs)
+        """
+        raise NotImplementedError
 
 
 class OneShotAcquisitionFunction(AcquisitionFunction, ABC):

--- a/botorch/acquisition/multi_objective/utils.py
+++ b/botorch/acquisition/multi_objective/utils.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+Utilities for multi-objective acquisition functions.
+"""
+
+import warnings
+
+from botorch.exceptions.warnings import BotorchWarning
+
+
+def get_default_partitioning_alpha(num_objectives: int) -> float:
+    """Adaptively selects a reasonable partitioning based on the number of objectives.
+
+    This strategy is derived from the results in [Daulton2020qehvi]_, which suggest
+    that this heuristic provides a reasonable trade-off between the closed-loop
+    performance and the wall time required for the partitioning.
+    """
+    if num_objectives == 2:
+        return 0.0
+    elif num_objectives > 6:
+        warnings.warn("EHVI works best for less than 7 objectives.", BotorchWarning)
+    return 10 ** (-8 + num_objectives)

--- a/botorch/utils/containers.py
+++ b/botorch/utils/containers.py
@@ -8,12 +8,14 @@ r"""
 Containers to standardize inputs into models and acquisition functions.
 """
 
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from torch import Tensor
 
 
-class TrainingData(NamedTuple):
+@dataclass
+class TrainingData:
     r"""Standardized struct of model training data for a single outcome."""
 
     X: Tensor


### PR DESCRIPTION
Summary: Implement the `construct_inputs` method from D28021531 for most acquisition funcitons

Differential Revision: D28170202

