### PR TITLE
Bugfix for specifying proximal weights in a multi-dim tensor

### DIFF
--- a/botorch/acquisition/proximal.py
+++ b/botorch/acquisition/proximal.py
@@ -74,7 +74,8 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
 
         # check to make sure that weights match the training data shape
         if (
-            self.proximal_weights.shape[0]
+            len(self.proximal_weights.shape) != 1
+            or self.proximal_weights.shape[0]
             != self.acq_func.model.train_inputs[0][-1].shape[-1]
         ):
             raise ValueError(

--- a/botorch/acquisition/proximal.py
+++ b/botorch/acquisition/proximal.py
@@ -57,13 +57,14 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
 
         self.acq_func = acq_function
 
-        if acq_function.X_pending is not None:
-            raise ProximalWarning(
-                "Proximal biasing behavior will be based on pending "
-                "observation points, may result in unintuitive "
-                "behavior."
-            )
-        self.X_pending = acq_function.X_pending
+        if hasattr(acq_function, "X_pending"):
+            if acq_function.X_pending is not None:
+                raise ProximalWarning(
+                    "Proximal biasing behavior will be based on pending "
+                    "observation points, may result in unintuitive "
+                    "behavior."
+                )
+            self.X_pending = acq_function.X_pending
 
         self.register_buffer("proximal_weights", proximal_weights)
 

--- a/botorch/acquisition/proximal.py
+++ b/botorch/acquisition/proximal.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import torch
 from botorch.acquisition import AcquisitionFunction
 from botorch.exceptions.errors import UnsupportedError
-from botorch.exceptions.warnings import ProximalWarning
 from botorch.utils import t_batch_mode_transform
 from torch import Tensor
 from torch.nn import Module
@@ -59,10 +58,8 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
 
         if hasattr(acq_function, "X_pending"):
             if acq_function.X_pending is not None:
-                raise ProximalWarning(
-                    "Proximal biasing behavior will be based on pending "
-                    "observation points, may result in unintuitive "
-                    "behavior."
+                raise UnsupportedError(
+                    "Proximal acquisition function requires `X_pending` to be None."
                 )
             self.X_pending = acq_function.X_pending
 

--- a/botorch/acquisition/proximal.py
+++ b/botorch/acquisition/proximal.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import torch
 from botorch.acquisition import AcquisitionFunction
 from botorch.exceptions.errors import UnsupportedError
+from botorch.exceptions.warnings import ProximalWarning
 from botorch.utils import t_batch_mode_transform
 from torch import Tensor
 from torch.nn import Module
@@ -55,6 +56,14 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
         Module.__init__(self)
 
         self.acq_func = acq_function
+
+        if acq_function.X_pending is not None:
+            raise ProximalWarning(
+                "Proximal biasing behavior will be based on pending "
+                "observation points, may result in unintuitive "
+                "behavior."
+            )
+        self.X_pending = acq_function.X_pending
 
         self.register_buffer("proximal_weights", proximal_weights)
 

--- a/botorch/exceptions/warnings.py
+++ b/botorch/exceptions/warnings.py
@@ -49,10 +49,3 @@ class BotorchTensorDimensionWarning(BotorchWarning):
     r"""Warning raised when a tensor possibly violates a botorch convention."""
 
     pass
-
-
-class ProximalWarning(BotorchWarning):
-    r"""Warning raised when Proximal biasing behavior is based on pending
-    observations."""
-
-    pass

--- a/botorch/exceptions/warnings.py
+++ b/botorch/exceptions/warnings.py
@@ -49,3 +49,10 @@ class BotorchTensorDimensionWarning(BotorchWarning):
     r"""Warning raised when a tensor possibly violates a botorch convention."""
 
     pass
+
+
+class ProximalWarning(BotorchWarning):
+    r"""Warning raised when Proximal biasing behavior is based on pending
+    observations."""
+
+    pass

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -12,7 +12,6 @@ from botorch.acquisition.analytic import ExpectedImprovement
 from botorch.acquisition.monte_carlo import qExpectedImprovement
 from botorch.acquisition.proximal import ProximalAcquisitionFunction
 from botorch.exceptions.errors import UnsupportedError
-from botorch.exceptions.warnings import ProximalWarning
 from botorch.models import SingleTaskGP
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model import Model
@@ -123,13 +122,14 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
 
             with self.assertRaises(ValueError):
                 ProximalAcquisitionFunction(
-                    ExpectedImprovement(model, 0.0), torch.rand(3, 3)
+                    ExpectedImprovement(model, 0.0),
+                    torch.rand(3, 3, device=self.device, dtype=dtype),
                 )
 
             # test for x_pending points
             pending_acq = DummyAcquisitionFunction(model)
-            pending_acq.set_X_pending(torch.rand(3, 3))
-            with self.assertRaises(ProximalWarning):
+            pending_acq.set_X_pending(torch.rand(3, 3, device=self.device, dtype=dtype))
+            with self.assertRaises(UnsupportedError):
                 ProximalAcquisitionFunction(pending_acq, proximal_weights)
 
             # test model with multi-batch training inputs

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -114,6 +114,11 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                     ExpectedImprovement(model, 0.0), proximal_weights[:1]
                 )
 
+            with self.assertRaises(ValueError):
+                ProximalAcquisitionFunction(
+                    ExpectedImprovement(model, 0.0), torch.rand(3, 3)
+                )
+
             # test model with multi-batch training inputs
             train_X = torch.rand(5, 2, 3, device=self.device, dtype=dtype)
             train_Y = train_X.norm(dim=-1, keepdim=True)

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -142,5 +142,3 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                 ProximalAcquisitionFunction(
                     ExpectedImprovement(bad_single_task, 0.0), proximal_weights
                 )
-
-


### PR DESCRIPTION
Fixes bug with proximal acquisition function where a user is allowed to specify a multi-dim proximal_weights tensor. Change prevents this and adds a test to verify