### PR TITLE
Move `train_inputs` transforms to `model.train/eval` calls.

### DIFF
--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -15,13 +15,10 @@ import warnings
 from copy import deepcopy
 from typing import Any, Callable
 
-from botorch.exceptions.errors import BotorchError, UnsupportedError
+from botorch.exceptions.errors import UnsupportedError
 from botorch.exceptions.warnings import BotorchWarning, OptimizationWarning
 from botorch.models.converter import batched_to_model_list, model_list_to_batched
-from botorch.models.gp_regression import HeteroskedasticSingleTaskGP
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
-from botorch.models.model import Model
-from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.optim.fit import fit_gpytorch_scipy
 from botorch.optim.utils import sample_all_priors
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
@@ -104,7 +101,6 @@ def fit_gpytorch_model(
             # transformed data using all transforms (including the transforms
             # with transform_on_train set to True).
             mll.train()
-            _set_transformed_inputs(model=mll.model)
             if tf is not None:
                 mll.model.outcome_transform = tf
             return mll.eval()
@@ -132,34 +128,10 @@ def fit_gpytorch_model(
             warnings.warn(w.message, w.category)
         # TODO: this counts hitting `maxiter` as an optimization failure!
         if not has_optwarning:
-            _set_transformed_inputs(model=mll.model)
             mll.eval()
             return mll
         retry += 1
         logging.log(logging.DEBUG, f"Fitting failed on try {retry}.")
 
     warnings.warn("Fitting failed on all retries.", OptimizationWarning)
-    _set_transformed_inputs(model=mll.model)
     return mll.eval()
-
-
-def _set_transformed_inputs(model: Model) -> None:
-    r"""Update training inputs with transformed inputs.
-
-    Args:
-        model: The model.
-    """
-    models = model.models if isinstance(model, ModelListGP) else [model]
-    for m in models:
-        if hasattr(m, "input_transform"):
-            X_tf = m.input_transform.preprocess_transform(m.train_inputs[0])
-            if not hasattr(m, "set_train_data"):
-                raise BotorchError(
-                    "fit_gpytorch_model requires that a model has a set_train_data "
-                    "method when an input_transform is used."
-                )
-            m.set_train_data(X_tf, strict=False)
-            # TODO: override set_train_data in HeteroskedasticSingleTaskGP to do this
-            # automatically
-            if isinstance(m, HeteroskedasticSingleTaskGP):
-                m.likelihood.noise_covar.noise_model.set_train_data(X_tf, strict=False)

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -10,6 +10,7 @@ Abstract base module for all BoTorch models.
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
@@ -24,7 +25,19 @@ from torch.nn import Module
 
 
 class Model(Module, ABC):
-    r"""Abstract base class for BoTorch models."""
+    r"""Abstract base class for BoTorch models.
+
+    Args:
+        _has_transformed_inputs: A boolean denoting whether `train_inputs` are currently
+            stored as transformed or not.
+        _original_train_inputs: A Tensor storing the original train inputs for use in
+            `_revert_to_original_inputs`. Note that this is necessary since
+            transform / untransform cycle introduces numerical errors which lead
+            to upstream errors during training.
+    """
+
+    _has_transformed_inputs: bool = False
+    _original_train_inputs: Optional[Tensor] = None
 
     @abstractmethod
     def posterior(
@@ -175,3 +188,47 @@ class Model(Module, ABC):
             return self.input_transform(X)
         except AttributeError:
             return X
+
+    def _set_transformed_inputs(self) -> None:
+        r"""Update training inputs with transformed inputs."""
+        if hasattr(self, "input_transform") and not self._has_transformed_inputs:
+            if hasattr(self, "train_inputs"):
+                self._original_train_inputs = self.train_inputs[0]
+                with torch.no_grad():
+                    X_tf = self.input_transform.preprocess_transform(
+                        self.train_inputs[0]
+                    )
+                self.set_train_data(X_tf, strict=False)
+                self._has_transformed_inputs = True
+            else:
+                warnings.warn(
+                    "Could not update `train_inputs` with transformed inputs"
+                    f"since {self.__class__.__name__} does not have a `train_inputs`"
+                    "attribute. Make sure that the `input_transform` is applied to"
+                    "both the train inputs and test inputs.",
+                    RuntimeWarning,
+                )
+
+    def _revert_to_original_inputs(self) -> None:
+        r"""Revert training inputs back to original."""
+        if hasattr(self, "input_transform") and self._has_transformed_inputs:
+            self.set_train_data(self._original_train_inputs, strict=False)
+            self._has_transformed_inputs = False
+
+    def eval(self) -> Model:
+        r"""Puts the model in `eval` mode and sets the transformed inputs."""
+        self._set_transformed_inputs()
+        return super().eval()
+
+    def train(self, mode: bool = True) -> Model:
+        r"""Puts the model in `train` mode and reverts to the original inputs.
+
+        Args:
+            mode: A boolean denoting whether to put in `train` or `eval` mode.
+                If `False`, model is put in `eval` mode.
+        """
+        if mode:
+            self._revert_to_original_inputs()
+        else:
+            self._set_transformed_inputs()
+        return super().train(mode=mode)

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -102,3 +102,13 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
             The current model, subset to the specified output indices.
         """
         return self.__class__(*[deepcopy(self.models[i]) for i in idcs])
+
+    def _set_transformed_inputs(self) -> None:
+        r"""Update training inputs with transformed inputs."""
+        for m in self.models:
+            m._set_transformed_inputs()
+
+    def _revert_to_original_inputs(self) -> None:
+        r"""Revert training inputs back to original."""
+        for m in self.models:
+            m._revert_to_original_inputs()

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -200,7 +200,7 @@ class MockAcquisitionFunction:
 def _get_random_data(
     batch_shape: torch.Size, m: int, d: int = 1, n: int = 10, **tkwargs
 ) -> Tuple[Tensor, Tensor]:
-    r"""Generate random data for testing pursposes.
+    r"""Generate random data for testing purposes.
 
     Args:
         batch_shape: The batch shape of the data.
@@ -240,7 +240,7 @@ def _get_test_posterior(
         interleaved: A boolean indicating the format of the
             MultitaskMultivariateNormal
         lazy: A boolean indicating if the posterior should be lazy
-        indepedent: A boolean indicating whether the outputs are independent
+        independent: A boolean indicating whether the outputs are independent
         tkwargs: `device` and `dtype` tensor constructor kwargs.
 
 

--- a/test/models/test_deterministic.py
+++ b/test/models/test_deterministic.py
@@ -107,3 +107,7 @@ class TestDeterministicModels(BotorchTestCase):
         expected_Y, _ = octf.untransform(model.forward(intf(test_X)))
         posterior = model.posterior(test_X)
         self.assertTrue(torch.allclose(expected_Y, posterior.mean))
+        # check that model.train/eval works and raises the warning
+        model.train()
+        with self.assertWarns(RuntimeWarning):
+            model.eval()

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -11,22 +11,18 @@ from unittest import mock
 
 import torch
 from botorch import fit_gpytorch_model, settings
-from botorch.exceptions.errors import BotorchError
 from botorch.exceptions.warnings import BotorchWarning, OptimizationWarning
-from botorch.fit import _set_transformed_inputs
 from botorch.models import FixedNoiseGP, HeteroskedasticSingleTaskGP, SingleTaskGP
-from botorch.models.transforms.input import Normalize
 from botorch.models.transforms.outcome import Standardize
 from botorch.optim.fit import (
     OptimizationIteration,
     fit_gpytorch_scipy,
     fit_gpytorch_torch,
 )
-from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
+from botorch.utils.testing import BotorchTestCase
 from gpytorch.constraints import GreaterThan, Interval
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
-from gpytorch.models.gp import GP
 from gpytorch.utils.errors import NanError, NotPSDError
 from gpytorch.utils.warnings import NumericalWarning
 
@@ -321,39 +317,3 @@ class TestFitGPyTorchModel(BotorchTestCase):
                             for w in ws
                         )
                     )
-
-
-class MockGP(MockModel, GP):
-    pass
-
-
-class TestSetTransformedInputs(BotorchTestCase):
-    def test_set_transformed_inputs(self):
-        for dtype in (torch.float, torch.double):
-            train_x = torch.rand(5, 1, dtype=dtype, device=self.device)
-            train_y = torch.rand(5, 1, dtype=dtype, device=self.device)
-            tf = Normalize(
-                d=1,
-                bounds=torch.tensor([[0.0], [2.0]], dtype=dtype, device=self.device),
-            )
-            model = SingleTaskGP(train_x, train_y, input_transform=tf)
-            self.assertTrue(torch.equal(model.train_inputs[0], train_x))
-            mll = ExactMarginalLogLikelihood(model.likelihood, model)
-            # check that input transform is only applied when
-            # transform_on_train=True
-            self.assertTrue(torch.equal(model.train_inputs[0], train_x))
-            tf.transform_on_train = False
-            _set_transformed_inputs(mll.model)
-            self.assertTrue(torch.equal(model.train_inputs[0], train_x))
-            tf.transform_on_train = True
-            _set_transformed_inputs(mll.model)
-            self.assertTrue(torch.equal(model.train_inputs[0], tf(train_x)))
-            model.eval()
-            # test no set_train_data method
-            mock_model = MockGP(MockPosterior())
-            mock_model.train_inputs = (train_x,)
-            mock_model.likelihood = model.likelihood
-            mock_model.input_transform = tf
-            mll = ExactMarginalLogLikelihood(mock_model.likelihood, mock_model)
-            with self.assertRaises(BotorchError):
-                _set_transformed_inputs(mll.model)


### PR DESCRIPTION
Summary:
This moves `_set_transformed_inputs` call from `fit_gpytorch_model` to `model.eval()`. In addition, this adds a `_revert_to_original_inputs` method, which is called in `model.train()`.
Addresses #893.

Differential Revision: D30030256

