### PR TITLE
Bump MTGP Posterior arxiv Link

### DIFF
--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -16,7 +16,7 @@ References
 
 .. [Maddox2021bohdo]
     W. Maddox, M. Balandat, A. Wilson, and E. Bakshy. Bayesian Optimization with
-    High-Dimensional Outputs. https://botorch.org, Jun 2021.
+    High-Dimensional Outputs. https://arxiv.org/abs/2106.12997, Jun 2021.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
The reference for MTGP posterior sampling is now on arxiv at: https://arxiv.org/abs/2106.12997.

## Motivation

see above.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

n/a

## Related PRs

n/a
