### PR TITLE
Add an Outcome Power Transform

### DIFF
--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -628,5 +628,5 @@ class Power(OutcomeTransform):
             )
         return TransformedPosterior(
             posterior=posterior,
-            sample_transform=lambda x: x.pow(1.0 /self.power),
+            sample_transform=lambda x: x.pow(1.0 / self.power),
         )

--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -506,7 +506,7 @@ class Log(OutcomeTransform):
 
 
 class Power(OutcomeTransform):
-    r"""Log-transform outcomes.
+    r"""Power-transform outcomes.
 
     Useful if the targets are modeled using a (multivariate) power transform of
     a Normal distribution. This means that we can use a standard GP model on the
@@ -514,7 +514,7 @@ class Power(OutcomeTransform):
     """
 
     def __init__(self, power: float, outputs: Optional[List[int]] = None) -> None:
-        r"""Log-transform outcomes.
+        r"""Power-transform outcomes.
 
         Args:
             outputs: Which of the outputs to power-transform. If omitted, all
@@ -549,7 +549,7 @@ class Power(OutcomeTransform):
     def forward(
         self, Y: Tensor, Yvar: Optional[Tensor] = None
     ) -> Tuple[Tensor, Optional[Tensor]]:
-        r"""Log-transform outcomes.
+        r"""Power-transform outcomes.
 
         Args:
             Y: A `batch_shape x n x m`-dim tensor of training targets.
@@ -582,19 +582,19 @@ class Power(OutcomeTransform):
     def untransform(
         self, Y: Tensor, Yvar: Optional[Tensor] = None
     ) -> Tuple[Tensor, Optional[Tensor]]:
-        r"""Un-transform log-transformed outcomes
+        r"""Un-transform power-transformed outcomes
 
         Args:
-            Y: A `batch_shape x n x m`-dim tensor of log-transfomred targets.
-            Yvar: A `batch_shape x n x m`-dim tensor of log- transformed
+            Y: A `batch_shape x n x m`-dim tensor of power-transfomred targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of power-transformed
                 observation noises associated with the training targets
                 (if applicable).
 
         Returns:
             A two-tuple with the un-transformed outcomes:
 
-            - The exponentiated outcome observations.
-            - The exponentiated observation noise (if applicable).
+            - The un-power transformed outcome observations.
+            - The un-power transformed observation noise (if applicable).
         """
         Y_utf = Y.pow(1.0 / self.power)
         outputs = normalize_indices(self._outputs, d=Y.size(-1))
@@ -614,10 +614,10 @@ class Power(OutcomeTransform):
         return Y_utf, Yvar
 
     def untransform_posterior(self, posterior: Posterior) -> Posterior:
-        r"""Un-transform the log-transformed posterior.
+        r"""Un-transform the power-transformed posterior.
 
         Args:
-            posterior: A posterior in the log-transformed space.
+            posterior: A posterior in the power-transformed space.
 
         Returns:
             The un-transformed posterior.

