### PR TITLE
Use powers of 2 in qMC docstrings & examples

### DIFF
--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -104,7 +104,7 @@ class qExpectedImprovement(MCAcquisitionFunction):
     Example:
         >>> model = SingleTaskGP(train_X, train_Y)
         >>> best_f = train_Y.max()[0]
-        >>> sampler = SobolQMCNormalSampler(1000)
+        >>> sampler = SobolQMCNormalSampler(1024)
         >>> qEI = qExpectedImprovement(model, best_f, sampler)
         >>> qei = qEI(test_X)
     """
@@ -126,7 +126,7 @@ class qExpectedImprovement(MCAcquisitionFunction):
                 a `batch_shape`-shaped tensor, which in case of a batched model
                 specifies potentially different values for each element of the batch.
             sampler: The sampler used to draw base samples. Defaults to
-                `SobolQMCNormalSampler(num_samples=500, collapse_batch_dims=True)`
+                `SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)`
             objective: The MCAcquisitionObjective under which the samples are evalauted.
                 Defaults to `IdentityMCObjective()`.
             X_pending:  A `m x d`-dim Tensor of `m` design points that have been
@@ -174,7 +174,7 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
 
     Example:
         >>> model = SingleTaskGP(train_X, train_Y)
-        >>> sampler = SobolQMCNormalSampler(1000)
+        >>> sampler = SobolQMCNormalSampler(1024)
         >>> qNEI = qNoisyExpectedImprovement(model, train_X, sampler)
         >>> qnei = qNEI(test_X)
     """
@@ -197,7 +197,7 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
                 that have already been observed. These points are considered as
                 the potential best design point.
             sampler: The sampler used to draw base samples. Defaults to
-                `SobolQMCNormalSampler(num_samples=500, collapse_batch_dims=True)`.
+                `SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)`.
             objective: The MCAcquisitionObjective under which the samples are
                 evaluated. Defaults to `IdentityMCObjective()`.
             X_pending: A `batch_shape x m x d`-dim Tensor of `m` design points
@@ -239,8 +239,8 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
         """
         q = X.shape[-2]
         X_full = torch.cat([X, match_batch_shape(self.X_baseline, X)], dim=-2)
-        # TODO (T41248036): Implement more efficient way to compute posterior
-        # over both training and test points in GPyTorch
+        # TODO: Implement more efficient way to compute posterior over both training and
+        # test points in GPyTorch (https://github.com/cornellius-gp/gpytorch/issues/567)
         posterior = self.model.posterior(X_full)
         samples = self.sampler(posterior)
         obj = self.objective(samples, X=X_full)
@@ -262,7 +262,7 @@ class qProbabilityOfImprovement(MCAcquisitionFunction):
     Example:
         >>> model = SingleTaskGP(train_X, train_Y)
         >>> best_f = train_Y.max()[0]
-        >>> sampler = SobolQMCNormalSampler(1000)
+        >>> sampler = SobolQMCNormalSampler(1024)
         >>> qPI = qProbabilityOfImprovement(model, best_f, sampler)
         >>> qpi = qPI(test_X)
     """
@@ -284,7 +284,7 @@ class qProbabilityOfImprovement(MCAcquisitionFunction):
                 be a `batch_shape`-shaped tensor, which in case of a batched model
                 specifies potentially different values for each element of the batch.
             sampler: The sampler used to draw base samples. Defaults to
-                `SobolQMCNormalSampler(num_samples=500, collapse_batch_dims=True)`
+                `SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)`
             objective: The MCAcquisitionObjective under which the samples are
                 evaluated. Defaults to `IdentityMCObjective()`.
             X_pending:  A `m x d`-dim Tensor of `m` design points that have
@@ -334,7 +334,7 @@ class qSimpleRegret(MCAcquisitionFunction):
 
     Example:
         >>> model = SingleTaskGP(train_X, train_Y)
-        >>> sampler = SobolQMCNormalSampler(1000)
+        >>> sampler = SobolQMCNormalSampler(1024)
         >>> qSR = qSimpleRegret(model, sampler)
         >>> qsr = qSR(test_X)
     """
@@ -371,7 +371,7 @@ class qUpperConfidenceBound(MCAcquisitionFunction):
 
     Example:
         >>> model = SingleTaskGP(train_X, train_Y)
-        >>> sampler = SobolQMCNormalSampler(1000)
+        >>> sampler = SobolQMCNormalSampler(1024)
         >>> qUCB = qUpperConfidenceBound(model, 0.1, sampler)
         >>> qucb = qUCB(test_X)
     """
@@ -390,7 +390,7 @@ class qUpperConfidenceBound(MCAcquisitionFunction):
             model: A fitted model.
             beta: Controls tradeoff between mean and standard deviation in UCB.
             sampler: The sampler used to draw base samples. Defaults to
