### PR TITLE
Move `input_transform.to(...)` call to `transform_inputs`

### DIFF
--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -90,8 +90,6 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP):
             >>> train_Y = torch.sin(train_X).sum(dim=1, keepdim=True)
             >>> model = SingleTaskGP(train_X, train_Y)
         """
-        if input_transform is not None:
-            input_transform.to(train_X)
         with torch.no_grad():
             transformed_X = self.transform_inputs(
                 X=train_X, input_transform=input_transform
@@ -206,8 +204,6 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
             >>> train_Yvar = torch.full_like(train_Y, 0.2)
             >>> model = FixedNoiseGP(train_X, train_Y, train_Yvar)
         """
-        if input_transform is not None:
-            input_transform.to(train_X)
         with torch.no_grad():
             transformed_X = self.transform_inputs(
                 X=train_X, input_transform=input_transform

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -95,8 +95,6 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
             raise UnsupportedError(
                 "SingleTaskMultiFidelityGP requires at least one fidelity parameter."
             )
-        if input_transform is not None:
-            input_transform.to(train_X)
         with torch.no_grad():
             transformed_X = self.transform_inputs(
                 X=train_X, input_transform=input_transform
@@ -207,8 +205,6 @@ class FixedNoiseMultiFidelityGP(FixedNoiseGP):
             raise UnsupportedError(
                 "FixedNoiseMultiFidelityGP requires at least one fidelity parameter."
             )
-        if input_transform is not None:
-            input_transform.to(train_X)
         with torch.no_grad():
             transformed_X = self.transform_inputs(
                 X=train_X, input_transform=input_transform

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -169,6 +169,7 @@ class Model(Module, ABC):
             A tensor of transformed inputs
         """
         if input_transform is not None:
+            input_transform.to(X)
             return input_transform(X)
         try:
             return self.input_transform(X)

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -96,8 +96,6 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel):
             >>> train_Y = torch.cat(f1(X1), f2(X2)).unsqueeze(-1)
             >>> model = MultiTaskGP(train_X, train_Y, task_feature=-1)
         """
-        if input_transform is not None:
-            input_transform.to(train_X)
         with torch.no_grad():
             transformed_X = self.transform_inputs(
                 X=train_X, input_transform=input_transform
@@ -312,8 +310,6 @@ class FixedNoiseMultiTaskGP(MultiTaskGP):
             >>> train_Yvar = 0.1 + 0.1 * torch.rand_like(train_Y)
             >>> model = FixedNoiseMultiTaskGP(train_X, train_Y, train_Yvar, -1)
         """
-        if input_transform is not None:
-            input_transform.to(train_X)
         with torch.no_grad():
             transformed_X = self.transform_inputs(
                 X=train_X, input_transform=input_transform
@@ -406,8 +402,6 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
             >>> train_Y = torch.cat([f_1(X), f_2(X)], dim=-1)
             >>> model = KroneckerMultiTaskGP(train_X, train_Y)
         """
-        if input_transform is not None:
-            input_transform.to(train_X)
         with torch.no_grad():
             transformed_X = self.transform_inputs(
                 X=train_X, input_transform=input_transform


### PR DESCRIPTION
Summary: Moves the `input_transform.to(...)` call from `model.__init__` to `transform_inputs(...)` call, reducing the boilerplate code in `model.__init__`.

Reviewed By: sdaulton

Differential Revision: D29266313

