### PR TITLE
Handle NotPSDError and hitting maxiter in fit_gpytorch_model

### DIFF
--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -132,8 +132,12 @@ def fit_gpytorch_model(
                 continue
         has_optwarning = False
         for w in ws:
-            # Do not count reaching `maxiter` as an optimization failure/
+            # Do not count reaching `maxiter` as an optimization failure.
             if "ITERATIONS REACHED LIMIT" in str(w.message):
+                logging.log(
+                    logging.DEBUG,
+                    "Fitting ended early due to reaching the iteration limit.",
+                )
                 continue
             has_optwarning |= issubclass(w.category, OptimizationWarning)
             warnings.warn(w.message, w.category)

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -97,8 +97,8 @@ class TestFitGPyTorchModel(BotorchTestCase):
                     self.assertTrue(
                         any(issubclass(w.category, OptimizationWarning)) for w in ws
                     )
-                    self.assertEqual(
-                        sum(1 for w in ws if MAX_RETRY_MSG in str(w.message)), 1
+                    self.assertFalse(
+                        any(MAX_RETRY_MSG in str(w.message) for w in ws)
                     )
             model = mll.model
             # Make sure all of the parameters changed
@@ -111,21 +111,13 @@ class TestFitGPyTorchModel(BotorchTestCase):
 
             # test overriding the default bounds with user supplied bounds
             mll = self._getModel(double=double)
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
-                mll = fit_gpytorch_model(
-                    mll,
-                    optimizer=optimizer,
-                    options=options,
-                    max_retries=1,
-                    bounds={"likelihood.noise_covar.raw_noise": (1e-1, None)},
-                )
-                if optimizer == fit_gpytorch_scipy:
-                    self.assertTrue(
-                        any(issubclass(w.category, OptimizationWarning)) for w in ws
-                    )
-                    self.assertEqual(
-                        sum(1 for w in ws if MAX_RETRY_MSG in str(w.message)), 1
-                    )
+            mll = fit_gpytorch_model(
+                mll,
+                optimizer=optimizer,
+                options=options,
+                max_retries=1,
+                bounds={"likelihood.noise_covar.raw_noise": (1e-1, None)},
+            )
 
             model = mll.model
             self.assertGreaterEqual(model.likelihood.raw_noise.abs().item(), 1e-1)
@@ -175,14 +167,9 @@ class TestFitGPyTorchModel(BotorchTestCase):
                     )
                 ),
             )
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
-                mll = fit_gpytorch_model(
-                    mll, optimizer=optimizer, options=options, max_retries=1
-                )
-                if optimizer == fit_gpytorch_scipy:
-                    self.assertEqual(
-                        sum(1 for w in ws if MAX_RETRY_MSG in str(w.message)), 1
-                    )
+            mll = fit_gpytorch_model(
+                mll, optimizer=optimizer, options=options, max_retries=1
+            )
             self.assertTrue(mll.dummy_param.grad is None)
 
             # test excluding a parameter
@@ -193,17 +180,9 @@ class TestFitGPyTorchModel(BotorchTestCase):
                 "model.mean_module.constant",
                 "likelihood.noise_covar.raw_noise",
             ]
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
-                mll = fit_gpytorch_model(
-                    mll, optimizer=optimizer, options=options, max_retries=1
-                )
-                if optimizer == fit_gpytorch_scipy:
-                    self.assertTrue(
-                        any(issubclass(w.category, OptimizationWarning)) for w in ws
-                    )
-                    self.assertEqual(
-                        sum(1 for w in ws if MAX_RETRY_MSG in str(w.message)), 1
-                    )
+            mll = fit_gpytorch_model(
+                mll, optimizer=optimizer, options=options, max_retries=1
+            )
             model = mll.model
             # Make excluded params did not change
             self.assertEqual(
@@ -221,21 +200,13 @@ class TestFitGPyTorchModel(BotorchTestCase):
             # test non-default setting for approximate MLL computation
             is_scipy = optimizer == fit_gpytorch_scipy
             mll = self._getModel(double=double)
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
-                mll = fit_gpytorch_model(
-                    mll,
-                    optimizer=optimizer,
-                    options=options,
-                    max_retries=1,
-                    approx_mll=is_scipy,
-                )
-                if is_scipy:
-                    self.assertTrue(
-                        any(issubclass(w.category, OptimizationWarning)) for w in ws
-                    )
-                    self.assertEqual(
-                        sum(1 for w in ws if MAX_RETRY_MSG in str(w.message)), 1
-                    )
+            mll = fit_gpytorch_model(
+                mll,
+                optimizer=optimizer,
+                options=options,
+                max_retries=1,
+                approx_mll=is_scipy,
+            )
             model = mll.model
             # Make sure all of the parameters changed
             self.assertGreater(model.likelihood.raw_noise.abs().item(), 1e-3)
@@ -268,8 +239,11 @@ class TestFitGPyTorchModel(BotorchTestCase):
             )
             mll = ExactMarginalLogLikelihood(gp.likelihood, gp)
             mll.to(device=self.device, dtype=dtype)
-            with self.assertRaises(NotPSDError):
+            with self.assertLogs(level="DEBUG") as logs:
                 fit_gpytorch_model(mll, options=options, max_retries=2)
+            self.assertTrue(
+                any(["NotPSDError" in l for l in logs.output])
+            )
             # ensure we can handle NaNErrors in the optimizer
             with mock.patch.object(SingleTaskGP, "__call__", side_effect=NanError):
                 gp = SingleTaskGP(X_train, Y_train, likelihood=test_likelihood)
