### PR TITLE
Add `maximize` flag to PosteriorMean 

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -163,6 +163,23 @@ class PosteriorMean(AnalyticAcquisitionFunction):
         >>> pm = PM(test_X)
     """
 
+    def __init__(
+        self,
+        model: Model,
+        objective: Optional[ScalarizedObjective] = None,
+        maximize: bool = True,
+    ) -> None:
+        r"""Single-outcome Posterior Mean.
+
+        Args:
+            model: A fitted single-outcome GP model (must be in batch mode if
+                candidate sets X will be)
+            objective: A ScalarizedObjective (optional).
+            maximize: If True, consider the problem a maximization problem.
+        """
+        super().__init__(model=model, objective=objective)
+        self.maximize = maximize
+
     @t_batch_mode_transform(expected_q=1)
     def forward(self, X: Tensor) -> Tensor:
         r"""Evaluate the posterior mean on the candidate set X.
@@ -176,7 +193,11 @@ class PosteriorMean(AnalyticAcquisitionFunction):
             points `X`.
         """
         posterior = self._get_posterior(X=X)
-        return posterior.mean.view(X.shape[:-2])
+        mean = posterior.mean.view(X.shape[:-2])
+        if self.maximize:
+            return mean
+        else:
+            return -mean
 
 
 class ProbabilityOfImprovement(AnalyticAcquisitionFunction):

--- a/test/acquisition/test_analytic.py
+++ b/test/acquisition/test_analytic.py
@@ -176,10 +176,17 @@ class TestPosteriorMean(BotorchTestCase):
         for dtype in (torch.float, torch.double):
             mean = torch.tensor([[0.25]], device=self.device, dtype=dtype)
             mm = MockModel(MockPosterior(mean=mean))
+
             module = PosteriorMean(model=mm)
             X = torch.empty(1, 1, device=self.device, dtype=dtype)
             pm = module(X)
             self.assertTrue(torch.equal(pm, mean.view(-1)))
+
+            module = PosteriorMean(model=mm, maximize=False)
+            X = torch.empty(1, 1, device=self.device, dtype=dtype)
+            pm = module(X)
+            self.assertTrue(torch.equal(pm, -mean.view(-1)))
+
             # check for proper error if multi-output model
             mean2 = torch.rand(1, 2, device=self.device, dtype=dtype)
             mm2 = MockModel(MockPosterior(mean=mean2))


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md
-->

## Motivation

The `PosteriorMean` acquisition function does not provide the convenience of a `maximize` flag as opposed to the other analytical acquisition function such as `UpperConfidenceBound`. The current state of the API therefore requires to use the following argument instead `objective=ScalarizedObjective(weights=torch.tensor([-1.0])`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The proposed change is trivial. I simply extended the unit test for the `PosteriorMean` acquisition function.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
