### PR TITLE
Modify input transforms to support one-to-many transforms

### DIFF
--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -128,6 +128,7 @@ def fit_gpytorch_model(
         for w in ws:
             has_optwarning |= issubclass(w.category, OptimizationWarning)
             warnings.warn(w.message, w.category)
+        # TODO: this counts hitting `maxiter` as an optimization failure!
         if not has_optwarning:
             _set_transformed_inputs(mll=mll)
             mll.eval()
@@ -136,6 +137,7 @@ def fit_gpytorch_model(
         logging.log(logging.DEBUG, f"Fitting failed on try {retry}.")
 
     warnings.warn("Fitting failed on all retries.", OptimizationWarning)
+    _set_transformed_inputs(mll=mll)
     return mll.eval()
 
 

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -145,7 +145,8 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         self.to(train_X)
 
     def forward(self, x: Tensor) -> MultivariateNormal:
-        x = self.transform_inputs(x)
+        if self.training:
+            x = self.transform_inputs(x)
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)
         return MultivariateNormal(mean_x, covar_x)
@@ -298,7 +299,8 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         return self.condition_on_observations(X=X, Y=Y_fantasized, noise=noise)
 
     def forward(self, x: Tensor) -> MultivariateNormal:
-        x = self.transform_inputs(x)
+        if self.training:
+            x = self.transform_inputs(x)
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)
         return MultivariateNormal(mean_x, covar_x)

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -326,7 +326,8 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                 )
 
     def forward(self, X: Tensor) -> MultivariateNormal:
-        X = self.transform_inputs(X)
+        if self.training:
+            X = self.transform_inputs(X)
 
         covariance_list = []
         covariance_list.append(self.covar_modules[0](X))

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 
 import torch
 from botorch import settings
+from botorch.models.utils import fantasize as fantasize_flag
 from botorch.posteriors import Posterior
 from botorch.sampling.samplers import MCSampler
 from botorch.utils.containers import TrainingData
@@ -34,6 +35,10 @@ class Model(Module, ABC):
         **kwargs: Any,
     ) -> Posterior:
         r"""Computes the posterior over model outputs at the provided points.
+
+        Note: The input transforms should be applied here using
+            `self.transform_inputs(X)` after the `self.eval()` call and before
+            any `model.forward` or `model.likelihood` calls.
 
         Args:
             X: A `b x q x d`-dim Tensor, where `d` is the dimension of the
@@ -134,10 +139,11 @@ class Model(Module, ABC):
             The constructed fantasy model.
         """
         propagate_grads = kwargs.pop("propagate_grads", False)