@@ -277,6 +251,18 @@ class TestFitGPyTorchModel(BotorchTestCase):
                 mll.to(device=self.device, dtype=dtype)
                 fit_gpytorch_model(
                     mll, options={"disp": False, "maxiter": 1}, max_retries=1
+                )
+            # ensure we catch NotPSDErrors
+            with mock.patch.object(SingleTaskGP, "__call__", side_effect=NotPSDError):
+                mll = self._getModel()
+                with self.assertLogs(level="DEBUG") as logs:
+                    fit_gpytorch_model(mll, max_retries=2)
+                self.assertEqual(
+                    logs.output,
+                    [
+                        "DEBUG:root:Fitting failed on try 1 due to a NotPSDError.",
+                        "DEBUG:root:Fitting failed on try 2 due to a NotPSDError.",
+                    ],
                 )
 
     def test_fit_gpytorch_model_torch(self):
@@ -317,3 +303,12 @@ class TestFitGPyTorchModel(BotorchTestCase):
                             for w in ws
                         )
                     )
+
+    def test_fit_w_maxiter(self):
+        options = {"maxiter": 1}
+        with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            mll = self._getModel()
+            fit_gpytorch_model(mll, options=options, max_retries=3)
+            mll = self._getBatchedModel()
+            fit_gpytorch_model(mll, options=options, max_retries=3)
+        self.assertFalse(any("ITERATIONS REACHED LIMIT" in str(w.message) for w in ws))

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -262,6 +262,19 @@ class TestFitGPyTorchModel(BotorchTestCase):
                         )
                     )
 
+            # Failure due to optimization warning
+
+            def optimize_w_warning(mll, **kwargs):
+                warnings.warn("Dummy warning.", OptimizationWarning)
+                return mll, None
+
+            mll = self._getModel()
+            with self.assertLogs(level="DEBUG") as logs, settings.debug(True):
+                fit_gpytorch_model(mll, optimizer=optimize_w_warning, max_retries=2)
+            self.assertTrue(
+                any("Fitting failed on try 1." in log for log in logs.output)
+            )
+
     def test_fit_gpytorch_model_torch(self):
         self.test_fit_gpytorch_model(optimizer=fit_gpytorch_torch)
 

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -239,7 +239,7 @@ class TestFitGPyTorchModel(BotorchTestCase):
             mll.to(device=self.device, dtype=dtype)
             with self.assertLogs(level="DEBUG") as logs:
                 fit_gpytorch_model(mll, options=options, max_retries=2)
-            self.assertTrue(any(["NotPSDError" in log for log in logs.output]))
+            self.assertTrue(any("NotPSDError" in log for log in logs.output))
             # ensure we can handle NaNErrors in the optimizer
             with mock.patch.object(SingleTaskGP, "__call__", side_effect=NanError):
                 gp = SingleTaskGP(X_train, Y_train, likelihood=test_likelihood)
@@ -253,13 +253,14 @@ class TestFitGPyTorchModel(BotorchTestCase):
                 mll = self._getModel()
                 with self.assertLogs(level="DEBUG") as logs:
                     fit_gpytorch_model(mll, max_retries=2)
-                self.assertEqual(
-                    logs.output,
-                    [
-                        "DEBUG:root:Fitting failed on try 1 due to a NotPSDError.",
-                        "DEBUG:root:Fitting failed on try 2 due to a NotPSDError.",
-                    ],
-                )
+                for retry in [1, 2]:
+                    self.assertTrue(
+                        any(
+                            f"Fitting failed on try {retry} due to a NotPSDError."
+                            in log
+                            for log in logs.output
+                        )
+                    )
 
     def test_fit_gpytorch_model_torch(self):
         self.test_fit_gpytorch_model(optimizer=fit_gpytorch_torch)

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -97,9 +97,7 @@ class TestFitGPyTorchModel(BotorchTestCase):
                     self.assertTrue(
                         any(issubclass(w.category, OptimizationWarning)) for w in ws
                     )
-                    self.assertFalse(
-                        any(MAX_RETRY_MSG in str(w.message) for w in ws)
-                    )
+                    self.assertFalse(any(MAX_RETRY_MSG in str(w.message) for w in ws))
             model = mll.model
             # Make sure all of the parameters changed
             self.assertGreater(model.likelihood.raw_noise.abs().item(), 1e-3)
@@ -241,9 +239,7 @@ class TestFitGPyTorchModel(BotorchTestCase):
             mll.to(device=self.device, dtype=dtype)
             with self.assertLogs(level="DEBUG") as logs:
                 fit_gpytorch_model(mll, options=options, max_retries=2)
-            self.assertTrue(
-                any(["NotPSDError" in l for l in logs.output])
-            )
+            self.assertTrue(any(["NotPSDError" in log for log in logs.output]))
             # ensure we can handle NaNErrors in the optimizer
             with mock.patch.object(SingleTaskGP, "__call__", side_effect=NanError):
                 gp = SingleTaskGP(X_train, Y_train, likelihood=test_likelihood)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

The current behavior of `fit_gpytorch_model` is to error out when it receives a `NotPSDError` and to count hitting `maxiter` during optimization as an optimization failure.

Labeling `maxiter` as an optimization failure leads to retrying the model fit, and likely reaching `maxiter` in each try and labeling all tries as failures. This ends up using more effort than the user intended to (by passing in `maxiter` in the first place), while offering no real benefit. The proposed solution here is to simply count hitting `maxiter` as a successful model fit and to return the fit obtained with the given budget.

The `NotPSDError` during model fit is one of the most common reasons that leads to me having to restart an experiment. What I observed is that when the first try raises `NotPSDError`, a second try starting from initial parameters sampled from the priors will most of the time produce a successful model fit. So, this proposes to catch the `NotPSDError` and retry the model fit with new initial parameter values. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unittests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)

cc @sdaulton 