### PR TITLE
Constrain optimization over unfixed features if `fixed_features` is passed.

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -10,10 +10,12 @@ Candidate generation utilities.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import torch
+from botorch.acquisition import AcquisitionFunction
+from botorch.generation.utils import _remove_fixed_features_from_optimization
 from botorch.optim.parameter_constraints import (
     _arrayify,
     make_scipy_bounds,
@@ -23,13 +25,12 @@ from botorch.optim.stopping import ExpMAStoppingCriterion
 from botorch.optim.utils import _filter_kwargs, columnwise_clamp, fix_features
 from scipy.optimize import minimize
 from torch import Tensor
-from torch.nn import Module
 from torch.optim import Optimizer
 
 
 def gen_candidates_scipy(
     initial_conditions: Tensor,
-    acquisition_function: Module,
+    acquisition_function: AcquisitionFunction,
     lower_bounds: Optional[Union[float, Tensor]] = None,
     upper_bounds: Optional[Union[float, Tensor]] = None,
     inequality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]] = None,
@@ -83,9 +84,45 @@ def gen_candidates_scipy(
             )
     """
     options = options or {}
+
+    # REDUCED is used indicate if we are optimizing over a reduced domain dimension
+    # after considering fixed_features.
+    # REDUCED mode if fixed_features is not None except for when fixed_features.values()
+    # contains None and linear constraints are passed.
+    REDUCED = fixed_features is not None
+    if inequality_constraints or equality_constraints:
+        REDUCED = REDUCED and (None not in fixed_features.values())
+
+    if REDUCED:
+        _no_fixed_features = _remove_fixed_features_from_optimization(
+            fixed_features=fixed_features,
+            acquisition_function=acquisition_function,
+            initial_conditions=initial_conditions,
+            lower_bounds=lower_bounds,
+            upper_bounds=upper_bounds,
+            inequality_constraints=inequality_constraints,
+            equality_constraints=equality_constraints,
+        )
+
+        # call the routine with no fixed_features
+        clamped_candidates, batch_acquisition = gen_candidates_scipy(
+            initial_conditions=_no_fixed_features.initial_conditions,
+            acquisition_function=_no_fixed_features.acquisition_function,
+            lower_bounds=_no_fixed_features.lower_bounds,
+            upper_bounds=_no_fixed_features.upper_bounds,
+            inequality_constraints=_no_fixed_features.inequality_constraints,
+            equality_constraints=_no_fixed_features.equality_constraints,
+            options=options,
+            fixed_features=None,
+        )
+        clamped_candidates = _no_fixed_features.acquisition_function._construct_X_full(
+            clamped_candidates
+        )
+        return clamped_candidates, batch_acquisition
+
     clamped_candidates = columnwise_clamp(
         X=initial_conditions, lower=lower_bounds, upper=upper_bounds
-    ).requires_grad_(True)
+    )
 
     shapeX = clamped_candidates.shape
     x0 = _arrayify(clamped_candidates.view(-1))
@@ -111,7 +148,7 @@ def gen_candidates_scipy(
             .contiguous()
             .requires_grad_(True)
         )
-        X_fix = fix_features(X=X, fixed_features=fixed_features)
+        X_fix = fix_features(X, fixed_features=fixed_features)
         loss = -acquisition_function(X_fix).sum()
         # compute gradient w.r.t. the inputs (does not accumulate in leaves)
         gradf = _arrayify(torch.autograd.grad(loss, X)[0].contiguous().view(-1))
@@ -137,20 +174,22 @@ def gen_candidates_scipy(
         options={k: v for k, v in options.items() if k not in ["method", "callback"]},
     )
     candidates = fix_features(
-        X=torch.from_numpy(res.x).to(initial_conditions).view(shapeX).contiguous(),
+        X=torch.from_numpy(res.x).to(initial_conditions).reshape(shapeX),
         fixed_features=fixed_features,
     )
+
     clamped_candidates = columnwise_clamp(
         X=candidates, lower=lower_bounds, upper=upper_bounds, raise_on_violation=True
     )
     with torch.no_grad():
         batch_acquisition = acquisition_function(clamped_candidates)
+
     return clamped_candidates, batch_acquisition
 
 
 def gen_candidates_torch(
     initial_conditions: Tensor,
-    acquisition_function: Callable,
+    acquisition_function: AcquisitionFunction,
     lower_bounds: Optional[Union[float, Tensor]] = None,
     upper_bounds: Optional[Union[float, Tensor]] = None,
     optimizer: Type[Optimizer] = torch.optim.Adam,
@@ -199,10 +238,41 @@ def gen_candidates_torch(
             )
     """
     options = options or {}