-                `SobolQMCNormalSampler(num_samples=500, collapse_batch_dims=True)`
+                `SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)`
             objective: The MCAcquisitionObjective under which the samples are
                 evaluated. Defaults to `IdentityMCObjective()`.
             X_pending: A `batch_shape x m x d`-dim Tensor of `m` design points that have

--- a/botorch/sampling/qmc.py
+++ b/botorch/sampling/qmc.py
@@ -33,7 +33,7 @@ class NormalQMCEngine:
 
     Example:
         >>> engine = NormalQMCEngine(3)
-        >>> samples = engine.draw(10)
+        >>> samples = engine.draw(16)
     """
 
     def __init__(
@@ -63,7 +63,7 @@ class NormalQMCEngine:
         r"""Draw `n` qMC samples from the standard Normal.
 
         Args:
-            n: The number of samples to draw.
+            n: The number of samples to draw. As a best practice, use powers of 2.
             out: An option output tensor. If provided, draws are put into this
                 tensor, and the function returns None.
             dtype: The desired torch data type (ignored if `out` is provided).
@@ -104,7 +104,7 @@ class MultivariateNormalQMCEngine:
         >>> mean = torch.tensor([1.0, 2.0])
         >>> cov = torch.tensor([[1.0, 0.25], [0.25, 2.0]])
         >>> engine = MultivariateNormalQMCEngine(mean, cov)
-        >>> samples = engine.draw(10)
+        >>> samples = engine.draw(16)
     """
 
     def __init__(
@@ -149,7 +149,7 @@ class MultivariateNormalQMCEngine:
         r"""Draw `n` qMC samples from the multivariate Normal.
 
         Args:
-            n: The number of samples to draw.
+            n: The number of samples to draw. As a best practice, use powers of 2.
             out: An option output tensor. If provided, draws are put into this
                 tensor, and the function returns None.
 

--- a/botorch/sampling/samplers.py
+++ b/botorch/sampling/samplers.py
@@ -227,7 +227,7 @@ class SobolQMCNormalSampler(MCSampler):
     r"""Sampler for quasi-MC base samples using Sobol sequences.
 
     Example:
-        >>> sampler = SobolQMCNormalSampler(1000, seed=1234)
+        >>> sampler = SobolQMCNormalSampler(1024, seed=1234)
         >>> posterior = model.posterior(test_X)
         >>> samples = sampler(posterior)
     """
@@ -243,7 +243,8 @@ class SobolQMCNormalSampler(MCSampler):
         r"""Sampler for quasi-MC base samples using Sobol sequences.
 
         Args:
-            num_samples: The number of samples to use.
+            num_samples: The number of samples to use. As a best practice,
+                use powers of 2.
             resample: If `True`, re-draw samples in each `forward` evaluation -
                 this results in stochastic acquisition functions (and thus should
                 not be used with deterministic optimization algorithms).

--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -167,7 +167,7 @@ def draw_sobol_samples(
         bounds: A `2 x d` dimensional tensor specifying box constraints on a
             `d`-dimensional space, where bounds[0, :] and bounds[1, :] correspond
             to lower and upper bounds, respectively.
-        n: The number of (q-batch) samples.
+        n: The number of (q-batch) samples. As a best practice, use powers of 2.
         q: The size of each q-batch.
         batch_shape: The batch shape of the samples. If given, returns samples
             of shape `n x batch_shape x q x d`, where each batch is an
@@ -181,7 +181,7 @@ def draw_sobol_samples(
 
     Example:
         >>> bounds = torch.stack([torch.zeros(3), torch.ones(3)])
-        >>> samples = draw_sobol_samples(bounds, 10, 2)
+        >>> samples = draw_sobol_samples(bounds, 16, 2)
     """
     batch_shape = batch_shape or torch.Size()
     batch_size = int(torch.prod(torch.tensor(batch_shape)))
@@ -210,7 +210,7 @@ def draw_sobol_normal_samples(
 
     Args:
         d: The dimension of the normal distribution.
-        n: The number of samples to return.
+        n: The number of samples to return. As a best practice, use powers of 2.
         device: The torch device.
         dtype:  The torch dtype.
         seed: The seed used for initializing Owen scrambling. If None (default),
@@ -221,7 +221,7 @@ def draw_sobol_normal_samples(
         and dtype specified by the input.
 
     Example:
-        >>> samples = draw_sobol_normal_samples(2, 10)
+        >>> samples = draw_sobol_normal_samples(2, 16)
     """
     normal_qmc_engine = NormalQMCEngine(d=d, seed=seed, inv_transform=True)
     samples = normal_qmc_engine.draw(n, dtype=torch.float if dtype is None else dtype)


### PR DESCRIPTION
Summary: This started as making `num_samples` in `acquisition/monte_carlo.py` consistent with the implementation (default 512 vs 500), and spiralled from there. It fixes the inconsistencies mentioned, and updates other qMC docstrings to encourage use of powers of 2 samples and the code examples to use powers of 2 as well.

Reviewed By: Balandat

Differential Revision: D28850368

