### PR TITLE
Matheron's rule post. sampling for MTGPs

### DIFF
--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -10,11 +10,6 @@ References
 .. [Zhe2019hogp]
     S. Zhe, W. Xing, and R. M. Kirby. Scalable high-order gaussian process regression.
     Proceedings of Machine Learning Research, volume 89, Apr 2019.
-
-.. [Doucet2010sampl]
-    A. Doucet. A Note on Efficient Conditional Simulation of Gaussian Distributions.
-    http://www.stats.ox.ac.uk/~doucet/doucet_simulationconditionalgaussian.pdf,
-    Apr 2010.
 """
 
 from __future__ import annotations
@@ -141,7 +136,8 @@ class FlattenedStandardize(Standardize):
 class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
     r"""
     A Higher order Gaussian process model (HOGP) (predictions are matrices/tensors) as
-    described in [Zhe2019hogp]_.
+    described in [Zhe2019hogp]_. The posterior uses Matheron's rule [Doucet2010sampl]_
+    as described in [Maddox2021bohdo]_.
     """
 
     def __init__(

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -6,12 +6,23 @@
 
 r"""
 Multi-Task GP models.
+
+References
+
+.. [Doucet2010sampl]
+    A. Doucet. A Note on Efficient Conditional Simulation of Gaussian Distributions.
+    http://www.stats.ox.ac.uk/~doucet/doucet_simulationconditionalgaussian.pdf,
+    Apr 2010.
+
+.. [Maddox2021bohdo]
+    W. Maddox, M. Balandat, A. Wilson, and E. Bakshy. Bayesian Optimization with
+    High-Dimensional Outputs. https://botorch.org, Jun 2021.
 """
 
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 from botorch.models.gp_regression import MIN_INFERRED_NOISE_LEVEL
@@ -19,6 +30,7 @@ from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.gpytorch import MultiTaskGPyTorchModel
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
+from botorch.posteriors.multitask import MultitaskGPPosterior
 from botorch.utils.containers import TrainingData
 from gpytorch.constraints import GreaterThan
 from gpytorch.distributions.multitask_multivariate_normal import (
@@ -29,6 +41,14 @@ from gpytorch.kernels.index_kernel import IndexKernel
 from gpytorch.kernels.matern_kernel import MaternKernel
 from gpytorch.kernels.multitask_kernel import MultitaskKernel
 from gpytorch.kernels.scale_kernel import ScaleKernel
+from gpytorch.lazy import (
+    BatchRepeatLazyTensor,
+    DiagLazyTensor,
+    KroneckerProductLazyTensor,
+    KroneckerProductDiagLazyTensor,
+    lazify,
+    RootLazyTensor,
+)
 from gpytorch.likelihoods.gaussian_likelihood import (
     FixedNoiseGaussianLikelihood,
     GaussianLikelihood,
@@ -43,6 +63,9 @@ from gpytorch.priors.lkj_prior import LKJCovariancePrior
 from gpytorch.priors.prior import Prior
 from gpytorch.priors.smoothed_box_prior import SmoothedBoxPrior
 from gpytorch.priors.torch_priors import GammaPrior
+from gpytorch.settings import cholesky_jitter, detach_test_caches
+from gpytorch.utils.errors import CachingError
+from gpytorch.utils.memoize import cached, pop_from_cache
 from torch import Tensor
 
 
@@ -361,6 +384,10 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
 
     This model assumes the "block design" case, i.e., it requires that all tasks
     are observed at all data points.
+
+    For posterior sampling, this model uses Matheron's rule [Doucet2010sampl] to compute
+    the posterior over all tasks as in [Maddox2021bohdo] by exploiting Kronecker
+    structure.
     """
 
     def __init__(
@@ -443,21 +470,17 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
         self.mean_module = MultitaskMean(
             base_means=ConstantMean(batch_shape=batch_shape), num_tasks=num_tasks
         )
-        self.covar_module = ScaleKernel(
-            MultitaskKernel(
-                data_covar_module=MaternKernel(
-                    nu=2.5,
-                    ard_num_dims=ard_num_dims,
-                    lengthscale_prior=GammaPrior(3.0, 6.0),
-                    batch_shape=batch_shape,
-                ),
-                num_tasks=num_tasks,
-                rank=rank,
+        self.covar_module = MultitaskKernel(
+            data_covar_module=MaternKernel(
+                nu=2.5,
+                ard_num_dims=ard_num_dims,
+                lengthscale_prior=GammaPrior(3.0, 6.0),
                 batch_shape=batch_shape,
-                task_covar_prior=task_covar_prior,
             ),
+            num_tasks=num_tasks,
+            rank=rank,
             batch_shape=batch_shape,
-            outputscale_prior=GammaPrior(2.0, 0.15),
+            task_covar_prior=task_covar_prior,
         )
 
         if outcome_transform is not None:
@@ -473,3 +496,224 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
         mean_x = self.mean_module(X)
         covar_x = self.covar_module(X)
         return MultitaskMultivariateNormal(mean_x, covar_x)
+
+    @property
+    def _task_covar_matrix(self):
+        res = self.covar_module.task_covar_module.covar_matrix
+        if detach_test_caches.on():
+            res = res.detach()
+        return res
+
+    @property
+    @cached(name="train_full_covar")
+    def train_full_covar(self):
+        train_x = self.transform_inputs(self.train_inputs[0])
+
+        # construct Kxx \otimes Ktt
+        train_full_covar = self.covar_module(train_x).evaluate_kernel()
+        if detach_test_caches.on():
+            train_full_covar = train_full_covar.detach()
+        return train_full_covar
+
+    @property
+    @cached(name="predictive_mean_cache")
+    def predictive_mean_cache(self):
+        train_x = self.transform_inputs(self.train_inputs[0])
+        train_noise = self.likelihood._shaped_noise_covar(train_x.shape)
+        if detach_test_caches.on():
+            train_noise = train_noise.detach()
+
+        train_diff = self.train_targets - self.mean_module(train_x)
+        train_solve = (self.train_full_covar + train_noise).inv_matmul(
+            train_diff.reshape(*train_diff.shape[:-2], -1)
+        )
+        if detach_test_caches.on():
+            train_solve = train_solve.detach()
+
+        return train_solve
+
+    def posterior(
+        self,
+        X: Tensor,
+        output_indices: Optional[List[int]] = None,
+        observation_noise: Union[bool, Tensor] = False,
+        **kwargs: Any,
+    ) -> MultitaskGPPosterior:
+        self.eval()
+
+        X = self.transform_inputs(X)
+        train_x = self.transform_inputs(self.train_inputs[0])
+
+        # construct Ktt
+        task_covar = self._task_covar_matrix
+        task_rootlt = self._task_covar_matrix.root_decomposition(
+            method="diagonalization"
+        )
+        task_root = task_rootlt.root
+        if task_covar.batch_shape != X.shape[:-2]:
+            task_covar = BatchRepeatLazyTensor(task_covar, batch_repeat=X.shape[:-2])
+            task_root = BatchRepeatLazyTensor(
+                lazify(task_root), batch_repeat=X.shape[:-2]
+            )
+
+        task_covar_rootlt = RootLazyTensor(task_root)
+
+        # construct RR' \approx Kxx
+        data_data_covar = self.train_full_covar.lazy_tensors[0]
+        # populate the diagonalziation caches for the root and inverse root
+        # decomposition
+        data_data_evals, data_data_evecs = data_data_covar.diagonalization()
+
+        # construct K_{xt, x}
+        test_data_covar = self.covar_module.data_covar_module(X, train_x)
+        # construct K_{xt, xt}
+        test_test_covar = self.covar_module.data_covar_module(X)
+
+        # now update root so that \tilde{R}\tilde{R}' \approx K_{(x,xt), (x,xt)}
+        # cloning preserves the gradient history
+        with cholesky_jitter(cholesky_jitter.value(X.dtype)):
+            updated_lazy_tensor = data_data_covar.cat_rows(
+                cross_mat=test_data_covar.clone(),
+                new_mat=test_test_covar,
+                method="diagonalization",
+            )
+            updated_root = updated_lazy_tensor.root_decomposition().root
+            # occasionally, there's device errors so enforce this comes out right
+            updated_root = updated_root.to(data_data_covar.device)
+
+        # build a root decomposition of the joint train/test covariance matrix
+        # construct (\tilde{R} \otimes M)(\tilde{R} \otimes M)' \approx
+        # (K_{(x,xt), (x,xt)} \otimes Ktt)
+        joint_covar = RootLazyTensor(
+            KroneckerProductLazyTensor(updated_root, task_covar_rootlt.root.detach())
+        )
+
+        # construct K_{xt, x} \otimes Ktt
+        test_obs_kernel = KroneckerProductLazyTensor(test_data_covar, task_covar)
+
+        # collect y - \mu(x) and \mu(X)
+        train_diff = self.train_targets - self.mean_module(train_x)
+        if detach_test_caches.on():
+            train_diff = train_diff.detach()
+        test_mean = self.mean_module(X)
+
+        train_noise = self.likelihood._shaped_noise_covar(train_x.shape)
+        diagonal_noise = isinstance(train_noise, DiagLazyTensor)
+        if detach_test_caches.on():
+            train_noise = train_noise.detach()
+        test_noise = (
+            self.likelihood._shaped_noise_covar(X.shape) if observation_noise else None
+        )
+
+        # predictive mean and variance for the mvn
+        # first the predictive mean
+        pred_mean = (
+            test_obs_kernel.matmul(self.predictive_mean_cache).reshape_as(test_mean)
+            + test_mean
+        )
+        # next the predictive variance, assume diagonal noise
+        test_var_term = KroneckerProductLazyTensor(test_test_covar, task_covar).diag()
+
+        if diagonal_noise:
+            task_evals, task_evecs = self._task_covar_matrix.diagonalization()
+            # TODO: make this be the default KPMatmulLT diagonal method in gpytorch
+            full_data_inv_evals = (
+                KroneckerProductDiagLazyTensor(
+                    DiagLazyTensor(data_data_evals), DiagLazyTensor(task_evals)
+                )
+                + train_noise
+            ).inverse()
+            test_train_hadamard = KroneckerProductLazyTensor(
+                test_data_covar.matmul(data_data_evecs).evaluate() ** 2,
+                task_covar.matmul(task_evecs).evaluate() ** 2,
+            )
+            data_var_term = test_train_hadamard.matmul(full_data_inv_evals).sum(dim=-1)
+        else:
+            # if non-diagonal noise (but still kronecker structured), we have to pull
+            # across the noise because the inverse is not closed form
+            # should be a kronecker lt, R = \Sigma_X^{-1/2} \kron \Sigma_T^{-1/2}
+            # TODO: enforce the diagonalization to return a KPLT for all shapes in
+            # gpytorch or dense linear algebra for small shapes
+            data_noise, task_noise = train_noise.lazy_tensors
+            data_noise_root = data_noise.root_inv_decomposition(
+                method="diagonalization"
+            )
+            task_noise_root = task_noise.root_inv_decomposition(
+                method="diagonalization"
+            )
+
+            # ultimately we need to compute the diagonal of
+            # (K_{x* X} \kron K_T)(K_{XX} \kron K_T + \Sigma_X \kron \Sigma_T)^{-1}
+            #                           (K_{x* X} \kron K_T)^T
+            # = (K_{x* X} \Sigma_X^{-1/2} Q_R)(\Lambda_R + I)^{-1}
+            #                       (K_{x* X} \Sigma_X^{-1/2} Q_R)^T
+            # where R = (\Sigma_X^{-1/2T}K_{XX}\Sigma_X^{-1/2} \kron
+            #                   \Sigma_T^{-1/2T}K_{T}\Sigma_T^{-1/2})
+            # first we construct the components of R's eigen-decomposition
+            # TODO: make this be the default KPMatmulLT diagonal method in gpytorch
+            whitened_data_covar = (
+                data_noise_root.transpose(-1, -2)
+                .matmul(data_data_covar)
+                .matmul(data_noise_root)
+            )
+            w_data_evals, w_data_evecs = whitened_data_covar.diagonalization()
+            whitened_task_covar = (
+                task_noise_root.transpose(-1, -2)
+                .matmul(self._task_covar_matrix)
+                .matmul(task_noise_root)
+            )
+            w_task_evals, w_task_evecs = whitened_task_covar.diagonalization()
+
+            # we add one to the eigenvalues as above (not just for stability)
+            full_data_inv_evals = (
+                KroneckerProductDiagLazyTensor(
+                    DiagLazyTensor(w_data_evals), DiagLazyTensor(w_task_evals)
+                )
+                .add_jitter(1.0)
+                .inverse()
+            )
+
+            test_data_comp = (
+                test_data_covar.matmul(data_noise_root).matmul(w_data_evecs).evaluate()
+                ** 2
+            )
+            task_comp = (
+                task_covar.matmul(task_noise_root).matmul(w_task_evecs).evaluate() ** 2
+            )
+
+            test_train_hadamard = KroneckerProductLazyTensor(test_data_comp, task_comp)
+            data_var_term = test_train_hadamard.matmul(full_data_inv_evals).sum(dim=-1)
+
+        pred_variance = test_var_term - data_var_term
+        specialized_mvn = MultitaskMultivariateNormal(
+            pred_mean, DiagLazyTensor(pred_variance)
+        )
+        if observation_noise:
+            specialized_mvn = self.likelihood(specialized_mvn)
+
+        posterior = MultitaskGPPosterior(
+            mvn=specialized_mvn,
+            joint_covariance_matrix=joint_covar,
+            test_train_covar=test_obs_kernel,
+            train_diff=train_diff,
+            test_mean=test_mean,
+            train_train_covar=self.train_full_covar,
+            train_noise=train_noise,
+            test_noise=test_noise,
+        )
+
+        if hasattr(self, "outcome_transform"):
+            posterior = self.outcome_transform.untransform_posterior(posterior)
+
+        return posterior
+
+    def train(self, val=True, *args, **kwargs):
+        if val:
+            fixed_cache_names = ["data_data_roots", "train_full_covar", "task_root"]
+            for name in fixed_cache_names:
+                try:
+                    pop_from_cache(self, name)
+                except CachingError:
+                    pass
+
+        return super().train(val, *args, **kwargs)

--- a/botorch/posteriors/__init__.py
+++ b/botorch/posteriors/__init__.py
@@ -7,6 +7,7 @@
 from botorch.posteriors.deterministic import DeterministicPosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.higher_order import HigherOrderGPPosterior
+from botorch.posteriors.multitask import MultitaskGPPosterior
 from botorch.posteriors.posterior import Posterior
 from botorch.posteriors.transformed import TransformedPosterior
 
@@ -15,6 +16,7 @@ __all__ = [
     "DeterministicPosterior",
     "GPyTorchPosterior",
     "HigherOrderGPPosterior",
+    "MultitaskGPPosterior",
     "Posterior",
     "TransformedPosterior",
 ]

--- a/botorch/posteriors/multitask.py
+++ b/botorch/posteriors/multitask.py
@@ -1,0 +1,242 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional, Union, Tuple
+
+import torch
+from botorch.posteriors.gpytorch import GPyTorchPosterior
+from gpytorch.distributions import MultivariateNormal
+from gpytorch.lazy import LazyTensor, lazify
+from torch import Tensor
+
+
+class MultitaskGPPosterior(GPyTorchPosterior):
+    def __init__(
+        self,
+        mvn: MultivariateNormal,
+        joint_covariance_matrix: LazyTensor,
+        test_train_covar: LazyTensor,
+        train_diff: Tensor,
+        test_mean: Tensor,
+        train_train_covar: LazyTensor,
+        train_noise: Union[LazyTensor, Tensor],
+        test_noise: Optional[Union[LazyTensor, Tensor]] = None,
+    ):
+        r"""
+        Posterior class for a Kronecker Multi-task GP model using with ICM kernel.
+        Extends the standard GPyTorch posterior class by overwriting the rsample
+        method. In general, this posterior should ONLY be used for MTGP models
+        that have structured covariances. It should also only be used internally when
+        called from the KroneckerMultiTaskGP.posterior(...) method.
+
+        Args:
+            mvn: Posterior multivariate normal distribution
+            joint_covariance_matrix: Joint test train covariance matrix over the entire
+                tensor
+            train_train_covar: covariance matrix of train points in the data space
+            test_obs_covar: covariance matrix of test x train points in the data space
+            train_diff: difference between train mean and train responses
+            train_noise: training noise covariance
+            test_noise: Only used if posterior should contain observation noise.
+                testing noise covariance
+        """
+        super().__init__(mvn=mvn)
+        self._is_mt = True
+
+        self.joint_covariance_matrix = joint_covariance_matrix
+        self.test_train_covar = test_train_covar
+        self.train_diff = train_diff
+        self.test_mean = test_mean
+        self.train_train_covar = train_train_covar
+        self.train_noise = train_noise
+        self.test_noise = test_noise
+        self.observation_noise = self.test_noise is not None
+
+        self.num_train = self.train_diff.shape[-2]
+        self.num_tasks = self.test_train_covar.lazy_tensors[-1].shape[-1]
+
+    @property
+    def base_sample_shape(self) -> torch.Size:
+        # overwrites the standard base sample shape call to inform samplers that
+        # n + 2 n_train samples need to be drawn rather than n samples
+        batch_shape = self.joint_covariance_matrix.shape[:-2]
+        sampling_shape = (
+            self.joint_covariance_matrix.shape[-2] + self.train_noise.shape[-2]
+        )
+        if self.observation_noise:
+            sampling_shape = sampling_shape + self.test_noise.shape[-2]
+        return batch_shape + torch.Size((sampling_shape,))
+
+    @property
+    def device(self) -> torch.device:
+        r"""The torch device of the posterior."""
+        return self.test_mean.device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        r"""The torch dtype of the posterior."""
+        return self.test_mean.dtype
+
+    def _prepare_base_samples(
+        self, sample_shape: torch.Size, base_samples: Tensor = None
+    ) -> Tuple[Tensor, Tensor]:
+        covariance_matrix = self.joint_covariance_matrix
+        joint_size = covariance_matrix.shape[-1]
+        batch_shape = covariance_matrix.batch_shape
+
+        # pre-allocated this as None
+        test_noise_base_samples = None
+        if base_samples is not None:
+            if base_samples.shape[: len(sample_shape)] != sample_shape:
+                raise RuntimeError(
+                    "sample_shape disagrees with shape of base_samples."
+                    f"provided base sample shape is {base_samples.shape} while"
+                    f"the expected shape is {sample_shape}."
+                )
+
+            if base_samples.shape[-1] != 1:
+                base_samples = base_samples.unsqueeze(-1)
+            unsqueezed_dim = -2
+
+            appended_shape = joint_size + self.train_train_covar.shape[-1]
+            if self.observation_noise:
+                appended_shape = appended_shape + self.test_noise.shape[-1]
+
+            if appended_shape != base_samples.shape[unsqueezed_dim]:
+                # get base_samples to the correct shape by expanding as sample shape,
+                # batch shape, then rest of dimensions. We have to add first the sample
+                # shape, then the batch shape of the model, and then finally the shape
+                # of the test data points squeezed into a single dimension, accessed
+                # from the test_train_covar.
+                base_sample_shapes = (
+                    sample_shape + batch_shape + self.test_train_covar.shape[-2:-1]
+                )
+                if base_samples.nelement() == base_sample_shapes.numel():
+                    base_samples = base_samples.reshape(base_sample_shapes)
+
+                    new_base_samples = torch.randn(
+                        *sample_shape,
+                        *batch_shape,
+                        appended_shape - base_samples.shape[-1],
+                    )
+                    base_samples = torch.cat((base_samples, new_base_samples), dim=-1)
+                    base_samples = base_samples.unsqueeze(-1)
+                else:
+                    # nuke the base samples if we cannot use them.
+                    base_samples = None
+
+        if base_samples is None:
+            # TODO: Allow qMC sampling
+            base_samples = torch.randn(
+                *sample_shape,
+                *batch_shape,
+                joint_size,
+                1,
+                device=covariance_matrix.device,
+                dtype=covariance_matrix.dtype,
+            )
+
+            noise_base_samples = torch.randn(
+                *sample_shape,
+                *batch_shape,
+                self.train_train_covar.shape[-1],
+                1,
+                device=covariance_matrix.device,
+                dtype=covariance_matrix.dtype,
+            )
+            if self.observation_noise:
+                test_noise_base_samples = torch.randn(
+                    *sample_shape,
+                    *self.test_noise.shape[:-1],
+                    1,
+                    device=covariance_matrix.device,
+                    dtype=covariance_matrix.dtype,
+                )
+        else:
+            # finally split up the base samples
+            noise_base_samples = base_samples[..., joint_size:, :]
+            base_samples = base_samples[..., :joint_size, :]
+            if self.observation_noise:
+                test_noise_base_samples = noise_base_samples[
+                    ..., -self.test_noise.shape[-1] :, :
+                ]
+                noise_base_samples = noise_base_samples[
+                    ..., : -self.test_noise.shape[-1], :
+                ]
+
+        return base_samples, noise_base_samples, test_noise_base_samples
+
+    def rsample(
+        self,
+        sample_shape: Optional[torch.Size] = None,
+        base_samples: Optional[Tensor] = None,
+        train_diff: Optional[Tensor] = None,
+    ) -> Tensor:
+        if sample_shape is None:
+            sample_shape = torch.Size([1])
+        if train_diff is None:
+            train_diff = self.train_diff
+
+        (
+            base_samples,
+            noise_base_samples,
+            test_noise_base_samples,
+        ) = self._prepare_base_samples(
+            sample_shape=sample_shape, base_samples=base_samples
+        )
+        joint_samples = self._draw_from_base_covar(
+            self.joint_covariance_matrix, base_samples
+        )
+        noise_samples = self._draw_from_base_covar(self.train_noise, noise_base_samples)
+
+        # pluck out the train + test samples and add the likelihood's noise to the
+        # train side. This should be fine for higher rank likelihoods.
+        n_obs = self.num_tasks * self.num_train
+        n_test = joint_samples.shape[-1] - n_obs
+        obs_samples, test_samples = torch.split(joint_samples, [n_obs, n_test], dim=-1)
+        updated_obs_samples = obs_samples + noise_samples
+        obs_minus_samples = (
+            train_diff.reshape(*train_diff.shape[:-2], -1) - updated_obs_samples
+        )
+        train_covar_plus_noise = self.train_train_covar + self.train_noise
+        obs_solve = train_covar_plus_noise.inv_matmul(obs_minus_samples.unsqueeze(-1))
+
+        # and multiply the test-observed matrix against the result of the solve
+        updated_samples = self.test_train_covar.matmul(obs_solve).squeeze(-1)
+
+        # finally, we add the conditioned samples to the prior samples
+        final_samples = test_samples + updated_samples
+
+        # add in likelihood noise if necessary
+        if self.observation_noise:
+            test_noise_samples = self._draw_from_base_covar(
+                self.test_noise, test_noise_base_samples
+            )
+            final_samples = final_samples + test_noise_samples
+
+        # and reshape
+        final_samples = final_samples.reshape(
+            *final_samples.shape[:-1], self.test_mean.shape[-2], self.num_tasks
+        )
+        final_samples = final_samples + self.test_mean
+
+        return final_samples
+
+    def _draw_from_base_covar(
+        self, covar: Union[Tensor, LazyTensor], base_samples: Tensor
+    ) -> Tensor:
+        # Now reparameterize those base samples
+        if not isinstance(covar, LazyTensor):
+            covar = lazify(covar)
+        covar_root = covar.root_decomposition().root
+        # If necessary, adjust base_samples for rank of root decomposition
+        if covar_root.shape[-1] < base_samples.shape[-2]:
+            base_samples = base_samples[..., : covar_root.shape[-1], :]
+        elif covar_root.shape[-1] > base_samples.shape[-2]:
+            raise RuntimeError("Incompatible dimension of `base_samples`")
+        # the mean is included in the posterior forwards so is not included here
+        res = covar_root.matmul(base_samples)
+
+        return res.squeeze(-1)

--- a/sphinx/source/posteriors.rst
+++ b/sphinx/source/posteriors.rst
@@ -34,6 +34,11 @@ Higher Order GP Posterior
 .. automodule:: botorch.posteriors.higher_order
     :members:
 
+Multitask GP Posterior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.posteriors.multitask
+    :members:
+
 Transformed Posterior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.posteriors.transformed

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -552,9 +552,8 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
             self.assertIsInstance(model.likelihood, MultitaskGaussianLikelihood)
             self.assertEqual(model.likelihood.rank, 0)
             self.assertIsInstance(model.mean_module, MultitaskMean)
-            self.assertIsInstance(model.covar_module, ScaleKernel)
-            base_kernel = model.covar_module.base_kernel
-            self.assertIsInstance(base_kernel, MultitaskKernel)
+            self.assertIsInstance(model.covar_module, MultitaskKernel)
+            base_kernel = model.covar_module
             self.assertIsInstance(base_kernel.data_covar_module, MaternKernel)
             self.assertIsInstance(base_kernel.task_covar_module, IndexKernel)
             task_covar_prior = base_kernel.task_covar_module.IndexKernelPrior
@@ -591,6 +590,7 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
                 self.assertTrue(torch.allclose(posterior_f.variance, expected_var))
             else:
                 # test observation noise
+                # TODO: outcome transform + likelihood noise?
                 posterior_noisy = model.posterior(test_x, observation_noise=True)
                 self.assertTrue(
                     torch.allclose(
@@ -639,9 +639,8 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
             self.assertIsInstance(model.likelihood, MultitaskGaussianLikelihood)
             self.assertEqual(model.likelihood.rank, 1)
             self.assertIsInstance(model.mean_module, MultitaskMean)
-            self.assertIsInstance(model.covar_module, ScaleKernel)
-            base_kernel = model.covar_module.base_kernel
-            self.assertIsInstance(base_kernel, MultitaskKernel)
+            self.assertIsInstance(model.covar_module, MultitaskKernel)
+            base_kernel = model.covar_module
             self.assertIsInstance(base_kernel.data_covar_module, MaternKernel)
             self.assertIsInstance(base_kernel.task_covar_module, IndexKernel)
             task_covar_prior = base_kernel.task_covar_module.IndexKernelPrior

--- a/test/posteriors/test_multitask.py
+++ b/test/posteriors/test_multitask.py
@@ -6,43 +6,44 @@
 
 import numpy as np
 import torch
-from botorch.models.higher_order_gp import HigherOrderGP
-from botorch.posteriors.higher_order import HigherOrderGPPosterior
+from botorch.models.multitask import KroneckerMultiTaskGP
+from botorch.posteriors.multitask import MultitaskGPPosterior
 from botorch.sampling import IIDNormalSampler
 from botorch.utils.testing import BotorchTestCase
 
 
-class TestHigherOrderGPPosterior(BotorchTestCase):
+class TestMultitaskGPPosterior(BotorchTestCase):
     def setUp(self):
         super().setUp()
         torch.random.manual_seed(0)
 
-        train_x = torch.rand(2, 10, 1, device=self.device)
-        train_y = torch.randn(2, 10, 3, 5, device=self.device)
+        train_x = torch.rand(10, 1, device=self.device)
+        train_y = torch.randn(10, 3, device=self.device)
 
-        m1 = HigherOrderGP(train_x, train_y)
-        m2 = HigherOrderGP(train_x[0], train_y[0])
+        m2 = KroneckerMultiTaskGP(train_x, train_y)
 
         torch.random.manual_seed(0)
         test_x = torch.rand(2, 5, 1, device=self.device)
 
-        posterior1 = m1.posterior(test_x)
-        posterior2 = m2.posterior(test_x[0])
-        posterior3 = m2.posterior(test_x)
+        posterior0 = m2.posterior(test_x[0])
+        posterior1 = m2.posterior(test_x)
+        posterior2 = m2.posterior(test_x[0], observation_noise=True)
+        posterior3 = m2.posterior(test_x, observation_noise=True)
 
         self.post_list = [
-            [m1, test_x, posterior1],
+            [m2, test_x[0], posterior0],
+            [m2, test_x, posterior1],
             [m2, test_x[0], posterior2],
             [m2, test_x, posterior3],
         ]
 
-    def test_HigherOrderGPPosterior(self):
-        sample_shaping = torch.Size([5, 3, 5])
+    def test_MultitaskGPPosterior(self):
+        sample_shaping = torch.Size([5, 3])
 
         for post_collection in self.post_list:
             model, test_x, posterior = post_collection
 
-            self.assertIsInstance(posterior, HigherOrderGPPosterior)
+            self.assertIsInstance(posterior, MultitaskGPPosterior)
 
             batch_shape = test_x.shape[:-2]
             expected_event_shape = batch_shape + sample_shaping
@@ -54,11 +55,22 @@ class TestHigherOrderGPPosterior(BotorchTestCase):
             self.assertEqual(samples_0.shape, torch.Size((1, *expected_event_shape)))
 
             # test that providing all base samples produces non-torch.random results
-            if len(batch_shape) > 0:
-                base_sample_shape = (8, 2, (5 + 10 + 10) * 3 * 5)
-            else:
-                base_sample_shape = (8, (5 + 10 + 10) * 3 * 5)
-            base_samples = torch.randn(*base_sample_shape, device=self.device)
+            scale = 2 if posterior.observation_noise else 1
+            base_sample_shaping = torch.Size(
+                [
+                    2 * model.train_targets.numel()
+                    + scale * sample_shaping[0] * sample_shaping[1]
+                ]
+            )
+
+            expected_base_sample_shape = batch_shape + base_sample_shaping
+            self.assertEqual(
+                posterior.base_sample_shape,
+                expected_base_sample_shape,
+            )
+            base_samples = torch.randn(
+                8, *expected_base_sample_shape, device=self.device
+            )
 
             samples_1 = posterior.rsample(
                 base_samples=base_samples, sample_shape=torch.Size((8,))
@@ -83,14 +95,14 @@ class TestHigherOrderGPPosterior(BotorchTestCase):
             self.assertEqual(samples_3.shape, torch.Size([8, *expected_event_shape]))
 
             # test that providing the wrong number base samples is okay
-            base_samples = torch.randn(8, 50 * 2 * 3 * 5, device=self.device)
+            base_samples = torch.randn(8, 50 * 2 * 3, device=self.device)
             samples_4 = posterior.rsample(
                 base_samples=base_samples, sample_shape=torch.Size((8,))
             )
             self.assertEqual(samples_4.shape, torch.Size([8, *expected_event_shape]))
 
             # test that providing the wrong shapes of base samples fails
-            base_samples = torch.randn(8, 5 * 2 * 3 * 5, device=self.device)
+            base_samples = torch.randn(8, 5 * 2 * 3, device=self.device)
             with self.assertRaises(RuntimeError):
                 samples_4 = posterior.rsample(
                     base_samples=base_samples, sample_shape=torch.Size((4,))
@@ -99,9 +111,15 @@ class TestHigherOrderGPPosterior(BotorchTestCase):
             # finally we check the quality of the variances and the samples
             # test that the posterior variances are the same as the evaluation variance
             posterior_variance = posterior.variance
+            posterior_mean = posterior.mean.view(-1)
 
             model.eval()
-            eval_mode_variance = model(test_x).variance.reshape_as(posterior_variance)
+            if not posterior.observation_noise:
+                eval_mode_variance = model(test_x).variance
+            else:
+                eval_mode_variance = model.likelihood(model(test_x)).variance
+            eval_mode_variance = eval_mode_variance.reshape_as(posterior_variance)
+
             self.assertLess(
                 (posterior_variance - eval_mode_variance).norm()
                 / eval_mode_variance.norm(),
@@ -109,11 +127,41 @@ class TestHigherOrderGPPosterior(BotorchTestCase):
             )
 
             # and finally test that sampling with no base samples is okay
-            samples_3 = posterior.rsample(sample_shape=torch.Size((5000,)))
+            samples_3 = posterior.rsample(sample_shape=torch.Size((10000,)))
             sampled_variance = samples_3.var(dim=0).view(-1)
+            sampled_mean = samples_3.mean(dim=0).view(-1)
+
             posterior_variance = posterior_variance.view(-1)
+
+            # slightly higher tolerance here because of the potential for low norms
+            self.assertLess(
+                (posterior_mean - sampled_mean).norm() / posterior_mean.norm(),
+                1e-1,
+            )
             self.assertLess(
                 (posterior_variance - sampled_variance).norm()
                 / posterior_variance.norm(),
                 5e-2,
             )
+
+    def test_draw_from_base_covar(self):
+        # grab a posterior
+        posterior = self.post_list[0][2]
+
+        base_samples = torch.randn(4, 30, 1, device=self.device)
+        base_mat = torch.randn(30, 30, device=self.device)
+        sym_mat = base_mat.matmul(base_mat.t())
+
+        # base, non-lt case
+        res = posterior._draw_from_base_covar(sym_mat, base_samples)
+        self.assertIsInstance(res, torch.Tensor)
+
+        # too many samples works
+        base_samples = torch.randn(4, 50, 1, device=self.device)
+        res = posterior._draw_from_base_covar(sym_mat, base_samples)
+        self.assertIsInstance(res, torch.Tensor)
+
+        # too few samples fails
+        base_samples = torch.randn(4, 10, 1, device=self.device)
+        with self.assertRaises(RuntimeError):
+            res = posterior._draw_from_base_covar(sym_mat, base_samples)


### PR DESCRIPTION
Summary: Implementation of Matheron's rule sampling for MTGPs. Matheron's rule sampling rather than distributional sampling enables exploitation of Kronecker structure throughout the sampling procedure, resulting in effectively n^3 + t^3 time complexity for sampling, rather than n^3 t^3 which is the case for distributional sampling.

Differential Revision: D29240044

