### PR TITLE
Fix coverage gap

### DIFF
--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -275,9 +275,7 @@ class TestFitGPyTorchModel(BotorchTestCase):
             with self.assertRaises(NotPSDError):
                 fit_gpytorch_model(mll, options=options, max_retries=2)
             # ensure we can handle NaNErrors in the optimizer
-            with mock.patch.object(
-                SingleTaskGP, "__call__", side_effect=NanError
-            ) as mock_call:
+            with mock.patch.object(SingleTaskGP, "__call__", side_effect=NanError):
                 gp = SingleTaskGP(X_train, Y_train, likelihood=test_likelihood)
                 mll = ExactMarginalLogLikelihood(gp.likelihood, gp)
                 mll.to(device=self.device, dtype=dtype)

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -275,11 +275,15 @@ class TestFitGPyTorchModel(BotorchTestCase):
             with self.assertRaises(NotPSDError):
                 fit_gpytorch_model(mll, options=options, max_retries=2)
             # ensure we can handle NaNErrors in the optimizer
-            with mock.patch.object(SingleTaskGP, '__call__', side_effect=NanError) as mock_call:
+            with mock.patch.object(
+                SingleTaskGP, "__call__", side_effect=NanError
+            ) as mock_call:
                 gp = SingleTaskGP(X_train, Y_train, likelihood=test_likelihood)
                 mll = ExactMarginalLogLikelihood(gp.likelihood, gp)
                 mll.to(device=self.device, dtype=dtype)
-                fit_gpytorch_model(mll, options={"disp": False, "maxiter": 1}, max_retries=1)
+                fit_gpytorch_model(
+                    mll, options={"disp": False, "maxiter": 1}, max_retries=1
+                )
 
     def test_fit_gpytorch_model_torch(self):
         self.test_fit_gpytorch_model(optimizer=fit_gpytorch_torch)


### PR DESCRIPTION
Fixes a gap in test coverage (when gpytorch raises an NanError).

We should probably rethink how we want to handle this case in the optimization, but for now at least  this fixes the coverage gap.
