### PR TITLE
Add note explaining the inheritance structure of InputTransform

### DIFF
--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -35,6 +35,10 @@ from torch.nn import Module, ModuleDict
 class InputTransform(ABC):
     r"""Abstract base class for input transforms.
 
+    Note: Input transforms must inherit from `torch.nn.Module`. This
+        is deferred to the subclasses to avoid any potential conflict
+        between `gpytorch.module.Module` and `torch.nn.Module` in `Warp`.
+
     Properties:
         transform_on_train: A boolean indicating whether to apply the
             transform in train() mode.
@@ -91,7 +95,7 @@ class InputTransform(ABC):
     def equals(self, other: InputTransform) -> bool:
         r"""Check if another input transform is equivalent.
 
-        Note: The reason that a custom equals method is definde rather than
+        Note: The reason that a custom equals method is defined rather than
         defining an __eq__ method is because defining an __eq__ method sets
         the __hash__ method to None. Hashing modules is currently used in
         pytorch. See https://github.com/pytorch/pytorch/issues/7733.


### PR DESCRIPTION
Update:
`InputTransform` defers the inheritance of `Module` to subclasses to avoid potential conflicts in `Warp`. Added a note explaining this reasoning.

Old:
Summary: Currently, the abstract class `InputTransform` does not inherit `Module` (instead each input transform inherits `Module` individually in some way). However, BoTorch implicitly assumes that any input transform is a subclass of `Module`, e.g., with the `input_transform.to(...)` call in `SingleTaskGP`. This changes the class definitions to make `InputTransform` inherit `Module`, eliminating the need for inheriting it separately for each newly defined input transform. This also makes it consistent with `OutcomeTransform`.

Differential Revision: D28818386

