### PR TITLE
Add Extra tests to test_outcome

### DIFF
--- a/botorch/models/transforms/__init__.py
+++ b/botorch/models/transforms/__init__.py
@@ -10,7 +10,12 @@ from botorch.models.transforms.input import (
     Normalize,
     Round,
 )
-from botorch.models.transforms.outcome import ChainedOutcomeTransform, Standardize, Log
+from botorch.models.transforms.outcome import (
+    ChainedOutcomeTransform, 
+    Log,
+    Power,
+    Standardize, 
+)
 
 
 __all__ = [
@@ -18,6 +23,7 @@ __all__ = [
     "ChainedOutcomeTransform",
     "Log",
     "Normalize",
+    "Power",
     "Round",
     "Standardize",
     "Warp",

--- a/botorch/models/transforms/__init__.py
+++ b/botorch/models/transforms/__init__.py
@@ -11,10 +11,10 @@ from botorch.models.transforms.input import (
     Round,
 )
 from botorch.models.transforms.outcome import (
-    ChainedOutcomeTransform, 
+    ChainedOutcomeTransform,
     Log,
     Power,
-    Standardize, 
+    Standardize,
 )
 
 

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -467,8 +467,9 @@ class TestOutcomeTransforms(BotorchTestCase):
             with self.assertRaises(NotImplementedError):
                 tf.untransform_posterior(None)
 
-    def test_power(self):
-
+    def test_power(self, seed=0):
+        torch.random.manual_seed(seed)
+        
         ms = (1, 2)
         batch_shapes = (torch.Size(), torch.Size([2]))
         dtypes = (torch.float, torch.double)

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -92,7 +92,7 @@ class TestOutcomeTransforms(BotorchTestCase):
             tf.eval()
             self.assertFalse(tf.training)
             Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
-            torch.allclose(Y_utf, Y)
+            self.assertTrue(torch.allclose(Y_utf, Y))
             self.assertIsNone(Yvar_utf)
 
             # subset_output
@@ -117,8 +117,8 @@ class TestOutcomeTransforms(BotorchTestCase):
             tf.eval()
             self.assertFalse(tf.training)
             Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
-            torch.allclose(Y_utf, Y)
-            torch.allclose(Yvar_utf, Yvar)
+            self.assertTrue(torch.allclose(Y_utf, Y))
+            self.assertTrue(torch.allclose(Yvar_utf, Yvar))
 
             # untransform_posterior
             for interleaved, lazy in itertools.product((True, False), (True, False)):
@@ -200,7 +200,7 @@ class TestOutcomeTransforms(BotorchTestCase):
             tf.eval()
             self.assertFalse(tf.training)
             Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
-            torch.allclose(Y_utf, Y)
+            self.assertTrue(torch.allclose(Y_utf, Y))
             self.assertIsNone(Yvar_utf)
 
             # subset_output
@@ -228,8 +228,8 @@ class TestOutcomeTransforms(BotorchTestCase):
             tf.eval()
             self.assertFalse(tf.training)
             Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
-            torch.allclose(Y_utf, Y)
-            torch.allclose(Yvar_utf, Yvar)
+            self.assertTrue(torch.allclose(Y_utf, Y))
+            self.assertTrue(torch.allclose(Yvar_utf, Yvar))
 
             # error on untransform_posterior
             with self.assertRaises(NotImplementedError):
@@ -491,7 +491,7 @@ class TestOutcomeTransforms(BotorchTestCase):
             tf.eval()
             self.assertFalse(tf.training)
             Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
-            torch.allclose(Y_utf, Y)
+            self.assertTrue(torch.allclose(Y_utf, Y))
             self.assertIsNone(Yvar_utf)
 
             # subset_output
@@ -552,7 +552,7 @@ class TestOutcomeTransforms(BotorchTestCase):
             tf.eval()
             self.assertFalse(tf.training)
             Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
-            torch.allclose(Y_utf, Y)
+            self.assertTrue(torch.allclose(Y_utf, Y))
             self.assertIsNone(Yvar_utf)
 
             # subset_output

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -469,7 +469,7 @@ class TestOutcomeTransforms(BotorchTestCase):
 
     def test_power(self, seed=0):
         torch.random.manual_seed(seed)
-        
+
         ms = (1, 2)
         batch_shapes = (torch.Size(), torch.Size([2]))
         dtypes = (torch.float, torch.double)


### PR DESCRIPTION
Added a few self.assertTrue calls to `test_outcome`. Realized these were missing.

## Motivation

see above

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

unit tests

## Related PRs

n/a
