### PR TITLE
fast low-rank cholesky updates for NEHVI

### DIFF
--- a/botorch/acquisition/multi_objective/utils.py
+++ b/botorch/acquisition/multi_objective/utils.py
@@ -21,13 +21,21 @@ from botorch.acquisition.multi_objective.objective import (
     IdentityMCMultiOutputObjective,
     MCMultiOutputObjective,
 )
-from botorch.exceptions.errors import UnsupportedError
+from botorch.exceptions.errors import BotorchError, UnsupportedError
 from botorch.exceptions.warnings import BotorchWarning
 from botorch.exceptions.warnings import SamplingWarning
 from botorch.models.model import Model
+from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.sampling.samplers import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.multi_objective.pareto import is_non_dominated
 from botorch.utils.transforms import normalize_indices
+from gpytorch.distributions.multitask_multivariate_normal import (
+    MultitaskMultivariateNormal,
+)
+from gpytorch.lazy.block_diag_lazy_tensor import BlockDiagLazyTensor
+from gpytorch.lazy.lazy_tensor import LazyTensor
+from gpytorch.utils.cholesky import psd_safe_cholesky
+from gpytorch.utils.errors import NanError
 from torch import Tensor
 from torch.quasirandom import SobolEngine
 
@@ -156,3 +164,139 @@ def prune_inferior_points_multi_objective(
         idcs = order_idcs[:max_points]
 
     return X[idcs]
+
+
+def extract_batch_covar(mt_mvn: MultitaskMultivariateNormal) -> LazyTensor:
+    r"""Extract a batched independent covariance matrix from a MTMVN.
+
+    Args:
+        mt_mvn: A multi-task multivariate normal with a block diagonal
+            covariance matrix.
+
+    Returns:
+        A lazy covariance matrix consisting of a batch of the blocks of the
+            diagonal of the MultitaskMultivariateNormal.
+
+    """
+    lazy_covar = mt_mvn.lazy_covariance_matrix
+    if not isinstance(lazy_covar, BlockDiagLazyTensor):
+        raise BotorchError(f"Expected BlockDiagLazyTensor, but got {type(lazy_covar)}.")
+    return lazy_covar.base_lazy_tensor
+
+
+def _reshape_base_samples(
+    base_samples: Tensor, sample_shape: torch.Size, posterior: GPyTorchPosterior
+) -> Tensor:
+    r"""Manipulate shape of base_samples to match `MultivariateNormal.rsample`.
+
+    This ensure that base_samples are used in the same way as in
+    gpytorch.distributions.MultivariateNormal. For CBD, it is important to ensure
+    that the same base samples are used for the in-sample points here and in the
+    cached box decompositions.
+
+    Args:
+        base_samples: The base samples.
+        sample_shape: The sample shape.
+        posterior: The joint posterior is over (X_baseline, X).
+
+    Returns:
+        Reshaped and expanded base samples.
+    """
+    loc = posterior.mvn.loc
+    peshape = posterior.event_shape
+    base_samples = base_samples.view(
+        sample_shape + torch.Size([1 for _ in range(loc.ndim - 1)]) + peshape[-2:]
+    ).expand(sample_shape + loc.shape[:-1] + peshape[-2:])
+    base_samples = base_samples.reshape(
+        -1, *loc.shape[:-1], posterior.mvn.lazy_covariance_matrix.shape[-1]
+    )
+    base_samples = base_samples.permute(*range(1, loc.dim() + 1), 0)
+    return base_samples.reshape(
+        *peshape[:-2],
+        peshape[-1],
+        peshape[-2],
+        *sample_shape,
+    )
+
+
+def sample_cached_cholesky(
+    posterior: GPyTorchPosterior,
+    baseline_L: Tensor,
+    q: int,
+    base_samples: Tensor,
+    sample_shape: torch.Size,
+    max_tries: int = 6,
+) -> Tensor:
+    r"""Get posterior samples at the `q` new points from the joint multi-output posterior.
+
+    TODO: support single output posteriors.
+
+    Args:
+        posterior: The joint posterior is over (X_baseline, X).
+        baseline_L: The baseline lower triangular cholesky factor.
+        q: The number of new points in X.
+        base_samples: The base samples.
+        sample_shape: The sample shape.
+        max_tries: The number of tries for computing the Cholesky
+            decomposition with increasing jitter.
+
+    Returns:
+        A `sample_shape x batch_shape x q x m`-dim tensor of posterior
+            samples at the new points.
+    """
+    # compute bottom left covariance block
+    if isinstance(posterior.mvn, MultitaskMultivariateNormal):
+        lazy_covar = extract_batch_covar(mt_mvn=posterior.mvn)
+    else:
+        raise NotImplementedError(
+            "Single-output MultivariateNormal distributions are "
+            "not currently supported."
+        )
+    # Get the `q` new rows of the batched covariance matrix
+    bottom_rows = lazy_covar[..., -q:, :].evaluate()
+    # The covariance in block form is:
+    # [K(X_baseline, X_baseline), K(X_baseline, X)]
+    # [K(X, X_baseline), K(X, X)]
+    # bl := K(X, X_baseline)
+    # br := K(X, X)
+    # Get bottom right block of new covariance
+    bl, br = torch.split(bottom_rows, bottom_rows.shape[-1] - q, dim=-1)
+    # Solve Ax = b
+    # where A = K(X_baseline, X_baseline) and b = K(X, X_baseline)^T
+    # and bl_chol := x^T
+    # bl_chol is the new `(batch_shape) x q x n`-dim bottom left block
+    # of the cholesky decomposition
+    bl_chol = torch.triangular_solve(
+        bl.transpose(-2, -1), baseline_L, upper=False
+    ).solution.transpose(-2, -1)
+    # Compute the new bottom right block of the Cholesky decomposition via:
+    # Cholesky(K(X, X) - bl_chol @ bl_chol^T)
+    br_to_chol = br - bl_chol @ bl_chol.transpose(-2, -1)
+    # TODO: technically we should make sure that we add a consistent
+    # nugget to the cached covariance and the new block
+    br_chol = psd_safe_cholesky(br_to_chol, max_tries=max_tries)
+    # Create a `(batch_shape) x q x (n+q)`-dim tensor containing the
+    # `q` new bottom rows of the Cholesky decomposition
+    new_Lq = torch.cat([bl_chol, br_chol], dim=-1)
+    mean = posterior.mvn.mean
+    base_samples = _reshape_base_samples(
+        base_samples=base_samples, sample_shape=sample_shape, posterior=posterior
+    )
+    new_mean = mean[..., -q:, :]
+    res = (
+        new_Lq.matmul(base_samples)
+        .permute(-1, *range(mean.dim() - 2), -2, -3)
+        .contiguous()
+        .add(new_mean)
+    )
+    contains_nans = torch.isnan(res).any()
+    contains_infs = torch.isinf(res).any()
+    if contains_nans or contains_infs:
+        suffix_args = []
+        if contains_nans:
+            suffix_args.append("nans")
+        if contains_infs:
+            suffix_args.append("infs")
+        suffix = " and ".join(suffix_args)
+        raise NanError(f"Samples contain {suffix}.")
+    return res

--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -177,6 +177,7 @@ def get_acquisition_function(
             alpha=kwargs.get("alpha", 0.0),
             X_pending=X_pending,
             marginalize_dim=kwargs.get("marginalize_dim"),
+            cache_root=kwargs.get("cache_root", True),
         )
     raise NotImplementedError(
         f"Unknown acquisition function {acquisition_function_name}"

--- a/test/acquisition/multi_objective/test_utils.py
+++ b/test/acquisition/multi_objective/test_utils.py
@@ -14,13 +14,26 @@ from botorch.acquisition.multi_objective.objective import (
     MCMultiOutputObjective,
     UnstandardizeMCMultiOutputObjective,
 )
-from botorch.acquisition.multi_objective.utils import get_default_partitioning_alpha
 from botorch.acquisition.multi_objective.utils import (
+    get_default_partitioning_alpha,
+    extract_batch_covar,
+    sample_cached_cholesky,
     prune_inferior_points_multi_objective,
 )
-from botorch.exceptions.errors import UnsupportedError
+from botorch.exceptions.errors import BotorchError, UnsupportedError
 from botorch.exceptions.warnings import SamplingWarning
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.model_list_gp_regression import ModelListGP
+from botorch.posteriors.gpytorch import GPyTorchPosterior
+from botorch.sampling.samplers import IIDNormalSampler
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
+from gpytorch.distributions.multitask_multivariate_normal import (
+    MultitaskMultivariateNormal,
+)
+from gpytorch.distributions.multivariate_normal import MultivariateNormal
+from gpytorch.lazy import lazify
+from gpytorch.lazy.block_diag_lazy_tensor import BlockDiagLazyTensor
+from gpytorch.utils.errors import NanError
 from torch import Tensor
 
 
@@ -178,3 +191,161 @@ class TestMultiObjectiveUtils(BotorchTestCase):
                 marginalize_dim=-3,
             )
             self.assertTrue(torch.equal(X_pruned, X[:2]))
+
+
+class TestExtractBatchCovar(BotorchTestCase):
+    def test_extract_batch_covar(self):
+        tkwargs = {"device": self.device}
+        for dtype in (torch.float, torch.double):
+            tkwargs["dtype"] = dtype
+            base_covar = torch.tensor(
+                [[1.0, 0.6, 0.9], [0.6, 1.0, 0.5], [0.9, 0.5, 1.0]], **tkwargs
+            )
+            lazy_covar = lazify(torch.stack([base_covar, base_covar * 2], dim=0))
+            block_diag_covar = BlockDiagLazyTensor(lazy_covar)
+            mt_mvn = MultitaskMultivariateNormal(
+                torch.zeros(3, 2, **tkwargs), block_diag_covar
+            )
+            batch_covar = extract_batch_covar(mt_mvn=mt_mvn)
+            self.assertTrue(torch.equal(batch_covar.evaluate(), lazy_covar.evaluate()))
+            # test non BlockDiagLazyTensor
+            mt_mvn = MultitaskMultivariateNormal(
+                torch.zeros(3, 2, **tkwargs), block_diag_covar.evaluate()
+            )
+            with self.assertRaises(BotorchError):
+                extract_batch_covar(mt_mvn=mt_mvn)
+
+
+class TestSampleCachedCholesky(BotorchTestCase):
+    def test_sample_cached_cholesky(self):
+        torch.manual_seed(0)
+        tkwargs = {"device": self.device}
+        # test single output posterior
+        with self.assertRaises(NotImplementedError):
+            sample_cached_cholesky(
+                posterior=GPyTorchPosterior(
+                    MultivariateNormal(torch.zeros(2), torch.eye(2))
+                ),
+                baseline_L=None,
+                q=1,
+                base_samples=None,
+                sample_shape=None,
+            )
+        for dtype in (torch.float, torch.double):
+            tkwargs["dtype"] = dtype
+            train_X = torch.rand(10, 2, **tkwargs)
+            train_Y = torch.randn(10, 2, **tkwargs)
+            for use_model_list in (True, False):
+                if use_model_list:
+                    model = ModelListGP(
+                        SingleTaskGP(
+                            train_X,
+                            train_Y[..., :1],
+                        ),
+                        SingleTaskGP(
+                            train_X,
+                            train_Y[..., 1:],
+                        ),
+                    )
+                else:
+                    model = SingleTaskGP(
+                        train_X,
+                        train_Y,
+                    )
+                sampler = IIDNormalSampler(3)
+                for q in (1, 3):
+                    # test batched baseline_L
+                    for train_batch_shape in (
+                        torch.Size([]),
+                        torch.Size([3]),
+                        torch.Size([3, 2]),
+                    ):
+                        # test batched test points
+                        for test_batch_shape in (
+                            torch.Size([]),
+                            torch.Size([4]),
+                            torch.Size([4, 2]),
+                        ):
+
+                            if len(train_batch_shape) > 0:
+                                train_X_ex = train_X.unsqueeze(0).expand(
+                                    train_batch_shape + train_X.shape
+                                )
+                            else:
+                                train_X_ex = train_X
+                            if len(test_batch_shape) > 0:
+                                test_X = train_X_ex.unsqueeze(0).expand(
+                                    test_batch_shape + train_X_ex.shape
+                                )
+                            else:
+                                test_X = train_X_ex
+                            with torch.no_grad():
+                                base_posterior = model.posterior(
+                                    train_X_ex[..., :-q, :]
+                                )
+                                mvn = base_posterior.mvn
+                                lazy_covar = mvn.lazy_covariance_matrix.base_lazy_tensor
+                                lazy_root = lazy_covar.root_decomposition()
+                                baseline_L = lazy_root.root.evaluate()
+                            test_X = test_X.clone().requires_grad_(True)
+                            new_posterior = model.posterior(test_X)
+                            samples = sampler(new_posterior)
+                            samples[..., -q:, :].sum().backward()
+                            test_X2 = test_X.detach().clone().requires_grad_(True)
+                            new_posterior2 = model.posterior(test_X2)
+                            q_samples = sample_cached_cholesky(
+                                posterior=new_posterior2,
+                                baseline_L=baseline_L,
+                                q=q,
+                                base_samples=sampler.base_samples.detach().clone(),
+                                sample_shape=sampler.sample_shape,
+                            )
+                            q_samples.sum().backward()
+                            all_close_kwargs = (
+                                {
+                                    "atol": 1e-4,
+                                    "rtol": 1e-2,
+                                }
+                                if dtype == torch.float
+                                else {}
+                            )
+                            self.assertTrue(
+                                torch.allclose(
+                                    q_samples.detach(),
+                                    samples[..., -q:, :].detach(),
+                                    **all_close_kwargs,
+                                )
+                            )
+                            self.assertTrue(
+                                torch.allclose(
+                                    test_X2.grad[..., -q:, :],
+                                    test_X.grad[..., -q:, :],
+                                    **all_close_kwargs,
+                                )
+                            )
+                            # test nans
+                            with torch.no_grad():
+                                test_posterior = model.posterior(test_X2)
+                            test_posterior.mvn.loc = torch.full_like(
+                                test_posterior.mvn.loc, float("nan")
+                            )
+                            with self.assertRaises(NanError):
+                                sample_cached_cholesky(
+                                    posterior=test_posterior,
+                                    baseline_L=baseline_L,
+                                    q=q,
+                                    base_samples=sampler.base_samples.detach().clone(),
+                                    sample_shape=sampler.sample_shape,
+                                )
+                            # test infs
+                            test_posterior.mvn.loc = torch.full_like(
+                                test_posterior.mvn.loc, float("inf")
+                            )
+                            with self.assertRaises(NanError):
+                                sample_cached_cholesky(
+                                    posterior=test_posterior,
+                                    baseline_L=baseline_L,
+                                    q=q,
+                                    base_samples=sampler.base_samples.detach().clone(),
+                                    sample_shape=sampler.sample_shape,
+                                )

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -479,6 +479,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
             alpha=0.0,
             X_pending=self.X_pending,
             marginalize_dim=None,
+            cache_root=True,
         )
         args, kwargs = mock_acqf.call_args
         self.assertEqual(args, ())

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -680,6 +680,7 @@ class TestSampleAroundBest(BotorchTestCase):
                     ref_point=ref_point,
                     X_baseline=X_train,
                     constraints=constraints,
+                    cache_root=False,
                 )
                 X_rnd = sample_points_around_best(
                     acq_function=acqf,

--- a/test/optim/test_utils.py
+++ b/test/optim/test_utils.py
@@ -365,7 +365,10 @@ class TestGetXBaseline(BotorchTestCase):
             ref_point = torch.zeros(2, **tkwargs)
             # test NEHVI with X_baseline
             acqf = qNoisyExpectedHypervolumeImprovement(
-                moo_model, ref_point=ref_point, X_baseline=X_train[:2]
+                moo_model,
+                ref_point=ref_point,
+                X_baseline=X_train[:2],
+                cache_root=False,
             )
             X = get_X_baseline(
                 acq_function=acqf,


### PR DESCRIPTION
Summary:
In NEI and NEHVI, we sample from the posterior of f(X_baseline, X) repeatedly for different X, but the same X_baseline. We can make the sampling more efficient by caching the cholesky decomposition for the posterior covariance matrix of f(X_baseline) and then only compute the bottom q new rows of the cholesky of the posterior covariance matrix f(X_baseline, X).

Using the cached cholesky is probably more important for NEHVI than NEI the pruned X_baseline for NEHVI will often be quite a bit larger than the pruned X_baseline for NEI.

Differential Revision: D25804787

