### PR TITLE
Acquisition function input constructor registry

### DIFF
--- a/botorch/acquisition/__init__.py
+++ b/botorch/acquisition/__init__.py
@@ -23,6 +23,7 @@ from botorch.acquisition.cost_aware import (
     InverseCostWeightedUtility,
 )
 from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
+from botorch.acquisition.input_constructors import get_acqf_input_constructor
 from botorch.acquisition.knowledge_gradient import (
     qKnowledgeGradient,
     qMultiFidelityKnowledgeGradient,
@@ -86,4 +87,5 @@ __all__ = [
     "MCAcquisitionObjective",
     "ScalarizedObjective",
     "get_acquisition_function",
+    "get_acqf_input_constructor",
 ]

--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+A registry of helpers for generating inputs to acquisition function
+constructors programmatically from a consistent input format.
+"""
+
+from typing import Any, Callable, Dict, Optional, Type
+
+import torch
+from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.analytic import (
+    ExpectedImprovement,
+    PosteriorMean,
+    ProbabilityOfImprovement,
+)
+from botorch.acquisition.monte_carlo import (
+    qExpectedImprovement,
+    qNoisyExpectedImprovement,
+    qSimpleRegret,
+)
+from botorch.acquisition.multi_objective import (
+    qExpectedHypervolumeImprovement,
+    ExpectedHypervolumeImprovement,
+)
+from botorch.acquisition.multi_objective.objective import (
+    IdentityAnalyticMultiOutputObjective,
+)
+from botorch.acquisition.multi_objective.utils import get_default_partitioning_alpha
+from botorch.acquisition.objective import (
+    AcquisitionObjective,
+    IdentityMCObjective,
+    ScalarizedObjective,
+)
+from botorch.exceptions.errors import UnsupportedError
+from botorch.models.model import Model
+from botorch.sampling.samplers import IIDNormalSampler, MCSampler, SobolQMCNormalSampler
+from botorch.utils.constraints import get_outcome_constraint_transforms
+from botorch.utils.containers import TrainingData
+from botorch.utils.multi_objective.box_decompositions.non_dominated import (
+    NondominatedPartitioning,
+)
+from torch import Tensor
+
+
+ACQF_INPUT_CONSTRUCTOR_REGISTRY = {}
+
+
+def get_acqf_input_constructor(
+    acqf_cls: Type[AcquisitionFunction],
+) -> Callable[..., Dict[str, Any]]:
+    r"""Get acqusition function input constructor from registry.
+
+    Args:
+        acqf_cls: The AcquisitionFunction class (not instance) for which
+            to retrieve the input constructor.
+
+    Returns:
+        The input constructor associated with `acqf_cls`.
+
+    """
+    if acqf_cls not in ACQF_INPUT_CONSTRUCTOR_REGISTRY:
+        raise RuntimeError(
+            f"Input constructor for acquisition class `{acqf_cls.__name__}` not "
+            "registered. Use the `@acqf_input_constructor` decorator to register "
+            "a new method."
+        )
+    return ACQF_INPUT_CONSTRUCTOR_REGISTRY[acqf_cls]
+
+
+def acqf_input_constructor(
+    *acqf_cls: Type[AcquisitionFunction],
+) -> Callable[..., AcquisitionFunction]:
+    r"""Decorator for registering acquisition function input constructors.
+
+    Args:
+        acqf_cls: The AcquisitionFunction classes (not instances) for which
+            to register the input constructor.
+    """
+    for acqf_cls_ in acqf_cls:
+        if acqf_cls_ in ACQF_INPUT_CONSTRUCTOR_REGISTRY:
+            raise ValueError(
+                "Cannot register duplicate arg constructor for acquisition "
+                f"class `{acqf_cls_.__name__}`"
+            )
+
+    def decorator(method):
+        for acqf_cls_ in acqf_cls:
+            ACQF_INPUT_CONSTRUCTOR_REGISTRY[acqf_cls_] = method
+        return method
+
+    return decorator
+
+
+# --------------------- Input argument constructors --------------------- #
+
+
+@acqf_input_constructor(PosteriorMean)
+def construct_inputs_analytic_base(
+    model: Model,
+    training_data: TrainingData,
+    objective: Optional[AcquisitionObjective] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    r"""Construct kwargs for basic analytic acquisition functions.
+
+    Args:
+        model: The model to be used in the acquisition function.
+        training_data: A TrainingData object contraining the model's
+            training data. `best_f` is extracted from here.
+        objective: The objective to in the acquisition function.
+
+    Returns:
+        A dict mapping kwarg names of the constructor to values.
+    """
+    return {"model": model, "objective": objective}
+
+
+@acqf_input_constructor(ExpectedImprovement, ProbabilityOfImprovement)
+def construct_inputs_best_f(
+    model: Model,
+    training_data: TrainingData,
+    objective: Optional[AcquisitionObjective] = None,
+    maximize: bool = True,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    r"""Construct kwargs for the acquisition functions requiring `best_f`.
+
+    Args:
+        model: The model to be used in the acquisition function.
+        training_data: A TrainingData object contraining the model's
+            training data. `best_f` is extracted from here.
+        objective: The objective to in the acquisition function.
+        maximize: If True, consider the problem a maximization problem.
+
+    Returns:
+        A dict mapping kwarg names of the constructor to values.
+    """
+    base_inputs = construct_inputs_analytic_base(
+        model=model, training_data=training_data, objective=objective
+    )
+    best_f = kwargs.get(
+        "best_f", get_best_f_analytic(training_data=training_data, objective=objective)
+    )
+    return {**base_inputs, "best_f": best_f, "maximize": maximize}
+
+
+@acqf_input_constructor(qSimpleRegret)
+def construct_inputs_mc_base(
+    model: Model,
+    training_data: TrainingData,
+    objective: Optional[AcquisitionObjective] = None,
+    X_pending: Optional[Tensor] = None,
+    sampler: Optional[MCSampler] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    r"""Construct kwargs for basic MC acquisition functions.
+
+    Args:
+        model: The model to be used in the acquisition function.
+        training_data: A TrainingData object contraining the model's
+            training data. Used e.g. to extract inputs such as `best_f`
+            for expected improvement acquisition functions.
+        objective: The objective to in the acquisition function.
+        X_pending: A `batch_shape, m x d`-dim Tensor of `m` design points
+            that have points that have been submitted for function evaluation
+            but have not yet been evaluated.
+        sampler: The sampler used to draw base samples. If omitted, uses
+            the acquisition functions's default sampler.
+
+    Returns:
+        A dict mapping kwarg names of the constructor to values.
+    """
+    return {
+        "model": model,
+        "objective": objective,
+        "X_pending": X_pending,
+        "sampler": sampler,
+    }
+
+
+@acqf_input_constructor(qExpectedImprovement)
+def construct_inputs_qEI(
+    model: Model,
+    training_data: TrainingData,
+    objective: Optional[AcquisitionObjective] = None,
+    X_pending: Optional[Tensor] = None,
+    sampler: Optional[MCSampler] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    r"""Construct kwargs for the `qExpectedImprovement` constructor.
+
+    Args:
+        model: The model to be used in the acquisition function.
+        training_data: A TrainingData object contraining the model's
+            training data. Used e.g. to extract inputs such as `best_f`
+            for expected improvement acquisition functions.
+        objective: The objective to in the acquisition function.
+        X_pending: A `m x d`-dim Tensor of `m` design points that have been
+            submitted for function evaluation but have not yet been evaluated.
+            Concatenated into X upon forward call.
+        sampler: The sampler used to draw base samples. If omitted, uses
+            the acquisition functions's default sampler.
+
+    Returns:
+        A dict mapping kwarg names of the constructor to values.
+    """
+    base_inputs = construct_inputs_mc_base(
+        model=model,
+        training_data=training_data,
+        objective=objective,
+        sampler=sampler,
+        X_pending=X_pending,
+    )
+    # TODO: Dedup handling of this here and in the constructor (maybe via a
+    # shared classmethod doing this)
+    best_f = kwargs.get(
+        "best_f", get_best_f_mc(training_data=training_data, objective=objective)
+    )
+    return {**base_inputs, "best_f": best_f}
+
+
+@acqf_input_constructor(qNoisyExpectedImprovement)
+def construct_inputs_qNEI(
+    model: Model,
+    training_data: TrainingData,
+    objective: Optional[AcquisitionObjective] = None,
+    X_pending: Optional[Tensor] = None,
+    sampler: Optional[MCSampler] = None,
+    X_baseline: Optional[Tensor] = None,
+    prune_baseline: bool = False,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    r"""Construct kwargs for the `qNoisyExpectedImprovement` constructor.
+
+    Args:
+        model: The model to be used in the acquisition function.
+        training_data: A TrainingData object contraining the model's
+            training data. Used e.g. to extract inputs such as `best_f`
+            for expected improvement acquisition functions. Only block-
+            design training data currently supported.
+        objective: The objective to in the acquisition function.
+        X_pending: A `m x d`-dim Tensor of `m` design points that have been
+            submitted for function evaluation but have not yet been evaluated.
+            Concatenated into X upon forward call.
+        sampler: The sampler used to draw base samples. If omitted, uses
+            the acquisition functions's default sampler.
+        X_baseline: A `batch_shape x r x d`-dim Tensor of `r` design points
+            that have already been observed. These points are considered as
+            the potential best design point. If omitted, use `training_data.X`.
+        prune_baseline: If True, remove points in `X_baseline` that are
+            highly unlikely to be the best point. This can significantly
+            improve performance and is generally recommended.
+
+    Returns:
+        A dict mapping kwarg names of the constructor to values.
+    """
+    base_inputs = construct_inputs_mc_base(
+        model=model,
+        training_data=training_data,
+        objective=objective,
+        sampler=sampler,
+        X_pending=X_pending,
+    )
+    if X_baseline is None:
+        if not training_data.is_block_design:
+            raise NotImplementedError("Currently only block designs are supported.")
+        X_baseline = training_data.X
+    return {
+        **base_inputs,
+        "X_baseline": X_baseline,
+        "prune_baseline": prune_baseline,
+    }
+
+
+@acqf_input_constructor(ExpectedHypervolumeImprovement)
+def construct_inputs_EHVI(
+    model: Model,
+    training_data: TrainingData,
+    objective_thresholds: Tensor,
+    objective: Optional[AcquisitionObjective] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    r"""Construct kwargs for `ExpectedHypervolumeImprovement` constructor."""
+    num_objectives = objective_thresholds.shape[0]
+    if kwargs.get("outcome_constraints") is not None:
+        raise NotImplementedError("EHVI does not yet support outcome constraints.")
+
+    X_observed = training_data.X
+    alpha = kwargs.get(
+        "alpha",
+        get_default_partitioning_alpha(num_objectives=num_objectives),
+    )
+    # This selects the objectives (a subset of the outcomes) and set each
+    # objective threhsold to have the proper optimization direction.
+    if objective is None:
+        objective = IdentityAnalyticMultiOutputObjective()
+    ref_point = objective(objective_thresholds)
+
+    # Compute posterior mean (for ref point computation ref pareto frontier)
+    # if one is not provided among arguments.
+    Y_pmean = kwargs.get("Y_pmean")
+    if Y_pmean is None:
+        with torch.no_grad():
+            Y_pmean = model.posterior(X_observed).mean
+
+    partitioning = NondominatedPartitioning(
+        ref_point=ref_point,
+        Y=objective(Y_pmean),
+        alpha=alpha,
+    )
+
+    return {
+        "model": model,
+        "ref_point": ref_point,
+        "partitioning": partitioning,
+        "objective": objective,
+    }
+
+
+@acqf_input_constructor(qExpectedHypervolumeImprovement)
+def construct_inputs_qEHVI(
+    model: Model,
+    training_data: TrainingData,
+    objective_thresholds: Tensor,
+    objective: Optional[AcquisitionObjective] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    r"""Construct kwargs for `qExpectedHypervolumeImprovement` constructor."""
+    X_observed = training_data.X
+
+    # compute posterior mean (for ref point computation ref pareto frontier)
+    with torch.no_grad():
+        Y_pmean = model.posterior(X_observed).mean
+
+    outcome_constraints = kwargs.pop("outcome_constraints", None)
+    # For HV-based acquisition functions we pass the constraint transform directly
+    if outcome_constraints is None:
+        cons_tfs = None
+    else:
+        cons_tfs = get_outcome_constraint_transforms(outcome_constraints)
+        # Adjust `Y_pmean` to contrain feasible points only.
+        feas = torch.stack([c(Y_pmean) <= 0 for c in cons_tfs], dim=-1).all(dim=-1)
+        Y_pmean = Y_pmean[feas]
+
+    ehvi_kwargs = construct_inputs_EHVI(
+        model=model,
+        training_data=training_data,
+        objective_thresholds=objective_thresholds,
+        objective=objective,
+        # Pass `Y_pmean` that accounts for constraints to `construct_inputs_EHVI`
+        # to ensure that correct non-dominated partitioning is produced.
+        Y_pmean=Y_pmean,
+        **kwargs,
+    )
+
+    # Set up sampler.
+    sampler = kwargs.get("sampler")
+    if sampler is None:
+        mc_samples = kwargs.get("mc_samples", 128)
+        qmc = kwargs.get("qmc", True)
+
+        # initialize the sampler
+        seed = int(torch.randint(1, 10000, (1,)).item())
+        if qmc:
+            sampler = SobolQMCNormalSampler(num_samples=mc_samples, seed=seed)
+        else:
+            sampler = IIDNormalSampler(num_samples=mc_samples, seed=seed)
+
+    add_qehvi_kwargs = {
+        "sampler": sampler,
+        "X_pending": kwargs.get("X_pending"),
+        "constraints": cons_tfs,
+    }
+    add_qehvi_kwargs["eta"] = kwargs.get("eta", 1e-3)
+    return {**ehvi_kwargs, **add_qehvi_kwargs}
+
+
+def get_best_f_analytic(
+    training_data: TrainingData,
+    objective: Optional[AcquisitionObjective] = None,
+) -> Tensor:
+    if not training_data.is_block_design:
+        raise NotImplementedError("Currently only block designs are supported.")
+    Y = training_data.Y
+    if isinstance(objective, ScalarizedObjective):
+        return objective.evaluate(Y).max(-1).values
+    if Y.shape[-1] > 1:
+        raise NotImplementedError
+    return Y.max(-2).values.squeeze(-1)
+
+
+def get_best_f_mc(
+    training_data: TrainingData,
+    objective: Optional[AcquisitionObjective] = None,
+) -> Tensor:
+    if not training_data.is_block_design:
+        raise NotImplementedError("Currently only block designs are supported.")
+    Y = training_data.Y
+    if objective is None:
+        if Y.shape[-1] > 1:
+            raise UnsupportedError
+        objective = IdentityMCObjective()
+    return objective(training_data.Y).max(-1).values

--- a/botorch/acquisition/multi_objective/objective.py
+++ b/botorch/acquisition/multi_objective/objective.py
@@ -116,7 +116,7 @@ class WeightedMCMultiOutputObjective(IdentityMCMultiOutputObjective):
             )
         elif outcomes is not None and weights.shape[0] != len(outcomes):
             raise BotorchTensorDimensionError(
-                "weights must contain the name number of elements as outcomes, "
+                "weights must contain the same number of elements as outcomes, "
                 f"but got {weights.numel()} weights and {len(outcomes)} outcomes."
             )
         self.register_buffer("weights", weights)

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -57,6 +57,17 @@ class ScalarizedObjective(AcquisitionObjective):
         self.register_buffer("weights", weights)
         self.offset = offset
 
+    def evaluate(self, Y: Tensor) -> Tensor:
+        r"""Evaluate the objective on a set of outcomes.
+
+        Args:
+            Y: A `batch_shape x q x m`-dim tensor of outcomes.
+
+        Returns:
+            A `batch_shape x q`-dim tensor of objective values.
+        """
+        return self.offset + Y @ self.weights
+
     def forward(self, posterior: GPyTorchPosterior) -> GPyTorchPosterior:
         r"""Compute the posterior of the affine transformation.
 

--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -20,7 +20,10 @@ from botorch.acquisition import analytic, multi_objective
 from botorch.acquisition import monte_carlo  # noqa F401
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.multi_objective import monte_carlo as moo_monte_carlo
-from botorch.acquisition.objective import IdentityMCObjective, MCAcquisitionObjective
+from botorch.acquisition.objective import (
+    IdentityMCObjective,
+    MCAcquisitionObjective,
+)
 from botorch.exceptions.errors import UnsupportedError
 from botorch.exceptions.warnings import SamplingWarning
 from botorch.models.model import Model

--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -582,7 +582,7 @@ class ModelListGPyTorchModel(GPyTorchModel, ABC):
 
 
 class MultiTaskGPyTorchModel(GPyTorchModel, ABC):
-    r"""Abstract base class for multi-task models baed on GPyTorch models.
+    r"""Abstract base class for multi-task models based on GPyTorch models.
 
     This class provides the `posterior` method to models that implement a
     "long-format" multi-task GP in the style of `MultiTaskGP`.

--- a/sphinx/source/acquisition.rst
+++ b/sphinx/source/acquisition.rst
@@ -120,6 +120,11 @@ Fixed Feature Acquisition Function
 .. automodule:: botorch.acquisition.fixed_feature
     :members:
 
+Constructors for Acquisition Function Input Arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.acquisition.input_constructors
+    :members:
+
 Penalized Acquisition Function Wrapper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.acquisition.penalized

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import mock
+
+import torch
+from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.analytic import (
+    ExpectedImprovement,
+    PosteriorMean,
+)
+from botorch.acquisition.input_constructors import (
+    acqf_input_constructor,
+    get_acqf_input_constructor,
+    get_best_f_analytic,
+    get_best_f_mc,
+)
+from botorch.acquisition.monte_carlo import (
+    qExpectedImprovement,
+    qNoisyExpectedImprovement,
+    qSimpleRegret,
+)
+from botorch.acquisition.multi_objective import (
+    qExpectedHypervolumeImprovement,
+    ExpectedHypervolumeImprovement,
+)
+from botorch.acquisition.multi_objective.objective import (
+    IdentityAnalyticMultiOutputObjective,
+    WeightedMCMultiOutputObjective,
+)
+from botorch.acquisition.multi_objective.utils import get_default_partitioning_alpha
+from botorch.acquisition.objective import LinearMCObjective
+from botorch.acquisition.objective import (
+    ScalarizedObjective,
+)
+from botorch.exceptions.errors import UnsupportedError
+from botorch.sampling.samplers import IIDNormalSampler, SobolQMCNormalSampler
+from botorch.utils.containers import TrainingData
+from botorch.utils.multi_objective.box_decompositions.non_dominated import (
+    NondominatedPartitioning,
+)
+from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
+
+
+class DummyAcquisitionFunction(AcquisitionFunction):
+    ...
+
+
+class InputConstructorBaseTestCase:
+    def setUp(self):
+        X = torch.rand(3, 2)
+        Y = torch.rand(3, 1)
+        self.bd_td = TrainingData.from_block_design(X=X, Y=Y)
+        self.bd_td_mo = TrainingData.from_block_design(X=X, Y=torch.rand(3, 2))
+        Xs = [torch.rand(2, 2), torch.rand(2, 2)]
+        Ys = [torch.rand(2, 1), torch.rand(2, 1)]
+        self.nbd_td = TrainingData(Xs=Xs, Ys=Ys)
+
+
+class TestInputConstructorUtils(InputConstructorBaseTestCase, BotorchTestCase):
+    def test_get_best_f_analytic(self):
+        with self.assertRaises(NotImplementedError):
+            get_best_f_analytic(training_data=self.nbd_td)
+        best_f = get_best_f_analytic(training_data=self.bd_td)
+        best_f_expected = self.bd_td.Y.squeeze().max()
+        self.assertEqual(best_f, best_f_expected)
+        with self.assertRaises(NotImplementedError):
+            get_best_f_analytic(training_data=self.bd_td_mo)
+        obj = ScalarizedObjective(weights=torch.rand(2))
+        best_f = get_best_f_analytic(training_data=self.bd_td_mo, objective=obj)
+        best_f_expected = obj.evaluate(self.bd_td_mo.Y).max()
+        self.assertEqual(best_f, best_f_expected)
+
+    def test_get_best_f_mc(self):
+        with self.assertRaises(NotImplementedError):
+            get_best_f_mc(training_data=self.nbd_td)
+        best_f = get_best_f_mc(training_data=self.bd_td)
+        best_f_expected = self.bd_td.Y.squeeze().max()
+        self.assertEqual(best_f, best_f_expected)
+        with self.assertRaises(UnsupportedError):
+            get_best_f_mc(training_data=self.bd_td_mo)
+        obj = LinearMCObjective(weights=torch.rand(2))
+        best_f = get_best_f_mc(training_data=self.bd_td_mo, objective=obj)
+        best_f_expected = (self.bd_td_mo.Y @ obj.weights).max()
+        self.assertEqual(best_f, best_f_expected)
+
+
+class TestAnalyticAcquisitionFunctionInputConstructors(
+    InputConstructorBaseTestCase, BotorchTestCase
+):
+    def test_acqf_input_constructor(self):
+        with self.assertRaises(RuntimeError) as e:
+            get_acqf_input_constructor(DummyAcquisitionFunction)
+            self.assertTrue("not registered" in str(e))
+
+        with self.assertRaises(ValueError) as e:
+
+            @acqf_input_constructor(ExpectedImprovement)
+            class NewAcquisitionFunction(AcquisitionFunction):
+                ...
+
+            self.assertTrue("duplicate" in str(e))
+
+    def test_construct_inputs_analytic_base(self):
+        c = get_acqf_input_constructor(PosteriorMean)
+        mock_model = mock.Mock()
+        kwargs = c(model=mock_model, training_data=self.bd_td)
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertIsNone(kwargs["objective"])
+        mock_obj = mock.Mock()
+        kwargs = c(model=mock_model, training_data=self.bd_td, objective=mock_obj)
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertEqual(kwargs["objective"], mock_obj)
+
+    def test_construct_inputs_best_f(self):
+        c = get_acqf_input_constructor(ExpectedImprovement)
+        mock_model = mock.Mock()
+        kwargs = c(model=mock_model, training_data=self.bd_td)
+        best_f_expected = self.bd_td.Y.squeeze().max()
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertIsNone(kwargs["objective"])
+        self.assertEqual(kwargs["best_f"], best_f_expected)
+        self.assertTrue(kwargs["maximize"])
+        kwargs = c(model=mock_model, training_data=self.bd_td, best_f=0.1)
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertIsNone(kwargs["objective"])
+        self.assertEqual(kwargs["best_f"], 0.1)
+        self.assertTrue(kwargs["maximize"])
+
+
+class TestMCAcquisitionFunctionInputConstructors(
+    InputConstructorBaseTestCase, BotorchTestCase
+):
+    def test_construct_inputs_mc_base(self):
+        c = get_acqf_input_constructor(qSimpleRegret)
+        mock_model = mock.Mock()
+        kwargs = c(model=mock_model, training_data=self.bd_td)
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertIsNone(kwargs["objective"])
+        self.assertIsNone(kwargs["X_pending"])
+        self.assertIsNone(kwargs["sampler"])
+        X_pending = torch.rand(2, 2)
+        objective = LinearMCObjective(torch.rand(2))
+        kwargs = c(
+            model=mock_model,
+            training_data=self.bd_td,
+            objective=objective,
+            X_pending=X_pending,
+        )
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertTrue(torch.equal(kwargs["objective"].weights, objective.weights))
+        self.assertTrue(torch.equal(kwargs["X_pending"], X_pending))
+        self.assertIsNone(kwargs["sampler"])
+        # TODO: Test passing through of sampler
+
+    def test_construct_inputs_qEI(self):
+        c = get_acqf_input_constructor(qExpectedImprovement)
+        mock_model = mock.Mock()
+        kwargs = c(model=mock_model, training_data=self.bd_td)
+        best_f_expected = self.bd_td.Y.squeeze().max()
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertIsNone(kwargs["objective"])
+        self.assertIsNone(kwargs["X_pending"])
+        self.assertIsNone(kwargs["sampler"])
+        X_pending = torch.rand(2, 2)
+        objective = LinearMCObjective(torch.rand(2))
+        kwargs = c(
+            model=mock_model,
+            training_data=self.bd_td_mo,
+            objective=objective,
+            X_pending=X_pending,
+        )
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertTrue(torch.equal(kwargs["objective"].weights, objective.weights))
+        self.assertTrue(torch.equal(kwargs["X_pending"], X_pending))
+        self.assertIsNone(kwargs["sampler"])
+        best_f_expected = objective(self.bd_td_mo.Y).max()
+        self.assertEqual(kwargs["best_f"], best_f_expected)
+
+    def test_construct_inputs_qNEI(self):
+        c = get_acqf_input_constructor(qNoisyExpectedImprovement)
+        mock_model = mock.Mock()
+        kwargs = c(model=mock_model, training_data=self.bd_td)
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertIsNone(kwargs["objective"])
+        self.assertIsNone(kwargs["X_pending"])
+        self.assertIsNone(kwargs["sampler"])
+        self.assertFalse(kwargs["prune_baseline"])
+        self.assertTrue(torch.equal(kwargs["X_baseline"], self.bd_td.X))
+        with self.assertRaises(NotImplementedError):
+            c(model=mock_model, training_data=self.nbd_td)
+        X_baseline = torch.rand(2, 2)
+        kwargs = c(
+            model=mock_model,
+            training_data=self.bd_td,
+            X_baseline=X_baseline,
+            prune_baseline=True,
+        )
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertIsNone(kwargs["objective"])
+        self.assertIsNone(kwargs["X_pending"])
+        self.assertIsNone(kwargs["sampler"])
+        self.assertTrue(kwargs["prune_baseline"])
+        self.assertTrue(torch.equal(kwargs["X_baseline"], X_baseline))
+
+
+class TestMultiObjectiveAcquisitionFunctionInputConstructors(
+    InputConstructorBaseTestCase, BotorchTestCase
+):
+    def test_construct_inputs_EHVI(self):
+        c = get_acqf_input_constructor(ExpectedHypervolumeImprovement)
+        mock_model = mock.Mock()
+        objective_thresholds = torch.rand(2)
+
+        # test error on unsupported outcome constraints
+        with self.assertRaises(NotImplementedError):
+            c(
+                model=mock_model,
+                training_data=self.bd_td,
+                objective_thresholds=objective_thresholds,
+                outcome_constraints=mock.Mock(),
+            )
+
+        # test with Y_pmean supplied explicitly
+        Y_pmean = torch.rand(3, 2)
+        kwargs = c(
+            model=mock_model,
+            training_data=self.bd_td,
+            objective_thresholds=objective_thresholds,
+            Y_pmean=Y_pmean,
+        )
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertIsInstance(kwargs["objective"], IdentityAnalyticMultiOutputObjective)
+        ref_point_expected = objective_thresholds
+        self.assertTrue(torch.equal(kwargs["ref_point"], ref_point_expected))
+        partitioning = kwargs["partitioning"]
+        alpha_expected = get_default_partitioning_alpha(2)
+        self.assertIsInstance(partitioning, NondominatedPartitioning)
+        self.assertEqual(partitioning.alpha, alpha_expected)
+        self.assertTrue(torch.equal(partitioning._neg_ref_point, -ref_point_expected))
+
+        # test with custom objective
+        weights = torch.rand(2)
+        obj = WeightedMCMultiOutputObjective(weights=weights)
+        kwargs = c(
+            model=mock_model,
+            training_data=self.bd_td,
+            objective_thresholds=objective_thresholds,
+            objective=obj,
+            Y_pmean=Y_pmean,
+            alpha=0.05,
+        )
+        self.assertEqual(kwargs["model"], mock_model)
+        self.assertIsInstance(kwargs["objective"], WeightedMCMultiOutputObjective)
+        ref_point_expected = objective_thresholds * weights
+        self.assertTrue(torch.equal(kwargs["ref_point"], ref_point_expected))
+        partitioning = kwargs["partitioning"]
+        self.assertIsInstance(partitioning, NondominatedPartitioning)
+        self.assertEqual(partitioning.alpha, 0.05)
+        self.assertTrue(torch.equal(partitioning._neg_ref_point, -ref_point_expected))
+
+        # Test without providing Y_pmean (computed from model)
+        mean = torch.rand(1, 2)
+        variance = torch.ones(1, 1)
+        mm = MockModel(MockPosterior(mean=mean, variance=variance))
+        kwargs = c(
+            model=mm,
+            training_data=self.bd_td,
+            objective_thresholds=objective_thresholds,
+        )
+        self.assertIsInstance(kwargs["objective"], IdentityAnalyticMultiOutputObjective)
+        ref_point_expected = objective_thresholds
+        self.assertTrue(torch.equal(kwargs["ref_point"], ref_point_expected))
+        partitioning = kwargs["partitioning"]
+        alpha_expected = get_default_partitioning_alpha(2)
+        self.assertIsInstance(partitioning, NondominatedPartitioning)
+        self.assertEqual(partitioning.alpha, alpha_expected)
+        self.assertTrue(torch.equal(partitioning._neg_ref_point, -ref_point_expected))
+        self.assertTrue(torch.equal(partitioning._neg_Y, -mean))
+
+    def test_construct_inputs_qEHVI(self):
+        c = get_acqf_input_constructor(qExpectedHypervolumeImprovement)
+        objective_thresholds = torch.rand(2)
+
+        # Test defaults
+        mean = torch.rand(1, 2)
+        variance = torch.ones(1, 1)
+        mm = MockModel(MockPosterior(mean=mean, variance=variance))
+        kwargs = c(
+            model=mm,
+            training_data=self.bd_td,
+            objective_thresholds=objective_thresholds,
+        )
+        self.assertIsInstance(kwargs["objective"], IdentityAnalyticMultiOutputObjective)
+        ref_point_expected = objective_thresholds
+        self.assertTrue(torch.equal(kwargs["ref_point"], ref_point_expected))
+        partitioning = kwargs["partitioning"]
+        alpha_expected = get_default_partitioning_alpha(2)
+        self.assertIsInstance(partitioning, NondominatedPartitioning)
+        self.assertEqual(partitioning.alpha, alpha_expected)
+        self.assertTrue(torch.equal(partitioning._neg_ref_point, -ref_point_expected))
+        self.assertTrue(torch.equal(partitioning._neg_Y, -mean))
+        sampler = kwargs["sampler"]
+        self.assertIsInstance(sampler, SobolQMCNormalSampler)
+        self.assertEqual(sampler.sample_shape, torch.Size([128]))
+        self.assertIsNone(kwargs["X_pending"])
+        self.assertIsNone(kwargs["constraints"])
+        self.assertEqual(kwargs["eta"], 1e-3)
+
+        # Test outcome constraints and custom inputs
+        mean = torch.tensor([[1.0, 0.25], [0.5, 1.0]])
+        variance = torch.ones(1, 1)
+        mm = MockModel(MockPosterior(mean=mean, variance=variance))
+        weights = torch.rand(2)
+        obj = WeightedMCMultiOutputObjective(weights=weights)
+        outcome_constraints = (torch.tensor([[0.0, 1.0]]), torch.tensor([[0.5]]))
+        X_pending = torch.rand(1, 2)
+        kwargs = c(
+            model=mm,
+            training_data=self.bd_td,
+            objective_thresholds=objective_thresholds,
+            objective=obj,
+            outcome_constraints=outcome_constraints,
+            X_pending=X_pending,
+            alpha=0.05,
+            eta=1e-2,
+            qmc=False,
+            mc_samples=64,
+        )
+        self.assertIsInstance(kwargs["objective"], WeightedMCMultiOutputObjective)
+        ref_point_expected = objective_thresholds * weights
+        self.assertTrue(torch.equal(kwargs["ref_point"], ref_point_expected))
+        partitioning = kwargs["partitioning"]
+        self.assertIsInstance(partitioning, NondominatedPartitioning)
+        self.assertEqual(partitioning.alpha, 0.05)
+        self.assertTrue(torch.equal(partitioning._neg_ref_point, -ref_point_expected))
+        Y_expected = mean[:1] * weights
+        self.assertTrue(torch.equal(partitioning._neg_Y, -Y_expected))
+        sampler = kwargs["sampler"]
+        self.assertIsInstance(sampler, IIDNormalSampler)
+        self.assertEqual(sampler.sample_shape, torch.Size([64]))
+        self.assertTrue(torch.equal(kwargs["X_pending"], X_pending))
+        cons_tfs = kwargs["constraints"]
+        self.assertEqual(len(cons_tfs), 1)
+        cons_eval = cons_tfs[0](mean)
+        cons_eval_expected = torch.tensor([-0.25, 0.5])
+        self.assertTrue(torch.equal(cons_eval, cons_eval_expected))
+        self.assertEqual(kwargs["eta"], 1e-2)
+
+        # Test custom sampler
+        custom_sampler = SobolQMCNormalSampler(num_samples=16, seed=1234)
+        kwargs = c(
+            model=mm,
+            training_data=self.bd_td,
+            objective_thresholds=objective_thresholds,
+            sampler=custom_sampler,
+        )
+        sampler = kwargs["sampler"]
+        self.assertIsInstance(sampler, SobolQMCNormalSampler)
+        self.assertEqual(sampler.sample_shape, torch.Size([16]))
+        self.assertEqual(sampler.seed, 1234)

--- a/test/acquisition/test_objective.py
+++ b/test/acquisition/test_objective.py
@@ -65,6 +65,11 @@ class TestScalarizedObjective(BotorchTestCase):
             # test error
             with self.assertRaises(ValueError):
                 ScalarizedObjective(weights=torch.rand(2, m))
+            # test evaluate
+            Y = torch.rand(2, m, device=self.device, dtype=dtype)
+            val = obj.evaluate(Y)
+            val_expected = offset + Y @ weights
+            self.assertTrue(torch.equal(val, val_expected))
 
 
 class TestMCAcquisitionObjective(BotorchTestCase):


### PR DESCRIPTION
Summary:
See https://github.com/pytorch/botorch/discussions/784#discussioncomment-707167.

This is currently not covering all acquisition functions, and focusing only on the ones in `analytic.py` and `monte_carlo.py`. In particular,  KG and MES-ish ones are missing for now

Differential Revision: D28277557

