### PR TITLE
Avoid test failures on Ampere devices

### DIFF
--- a/test/acquisition/test_knowledge_gradient.py
+++ b/test/acquisition/test_knowledge_gradient.py
@@ -113,6 +113,11 @@ class TestQKnowledgeGradient(BotorchTestCase):
                 qKnowledgeGradient(model=mm2)
 
     def test_evaluate_q_knowledge_gradient(self):
+        # Stop gap measure to avoid test failures on Ampere devices
+        # TODO: Find an elegant way of disallowing tf32 for botorch/gpytorch
+        # without blanket-disallowing it for all of torch.
+        torch.backends.cuda.matmul.allow_tf32 = False
+
         for dtype in (torch.float, torch.double):
             # basic test
             n_f = 4


### PR DESCRIPTION
Summary:
tf32 is enabled by default for matmul on Ampere devices. This is a problem where we need precision (pretty much everywhere where we deal with GPs...).

See https://www.internalfb.com/diff/D30533768?dst_version_fbid=970943846783006&transaction_fbid=317461206583876

Differential Revision: D30953350

