### PR TITLE
Add evaluate method to ScalarizedObjective

### DIFF
--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -57,6 +57,17 @@ class ScalarizedObjective(AcquisitionObjective):
         self.register_buffer("weights", weights)
         self.offset = offset
 
+    def evaluate(self, Y: Tensor) -> Tensor:
+        r"""Evaluate the objective on a set of outcomes.
+
+        Args:
+            Y: A `batch_shape x q x m`-dim tensor of outcomes.
+
+        Returns:
+            A `batch_shape x q`-dim tensor of objective values.
+        """
+        return self.offset + Y @ self.weights
+
     def forward(self, posterior: GPyTorchPosterior) -> GPyTorchPosterior:
         r"""Compute the posterior of the affine transformation.
 

--- a/test/acquisition/test_objective.py
+++ b/test/acquisition/test_objective.py
@@ -65,6 +65,11 @@ class TestScalarizedObjective(BotorchTestCase):
             # test error
             with self.assertRaises(ValueError):
                 ScalarizedObjective(weights=torch.rand(2, m))
+            # test evaluate
+            Y = torch.rand(2, m, device=self.device, dtype=dtype)
+            val = obj.evaluate(Y)
+            val_expected = offset + Y @ weights
+            self.assertTrue(torch.equal(val, val_expected))
 
 
 class TestMCAcquisitionObjective(BotorchTestCase):


### PR DESCRIPTION
Summary: Convenience function for evaluating scalarized objectives on outcomes (rather than posteriors). Used in D28277557

Differential Revision: D28389808

