### PR TITLE
Use lazy covariance in `BatchedMultiOutputGPyTorchModel.posterior`

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -32,7 +32,6 @@ from botorch.models.utils import (
 )
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
-from gpytorch.lazy import lazify
 from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
 from gpytorch.utils.broadcasting import _mul_broadcast_shape
 from torch import Tensor
@@ -344,12 +343,12 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
                     mvn = self.likelihood(mvn, X)
             if self._num_outputs > 1:
                 mean_x = mvn.mean
-                covar_x = mvn.covariance_matrix
+                covar_x = mvn.lazy_covariance_matrix
                 output_indices = output_indices or range(self._num_outputs)
                 mvns = [
                     MultivariateNormal(
                         mean_x.select(dim=output_dim_idx, index=t),
-                        lazify(covar_x.select(dim=output_dim_idx, index=t)),
+                        covar_x[(slice(None),) * output_dim_idx + (t,)],
                     )
                     for t in output_indices
                 ]


### PR DESCRIPTION
Part of the fix for #971.

<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This prevents the evaluation of the entire covariance matrix for multi-output posterior evaluation, so `SingleTaskGP.posterior` is O(n) instead of O(n^2).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

I skimmed it. Agreed to CLA.

## Test Plan

I tested the changes locally with monkey-patches. Here is the script:

```python
import contextlib
from time import perf_counter as time

import numpy as np
import torch
from botorch.models.gp_regression import SingleTaskGP

def main():
	rng = np.random.default_rng(0)
	
	d = 2
	k = 2
	X_train = torch.tensor(rng.uniform(size = (5, d)))
	Y_train = torch.tensor(rng.uniform(size = (5, k)))
	
	gp = SingleTaskGP(X_train, Y_train)
	
	print("{:>5} | {:>6} | {:>6} | {:>7}".format("n", "orig", "patch", "speedup"))
	
	for n_eval in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096]:
		time = Timer()
		
		X_eval = torch.tensor(rng.uniform(size = (n_eval, d)))
		
		p1 = gp.posterior(X_eval)
		with time('unpatched'):
			for _ in range(10):
				_ = gp.posterior(X_eval)
		
		with monkey_patches():
			p2 = gp.posterior(X_eval)
			with time('patched'):
				for _ in range(10):
					_ = gp.posterior(X_eval)
		
		assert torch.allclose(p1.mean, p2.mean)
		assert torch.allclose(p1.variance, p2.variance)
		
		print("{:>5} | {:>6.4f} | {:>6.4f} | {:>6.1f}x".format(
			n_eval, time['unpatched'] / 10, time['patched'] / 10,
			time['unpatched'] / time['patched'],
		))

class Timer:
	def __init__(self):
		self.times = {}
	
	def __getitem__(self, key):
		return self.times[key]
	
	@contextlib.contextmanager
	def __call__(self, key):
		t0 = time()
		yield
		t1 = time()
		self.times[key] = t1 - t0

@contextlib.contextmanager
def monkey_patches():
	from gpytorch.kernels import Kernel
	from gpytorch.lazy import LazyEvaluatedKernelTensor
	from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
	
	orig_Kernel_getitem = Kernel.__getitem__
	orig_LazyEvaluatedKernelTensor_unsqueeze_batch = LazyEvaluatedKernelTensor._unsqueeze_batch
	orig_BatchedMultiOutputGPyTorchModel_posterior = BatchedMultiOutputGPyTorchModel.posterior
	
	try:
		Kernel.__getitem__ = patch_Kernel_getitem
		LazyEvaluatedKernelTensor._unsqueeze_batch = patch_LazyEvaluatedKernelTensor_unsqueeze_batch
		BatchedMultiOutputGPyTorchModel.posterior = patch_BatchedMultiOutputGPyTorchModel_posterior
		yield
	finally:
		BatchedMultiOutputGPyTorchModel.posterior = orig_BatchedMultiOutputGPyTorchModel_posterior
		LazyEvaluatedKernelTensor._unsqueeze_batch = orig_LazyEvaluatedKernelTensor_unsqueeze_batch
		Kernel.__getitem__ = orig_Kernel_getitem

def patch_Kernel_getitem(self, index):
	from copy import deepcopy
	
	if len(self.batch_shape) == 0:
		return self
	new_kernel = deepcopy(self)
	index = index if isinstance(index, tuple) else (index,)
	
	for param_name, param in self._parameters.items():
		new_kernel._parameters[param_name].data = param.__getitem__(index)
		ndim_removed = len(param.shape) - len(new_kernel._parameters[param_name].shape)
		new_batch_shape_len = len(self.batch_shape) - ndim_removed
		obs = new_kernel.batch_shape
		new_kernel.batch_shape = new_kernel._parameters[param_name].shape[:new_batch_shape_len]
	
	for sub_module_name, sub_module in new_kernel.named_sub_kernels():
		new_kernel._modules[sub_module_name] = sub_module.__getitem__(index)
	
	return new_kernel

def patch_LazyEvaluatedKernelTensor_unsqueeze_batch(self, dim):
	return self[(slice(None),) * dim + (None,)]

def patch_BatchedMultiOutputGPyTorchModel_posterior(
	self, X, output_indices = None, observation_noise = False, **kwargs,
):
	from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
	from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
	from botorch.models.utils import add_output_dim, gpt_posterior_settings
	from botorch.posteriors.gpytorch import GPyTorchPosterior
	
	self.eval()  # make sure model is in eval mode
	# input transforms are applied at `posterior` in `eval` mode, and at
	# `model.forward()` at the training time
	X = self.transform_inputs(X)
	
	with gpt_posterior_settings():
		# insert a dimension for the output dimension
		if self._num_outputs > 1:
			X, output_dim_idx = add_output_dim(
				X=X, original_batch_shape=self._input_batch_shape
			)
		mvn = self(X)
		if observation_noise is not False:
			if torch.is_tensor(observation_noise):
				# TODO: Validate noise shape
				# make observation_noise `batch_shape x q x n`
				obs_noise = observation_noise.transpose(-1, -2)
				mvn = self.likelihood(mvn, X, noise=obs_noise)
			elif isinstance(self.likelihood, FixedNoiseGaussianLikelihood):
				# Use the mean of the previous noise values (TODO: be smarter here).
				noise = self.likelihood.noise.mean().expand(X.shape[:-1])
				mvn = self.likelihood(mvn, X, noise=noise)
			else:
				mvn = self.likelihood(mvn, X)
		if self._num_outputs > 1:
			mean_x = mvn.mean
			covar_x = mvn.lazy_covariance_matrix
			output_indices = output_indices or range(self._num_outputs)
			mvns = [
				MultivariateNormal(
					mean_x.select(dim=output_dim_idx, index=t),
					covar_x[(slice(None),) * output_dim_idx + (t,)],
				)
				for t in output_indices
			]
			mvn = MultitaskMultivariateNormal.from_independent_mvns(mvns=mvns)
	
	posterior = GPyTorchPosterior(mvn=mvn)
	if hasattr(self, "outcome_transform"):
		posterior = self.outcome_transform.untransform_posterior(posterior)
	return posterior

if __name__ == '__main__':
	main()
```

## Related PRs

In GPyTorch:
- cornellius-gp/gpytorch#1811
- cornellius-gp/gpytorch#1813