### PR TITLE
Ignore categorical dimensions when validating training inputs in MixedSingleTaskGP

### DIFF
--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -97,7 +97,10 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         if outcome_transform is not None:
             train_Y, _ = outcome_transform(train_Y)
         self._validate_tensor_args(X=transformed_X, Y=train_Y)
-        validate_input_scaling(train_X=transformed_X, train_Y=train_Y)
+        ignore_X_dims = getattr(self, "_ignore_X_dims_scaling_check", None)
+        validate_input_scaling(
+            train_X=transformed_X, train_Y=train_Y, ignore_X_dims=ignore_X_dims
+        )
         self._set_dimensions(train_X=train_X, train_Y=train_Y)
         train_X, train_Y, _ = self._transform_tensor_args(X=train_X, Y=train_Y)
         if likelihood is None:

--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -96,6 +96,7 @@ class MixedSingleTaskGP(SingleTaskGP):
             raise ValueError(
                 "Must specify categorical dimensions for MixedSingleTaskGP"
             )
+        self._ignore_X_dims_scaling_check = cat_dims
         input_batch_shape, aug_batch_shape = self.get_batch_dimensions(
             train_X=train_X, train_Y=train_Y
         )

--- a/test/models/test_gp_regression_mixed.py
+++ b/test/models/test_gp_regression_mixed.py
@@ -65,6 +65,7 @@ class TestMixedSingleTaskGP(BotorchTestCase):
                 continue
 
             model = MixedSingleTaskGP(train_X, train_Y, cat_dims=cat_dims)
+            self.assertEqual(model._ignore_X_dims_scaling_check, cat_dims)
             mll = ExactMarginalLogLikelihood(model.likelihood, model).to(**tkwargs)
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=OptimizationWarning)

--- a/test/models/test_utils.py
+++ b/test/models/test_utils.py
@@ -126,6 +126,12 @@ class TestInputDataChecks(BotorchTestCase):
                 self.assertTrue(any("not contained" in str(w.message) for w in ws))
             with self.assertRaises(InputDataError):
                 check_min_max_scaling(X=X, strict=True, raise_on_fail=True)
+            # check ignore_dims
+            with warnings.catch_warnings(record=True) as ws:
+                check_min_max_scaling(X=X, ignore_dims=[0])
+                self.assertFalse(
+                    any(issubclass(w.category, InputDataWarning) for w in ws)
+                )
 
     def test_check_standardization(self):
         Y = torch.randn(3, 4, 2)


### PR DESCRIPTION
Summary: In MixedSingleTaskGP, the Categorical Kernel operates on the categorical dimensions (`cat_dims`). The scaling of the data doesn't matter here since the distance is computed via an equality check.

Differential Revision: D29920517

