### PR TITLE
add initialization heuristic that samples around best points

### DIFF
--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -17,17 +17,22 @@ from botorch.acquisition.knowledge_gradient import (
     qKnowledgeGradient,
 )
 from botorch.acquisition.utils import is_nonnegative
-from botorch.exceptions.warnings import BadInitialCandidatesWarning, SamplingWarning
+from botorch.exceptions.warnings import (
+    BadInitialCandidatesWarning,
+    SamplingWarning,
+)
 from botorch.models.model import Model
-from botorch.optim.utils import fix_features
+from botorch.optim.utils import fix_features, get_X_baseline
+from botorch.utils.multi_objective.pareto import is_non_dominated
 from botorch.utils.sampling import (
     batched_multinomial,
     draw_sobol_samples,
     manual_seed,
     get_polytope_samples,
 )
-from botorch.utils.transforms import standardize
+from botorch.utils.transforms import unnormalize, normalize, standardize
 from torch import Tensor
+from torch.distributions import Normal
 from torch.quasirandom import SobolEngine
 
 
@@ -137,7 +142,22 @@ def gen_batch_initial_conditions(
                     .view(n, q, -1)
                     .cpu()
                 )
-
+            # sample points around best
+            if options.get("sample_around_best", False):
+                X_best_rnd = sample_points_around_best(
+                    acq_function=acq_function,
+                    n_discrete_points=n * q,
+                    sigma=options.get("sample_around_best_std", 1e-3),
+                    bounds=bounds,
+                )
+                if X_best_rnd is not None:
+                    X_rnd = torch.cat(
+                        [
+                            X_rnd,
+                            X_best_rnd.view(n, q, bounds.shape[-1]).cpu(),
+                        ],
+                        dim=0,
+                    )
             X_rnd = fix_features(X_rnd, fixed_features=fixed_features)
             with torch.no_grad():
                 if batch_limit is None:
