### PR TITLE
Remove squaring operation over lengthscale to help with CatKernel precision

### DIFF
--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -132,7 +132,7 @@ class MixedSingleTaskGP(SingleTaskGP):
                 CategoricalKernel(
                     batch_shape=aug_batch_shape,
                     ard_num_dims=len(cat_dims),
-                    lengthscale_constraint=GreaterThan(1e-04),
+                    lengthscale_constraint=GreaterThan(1e-06),
                 )
             )
         else:
@@ -147,7 +147,7 @@ class MixedSingleTaskGP(SingleTaskGP):
                         batch_shape=aug_batch_shape,
                         ard_num_dims=len(cat_dims),
                         active_dims=cat_dims,
-                        lengthscale_constraint=GreaterThan(1e-04),
+                        lengthscale_constraint=GreaterThan(1e-06),
                     )
                 )
             )
@@ -161,7 +161,7 @@ class MixedSingleTaskGP(SingleTaskGP):
                     batch_shape=aug_batch_shape,
                     ard_num_dims=len(cat_dims),
                     active_dims=cat_dims,
-                    lengthscale_constraint=GreaterThan(1e-04),
+                    lengthscale_constraint=GreaterThan(1e-06),
                 )
             )
             covar_module = sum_kernel + prod_kernel

--- a/botorch/models/kernels/categorical.py
+++ b/botorch/models/kernels/categorical.py
@@ -12,8 +12,10 @@ from torch import Tensor
 class CategoricalKernel(Kernel):
     r"""A Kernel for categorical features.
 
-    Computes `exp(-(dist(x1, x2) / lengthscale)**2)`, where
+    Computes `exp(-dist(x1, x2) / lengthscale)`, where
     `dist(x1, x2)` is zero if `x1 == x2` and one if `x1 != x2`.
+    If the last dimension is not a batch dimension, then the
+    mean is considered.
 
     Note: This kernel is NOT differentiable w.r.t. the inputs.
     """
@@ -29,7 +31,7 @@ class CategoricalKernel(Kernel):
         **kwargs
     ) -> Tensor:
         delta = x1.unsqueeze(-2) != x2.unsqueeze(-3)
-        dists = (delta / self.lengthscale.unsqueeze(-2)).pow(2)
+        dists = delta / self.lengthscale.unsqueeze(-2)
         if last_dim_is_batch:
             dists = dists.transpose(-3, -1)
         else:

--- a/test/models/kernels/test_categorical.py
+++ b/test/models/kernels/test_categorical.py
@@ -42,8 +42,8 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
         lengthscale = 2
         kernel = CategoricalKernel().initialize(lengthscale=lengthscale)
         kernel.eval()
-        sq_sc_dists = (x1.unsqueeze(-2) != x2.unsqueeze(-3)) ** 2 / lengthscale ** 2
-        actual = torch.exp(-sq_sc_dists.mean(-1))
+        sc_dists = (x1.unsqueeze(-2) != x2.unsqueeze(-3)) / lengthscale
+        actual = torch.exp(-sc_dists.mean(-1))
         res = kernel(x1, x2).evaluate()
         self.assertTrue(torch.allclose(res, actual))
 
@@ -54,8 +54,8 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
         kernel = CategoricalKernel(active_dims=[0]).initialize(lengthscale=lengthscale)
         kernel.eval()
         dists = x1[:, :1].unsqueeze(-2) != x2[:, :1].unsqueeze(-3)
-        sq_sc_dists = dists ** 2 / lengthscale ** 2
-        actual = torch.exp(-sq_sc_dists.mean(-1))
+        sc_dists = dists / lengthscale
+        actual = torch.exp(-sc_dists.mean(-1))
         res = kernel(x1, x2).evaluate()
         self.assertTrue(torch.allclose(res, actual))
 
@@ -68,10 +68,9 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
         kernel.initialize(lengthscale=lengthscales)
         kernel.eval()
 
-        sq_sc_dists = (
-            x1.unsqueeze(-2) != x2.unsqueeze(-3)
-        ) ** 2 / lengthscales.unsqueeze(-2) ** 2
-        actual = torch.exp(-sq_sc_dists.mean(-1))
+        sc_dists = x1.unsqueeze(-2) != x2.unsqueeze(-3)
+        sc_dists = sc_dists / lengthscales.unsqueeze(-2)
+        actual = torch.exp(-sc_dists.mean(-1))
         res = kernel(x1, x2).evaluate()
         self.assertTrue(torch.allclose(res, actual))
 
@@ -81,7 +80,7 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
         self.assertTrue(torch.allclose(res, actual))
 
         # batch_dims
-        actual = torch.exp(-sq_sc_dists).transpose(-1, -3)
+        actual = torch.exp(-sc_dists).transpose(-1, -3)
         res = kernel(x1, x2, last_dim_is_batch=True).evaluate()
         self.assertTrue(torch.allclose(res, actual))
 
@@ -104,10 +103,9 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
         kernel.initialize(lengthscale=lengthscales)
         kernel.eval()
 
-        sq_sc_dists = (
-            x1.unsqueeze(-2) != x2.unsqueeze(-3)
-        ) ** 2 / lengthscales.unsqueeze(-2) ** 2
-        actual = torch.exp(-sq_sc_dists.mean(-1))
+        sc_dists = x1.unsqueeze(-2) != x2.unsqueeze(-3)
+        sc_dists = sc_dists / lengthscales.unsqueeze(-2)
+        actual = torch.exp(-sc_dists.mean(-1))
         res = kernel(x1, x2).evaluate()
         self.assertTrue(torch.allclose(res, actual))
 
@@ -126,10 +124,9 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
         kernel.initialize(lengthscale=lengthscales)
         kernel.eval()
 
-        sq_sc_dists = (
-            x1.unsqueeze(-2) != x2.unsqueeze(-3)
-        ) ** 2 / lengthscales.unsqueeze(-2) ** 2
-        actual = torch.exp(-sq_sc_dists.mean(-1))
+        sc_dists = x1.unsqueeze(-2) != x2.unsqueeze(-3)
+        sc_dists = sc_dists / lengthscales.unsqueeze(-2)
+        actual = torch.exp(-sc_dists.mean(-1))
         res = kernel(x1, x2).evaluate()
         self.assertTrue(torch.allclose(res, actual))
 
@@ -139,7 +136,7 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
         self.assertTrue(torch.allclose(res, actual))
 
         # batch_dims
-        actual = torch.exp(-sq_sc_dists).transpose(-1, -3)
+        actual = torch.exp(-sc_dists).transpose(-1, -3)
         res = kernel(x1, x2, last_dim_is_batch=True).evaluate()
         self.assertTrue(torch.allclose(res, actual))
 


### PR DESCRIPTION
Summary:
The existing form of the categorical kernel is `exp((-I(x != y) / lengthscale)^2)` where `I` is the indicator. There are two things to note here:
- Squaring the indicator is unnecessary.
- Squaring the lengthscale means that the lengthscale is no longer the lengthscale but a "squared lengthscale", and is susceptible to numerical issues as noted in D29371529 (https://github.com/pytorch/botorch/commit/29cf00d0fb5f7deba389c2a367e886887ffa0ec7)

This might be a backwards incompatible change if people access lengthscale.

Reviewed By: Balandat

Differential Revision: D29397230

