### PR TITLE
Adds functionality to publish_site.sh script to remove leading "v"

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -119,5 +119,7 @@ jobs:
         pip install .[tutorials]
         pip install beautifulsoup4 ipython "nbconvert<6.0"
     - name: Publish latest website
+      env:
+        DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}
       run: |
         ./scripts/publish_site.sh -d -v ${{ github.event.release.tag_name }}

--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -35,6 +35,10 @@ while getopts 'dhv:' option; do
   esac
 done
 
+if [[ $VERSION != false ]]; then
+  # Strip any leading "v" in the VERSION string
+  VERSION=$(echo "$VERSION"  | sed "s/v//");
+fi
 
 # Function to get absolute filename
 fullpath() {


### PR DESCRIPTION
This has caused issues with the automated deployment script since the env var specifying the git tag name contains a leading "v".