### PR TITLE
Modify qNEHVI to support DeterministicModels

### DIFF
--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -40,9 +40,11 @@ from botorch.acquisition.multi_objective.utils import (
 )
 from botorch.exceptions.errors import UnsupportedError
 from botorch.exceptions.warnings import BotorchWarning
+from botorch.models.deterministic import DeterministicModel
 from botorch.models.model import Model
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import MultiTaskGP
+from botorch.posteriors import DeterministicPosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.posterior import Posterior
 from botorch.sampling.samplers import MCSampler, SobolQMCNormalSampler
@@ -449,6 +451,8 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
             self.p_class = FastNondominatedPartitioning
         self.register_buffer("_X_baseline", X_baseline)
         self.register_buffer("_X_baseline_and_pending", X_baseline)
+        if isinstance(model, DeterministicModel):
+            cache_root = False
         self._cache_root = cache_root
         self.register_buffer(
             "cache_pending",
@@ -687,6 +691,7 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
             if (
                 self.X_baseline.shape[0] > 0
                 and self.base_sampler.base_samples is not None
+                and not isinstance(posterior, DeterministicPosterior)
             ):
                 current_base_samples = self.base_sampler.base_samples.detach().clone()
                 view_shape = (

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -3,7 +3,6 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import itertools
 import warnings
 from copy import deepcopy
 from itertools import product


### PR DESCRIPTION
## Motivation

Fixes #966 by disabling `_cache_root` and `_set_sampler` when using a deterministic model with qNEHVI.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
#896 - I will update that once I figure out a good way to support set valued objectives as discussed offline.
cc @sdaulton 