### PR TITLE
Bump pytorch requriment to >=1.8.

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - python>=3.7
     - setuptools_scm
   run:
-    - pytorch>=1.8
+    - pytorch>=1.8.1
     - gpytorch>=1.4
     - scipy
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Optimization simply use Ax.
 
 **Installation Requirements**
 - Python >= 3.7
-- PyTorch >= 1.8
+- PyTorch >= 1.8.1
 - gpytorch >= 1.4
 - scipy
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -14,7 +14,7 @@ Before jumping the gun, we recommend you start with the high-level
 #### Installation Requirements:
 
 - Python >= 3.7
-- PyTorch >= 1.8
+- PyTorch >= 1.8.1
 - gpytorch >= 1.4
 - scipy
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,6 @@ channels:
   - pytorch
   - gpytorch
 dependencies:
-  - pytorch>=1.8
+  - pytorch>=1.8.1
   - gpytorch>=1.4
   - scipy

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
             else "node-and-date"
         ),
     },
-    install_requires=["torch>=1.8", "gpytorch>=1.4", "scipy"],
+    install_requires=["torch>=1.8.1", "gpytorch>=1.4", "scipy"],
     packages=find_packages(),
     extras_require={
         "dev": DEV_REQUIRES,


### PR DESCRIPTION
It's a bit too early to have a hard requirement on torch 1.9, so let's bump to 1.8.1 instead