### PR TITLE
Adding proximal acquisition function wrapper

### DIFF
--- a/botorch/acquisition/__init__.py
+++ b/botorch/acquisition/__init__.py
@@ -42,6 +42,7 @@ from botorch.acquisition.monte_carlo import (
     qSimpleRegret,
     qUpperConfidenceBound,
 )
+from botorch.acquisition.proximal import ProximalAcquisitionFunction
 from botorch.acquisition.multi_step_lookahead import qMultiStepLookahead
 from botorch.acquisition.objective import (
     ConstrainedMCObjective,
@@ -65,6 +66,7 @@ __all__ = [
     "OneShotAcquisitionFunction",
     "PosteriorMean",
     "ProbabilityOfImprovement",
+    "ProximalAcquisitionFunction",
     "UpperConfidenceBound",
     "qExpectedImprovement",
     "qKnowledgeGradient",

--- a/botorch/acquisition/proximal.py
+++ b/botorch/acquisition/proximal.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+A wrapper around AquisitionFunctions to fix certain features for optimization.
+This is useful e.g. for performing contextual optimization.
+"""
+
+from __future__ import annotations
+
+import torch
+from botorch.acquisition.analytic import AnalyticAcquisitionFunction
+from torch import Tensor
+from torch.nn import Module
+
+from botorch.utils import t_batch_mode_transform
+
+
+class ProximalAcquisitionFunction(AnalyticAcquisitionFunction):
+    """A wrapper around AquisitionFunctions to add proximal weighting of the acquisition function. Acquisition
+    function is weighted via a squared exponential centered at the last training point with varying lengthscales
+    corresponding to 'proximal_weights'. Can only be used with single batch analytical acquisition functions.
+
+    Example:
+        >>> model = SingleTaskGP(train_X, train_Y)  # d = 2
+        >>> EI = ExpectedImprovement(model, best_f=0.0)
+        >>> proximal_weights = torch.ones(d)
+        >>> EI_proximal = ProximalAcquisitionFunction(EI, proximal_weights)
+        >>> eip = EI_proximal(test_X)  # d' = 3
+    """
+
+    def __init__(
+        self,
+        acq_function: AnalyticAcquisitionFunction,
+        proximal_weights: Tensor,
+    ) -> None:
+        r"""Derived Acquisition Function by fixing a subset of input features.
+
+        Args:
+            acq_function: The base acquisition function, operating on input
+                tensors `X_full` of feature dimension `d`.
+            proximal_weights: Tensor used to bias locality along each axis, should be in the shape of ('d',).
+
+        """
+        Module.__init__(self)
+        self.acq_func = acq_function
+
+        self.register_buffer('proximal_weights', proximal_weights)
+
+        # check to make sure that weights match the training data shape
+        assert self.proximal_weights.shape[0] == self.acq_func.model.train_inputs[0][-1].shape[-1]
+
+    @t_batch_mode_transform(expected_q=1, assert_output_shape=False)
+    def forward(self, X: Tensor):
+        r"""Evaluate base acquisition function with proximal weighting.
+
+        Args:
+            X: Input tensor of feature dimension `d` .
+
+        Returns:
+            Base acquisition function evaluated on tensor `X` multiplied by a squared exponenital centered at the last
+            training point and is weighted according to the weighting of each dimension.
+        """
+        d = self.proximal_weights.shape[0]
+        last_X = self.acq_func.model.train_inputs[0][-1].reshape(1, 1, -1)
+        _unbroadcasted_scale_tril = torch.diag(torch.sqrt(self.proximal_weights)).reshape(1, 1, d, d)
+
+        diff = X - last_X
+        M = _batch_mahalanobis(_unbroadcasted_scale_tril, diff)
+        proximal_acq_weight = torch.exp(-0.5 * M)
+        return self.acq_func(X) * proximal_acq_weight
+
+
+def _batch_mahalanobis(bL, bx):
+    r"""
+    Computes the squared Mahalanobis distance :math:`\mathbf{x}^\top\mathbf{M}^{-1}\mathbf{x}`
+    for a factored :math:`\mathbf{M} = \mathbf{L}\mathbf{L}^\top`.
+
+    Accepts batches for both bL and bx. They are not necessarily assumed to have the same batch
+    shape, but `bL` one should be able to broadcasted to `bx` one.
+    """
+    n = bx.size(-1)
+    bx_batch_shape = bx.shape[:-1]
+
+    # Assume that bL.shape = (i, 1, n, n), bx.shape = (..., i, j, n),
+    # we are going to make bx have shape (..., 1, j,  i, 1, n) to apply batched tri.solve
+    bx_batch_dims = len(bx_batch_shape)
+    bL_batch_dims = bL.dim() - 2
+    outer_batch_dims = bx_batch_dims - bL_batch_dims
+    old_batch_dims = outer_batch_dims + bL_batch_dims
+    new_batch_dims = outer_batch_dims + 2 * bL_batch_dims
+    # Reshape bx with the shape (..., 1, i, j, 1, n)
+    bx_new_shape = bx.shape[:outer_batch_dims]
+    for (sL, sx) in zip(bL.shape[:-2], bx.shape[outer_batch_dims:-1]):
+        bx_new_shape += (sx // sL, sL)
+    bx_new_shape += (n,)
+    bx = bx.reshape(bx_new_shape)
+    # Permute bx to make it have shape (..., 1, j, i, 1, n)
+    permute_dims = (list(range(outer_batch_dims)) +
+                    list(range(outer_batch_dims, new_batch_dims, 2)) +
+                    list(range(outer_batch_dims + 1, new_batch_dims, 2)) +
+                    [new_batch_dims])
+    bx = bx.permute(permute_dims)
+
+    flat_L = bL.reshape(-1, n, n)  # shape = b x n x n
+    flat_x = bx.reshape(-1, flat_L.size(0), n)  # shape = c x b x n
+    flat_x_swap = flat_x.permute(1, 2, 0)  # shape = b x n x c
+    M_swap = torch.triangular_solve(flat_x_swap, flat_L, upper=False)[0].pow(2).sum(-2)  # shape = b x c
+    M = M_swap.t()  # shape = c x b
+
+    # Now we revert the above reshape and permute operators.
+    permuted_M = M.reshape(bx.shape[:-1])  # shape = (..., 1, j, i, 1)
+    permute_inv_dims = list(range(outer_batch_dims))
+    for i in range(bL_batch_dims):
+        permute_inv_dims += [outer_batch_dims + i, old_batch_dims + i]
+    reshaped_M = permuted_M.permute(permute_inv_dims)  # shape = (..., 1, i, j, 1)
+    return reshaped_M.reshape(bx_batch_shape)
+
+

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from botorch.acquisition.proximal import ProximalAcquisitionFunction
+from botorch.acquisition.analytic import ExpectedImprovement
+from botorch.models import SingleTaskGP
+from botorch.utils.testing import BotorchTestCase
+
+
+class TestFixedFeatureAcquisitionFunction(BotorchTestCase):
+    def test_fixed_features(self):
+        train_X = torch.rand(5, 3, device=self.device)
+        train_Y = train_X.norm(dim=-1, keepdim=True)
+        model = SingleTaskGP(train_X, train_Y).to(device=self.device).eval()
+        EI = ExpectedImprovement(model, best_f=0.0)
+
+        # test single point
+        proximal_weights = torch.ones(3)
+        test_X = torch.rand(1, 3, device=self.device)
+        EI_prox = ProximalAcquisitionFunction(
+            EI, proximal_weights=proximal_weights)
+
+        ei_prox = EI_prox(test_X)
+
+        # test t-batch with broadcasting
+        test_X = torch.rand(1, 3, device=self.device).expand(4, 1, 3)
+        ei_prox = EI_prox(test_X)
+
+        # test gradient
+        test_X = torch.rand(1, 3, device=self.device, requires_grad=True)
+        ei_prox = EI_prox(test_X)
+        ei_prox.backward()

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from botorch.acquisition.proximal import ProximalAcquisitionFunction
 from botorch.acquisition.analytic import ExpectedImprovement
+from botorch.acquisition.proximal import ProximalAcquisitionFunction
 from botorch.models import SingleTaskGP
 from botorch.utils.testing import BotorchTestCase
 
@@ -21,8 +21,7 @@ class TestFixedFeatureAcquisitionFunction(BotorchTestCase):
         # test single point
         proximal_weights = torch.ones(3)
         test_X = torch.rand(1, 3, device=self.device)
-        EI_prox = ProximalAcquisitionFunction(
-            EI, proximal_weights=proximal_weights)
+        EI_prox = ProximalAcquisitionFunction(EI, proximal_weights=proximal_weights)
 
         ei_prox = EI_prox(test_X)
 


### PR DESCRIPTION
## Motivation

The goal of this acquisition function is to bias a GP optimization towards smooth optimization through the input domain. The proximal AF multiplies the base acquisition function by a squared exponential with a user defined lengthscale, centered at the most recently observed training point (assumed to be model.train_inputs[-1]). If the associated lengthscale is short the algorithm makes small jumps in input space, if it is long it is not strongly biased. This method differs from simply restricting the max travel size in input space by allowing large travel distances if the predicted value is large enough. See https://journals.aps.org/prab/abstract/10.1103/PhysRevAccelBeams.24.062801 for discussion and analysis.

This becomes relevant when using Bayesian optimization techniques on optimizing physical systems, where there is a cost associated with changing input parameters. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes, I've tried my best to satisfy all requirements although there are possibly errors (first time contributing to a major project like this).

## Test Plan

Test script test_proximal.py has been added to test/acquisition. I can also provide numerical proof that this works with a simple script but I was unsure where to include. Result is show below
![figure_1](https://user-images.githubusercontent.com/24279776/130523338-05f00937-0c0e-4847-800b-96a02c92c411.png)

Please comment if I need to change anything, thanks!

## Related PRs
None
