### PR TITLE
Fixes input transform bug in fantasize call

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -156,7 +156,9 @@ class Model(Module, ABC):
             with settings.propagate_grads(propagate_grads):
                 post_X = self.posterior(X, observation_noise=observation_noise)
             Y_fantasized = sampler(post_X)  # num_fantasies x batch_shape x n' x m
-            return self.condition_on_observations(X=X, Y=Y_fantasized, **kwargs)
+            return self.condition_on_observations(
+                X=self.transform_inputs(X), Y=Y_fantasized, **kwargs
+            )
 
     @classmethod
     def construct_inputs(


### PR DESCRIPTION
Summary:
Fixes #899.
`fantasize` call was adding the fantasy `X` to `train_inputs` without applying the input transforms. This adds a `transform_inputs` call to fix that. In addition, the `FixedNoiseGP` fantasize call was not using the `fantasize` flag (to disable one-to-many input transforms), which is also fixed here.

Differential Revision: D30254090

