### PR TITLE
Avoid adding unnecessary components to binary and source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,7 @@
 include LICENSE
+recursive-exclude docs *
+recursive-exclude scripts *
+recursive-exclude sphinx *
+recursive-exclude test *
+recursive-exclude tutorials *
+recursive-exclude website *

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         ),
     },
     install_requires=["torch>=1.9", "gpytorch>=1.6", "scipy"],
-    packages=find_packages(),
+    packages=find_packages(exclude=["test", "test.*"]),
     extras_require={
         "dev": DEV_REQUIRES,
         "test": TEST_REQUIRES,


### PR DESCRIPTION
Removes the `test/` folder from the binary (wheel) distribution.

Removes excessive weight from the source distribution (docs, website, tutorials, etc.) This reduces the size of the source distribution from ~6MB -> ~400KB.

Addresses #1019