### PR TITLE
Modify qNEHVI to support one-to-many input transforms

### DIFF
--- a/botorch/acquisition/multi_objective/multi_output_risk_measures.py
+++ b/botorch/acquisition/multi_objective/multi_output_risk_measures.py
@@ -201,6 +201,8 @@ class MVaR(MultiOutputRiskMeasureMCObjective):
     VaR. We support this alternative with an `expectation` flag.
     """
 
+    _verify_output_shape = False
+
     def __init__(
         self,
         n_w: int,

--- a/botorch/acquisition/multi_objective/objective.py
+++ b/botorch/acquisition/multi_objective/objective.py
@@ -23,7 +23,13 @@ from torch import Tensor
 
 
 class MCMultiOutputObjective(MCAcquisitionObjective):
-    r"""Abstract base class for MC multi-output objectives."""
+    r"""Abstract base class for MC multi-output objectives.
+
+    Args:
+        _is_mo: A boolean denoting whether the objectives are multi-output.
+    """
+
+    _is_mo: bool = True
 
     @abstractmethod
     def forward(self, samples: Tensor, X: Optional[Tensor] = None, **kwargs) -> Tensor:

--- a/botorch/acquisition/multi_objective/utils.py
+++ b/botorch/acquisition/multi_objective/utils.py
@@ -153,5 +153,6 @@ def prune_inferior_points_multi_objective(
     if idcs.shape[0] > max_points:
         counts, order_idcs = torch.sort(probs, descending=True)
         idcs = order_idcs[:max_points]
-
+    effective_n_w = obj_vals.shape[-2] // X.shape[-2]
+    idcs = (idcs / effective_n_w).long().unique()
     return X[idcs]

--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -191,7 +191,7 @@ def get_acquisition_function(
             sampler=sampler,
             objective=objective,
             constraints=constraints,
-            prune_baseline=True,
+            prune_baseline=kwargs.get("prune_baseline", True),
             alpha=kwargs.get("alpha", 0.0),
             X_pending=X_pending,
             marginalize_dim=kwargs.get("marginalize_dim"),

--- a/test/acquisition/test_objective.py
+++ b/test/acquisition/test_objective.py
@@ -84,6 +84,20 @@ class TestMCAcquisitionObjective(BotorchTestCase):
         with self.assertRaises(TypeError):
             MCAcquisitionObjective()
 
+    def test_verify_output_shape(self):
+        obj = IdentityMCObjective()
+        self.assertTrue(obj._verify_output_shape)
+        samples = torch.zeros(2, 3, 1)
+        X = torch.ones(2, 1)
+        # No error if X is not given.
+        obj(samples=samples)
+        # Error if X is given, 2 != 3
+        with self.assertRaises(RuntimeError):
+            obj(samples=samples, X=X)
+        # No error if _verify_output_shape=False
+        obj._verify_output_shape = False
+        obj(samples=samples, X=X)
+
 
 class TestGenericMCObjective(BotorchTestCase):
     def test_generic_mc_objective(self):

--- a/test/acquisition/test_penalized.py
+++ b/test/acquisition/test_penalized.py
@@ -185,7 +185,7 @@ class TestPenalizedMCObjective(BotorchTestCase):
             )
             # test 'd' Tensor X
             samples = torch.randn(4, 3, device=self.device, dtype=dtype)
-            X = torch.randn(5, device=self.device, dtype=dtype)
+            X = torch.randn(4, 5, device=self.device, dtype=dtype)
             penalized_obj = generic_obj(samples) - 0.1 * l1_penalty_obj(X)
             self.assertTrue(torch.equal(obj(samples, X), penalized_obj))
             # test 'q x d' Tensor X

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -41,12 +41,12 @@ from torch import Tensor
 
 
 class DummyMCObjective(MCAcquisitionObjective):
-    def forward(self, samples: Tensor) -> Tensor:
+    def forward(self, samples: Tensor, X=None) -> Tensor:
         return samples.sum(-1)
 
 
 class DummyMCMultiOutputObjective(MCMultiOutputObjective):
-    def forward(self, samples: Tensor) -> Tensor:
+    def forward(self, samples: Tensor, X=None) -> Tensor:
         return samples
 
 


### PR DESCRIPTION
Summary: Moves the `objective` call from `_compute_qehvi` to `forward` in order to support one-to-many input transforms. Also adds a `constraint_objective` that is applied to `samples` before evaluating the constraints.

Differential Revision: D29336709