+
+    # REDUCED is used indicate if we are optimizing over a reduced domain dimension
+    # after considering fixed_features.
+    REDUCED = fixed_features is not None
+
+    if REDUCED:
+        _no_fixed_features = _remove_fixed_features_from_optimization(
+            fixed_features=fixed_features,
+            acquisition_function=acquisition_function,
+            initial_conditions=initial_conditions,
+            lower_bounds=lower_bounds,
+            upper_bounds=upper_bounds,
+            inequality_constraints=None,
+            equality_constraints=None,
+        )
+
+        # call the routine with no fixed_features
+        clamped_candidates, batch_acquisition = gen_candidates_torch(
+            initial_conditions=_no_fixed_features.initial_conditions,
+            acquisition_function=_no_fixed_features.acquisition_function,
+            lower_bounds=_no_fixed_features.lower_bounds,
+            upper_bounds=_no_fixed_features.upper_bounds,
+            optimizer=optimizer,
+            options=options,
+            verbose=verbose,
+            fixed_features=None,
+        )
+        clamped_candidates = _no_fixed_features.acquisition_function._construct_X_full(
+            clamped_candidates
+        )
+        return clamped_candidates, batch_acquisition
+
     clamped_candidates = columnwise_clamp(
         X=initial_conditions, lower=lower_bounds, upper=upper_bounds
     ).requires_grad_(True)
-    candidates = fix_features(clamped_candidates, fixed_features)
     bayes_optimizer = optimizer(
         params=[clamped_candidates], lr=options.get("lr", 0.025)
     )
@@ -215,11 +285,11 @@ def gen_candidates_torch(
     )
     while not stop:
         i += 1
-        loss = -acquisition_function(candidates).sum()
+        loss = -acquisition_function(clamped_candidates).sum()
         if verbose:
             print("Iter: {} - Value: {:.3f}".format(i, -(loss.item())))
         loss_trajectory.append(loss.item())
-        param_trajectory["candidates"].append(candidates.clone())
+        param_trajectory["candidates"].append(clamped_candidates.clone())
 
         def closure():
             bayes_optimizer.zero_grad()
@@ -227,17 +297,21 @@ def gen_candidates_torch(
             return loss
 
         bayes_optimizer.step(closure)
-        clamped_candidates.data = columnwise_clamp(
-            clamped_candidates, lower_bounds, upper_bounds
-        )
-        candidates = fix_features(clamped_candidates, fixed_features)
+        with torch.no_grad():
+            clamped_candidates = columnwise_clamp(
+                X=clamped_candidates, lower=lower_bounds, upper=upper_bounds
+            )
         stop = stopping_criterion.evaluate(fvals=loss.detach())
     clamped_candidates = columnwise_clamp(
-        X=candidates, lower=lower_bounds, upper=upper_bounds, raise_on_violation=True
+        X=clamped_candidates,
+        lower=lower_bounds,
+        upper=upper_bounds,
+        raise_on_violation=True,
     )
     with torch.no_grad():
-        batch_acquisition = acquisition_function(candidates)
-    return candidates, batch_acquisition
+        batch_acquisition = acquisition_function(clamped_candidates)
+
+    return clamped_candidates, batch_acquisition
 
 
 def get_best_candidates(batch_candidates: Tensor, batch_values: Tensor) -> Tensor:

--- a/test/generation/test_gen.py
+++ b/test/generation/test_gen.py
@@ -134,6 +134,27 @@ class TestGenCandidates(TestBaseCandidateGeneration):
             self.assertTrue(-EPS <= candidates[0] <= 1 + EPS)
             self.assertTrue(candidates[1].item() == 0.25)
 
+    def test_gen_candidates_scipy_with_fixed_features_inequality_constraints(self):
+        options = {"maxiter": 5}
+        for double in (True, False):
+            self._setUp(double=double, expand=True)
+            qEI = qExpectedImprovement(self.model, best_f=self.f_best)
+            candidates, _ = gen_candidates_scipy(
+                initial_conditions=self.initial_conditions.reshape(1, 1, -1),
+                acquisition_function=qEI,
+                inequality_constraints=[
+                    (torch.tensor([0]), torch.tensor([1]), 0),
+                    (torch.tensor([1]), torch.tensor([-1]), -1),
+                ],
+                fixed_features={1: 0.25},
+                options=options,
+            )
+            # candidates is of dimension 1 x 1 x 2
+            # so we are squeezing all the singleton dimensions
+            candidates = candidates.squeeze()
+            self.assertTrue(-EPS <= candidates[0] <= 1 + EPS)
+            self.assertTrue(candidates[1].item() == 0.25)
+
     def test_gen_candidates_torch_with_fixed_features(self):
         self.test_gen_candidates_with_fixed_features(
             gen_candidates=gen_candidates_torch, options={"disp": False}


### PR DESCRIPTION
Summary: This is a sensible thing to do and will potentially save a lot of compute.

On this stack: #836 --> **this PR**

Differential Revision: D29265778