@@ -566,3 +586,118 @@ def initialize_q_batch_nonneg(
     if max_idx not in idcs:
         idcs[-1] = max_idx
     return X[idcs]
+
+
+def sample_points_around_best(
+    acq_function: AcquisitionFunction,
+    n_discrete_points: int,
+    sigma: float,
+    bounds: Tensor,
+    best_pct: float = 5.0,
+) -> Optional[Tensor]:
+    r"""Find best points and sample nearby points.
+
+    Args:
+        acq_function: The acquisition function.
+        n_discrete_points: The number of points to sample.
+        sigma: The standard deviation of the additive gaussian noise for
+            perturbing the best points.
+        bounds: A `2 x d`-dim tensor containing the bounds.
+        best_pct: The percentage of best points to perturb.
+
+    Returns:
+        An optional `n_discrete_points x d`-dim tensor containing the
+            sampled points. This is None if no baseline points are found.
+    """
+    X = get_X_baseline(acq_function=acq_function)
+    if X is None:
+        return
+    with torch.no_grad():
+        posterior = acq_function.model.posterior(X)
+        mean = posterior.mean
+        while mean.ndim > 2:
+            # take average over batch dims
+            mean = mean.mean(dim=0)
+
+        f_pred = acq_function.objective(mean)
+        try:
+            # handle constraints for EHVI-based acquisition functions
+            constraints = acq_function.constraints
+            if constraints is not None:
+                neg_violation = -torch.stack(
+                    [c(mean).clamp_min(0.0) for c in constraints], dim=-1
+                ).sum(dim=-1)
+                feas = neg_violation == 0
+                if feas.any():
+                    f_pred[~feas] = float("-inf")
+                else:
+                    # set objective equal to negative violation
+                    f_pred = neg_violation
+        except AttributeError:
+            pass
+        if f_pred.ndim == mean.ndim and f_pred.shape[-1] > 1:
+            # multi-objective
+            # find pareto set
+            is_pareto = is_non_dominated(f_pred)
+            best_X = X[is_pareto]
+        else:
+            n_best = max(1, round(X.shape[0] * best_pct / 100))
+            best_idcs = torch.topk(f_pred, n_best).indices
+            best_X = X[best_idcs]
+    return sample_truncated_normal_perturbations(
+        X=best_X,
+        n_discrete_points=n_discrete_points,
+        sigma=sigma,
+        bounds=bounds,
+    )
+
+
+def sample_truncated_normal_perturbations(
+    X: Tensor,
+    n_discrete_points: int,
+    sigma: float,
+    bounds: Tensor,
+    qmc: bool = True,
+) -> Tensor:
+    r"""Sample points around `X`.
+
+    Sample perturbed points around `X` such that the added perturbations
+    are sampled from N(0, sigma^2 I) and truncated to be within [0,1]^d.
+
+    Args:
+        X: A `n x d`-dim tensor starting points.
+        n_discrete_points: The number of points to sample.
+        sigma: The standard deviation of the additive gaussian noise for
+            perturbing the points.
+        bounds: A `2 x d`-dim tensor containing the bounds.
+        qmc: A boolean indicating whether to use qmc.
+
+    Returns:
+        A `n_discrete_points x d`-dim tensor containing the sampled points.
+    """
+    X = normalize(X, bounds=bounds)
+    d = X.shape[1]
+    # sample points from N(X_center, sigma^2 I), truncated to be within
+    # [0, 1]^d.
+    if X.shape[0] > 1:
+        rand_indices = torch.randint(X.shape[0], (n_discrete_points,), device=X.device)
+        X = X[rand_indices]
+    if qmc:
+        std_bounds = torch.zeros(2, d, dtype=X.dtype, device=X.device)
+        std_bounds[1] = 1
+        u = draw_sobol_samples(bounds=std_bounds, n=n_discrete_points, q=1).squeeze(1)
+    else:
+        u = torch.rand((n_discrete_points, d), dtype=X.dtype, device=X.device)
+    # compute bounds to sample from
+    a = -X
+    b = 1 - X
+    # compute z-score of bounds
+    alpha = a / sigma
+    beta = b / sigma
+    normal = Normal(0, 1)
+    cdf_alpha = normal.cdf(alpha)
+    # use inverse transform
+    perturbation = normal.icdf(cdf_alpha + u * (normal.cdf(beta) - cdf_alpha)) * sigma
+    # add perturbation and clip points that are still outside
+    perturbed_X = (X + perturbation).clamp(0.0, 1.0)
+    return unnormalize(perturbed_X, bounds=bounds)

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -27,6 +27,14 @@ from botorch.optim.initializers import (
 from botorch.optim.stopping import ExpMAStoppingCriterion
 from torch import Tensor
 
+INIT_OPTION_KEYS = (
+    "init_batch_limit",
+    "batch_limit",
+    "nonnegative",
+    "sample_around_best",
+    "sample_around_best_std",
+)
+
 
 def optimize_acqf(
     acq_function: AcquisitionFunction,
@@ -186,11 +194,7 @@ def optimize_acqf(
             acquisition_function=acq_function,
             lower_bounds=bounds[0],
             upper_bounds=bounds[1],
-            options={
-                k: v
-                for k, v in options.items()
-                if k not in ("init_batch_limit", "batch_limit", "nonnegative")
-            },
+            options={k: v for k, v in options.items() if k not in INIT_OPTION_KEYS},
             inequality_constraints=inequality_constraints,
             equality_constraints=equality_constraints,
             fixed_features=fixed_features,

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -14,15 +14,26 @@ import torch
 from botorch import settings
 from botorch.acquisition.analytic import PosteriorMean
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
+from botorch.acquisition.monte_carlo import (
+    qNoisyExpectedImprovement,
+    qExpectedImprovement,
+)
+from botorch.acquisition.multi_objective.monte_carlo import (
+    qNoisyExpectedHypervolumeImprovement,
+)
 from botorch.exceptions import BadInitialCandidatesWarning, SamplingWarning
+from botorch.exceptions.warnings import BotorchWarning
 from botorch.models import SingleTaskGP
 from botorch.optim import initialize_q_batch, initialize_q_batch_nonneg
 from botorch.optim.initializers import (
     gen_batch_initial_conditions,
     gen_one_shot_kg_initial_conditions,
     gen_value_function_initial_conditions,
+    sample_truncated_normal_perturbations,
+    sample_points_around_best,
 )
 from botorch.sampling import IIDNormalSampler
+from botorch.utils.sampling import draw_sobol_samples
 from botorch.utils.testing import (
     BotorchTestCase,
     MockAcquisitionFunction,
@@ -111,12 +122,15 @@ class TestInitializeQBatch(BotorchTestCase):
 class TestGenBatchInitialCandidates(BotorchTestCase):
     def test_gen_batch_initial_conditions(self):
         bounds = torch.stack([torch.zeros(2), torch.ones(2)])
+        mock_acqf = MockAcquisitionFunction()
+        mock_acqf.objective = lambda y: y.squeeze(-1)
         for dtype in (torch.float, torch.double):
             bounds = bounds.to(device=self.device, dtype=dtype)
-            for nonnegative, seed, init_batch_limit, ffs in product(
-                [True, False], [None, 1234], [None, 1], [None, {0: 0.5}]
+            mock_acqf.X_baseline = bounds  # for testing sample_around_best
+            mock_acqf.model = MockModel(MockPosterior(mean=bounds[:, :1]))
+            for nonnegative, seed, init_batch_limit, ffs, sample_around_best in product(
+                [True, False], [None, 1234], [None, 1], [None, {0: 0.5}], [True, False]
             ):
-                mock_acqf = MockAcquisitionFunction()
                 with mock.patch.object(
                     MockAcquisitionFunction,
                     "__call__",
@@ -135,6 +149,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                             "alpha": 0.1,
                             "seed": seed,
                             "init_batch_limit": init_batch_limit,
+                            "sample_around_best": sample_around_best,
                         },
                     )
                     expected_shape = torch.Size([2, 1, 2])
@@ -148,7 +163,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                     )
                     raw_samps = mock_acqf_call.call_args[0][0]
                     batch_shape = (
-                        torch.Size([10])
+                        torch.Size([20 if sample_around_best else 10])
                         if init_batch_limit is None
                         else torch.Size([init_batch_limit])
                     )
@@ -165,10 +180,15 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
         d = 2200  # 2200 * 10 (q) > 21201 (sobol max dim)
         bounds = torch.stack([torch.zeros(d), torch.ones(d)])
         ffs_map = {i: random() for i in range(0, d, 2)}
+        mock_acqf = MockAcquisitionFunction()
+        mock_acqf.objective = lambda y: y.squeeze(-1)
         for dtype in (torch.float, torch.double):
             bounds = bounds.to(device=self.device, dtype=dtype)
-            for nonnegative, seed, ffs in product(
-                [True, False], [None, 1234], [None, ffs_map]
+            mock_acqf.X_baseline = bounds  # for testing sample_around_best
+            mock_acqf.model = MockModel(MockPosterior(mean=bounds[:, :1]))
+
+            for nonnegative, seed, ffs, sample_around_best in product(
+                [True, False], [None, 1234], [None, ffs_map], [True, False]
             ):
                 with warnings.catch_warnings(record=True) as ws, settings.debug(True):
                     batch_initial_conditions = gen_batch_initial_conditions(
@@ -183,6 +203,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                             "eta": 0.01,
                             "alpha": 0.1,
                             "seed": seed,
+                            "sample_around_best": sample_around_best,
                         },
                     )
                     self.assertTrue(
@@ -428,3 +449,156 @@ class TestGenValueFunctionInitialConditions(BotorchTestCase):
         self.assertTrue(torch.all(ics <= bounds[1]))
         # test dtype
         self.assertEqual(dtype, ics.dtype)
+
+
+class TestSampleAroundBest(BotorchTestCase):
+    def test_sample_truncated_normal_perturbations(self):
+        tkwargs = {"device": self.device}
+        n_discrete_points = 5
+        _bounds = torch.ones(2, 4)
+        _bounds[1] = 2
+        for dtype in (torch.float, torch.double):
+            tkwargs["dtype"] = dtype
+            bounds = _bounds.to(**tkwargs)
+            for n_best in (1, 2):
+                X = 1 + torch.rand(n_best, 4, **tkwargs)
+                # basic test
+                perturbed_X = sample_truncated_normal_perturbations(
+                    X=X,
+                    n_discrete_points=n_discrete_points,
+                    sigma=4,
+                    bounds=bounds,
+                    qmc=False,
+                )
+                self.assertEqual(perturbed_X.shape, torch.Size([n_discrete_points, 4]))
+                self.assertTrue((perturbed_X >= 1).all())
+                self.assertTrue((perturbed_X <= 2).all())
+                # test qmc
+                with mock.patch(
+                    "botorch.optim.initializers.draw_sobol_samples",
+                    wraps=draw_sobol_samples,
+                ) as mock_sobol:
+                    perturbed_X = sample_truncated_normal_perturbations(
+                        X=X,
+                        n_discrete_points=n_discrete_points,
+                        sigma=4,
+                        bounds=bounds,
+                        qmc=True,
+                    )
+                    mock_sobol.assert_called_once()
+                self.assertEqual(perturbed_X.shape, torch.Size([n_discrete_points, 4]))
+                self.assertTrue((perturbed_X >= 1).all())
+                self.assertTrue((perturbed_X <= 2).all())
+
+    def test_sample_points_around_best(self):
+        tkwargs = {"device": self.device}
+        _bounds = torch.ones(2, 2)
+        _bounds[1] = 2
+        for dtype in (torch.float, torch.double):
+            tkwargs["dtype"] = dtype
+            bounds = _bounds.to(**tkwargs)
+            X_train = 1 + torch.rand(20, 2, **tkwargs)
+            model = MockModel(
+                MockPosterior(mean=(2 * X_train + 1).sum(dim=-1, keepdim=True))
+            )
+            # test NEI with X_baseline
+            acqf = qNoisyExpectedImprovement(model, X_baseline=X_train)
+            X_rnd = sample_points_around_best(
+                acq_function=acqf,
+                n_discrete_points=4,
+                sigma=1e-3,
+                bounds=bounds,
+            )
+            self.assertTrue(X_rnd.shape, torch.Size([4, 2]))
+            self.assertTrue((X_rnd >= 1).all())
+            self.assertTrue((X_rnd <= 2).all())
+            # test model that returns a batched mean
+            model = MockModel(
+                MockPosterior(
+                    mean=(2 * X_train + 1).sum(dim=-1, keepdim=True).unsqueeze(0)
+                )
+            )
+            # test NEI with X_baseline
+            X_rnd = sample_points_around_best(
+                acq_function=acqf,
+                n_discrete_points=4,
+                sigma=1e-3,
+                bounds=bounds,
+            )
+            self.assertTrue(X_rnd.shape, torch.Size([4, 2]))
+            self.assertTrue((X_rnd >= 1).all())
+            self.assertTrue((X_rnd <= 2).all())
+
+            # test EI without X_baseline
+            acqf = qExpectedImprovement(model, best_f=0.0)
+
+            with warnings.catch_warnings(record=True) as w, settings.debug(True):
+
+                X_rnd = sample_points_around_best(
+                    acq_function=acqf,
+                    n_discrete_points=4,
+                    sigma=1e-3,
+                    bounds=bounds,
+                )
+                self.assertEqual(len(w), 1)
+                self.assertTrue(issubclass(w[-1].category, BotorchWarning))
+                self.assertIsNone(X_rnd)
+
+            # set train inputs
+            model.train_inputs = (X_train,)
+            X_rnd = sample_points_around_best(
+                acq_function=acqf,
+                n_discrete_points=4,
+                sigma=1e-3,
+                bounds=bounds,
+            )
+            self.assertTrue(X_rnd.shape, torch.Size([4, 2]))
+            self.assertTrue((X_rnd >= 1).all())
+            self.assertTrue((X_rnd <= 2).all())
+
+            # test constraints with NEHVI
+            constraints = [lambda Y: Y[..., 0]]
+            ref_point = torch.zeros(2, **tkwargs)
+            # test cases when there are and are not any feasible points
+            for any_feas in (True, False):
+                Y_train = torch.stack(
+                    [
+                        torch.linspace(-0.5, 0.5, X_train.shape[0], **tkwargs)
+                        if any_feas
+                        else torch.ones(X_train.shape[0], **tkwargs),
+                        X_train.sum(dim=-1),
+                    ],
+                    dim=-1,
+                )
+                moo_model = MockModel(MockPosterior(mean=Y_train, samples=Y_train))
+
+                acqf = qNoisyExpectedHypervolumeImprovement(
+                    moo_model,
+                    ref_point=ref_point,
+                    X_baseline=X_train,
+                    constraints=constraints,
+                )
+                X_rnd = sample_points_around_best(
+                    acq_function=acqf,
+                    n_discrete_points=4,
+                    sigma=0.0,
+                    bounds=bounds,
+                )
+                self.assertTrue(X_rnd.shape, torch.Size([4, 2]))
+                # this should be true since sigma=0
+                # and we should only be returning feasible points
+                violation = constraints[0](Y_train)
+                neg_violation = -violation.clamp_min(0.0)
+                feas = neg_violation == 0
+                eq_mask = (X_train.unsqueeze(1) == X_rnd.unsqueeze(0)).all(dim=-1)
+                if feas.any():
+                    # determine
+                    # create n_train x n_rnd tensor of booleans
+                    eq_mask = (X_train.unsqueeze(1) == X_rnd.unsqueeze(0)).all(dim=-1)
+                    # check that all X_rnd correspond to feasible points
+                    self.assertEqual(eq_mask[feas].sum(), 4)
+                else:
+                    idcs = torch.topk(neg_violation, k=2).indices
+                    self.assertEqual(eq_mask[idcs].sum(), 4)
+                self.assertTrue((X_rnd >= 1).all())
+                self.assertTrue((X_rnd <= 2).all())


### PR DESCRIPTION
Summary:
This adds a heuristic for generating initial conditions by adding gaussian noise to the best points (in addition to the standard sobol initial conditions), which improves optimization performance on some benchmark problems (e.g. ZDT1).

This is turned off by default currently.

Differential Revision: D32548535

