### PR TITLE
update default partitioning selection heuristic

### DIFF
--- a/botorch/acquisition/multi_objective/utils.py
+++ b/botorch/acquisition/multi_objective/utils.py
@@ -33,13 +33,19 @@ from torch.quasirandom import SobolEngine
 
 
 def get_default_partitioning_alpha(num_objectives: int) -> float:
-    """Adaptively selects a reasonable partitioning based on the number of objectives.
+    r"""Determines an approximation level based on the number of objectives.
 
-    This strategy is derived from the results in [Daulton2020qehvi]_, which suggest
-    that this heuristic provides a reasonable trade-off between the closed-loop
-    performance and the wall time required for the partitioning.
+    If `alpha` is 0, FastNondominatedPartitioning should be used. Otherwise,
+    an approximate NondominatedPartitioning should be used with approximation
+    level `alpha`.
+
+    Args:
+        num_objectives: the number of objectives.
+
+    Returns:
+        The approximation level `alpha`.
     """
-    if num_objectives == 2:
+    if num_objectives <= 4:
         return 0.0
     elif num_objectives > 6:
         warnings.warn("EHVI works best for less than 7 objectives.", BotorchWarning)

--- a/test/acquisition/multi_objective/test_utils.py
+++ b/test/acquisition/multi_objective/test_utils.py
@@ -26,9 +26,11 @@ from torch import Tensor
 
 class TestUtils(BotorchTestCase):
     def test_get_default_partitioning_alpha(self):
-        self.assertEqual(0.0, get_default_partitioning_alpha(num_objectives=2))
-        self.assertEqual(1e-5, get_default_partitioning_alpha(num_objectives=3))
-        self.assertEqual(1e-4, get_default_partitioning_alpha(num_objectives=4))
+        for m in range(2, 7):
+            expected_val = 0.0 if m < 5 else 10 ** (-8 + m)
+            self.assertEqual(
+                expected_val, get_default_partitioning_alpha(num_objectives=m)
+            )
         # In `BotorchTestCase.setUp` warnings are filtered, so here we
         # remove the filter to ensure a warning is issued as expected.
         warnings.resetwarnings()


### PR DESCRIPTION
Summary:
We now have a very fast non-dominated partitioning that is much more scalable with the number of objectives.

Using 100 data points on the PF (a very large PF):
For 3 objectives, FastNondominatedPartitioning (exact) is faster. For 4 objectives, FastNondominatedPartitioning (exact) is competitive with the approximate heuristic. For 5 objectives, FastNondominatedPartitioning is a good deal slower (still not that bad).

Differential Revision: D29353926

