### PR TITLE
Support negative weights for minimization objectives in ParEGO

### DIFF
--- a/test/utils/multi_objective/test_scalarization.py
+++ b/test/utils/multi_objective/test_scalarization.py
@@ -68,7 +68,20 @@ class TestGetChebyshevScalarization(BotorchTestCase):
                     dim=-1
                 ).values + 0.05 * (weights * normalized_Y_test).sum(dim=-1)
                 self.assertTrue(torch.equal(Y_transformed, expected_Y_transformed))
+                # test that when minimizing an objective (i.e. with a negative weight),
+                # normalized Y values are shifted from [0,1] to [-1,0]
+                weights = torch.tensor([0.3, -0.7], **tkwargs)
+                objective_transform = get_chebyshev_scalarization(
+                    weights=weights, Y=Y_train
+                )
+                Y_transformed = objective_transform(Y_test)
+                normalized_Y_test[..., -1] = normalized_Y_test[..., -1] - 1
+                expected_Y_transformed = (weights * normalized_Y_test).min(
+                    dim=-1
+                ).values + 0.05 * (weights * normalized_Y_test).sum(dim=-1)
+                self.assertTrue(torch.equal(Y_transformed, expected_Y_transformed))
                 # test that with no observations there is no normalization
+                weights = torch.tensor([0.3, 0.7], **tkwargs)
                 objective_transform = get_chebyshev_scalarization(
                     weights=weights, Y=Y_train[:0]
                 )


### PR DESCRIPTION
Summary: In the previous implementation, all objectives are normalized to [0,1]. Maximization objectives are assigned random positive weights and minimization objectives are assigned random negative weights (in Ax) such that sum(w\*y) makes sense. However, this will make w\*y negative for the minimization objectives, which makes the min(w\*y) term in augmented Chebyshev scalarization always points to the scalarized minimization objectives and neglects the scalarized maximization objectives. This will cause issue in optimization, as we want the min(w\*y) term to focus on the scalarized objective that has small weight and hence neglected by the sum(w\*y) term. The fix is to shift the normalized minimization objectives from [0,1] to [-1,0]. The direction of the maximization is still preserved since it is a shift, and the weights are still going to be negative for minimization objectives. But now all w\*y's are in the positive range and min(w\*y) makes sense again.

Reviewed By: sdaulton

Differential Revision: D29945933

