### PR TITLE
Add error message for one shot acqf in optimize_acqf_discrete

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -18,6 +18,7 @@ from botorch.acquisition.acquisition import (
     OneShotAcquisitionFunction,
 )
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
+from botorch.exceptions import UnsupportedError
 from botorch.generation.gen import gen_candidates_scipy
 from botorch.logging import logger
 from botorch.optim.initializers import (
@@ -594,6 +595,11 @@ def optimize_acqf_discrete(
         - a `q x d`-dim tensor of generated candidates.
         - an associated acquisition value.
     """
+    if isinstance(acq_function, OneShotAcquisitionFunction):
+        raise UnsupportedError(
+            "Discrete optimization is not supported for"
+            "one-shot acquisition functions."
+        )
     choices_batched = choices.unsqueeze(-2)
     if q > 1:
         candidate_list, acq_value_list = [], []

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -13,6 +13,7 @@ from botorch.acquisition.acquisition import (
     AcquisitionFunction,
     OneShotAcquisitionFunction,
 )
+from botorch.exceptions import UnsupportedError
 from botorch.optim.optimize import (
     _filter_infeasible,
     _filter_invalid,
@@ -927,6 +928,14 @@ class TestOptimizeAcqfDiscrete(BotorchTestCase):
             expected_acq_value = exp_acq_vals[best_idx].repeat(q)
             self.assertTrue(torch.allclose(acq_value, expected_acq_value))
             self.assertTrue(torch.allclose(candidates, expected_candidates))
+
+        with self.assertRaises(UnsupportedError):
+            acqf = MockOneShotAcquisitionFunction()
+            optimize_acqf_discrete(
+                acq_function=acqf,
+                q=1,
+                choices=torch.tensor([[0.5], [0.2]]),
+            )
 
     def test_optimize_acqf_discrete_local_search(self):
         for q, dtype in itertools.product((1, 2), (torch.float, torch.double)):


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

As noted in #938, use of one-shot acquisition functions in optimize_acqf_mixed/discrete leads to errors down the line that are hard to interpret. This PR adds an explicit error message noting that this is not supported.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Units.