-        with settings.propagate_grads(propagate_grads):
-            post_X = self.posterior(X, observation_noise=observation_noise)
-        Y_fantasized = sampler(post_X)  # num_fantasies x batch_shape x n' x m
-        return self.condition_on_observations(X=X, Y=Y_fantasized, **kwargs)
+        with fantasize_flag():
+            with settings.propagate_grads(propagate_grads):
+                post_X = self.posterior(X, observation_noise=observation_noise)
+            Y_fantasized = sampler(post_X)  # num_fantasies x batch_shape x n' x m
+            return self.condition_on_observations(X=X, Y=Y_fantasized, **kwargs)
 
     @classmethod
     def construct_inputs(
@@ -149,7 +155,9 @@ class Model(Module, ABC):
         )
 
     def transform_inputs(
-        self, X: Tensor, input_transform: Optional[Module] = None
+        self,
+        X: Tensor,
+        input_transform: Optional[Module] = None,
     ) -> Tensor:
         r"""Transform inputs.
 

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -156,7 +156,8 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel):
         return x_basic, task_idcs
 
     def forward(self, x: Tensor) -> MultivariateNormal:
-        x = self.transform_inputs(x)
+        if self.training:
+            x = self.transform_inputs(x)
         x_basic, task_idcs = self._split_inputs(x)
         # Compute base mean and covariance
         mean_x = self.mean_module(x_basic)

--- a/botorch/models/utils.py
+++ b/botorch/models/utils.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Tuple
 import torch
 from botorch import settings
 from botorch.exceptions import InputDataError, InputDataWarning
+from botorch.settings import _Flag
 from gpytorch import settings as gpt_settings
 from gpytorch.module import Module
 from gpytorch.utils.broadcasting import _mul_broadcast_shape
@@ -262,3 +263,8 @@ def gpt_posterior_settings():
             gpt_settings.detach_test_caches(settings.propagate_grads.off())
         )
         yield
+
+
+class fantasize(_Flag):
+    r"""A flag denoting whether we are currently in a `fantasize` context."""
+    _state: bool = False

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -61,9 +61,7 @@ class TestSingleTaskGP(BotorchTestCase):
             tkwargs = {"device": self.device, "dtype": dtype}
             octf = Standardize(m=m, batch_shape=batch_shape) if use_octf else None
             intf = (
-                Normalize(
-                    d=1, bounds=bounds.to(**tkwargs), transform_on_preprocess=True
-                )
+                Normalize(d=1, bounds=bounds.to(**tkwargs), transform_on_train=True)
                 if use_intf
                 else None
             )
@@ -72,7 +70,7 @@ class TestSingleTaskGP(BotorchTestCase):
                 m=m,
                 outcome_transform=octf,
                 input_transform=intf,
-                **tkwargs
+                **tkwargs,
             )
             mll = ExactMarginalLogLikelihood(model.likelihood, model).to(**tkwargs)
             with warnings.catch_warnings():
@@ -422,6 +420,7 @@ class TestHeteroskedasticSingleTaskGP(TestSingleTaskGP):
 
 
 def _get_pvar_expected(posterior, model, X, m):
+    X = model.transform_inputs(X)
     lh_kwargs = {}
     if isinstance(model.likelihood, FixedNoiseGaussianLikelihood):
         lh_kwargs["noise"] = model.likelihood.noise.mean().expand(X.shape[:-1])

--- a/test/models/test_gp_regression_mixed.py
+++ b/test/models/test_gp_regression_mixed.py
@@ -56,7 +56,7 @@ class TestMixedSingleTaskGP(BotorchTestCase):
                     train_Y,
                     cat_dims=cat_dims,
                     input_transform=Normalize(
-                        d=d, bounds=bounds.to(**tkwargs), transform_on_preprocess=True
+                        d=d, bounds=bounds.to(**tkwargs), transform_on_train=True
                     ),
                 )
             if len(cat_dims) == 0:

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -117,9 +117,7 @@ class TestMultiTaskGP(BotorchTestCase):
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
             intf = (
-                Normalize(
-                    d=2, bounds=bounds.to(**tkwargs), transform_on_preprocess=True
-                )
+                Normalize(d=2, bounds=bounds.to(**tkwargs), transform_on_train=True)
                 if use_intf
                 else None
             )
@@ -259,9 +257,7 @@ class TestFixedNoiseMultiTaskGP(BotorchTestCase):
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
             intf = (
-                Normalize(
-                    d=2, bounds=bounds.to(**tkwargs), transform_on_preprocess=True
-                )
+                Normalize(d=2, bounds=bounds.to(**tkwargs), transform_on_train=True)
                 if use_intf
                 else None
             )

--- a/test/models/test_utils.py
+++ b/test/models/test_utils.py
@@ -14,6 +14,7 @@ from botorch.models.utils import (
     check_min_max_scaling,
     check_no_nans,
     check_standardization,
+    fantasize,
     gpt_posterior_settings,
     multioutput_to_batch_mode_transform,
     validate_input_scaling,
@@ -212,3 +213,15 @@ class TestGPTPosteriorSettings(BotorchTestCase):
                         self.assertTrue(gpt_settings.detach_test_caches.on())
                     else:
                         self.assertTrue(gpt_settings.detach_test_caches.off())
+
+
+class TestFantasize(BotorchTestCase):
+    def test_fantasize(self):
+        self.assertFalse(fantasize.on())
+        self.assertTrue(fantasize.off())
+        with fantasize():
+            self.assertTrue(fantasize.on())
+            self.assertFalse(fantasize.off())
+        with fantasize(False):
+            self.assertFalse(fantasize.on())
+            self.assertTrue(fantasize.off())

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -335,15 +335,17 @@ class TestSetTransformedInputs(BotorchTestCase):
             tf = Normalize(
                 d=1,
                 bounds=torch.tensor([[0.0], [2.0]], dtype=dtype, device=self.device),
-                transform_on_preprocess=False,
             )
             model = SingleTaskGP(train_x, train_y, input_transform=tf)
             self.assertTrue(torch.equal(model.train_inputs[0], train_x))
             mll = ExactMarginalLogLikelihood(model.likelihood, model)
-            # check that input transform is only applied when the transform
-            # is a transform_on_preprocess is True
+            # check that input transform is only applied when
+            # transform_on_train=True
             self.assertTrue(torch.equal(model.train_inputs[0], train_x))
-            tf.transform_on_preprocess = True
+            tf.transform_on_train = False
+            _set_transformed_inputs(mll)
+            self.assertTrue(torch.equal(model.train_inputs[0], train_x))
+            tf.transform_on_train = True
             _set_transformed_inputs(mll)
             self.assertTrue(torch.equal(model.train_inputs[0], tf(train_x)))
             model.eval()


### PR DESCRIPTION
Summary:
This modifies the input transform to support one-to-many transforms that are needed for robust BO.

Changes:
- `transform_inputs` is applied in `model.forward` if the model is in `train` mode, otherwise it is applied in the `posterior` call. Moving it to `posterior` is necessary to make one-to-many transforms work, applying in `model.forward` is necessary to make sure certain transforms get applied at training.
- If the transform has `transform_on_train=True`, at the end of model fit using `fit_gpytorch_model`, `model.train_inputs` is updated with the transformed version. This makes sure that the `train_inputs` are transformed at both training and eval if and only if `transform_on_train=True`.
- With this change, `transform_on_preprocess` attribute becomes redundant and is removed. 
- Implements a `fantasize` flag and a `transform_on_fantasize` attribute to allow for turning off certain one-to-many transforms during `model.fantasize` call. Example use case: In the risk measure setting, we have a model trained on `(x, w)` inputs, for which we want to draw posterior samples of the risk measure (computed over w's) for a given x. This is achieved by using an input transform that appends w's to the given x, evaluating `posterior` on the resulting `(x, w)` pairs, and applying the risk measure (as an objective) to the resulting samples. So, in this case we would have the input transform taking in `x` and giving out a bunch of `(x, w)`s. However, when we want to fantasize on this model, we would call `fantasize` with an `(x, w)`, which if transformed would turn to `(x, w, w)` - not good. `transform_on_fantasize=False` along with the `fantasize` flag makes sure this doesn't happen.

Note: This does not touch `PairwiseGP` model. `PairwiseGP` implements its own `posterior` , uses input transforms manually on train and test inputs, and should not be affected by these changes.

Differential Revision: D28944189