### PR TITLE
Implements ExpectationPosteriorTransform

### DIFF
--- a/botorch/acquisition/multi_objective/multi_output_risk_measures.py
+++ b/botorch/acquisition/multi_objective/multi_output_risk_measures.py
@@ -95,7 +95,13 @@ class MultiOutputRiskMeasureMCObjective(
 
 
 class MultiOutputExpectation(MultiOutputRiskMeasureMCObjective):
-    r"""A multi-output MC expectation risk measure."""
+    r"""A multi-output MC expectation risk measure.
+
+    For unconstrained problems, we recommend using the `ExpectationPosteriorTransform`
+    instead. `ExpectationPosteriorTransform` directly transforms the posterior
+    distribution over `q * n_w` to a posterior of `q` expectations, significantly
+    reducing the cost of posterior sampling as a result.
+    """
 
     def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
         r"""Calculate the expectation of the given samples. Expectation is

--- a/botorch/acquisition/risk_measures.py
+++ b/botorch/acquisition/risk_measures.py
@@ -228,7 +228,13 @@ class WorstCase(RiskMeasureMCObjective):
 
 
 class Expectation(RiskMeasureMCObjective):
-    r"""The expectation risk measure."""
+    r"""The expectation risk measure.
+
+    For unconstrained problems, we recommend using the `ExpectationPosteriorTransform`
+    instead. `ExpectationPosteriorTransform` directly transforms the posterior
+    distribution over `q * n_w` to a posterior of `q` expectations, significantly
+    reducing the cost of posterior sampling as a result.
+    """
 
     def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
         r"""Calculate the expectation corresponding to the given samples.

--- a/test/acquisition/test_objective.py
+++ b/test/acquisition/test_objective.py
@@ -12,6 +12,7 @@ from botorch import settings
 from botorch.acquisition import LearnedObjective
 from botorch.acquisition.objective import (
     ConstrainedMCObjective,
+    ExpectationPosteriorTransform,
     GenericMCObjective,
     IdentityMCObjective,
     LinearMCObjective,
@@ -19,11 +20,15 @@ from botorch.acquisition.objective import (
     PosteriorTransform,
     ScalarizedPosteriorTransform,
 )
+from botorch.exceptions.errors import UnsupportedError
 from botorch.models.deterministic import PosteriorMeanModel
 from botorch.models.pairwise_gp import PairwiseGP
+from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling.samplers import SobolQMCNormalSampler
 from botorch.utils import apply_constraints
 from botorch.utils.testing import _get_test_posterior, BotorchTestCase
+from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
+from gpytorch.lazy import lazify
 from torch import Tensor
 
 
@@ -81,6 +86,143 @@ class TestScalarizedPosteriorTransform(BotorchTestCase):
             val = obj.evaluate(Y)
             val_expected = offset + Y @ weights
             self.assertTrue(torch.equal(val, val_expected))
+
+
+class TestExpectationPosteriorTransform(BotorchTestCase):
+    def test_init(self):
+        # Without weights.
+        tf = ExpectationPosteriorTransform(n_w=5)
+        self.assertEqual(tf.n_w, 5)
+        self.assertTrue(torch.allclose(tf.weights, torch.ones(5, 1) * 0.2))
+        # Errors with weights.
+        with self.assertRaisesRegex(ValueError, "a tensor of size"):
+            ExpectationPosteriorTransform(n_w=3, weights=torch.ones(5, 1))
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            ExpectationPosteriorTransform(n_w=3, weights=-torch.ones(3, 1))
+        # Successful init with weights.
+        weights = torch.tensor([[1.0, 2.0], [2.0, 4.0], [3.0, 6.0]])
+        tf = ExpectationPosteriorTransform(n_w=3, weights=weights)
+        self.assertTrue(torch.allclose(tf.weights, weights / torch.tensor([6.0, 12.0])))
+
+    def test_evaluate(self):
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"dtype": dtype, "device": self.device}
+            # Without weights.
+            tf = ExpectationPosteriorTransform(n_w=3)
+            Y = torch.rand(3, 6, 2, **tkwargs)
+            self.assertTrue(
+                torch.allclose(tf.evaluate(Y), Y.view(3, 2, 3, 2).mean(dim=-2))
+            )
+            # With weights - weights intentionally doesn't use tkwargs.
+            weights = torch.tensor([[1.0, 2.0], [2.0, 1.0]])
+            tf = ExpectationPosteriorTransform(n_w=2, weights=weights)
+            expected = (Y.view(3, 3, 2, 2) * weights.to(Y)).sum(dim=-2) / 3.0
+            self.assertTrue(torch.allclose(tf.evaluate(Y), expected))
+
+    def test_expectation_posterior_transform(self):
+        tkwargs = {"dtype": torch.float, "device": self.device}
+        # Without weights, simple expectation, single output, no batch.
+        # q = 2, n_w = 3.
+        org_loc = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], **tkwargs)
+        org_covar = torch.tensor(
+            [
+                [1.0, 0.8, 0.7, 0.3, 0.2, 0.1],
+                [0.8, 1.0, 0.9, 0.25, 0.15, 0.1],
+                [0.7, 0.9, 1.0, 0.2, 0.2, 0.05],
+                [0.3, 0.25, 0.2, 1.0, 0.7, 0.6],
+                [0.2, 0.15, 0.2, 0.7, 1.0, 0.7],
+                [0.1, 0.1, 0.05, 0.6, 0.7, 1.0],
+            ],
+            **tkwargs
+        )
+        org_mvn = MultivariateNormal(org_loc, lazify(org_covar))
+        org_post = GPyTorchPosterior(mvn=org_mvn)
+        tf = ExpectationPosteriorTransform(n_w=3)
+        tf_post = tf(org_post)
+        self.assertIsInstance(tf_post, GPyTorchPosterior)
+        self.assertEqual(tf_post.sample().shape, torch.Size([1, 2, 1]))
+        tf_mvn = tf_post.mvn
+        self.assertIsInstance(tf_mvn, MultivariateNormal)
+        expected_loc = torch.tensor([2.0, 5.0], **tkwargs)
+        # This is the average of each 3 x 3 block.
+        expected_covar = torch.tensor([[0.8667, 0.1722], [0.1722, 0.7778]], **tkwargs)
+        self.assertTrue(torch.allclose(tf_mvn.loc, expected_loc))
+        self.assertTrue(
+            torch.allclose(tf_mvn.covariance_matrix, expected_covar, atol=1e-3)
+        )
+
+        # With weights, 2 outputs, batched.
+        tkwargs = {"dtype": torch.double, "device": self.device}
+        # q = 2, n_w = 2, m = 2, leading to 8 values for loc and 8x8 cov.
+        org_loc = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], **tkwargs)
+        # We have 2 4x4 matrices with 0s as filler. Each block is for one outcome.
+        # Each 2x2 sub block corresponds to `n_w`.
+        org_covar = torch.tensor(
+            [
+                [1.0, 0.8, 0.3, 0.2, 0.0, 0.0, 0.0, 0.0],
+                [0.8, 1.4, 0.2, 0.1, 0.0, 0.0, 0.0, 0.0],
+                [0.3, 0.2, 1.2, 0.5, 0.0, 0.0, 0.0, 0.0],
+                [0.2, 0.1, 0.5, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 0.7, 0.4, 0.3],
+                [0.0, 0.0, 0.0, 0.0, 0.7, 0.8, 0.3, 0.2],
+                [0.0, 0.0, 0.0, 0.0, 0.4, 0.3, 1.4, 0.5],
+                [0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.5, 1.2],
+            ],
+            **tkwargs
+        )
+        # Making it batched by adding two more batches, mostly the same.
+        org_loc = org_loc.repeat(3, 1)
+        org_loc[1] += 100
+        org_loc[2] += 1000
+        org_covar = org_covar.repeat(3, 1, 1)
+        # Construct the transform with weights.
+        weights = torch.tensor([[1.0, 3.0], [2.0, 1.0]])
+        tf = ExpectationPosteriorTransform(n_w=2, weights=weights)
+        # Construct the posterior.
+        org_mvn = MultitaskMultivariateNormal(
+            # The return of mvn.loc and the required input are different.
+            # We constructed it according to the output of mvn.loc,
+            # reshaping here to have the required `b x n x t` shape.
+            org_loc.view(3, 2, 4).transpose(-2, -1),
+            lazify(org_covar),
+            interleaved=True,  # To test the error.
+        )
+        org_post = GPyTorchPosterior(mvn=org_mvn)
+        # Error if interleaved.
+        with self.assertRaisesRegex(UnsupportedError, "interleaved"):
+            tf(org_post)
+        # Construct the non-interleaved posterior.
+        org_mvn = MultitaskMultivariateNormal(
+            org_loc.view(3, 2, 4).transpose(-2, -1),
+            lazify(org_covar),
+            interleaved=False,
+        )
+        org_post = GPyTorchPosterior(mvn=org_mvn)
+        self.assertTrue(torch.equal(org_mvn.loc, org_loc))
+        tf_post = tf(org_post)
+        self.assertIsInstance(tf_post, GPyTorchPosterior)
+        self.assertEqual(tf_post.sample().shape, torch.Size([1, 3, 2, 2]))
+        tf_mvn = tf_post.mvn
+        self.assertIsInstance(tf_mvn, MultitaskMultivariateNormal)
+        expected_loc = torch.tensor([[1.6667, 3.6667, 5.25, 7.25]], **tkwargs).repeat(
+            3, 1
+        )
+        expected_loc[1] += 100
+        expected_loc[2] += 1000
+        # This is the weighted average of each 2 x 2 block.
+        expected_covar = torch.tensor(
+            [
+                [1.0889, 0.1667, 0.0, 0.0],
+                [0.1667, 0.8, 0.0, 0.0],
+                [0.0, 0.0, 0.875, 0.35],
+                [0.0, 0.0, 0.35, 1.05],
+            ],
+            **tkwargs
+        ).repeat(3, 1, 1)
+        self.assertTrue(torch.allclose(tf_mvn.loc, expected_loc, atol=1e-3))
+        self.assertTrue(
+            torch.allclose(tf_mvn.covariance_matrix, expected_covar, atol=1e-3)
+        )
 
 
 class TestMCAcquisitionObjective(BotorchTestCase):


### PR DESCRIPTION
Summary:
Implements ExpectationPosteriorTransform, which transforms the batch x (q * n_w) x m posterior to a batch x q x m posterior of the expectation over the n_w points.
Unlike the RiskMeasureMCObjective, this avoids the posterior sampling over q * n_w points, which leads to significant speed-ups for large q * n_w.

Differential Revision: D29277116

