### PR TITLE
 Pin setuptools version to <48

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -14,7 +14,8 @@ build:
 requirements:
   host:
     - python>=3.7
-    - setuptools_scm
+    - setuptools<48  # setup_requires was deprecated in v48.0.0
+    - setuptools-scm
   run:
     - pytorch>=1.8.1
     - gpytorch>=1.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.setuptools_scm]
 
 [build-system]
-requires = ["setuptools>=34.4", "wheel", "setuptools-scm"]
+requires = ["setuptools<48", "wheel", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.usort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.setuptools_scm]
 
 [build-system]
-requires = ["setuptools>=34.4", "wheel", "setuptools_scm"]
+requires = ["setuptools>=34.4", "wheel", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.usort]

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">=3.7",
-    setup_requires=["setuptools_scm"],
+    setup_requires=["setuptools-scm"],
     use_scm_version={
         "root": ".",
         "relative_to": __file__,


### PR DESCRIPTION
`setuptools` deprecated usage of `setup_requires` in `setup` of `setup.py`, which makes setuptools-scm versioning fail.

The proper fix is to fully migrate to using `pyproject.toml` to configure `setuptools-scm`. However, at this point I am not sure how to dynamically set these options (e.g. the file locations or grabbing the `SCM_NO_LOCAL_VERSION` env var)  from within `pyproject.toml`, so for now we pin the `setuptools` version.