### PR TITLE
Fix lint issue in get_chebyshev_scalarization

### DIFF
--- a/botorch/utils/multi_objective/scalarization.py
+++ b/botorch/utils/multi_objective/scalarization.py
@@ -92,7 +92,7 @@ def get_chebyshev_scalarization(
         # scale to [0,1]
         Y_normalized = normalize(Y, bounds=Y_bounds)
         # If minimizing an objective, convert Y_normalized values to [-1,0],
-        # such that the min(w * y) term makes sense, we want all w_i * y_i's to be positive
+        # such that min(w*y) makes sense, we want all w*y's to be positive
         Y_normalized[..., minimize] = Y_normalized[..., minimize] - 1
         return chebyshev_obj(Y=Y_normalized)
 


### PR DESCRIPTION
Summary: Fix lint issue as encountered when adding support for negative weights for minimizing objectives in ParEGO (D29945933 (https://github.com/pytorch/botorch/commit/39128f6338e427b0020196e7ebc2d9442fed9517)).

Reviewed By: bletham

Differential Revision: D29968835

