### PR TITLE
Fix qMFKG evaluate bug

### DIFF
--- a/botorch/acquisition/knowledge_gradient.py
+++ b/botorch/acquisition/knowledge_gradient.py
@@ -251,8 +251,8 @@ class qKnowledgeGradient(MCAcquisitionFunction, OneShotAcquisitionFunction):
         values, _ = torch.max(values, dim=0)
         if self.current_value is not None:
             values = values - self.current_value
-
-        if hasattr(self, "cost_aware_utility"):
+        # NOTE: using getattr to cover both no-attribute with qKG and None with qMFKG
+        if getattr(self, "cost_aware_utility", None) is not None:
             values = self.cost_aware_utility(
                 X=X, deltas=values, sampler=self.cost_sampler
             )

--- a/test/acquisition/test_knowledge_gradient.py
+++ b/test/acquisition/test_knowledge_gradient.py
@@ -507,9 +507,22 @@ class TestQMultiFidelityKnowledgeGradient(BotorchTestCase):
                         torch.ones(1, 2, 1, device=self.device, dtype=dtype),
                     )
                 )
-            self.assertEqual(
-                val, cau(None, torch.ones(1, device=self.device, dtype=dtype))
-            )
+                self.assertEqual(
+                    val, cau(None, torch.ones(1, device=self.device, dtype=dtype))
+                )
+                # test with defaults - should see no errors
+                qMFKG = qMultiFidelityKnowledgeGradient(
+                    model=mm,
+                    num_fantasies=n_f,
+                )
+                qMFKG.evaluate(
+                    X=torch.zeros(1, 1, 1, device=self.device, dtype=dtype),
+                    bounds=torch.tensor(
+                        [[0.0], [1.0]], device=self.device, dtype=dtype
+                    ),
+                    num_restarts=1,
+                    raw_samples=1,
+                )
 
 
 class TestKGUtils(BotorchTestCase):


### PR DESCRIPTION
Summary: In `qMFKG.evalute` the use of `if hasattr(self, "cost_aware_utility")` leads to a bug when `cost_aware_utility=None` (ends up calling `None` as a function). This replaces that with `if getattr(self, "cost_aware_utility", None) is not None`, which handles both not having a `cost_aware_utility` attribute (qKG) and `cost_aware_utility=None` (qMFKG).

Differential Revision: D29565578

