### PR TITLE
add heuristic for reference point selection

### DIFF
--- a/botorch/utils/multi_objective/__init__.py
+++ b/botorch/utils/multi_objective/__init__.py
@@ -4,13 +4,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from botorch.utils.multi_objective.hypervolume import Hypervolume
+from botorch.utils.multi_objective.hypervolume import Hypervolume, infer_reference_point
 from botorch.utils.multi_objective.pareto import is_non_dominated
 from botorch.utils.multi_objective.scalarization import get_chebyshev_scalarization
 
 
 __all__ = [
     "get_chebyshev_scalarization",
+    "infer_reference_point",
     "is_non_dominated",
     "Hypervolume",
 ]

--- a/botorch/utils/multi_objective/hypervolume.py
+++ b/botorch/utils/multi_objective/hypervolume.py
@@ -13,6 +13,11 @@ References
     algorithm for the hypervolume indicator. In IEEE Congress on Evolutionary
     Computation, pages 1157-1163, Vancouver, Canada, July 2006.
 
+.. [Ishibuchi2011]
+    H. Ishibuchi, N. Akedo, and Y. Nojima. A many-objective test problem
+    for visually examining diversity maintenance behavior in a decision
+    space. Proc. 13th Annual Conf. Genetic Evol. Comput., 2011.
+
 """
 
 from __future__ import annotations
@@ -20,8 +25,72 @@ from __future__ import annotations
 from typing import List, Optional
 
 import torch
-from botorch.exceptions.errors import BotorchTensorDimensionError
+from botorch.exceptions.errors import BotorchTensorDimensionError, BotorchError
 from torch import Tensor
+
+MIN_Y_RANGE = 1e-7
+
+
+def infer_reference_point(
+    pareto_Y: Tensor,
+    max_ref_point: Optional[Tensor] = None,
+    scale: float = 0.1,
+    scale_max_ref_point: bool = False,
+) -> Tensor:
+    r"""Get reference point for hypervolume computations.
+
+    This sets the reference point to be `ref_point = nadir - 0.1 * range`
+    when there is no pareto_Y that is better than the reference point.
+
+    [Ishibuchi2011]_ find 0.1 to be a robust multiplier for scaling the
+    nadir point.
+
+    Note: this assumes maximization of all objectives.
+
+    Args:
+        pareto_Y: A `n x m`-dim tensor of Pareto-optimal points.
+        max_ref_point: A `m` dim tensor indicating the maximum reference point.
+        scale: A multiplier used to scale back the reference point based on the
+            range of each objective.
+        scale_max_ref_point: A boolean indicating whether to apply scaling to
+            the max_ref_point based on the range of each objective.
+
+    Returns:
+        A `m`-dim tensor containing the reference point.
+    """
+
+    if pareto_Y.shape[0] == 0:
+        if max_ref_point is None:
+            raise BotorchError("Empty pareto set and no max ref point provided")
+        if scale_max_ref_point:
+            return max_ref_point - scale * max_ref_point.abs()
+        return max_ref_point
+    if max_ref_point is not None:
+        better_than_ref = (pareto_Y > max_ref_point).all(dim=-1)
+    else:
+        better_than_ref = torch.full(
+            pareto_Y.shape[:1], 1, dtype=bool, device=pareto_Y.device
+        )
+    if max_ref_point is not None and better_than_ref.any():
+        Y_range = pareto_Y[better_than_ref].max(dim=0).values - max_ref_point
+        if scale_max_ref_point:
+            return max_ref_point - scale * Y_range
+        return max_ref_point
+    elif pareto_Y.shape[0] == 1:
+        # no points better than max_ref_point and only a single observation
+        # subtract MIN_Y_RANGE to handle the case that pareto_Y is a singleton
+        # with objective value of 0.
+        return (pareto_Y - scale * pareto_Y.abs().clamp_min(MIN_Y_RANGE)).view(-1)
+    # no points better than max_ref_point and multiple observations
+    # make sure that each dimension of the nadir point is no greater than
+    # the max_ref_point
+    nadir = pareto_Y.min(dim=0).values
+    if max_ref_point is not None:
+        nadir = torch.min(nadir, max_ref_point)
+    ideal = pareto_Y.max(dim=0).values
+    # handle case where all values for one objective are the same
+    Y_range = (ideal - nadir).clamp_min(MIN_Y_RANGE)
+    return nadir - scale * Y_range
 
 
 class Hypervolume:


### PR DESCRIPTION
Summary: This heuristic is useful for setting the reference point to for EHVI to identify the entire pareto frontier.

Reviewed By: Balandat

Differential Revision: D28163747

