### PR TITLE
expose inducing point init method

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -391,7 +391,7 @@ def _select_inducing_points(X, covar_module, num_inducing, input_batch_shape) ->
         X, train_train_kernel, max_length=num_inducing
     )
 
-    # previous batch handling didn't work in the multitask setting
+    # make sure batch handling works in the multitask setting
     if len(input_batch_shape) > 0:
         inducing_points = inducing_points.expand(*input_batch_shape, -1, -1)
 

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -447,7 +447,7 @@ def _select_inducing_points(
             inducing_points.append(_pivoted_cholesky_init(
                 input_element, kernel_element, max_length=num_inducing
             ))
-        inducing_points = torch.stack(inducing_points).view(inputs.shape[:-2], num_inducing, -1)
+        inducing_points = torch.stack(inducing_points).view(*inputs.shape[:-2], num_inducing, -1)
 
     return inducing_points
 

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -406,7 +406,7 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
                 inputs=inputs,
                 covar_module=self.model.covar_module,
                 num_inducing=num_inducing,
-                input_batch_shape=self._input_batch_shape
+                input_batch_shape=self._input_batch_shape,
             )
             var_strat.inducing_points.copy_(inducing_points)
             var_strat.variational_params_initialized.fill_(0)
@@ -441,7 +441,7 @@ def _select_inducing_points(
         inducing_points = _pivoted_cholesky_init(
             train_inputs=inputs,
             kernel_matrix=train_train_kernel,
-            max_length=num_inducing
+            max_length=num_inducing,
         )
     # multi-task case
     elif train_train_kernel.ndimension() == 3 and len(input_batch_shape) == 0:
@@ -450,7 +450,7 @@ def _select_inducing_points(
         inducing_points = _pivoted_cholesky_init(
             train_inputs=input_element,
             kernel_matrix=kernel_element,
-            max_length=num_inducing
+            max_length=num_inducing,
         )
     # batched input cases
     else:
@@ -474,7 +474,7 @@ def _select_inducing_points(
                 _pivoted_cholesky_init(
                     train_inputs=input_element,
                     kernel_matrix=kernel_element,
-                    max_length=num_inducing
+                    max_length=num_inducing,
                 )
             )
         inducing_points = torch.stack(inducing_points).view(

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -438,8 +438,7 @@ def _select_inducing_points(
     else:
         reshaped_inputs = inputs.flatten(end_dim=-3)
         inducing_points = []
-        for batch_idx in reshaped_inputs.size(0):
-            input_element = reshaped_inputs[batch_idx]
+        for input_element in reshaped_inputs:
             # the extra kernel evals are a little wasteful but make it easier to infer the task batch size
             kernel_element = covar_module(input_element).evaluate_kernel()
             # handle extra task batch dimension

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -414,13 +414,13 @@ def _select_inducing_points(
     locations based on the pivoted Cholesky heuristic.
 
     Args:
-        inputs: input data (*batch_shape, n, d)
-        covar_module: GPyTorch Module returning a LazyTensor kernel matrix
-        num_inducing: the max number (m) of inducing points (m <= n)
-        input_batch_shape: non-task-related batch shape
+        inputs: A (*batch_shape, n, d)-dim input data tensor.
+        covar_module: GPyTorch Module returning a LazyTensor kernel matrix.
+        num_inducing: The maximun number (m) of inducing points (m <= n).
+        input_batch_shape: The non-task-related batch shape.
 
     Returns:
-        (*batch_shape, m, d) inducing point locations
+        A (*batch_shape, m, d)-din tensor of inducing point locations.
     """
 
     train_train_kernel = covar_module(inputs).evaluate_kernel()

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -213,7 +213,12 @@ class _SingleTaskVariationalGP(ApproximateGP):
                 # as a heuristic
                 inducing_points = int(0.25 * train_X.shape[-2])
 
-            inducing_points = _select_inducing_points(train_X, covar_module, inducing_points, batch_shape)
+            inducing_points = _select_inducing_points(
+                inputs=train_X,
+                covar_module=covar_module,
+                num_inducing=inducing_points,
+                input_batch_shape=batch_shape,
+            )
 
         if variational_distribution is None:
             variational_distribution = CholeskyVariationalDistribution(

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -462,7 +462,8 @@ def _select_inducing_points(
         reshaped_inputs = batched_inputs.flatten(end_dim=-3)
         inducing_points = []
         for input_element in reshaped_inputs:
-            # the extra kernel evals are a little wasteful but make it easier to infer the task batch size
+            # the extra kernel evals are a little wasteful but make it
+            # easier to infer the task batch size
             kernel_element = covar_module(input_element).evaluate_kernel()
             # handle extra task batch dimension
             kernel_element = (

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -382,10 +382,10 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
         The variational distribution and variational strategy caches are reset.
 
         Args:
-            inputs: input_data (*batch_shape, n, d)
+            inputs: (*batch_shape, n, d)-dim input data tensor.
 
         Returns:
-            (*batch_shape, m, d) selected inducing point locations
+            (*batch_shape, m, d)-dim tensor of selected inducing point locations.
         """
         var_strat = self.model.variational_strategy
         clear_cache_hook(var_strat)

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -419,7 +419,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
                 `MultitaskGaussianLikelihood` with a `GammaPrior(1.1, 0.05)`
                 noise prior.
             data_covar_module: The module computing the covariance (Kernel) matrix
-            in data space. If omitted, use a `MaternKernel`.
+                in data space. If omitted, use a `MaternKernel`.
             task_covar_prior : A Prior on the task covariance matrix. Must operate
                 on p.s.d. matrices. A common prior for this is the `LKJ` prior. If
                 omitted, uses `LKJCovariancePrior` with `eta` parameter as specified

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -418,8 +418,8 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
             likelihood: A `MultitaskGaussianLikelihood`. If omitted, uses a
                 `MultitaskGaussianLikelihood` with a `GammaPrior(1.1, 0.05)`
                 noise prior.
-            data_covar_module: The module computing the covariance (Kernel) matrix in data space.
-                If omitted, use a `MaternKernel`.
+            data_covar_module: The module computing the covariance (Kernel) matrix
+            in data space. If omitted, use a `MaternKernel`.
             task_covar_prior : A Prior on the task covariance matrix. Must operate
                 on p.s.d. matrices. A common prior for this is the `LKJ` prior. If
                 omitted, uses `LKJCovariancePrior` with `eta` parameter as specified

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -403,6 +403,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
         train_X: Tensor,
         train_Y: Tensor,
         likelihood: Optional[MultitaskGaussianLikelihood] = None,
+        data_covar_module: Optional[Module] = None,
         task_covar_prior: Optional[Prior] = None,
         rank: Optional[int] = None,
         input_transform: Optional[InputTransform] = None,
@@ -417,6 +418,8 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
             likelihood: A `MultitaskGaussianLikelihood`. If omitted, uses a
                 `MultitaskGaussianLikelihood` with a `GammaPrior(1.1, 0.05)`
                 noise prior.
+            data_covar_module: The module computing the covariance (Kernel) matrix in data space.
+                If omitted, use a `MaternKernel`.
             task_covar_prior : A Prior on the task covariance matrix. Must operate
                 on p.s.d. matrices. A common prior for this is the `LKJ` prior. If
                 omitted, uses `LKJCovariancePrior` with `eta` parameter as specified
@@ -478,13 +481,18 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
         self.mean_module = MultitaskMean(
             base_means=ConstantMean(batch_shape=batch_shape), num_tasks=num_tasks
         )
-        self.covar_module = MultitaskKernel(
-            data_covar_module=MaternKernel(
+        if data_covar_module is None:
+            data_covar_module = MaternKernel(
                 nu=2.5,
                 ard_num_dims=ard_num_dims,
                 lengthscale_prior=GammaPrior(3.0, 6.0),
                 batch_shape=batch_shape,
-            ),
+            )
+        else:
+            data_covar_module = data_covar_module
+
+        self.covar_module = MultitaskKernel(
+            data_covar_module=data_covar_module,
             num_tasks=num_tasks,
             rank=rank,
             batch_shape=batch_shape,

--- a/test/models/test_approximate_gp.py
+++ b/test/models/test_approximate_gp.py
@@ -186,3 +186,16 @@ class TestSingleTaskVariationalGP(BotorchTestCase):
                 self.assertIsInstance(posterior, TransformedPosterior)
             else:
                 self.assertFalse(hasattr(model, "outcome_transform"))
+
+    def test_inducing_point_init(self):
+        train_X_1 = torch.rand(15, 1, device=self.device)
+        train_X_2 = torch.rand(15, 1, device=self.device)
+
+        model_1 = SingleTaskVariationalGP(train_X=train_X_1, inducing_points=5)
+        model_1.init_inducing_points(train_X_2)
+        model_1_inducing = model_1.model.variational_strategy.inducing_points
+
+        model_2 = SingleTaskVariationalGP(train_X=train_X_2, inducing_points=5)
+        model_2_inducing = model_2.model.variational_strategy.inducing_points
+
+        self.assertTrue(torch.allclose(model_1_inducing, model_2_inducing))

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -689,6 +689,10 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
                 rank=1,
                 batch_shape=batch_shape,
             )
+            data_covar_module = MaternKernel(
+                nu=1.5,
+                lengthscale_prior=GammaPrior(2.0, 4.0),
+            )
             task_covar_prior = LKJCovariancePrior(
                 n=2,
                 eta=0.5,
@@ -696,6 +700,7 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
             )
             model_kwargs = {
                 "likelihood": likelihood,
+                "data_covar_module": data_covar_module,
                 "task_covar_prior": task_covar_prior,
                 "rank": 1,
             }
@@ -717,8 +722,8 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
             self.assertEqual(task_covar_prior.correlation_prior.eta, 0.5)
             lengthscale_prior = base_kernel.data_covar_module.lengthscale_prior
             self.assertIsInstance(lengthscale_prior, GammaPrior)
-            self.assertEqual(lengthscale_prior.concentration, 3.0)
-            self.assertEqual(lengthscale_prior.rate, 6.0)
+            self.assertEqual(lengthscale_prior.concentration, 2.0)
+            self.assertEqual(lengthscale_prior.rate, 4.0)
             self.assertEqual(base_kernel.task_covar_module.covar_factor.shape[-1], 1)
 
             # test model fitting


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR creates a public method for `SingleTaskVariationalGP` that allows a user to use the pivoted cholesky inducing point inititialization heuristic once the model object has been created. Currently the inducing point initialization is baked into the `__init__` method, which is inconvenient in my use case.  

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

In general `SingleTaskVariationalGP` needs better test coverage around batch handling (batched, non-batched, single output, multi-output, etc.).

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
