### PR TITLE
Fixes Griewank Test Function

### DIFF
--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -234,7 +234,7 @@ class Griewank(SyntheticTestFunction):
     def evaluate_true(self, X: Tensor) -> Tensor:
         part1 = torch.sum(X ** 2 / 4000.0, dim=-1)
         d = X.shape[-1]
-        part2 = -(torch.prod(torch.cos(X / torch.sqrt(X.new(range(1, d + 1))))))
+        part2 = -(torch.prod(torch.cos(X / torch.sqrt(X.new(range(1, d + 1)))), dim=-1))
         return part1 + part2 + 1.0
 
 


### PR DESCRIPTION
## Motivation

Fixes an error in the Griewank test function that lead to faulty results when evaluating multiple solutions at once. The error is particularly visible when evaluating a large number of solutions, since `part2` would converge to `0` due to being the product of large number of values between `-1` and `1`. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
import torch
from botorch.test_functions import Griewank
func = Griewank(dim=2)
X = torch.rand(1000, 2)
Y = func(X)
Y.min(), Y.max()
```
new output: `(tensor(6.5029e-05), tensor(0.5864))`
old output: `(tensor(1.0000), tensor(1.0005))`
