### PR TITLE
Fix flaky test_warp_transform test

### DIFF
--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -460,8 +460,8 @@ class TestInputTransforms(BotorchTestCase):
 
             self.assertEqual(warp_tf.indices.tolist(), indices)
 
-            # We don't want these data points to end up all the way near zero, since this
-            # would cause numerical issues and thus result in aflaky test.
+            # We don't want these data points to end up all the way near zero, since
+            # this would cause numerical issues and thus result in a flaky test.
             X = 0.025 + 0.95 * torch.rand(*batch_shape, 4, 3, **tkwargs)
             X = X.unsqueeze(-3) if len(warp_batch_shape) > 0 else X
             with torch.no_grad():

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -460,6 +460,8 @@ class TestInputTransforms(BotorchTestCase):
 
             self.assertEqual(warp_tf.indices.tolist(), indices)
 
+            # We don't want these data points to end up all the way near zero, since this
+            # would cause numerical issues and thus result in aflaky test.
             X = 0.025 + 0.95 * torch.rand(*batch_shape, 4, 3, **tkwargs)
             X = X.unsqueeze(-3) if len(warp_batch_shape) > 0 else X
             with torch.no_grad():


### PR DESCRIPTION
The data points generated could ended up near zero, which causes numerical issues. This also adjusts the eps in the Warp transform based on the dtype.