### PR TITLE
Additional input constructors

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -342,7 +342,7 @@ class ConstrainedExpectedImprovement(AnalyticAcquisitionFunction):
         Args:
             model: A fitted single-outcome model.
             best_f: Either a scalar or a `b`-dim Tensor (batch mode) representing
-                the best function value observed so far (assumed noiseless).
+                the best feasible function value observed so far (assumed noiseless).
             objective_index: The index of the objective.
             constraints: A dictionary of the form `{i: [lower, upper]}`, where
                 `i` is the output index, and `lower` and `upper` are lower and upper


### PR DESCRIPTION
Summary:
Add additional constructors that were not part of D28277557 (https://github.com/pytorch/botorch/commit/d6393d5c514bcadffb127e4a6c6c96d44eb9bbb7) / https://github.com/pytorch/botorch/pull/788.

Punting on `ConstrainedExpectedImprovement` for now.

Differential Revision: D28454735

