### PR TITLE
Make `variance` optional for `TransformedPosterior.mean` call

### DIFF
--- a/botorch/posteriors/transformed.py
+++ b/botorch/posteriors/transformed.py
@@ -68,7 +68,11 @@ class TransformedPosterior(Posterior):
         r"""The mean of the posterior as a `batch_shape x n x m`-dim Tensor."""
         if self._mean_transform is None:
             raise NotImplementedError("No mean transform provided.")
-        return self._mean_transform(self._posterior.mean, self._posterior.variance)
+        try:
+            variance = self._posterior.variance
+        except (NotImplementedError, AttributeError):
+            variance = None
+        return self._mean_transform(self._posterior.mean, variance)
 
     @property
     def variance(self) -> Tensor:

--- a/test/posteriors/test_transformed.py
+++ b/test/posteriors/test_transformed.py
@@ -69,3 +69,22 @@ class TestTransformedPosterior(BotorchTestCase):
                     p_tf_2.mean
                 with self.assertRaises(NotImplementedError):
                     p_tf_2.variance
+
+        # check that `mean` works even if posterior doesn't have `variance`
+        for error in (AttributeError, NotImplementedError):
+
+            class DummyPosterior(object):
+                mean = torch.zeros(5)
+
+                @property
+                def variance(self):
+                    raise error
+
+            post = DummyPosterior()
+            transformed_post = TransformedPosterior(
+                posterior=post,
+                sample_transform=None,
+                mean_transform=lambda x, _: x + 1,
+            )
+            transformed_mean = transformed_post.mean
+            self.assertTrue(torch.allclose(transformed_mean, torch.ones(5)))


### PR DESCRIPTION
Summary: Currently, `TransformedPosterior.mean` throws an error if the `_posterior` doesn't have a `variance` attribute or if the `variance` throws a `NotImplementedError`. This wraps `_posterior.variance` with a `try/except` block to support the use with posteriors that don't have a `variance`.

Differential Revision: D29506115