--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -596,7 +596,7 @@ class Power(OutcomeTransform):
             - The exponentiated outcome observations.
             - The exponentiated observation noise (if applicable).
         """
-        Y_utf = Y.pow(1./ self.power)
+        Y_utf = Y.pow(1.0 / self.power)
         outputs = normalize_indices(self._outputs, d=Y.size(-1))
         if outputs is not None:
             Y_utf = torch.stack(
@@ -628,5 +628,5 @@ class Power(OutcomeTransform):
             )
         return TransformedPosterior(
             posterior=posterior,
-            sample_transform=lambda x: x.pow(1./self.power),
+            sample_transform=lambda x: x.pow(1.0 /self.power),
         )

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -579,4 +579,3 @@ class TestOutcomeTransforms(BotorchTestCase):
             Y_tf_subset, Yvar_tf_subset = tf_subset(Y[..., [0]], None)
             self.assertTrue(torch.equal(Y_tf_subset, Y_tf[..., [0]]))
             self.assertIsNone(Yvar_tf_subset)
-            

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -472,7 +472,7 @@ class TestOutcomeTransforms(BotorchTestCase):
         ms = (1, 2)
         batch_shapes = (torch.Size(), torch.Size([2]))
         dtypes = (torch.float, torch.double)
-        power = 1/3
+        power = 1 / 3
 
         # test transform and untransform
         for m, batch_shape, dtype in itertools.product(ms, batch_shapes, dtypes):
@@ -486,7 +486,7 @@ class TestOutcomeTransforms(BotorchTestCase):
             Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
             Y_tf, Yvar_tf = tf(Y, None)
             self.assertTrue(tf.training)
-            self.assertTrue(torch.allclose(Y_tf, Y.pow(1/3)))
+            self.assertTrue(torch.allclose(Y_tf, Y.pow(power)))
             self.assertIsNone(Yvar_tf)
             tf.eval()
             self.assertFalse(tf.training)
@@ -522,13 +522,7 @@ class TestOutcomeTransforms(BotorchTestCase):
             self.assertIsInstance(p_utf, TransformedPosterior)
             self.assertEqual(p_utf.device.type, self.device.type)
             self.assertTrue(p_utf.dtype == dtype)
-            # self.assertTrue(p_utf._sample_transform == torch.exp)
-            # mean_expected = norm_to_lognorm_mean(posterior.mean, posterior.variance)
-            # variance_expected = norm_to_lognorm_variance(
-            #     posterior.mean, posterior.variance
-            # )
-            # self.assertTrue(torch.allclose(p_utf.mean, mean_expected))
-            # self.assertTrue(torch.allclose(p_utf.variance, variance_expected))
+
             samples = p_utf.rsample()
             self.assertEqual(samples.shape, torch.Size([1]) + shape)
             samples = p_utf.rsample(sample_shape=torch.Size([4]))
@@ -552,7 +546,7 @@ class TestOutcomeTransforms(BotorchTestCase):
             Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
             Y_tf, Yvar_tf = tf(Y, None)
             self.assertTrue(tf.training)
-            self.assertTrue(torch.allclose(Y_tf[..., 1], Y[...,1].pow(power)))
+            self.assertTrue(torch.allclose(Y_tf[..., 1], Y[..., 1].pow(power)))
             self.assertTrue(torch.allclose(Y_tf[..., 0], Y[..., 0]))
             self.assertIsNone(Yvar_tf)
             tf.eval()
@@ -585,3 +579,4 @@ class TestOutcomeTransforms(BotorchTestCase):
             Y_tf_subset, Yvar_tf_subset = tf_subset(Y[..., [0]], None)
             self.assertTrue(torch.equal(Y_tf_subset, Y_tf[..., [0]]))
             self.assertIsNone(Yvar_tf_subset)
+            

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -12,6 +12,7 @@ from botorch.models.transforms.outcome import (
     ChainedOutcomeTransform,
     Log,
     OutcomeTransform,
+    Power,
     Standardize,
 )
 from botorch.models.transforms.utils import (
@@ -465,3 +466,122 @@ class TestOutcomeTransforms(BotorchTestCase):
             # error on untransform_posterior
             with self.assertRaises(NotImplementedError):
                 tf.untransform_posterior(None)
+
+    def test_power(self):
+
+        ms = (1, 2)
+        batch_shapes = (torch.Size(), torch.Size([2]))
+        dtypes = (torch.float, torch.double)
+        power = 1/3
+
+        # test transform and untransform
+        for m, batch_shape, dtype in itertools.product(ms, batch_shapes, dtypes):
+
+            # test init
+            tf = Power(power=power)
+            self.assertTrue(tf.training)
+            self.assertIsNone(tf._outputs)
+
+            # no observation noise
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Y_tf, Yvar_tf = tf(Y, None)
+            self.assertTrue(tf.training)
+            self.assertTrue(torch.allclose(Y_tf, Y.pow(1/3)))
+            self.assertIsNone(Yvar_tf)
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            torch.allclose(Y_utf, Y)
+            self.assertIsNone(Yvar_utf)
+
+            # subset_output
+            tf_subset = tf.subset_output(idcs=[0])
+            Y_tf_subset, Yvar_tf_subset = tf_subset(Y[..., [0]])
+            self.assertTrue(torch.equal(Y_tf[..., [0]], Y_tf_subset))
+            self.assertIsNone(Yvar_tf_subset)
+
+            # test error if observation noise present
+            tf = Power(power=power)
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Yvar = 1e-8 + torch.rand(
+                *batch_shape, 3, m, device=self.device, dtype=dtype
+            )
+            with self.assertRaises(NotImplementedError):
+                tf(Y, Yvar)
+            tf.eval()
+            with self.assertRaises(NotImplementedError):
+                tf.untransform(Y, Yvar)
+
+            # untransform_posterior
+            tf = Power(power=power)
+            Y_tf, Yvar_tf = tf(Y, None)
+            tf.eval()
+            shape = batch_shape + torch.Size([3, m])
+            posterior = _get_test_posterior(shape, device=self.device, dtype=dtype)
+            p_utf = tf.untransform_posterior(posterior)
+            self.assertIsInstance(p_utf, TransformedPosterior)
+            self.assertEqual(p_utf.device.type, self.device.type)
+            self.assertTrue(p_utf.dtype == dtype)
+            # self.assertTrue(p_utf._sample_transform == torch.exp)
+            # mean_expected = norm_to_lognorm_mean(posterior.mean, posterior.variance)
+            # variance_expected = norm_to_lognorm_variance(
+            #     posterior.mean, posterior.variance
+            # )
+            # self.assertTrue(torch.allclose(p_utf.mean, mean_expected))
+            # self.assertTrue(torch.allclose(p_utf.variance, variance_expected))
+            samples = p_utf.rsample()
+            self.assertEqual(samples.shape, torch.Size([1]) + shape)
+            samples = p_utf.rsample(sample_shape=torch.Size([4]))
+            self.assertEqual(samples.shape, torch.Size([4]) + shape)
+            samples2 = p_utf.rsample(sample_shape=torch.Size([4, 2]))
+            self.assertEqual(samples2.shape, torch.Size([4, 2]) + shape)
+
+        # test transforming a subset of outcomes
+        for batch_shape, dtype in itertools.product(batch_shapes, dtypes):
+
+            m = 2
+            outputs = [-1]
+
+            # test init
+            tf = Power(power=power, outputs=outputs)
+            self.assertTrue(tf.training)
+            # cannot normalize indices b/c we don't know dimension yet
+            self.assertEqual(tf._outputs, [-1])
+
+            # no observation noise
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Y_tf, Yvar_tf = tf(Y, None)
+            self.assertTrue(tf.training)
+            self.assertTrue(torch.allclose(Y_tf[..., 1], Y[...,1].pow(power)))
+            self.assertTrue(torch.allclose(Y_tf[..., 0], Y[..., 0]))
+            self.assertIsNone(Yvar_tf)
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            torch.allclose(Y_utf, Y)
+            self.assertIsNone(Yvar_utf)
+
+            # subset_output
+            with self.assertRaises(NotImplementedError):
+                tf_subset = tf.subset_output(idcs=[0])
+
+            # with observation noise
+            tf = Power(power=power, outputs=outputs)
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Yvar = 1e-8 + torch.rand(
+                *batch_shape, 3, m, device=self.device, dtype=dtype
+            )
+            with self.assertRaises(NotImplementedError):
+                tf(Y, Yvar)
+
+            # error on untransform_posterior
+            with self.assertRaises(NotImplementedError):
+                tf.untransform_posterior(None)
+
+            # test subset_output with positive on subset of outcomes (pos. index)
+            tf = Power(power=power, outputs=[0])
+            Y_tf, Yvar_tf = tf(Y, None)
+            tf_subset = tf.subset_output(idcs=[0])
+            Y_tf_subset, Yvar_tf_subset = tf_subset(Y[..., [0]], None)
+            self.assertTrue(torch.equal(Y_tf_subset, Y_tf[..., [0]]))
+            self.assertIsNone(Yvar_tf_subset)


### PR DESCRIPTION
Adds an outcome power transform into botorch.transforms.outcome.

## Motivation

Useful for transforming skewed outcomes cc @qingfeng10 .

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.

## Related PRs

N/a.