### PR TITLE
Pass `fixed_features` to initial candidate generation functions

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -169,6 +169,7 @@ def optimize_acqf(
             q=q,
             num_restarts=num_restarts,
             raw_samples=raw_samples,
+            fixed_features=fixed_features,
             options=options,
             inequality_constraints=inequality_constraints,
             equality_constraints=equality_constraints,


### PR DESCRIPTION
Summary: Currently in `optimize_acqf`, `fixed_features` is not being respected at the initial candidate generation phase. This is particularly problematic when `fixed_features` is passed and overwrites parts of the initial candidates generated. This diff ensures that `fixed_features` is respected throughout.

Differential Revision: D28645293

