### PR TITLE
Make deploy_on_release workflow manually triggerable

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -3,6 +3,7 @@ name: Deploy On Release
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
For whatever reason GitHub actions decided not to automatically trigger this workflow on creating the 0.6.0 release, so we'll have to do it manually....