### PR TITLE
Extend `optimize_acqf_mixed` to allow batch optimization

### DIFF
--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -191,7 +191,7 @@ class MockAcquisitionFunction:
         self.X_pending = None
 
     def __call__(self, X):
-        return X[..., 0].max(dim=-1)[0]
+        return X[..., 0].max(dim=-1).values
 
     def set_X_pending(self, X_pending: Optional[Tensor] = None):
         self.X_pending = X_pending


### PR DESCRIPTION
Summary: This function was previously implemented with the implicit assumption that `q=1`. This adds support for `q>`1 by doing sequential optimization (since enumerating all possible `n_combo^q` combinations of fixed features to generate the `q`-batch jointly is not scalable.

Differential Revision: D28577786

