### PR TITLE
Store tensor attributes of input transforms as buffers

### DIFF
--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -804,7 +804,7 @@ class AppendFeatures(InputTransform, Module):
         super().__init__()
         if feature_set.dim() != 2:
             raise ValueError("`feature_set` must be an `n_f x d_f`-dim tensor!")
-        self.feature_set = feature_set
+        self.register_buffer("feature_set", feature_set)
         self.transform_on_train = transform_on_train
         self.transform_on_eval = transform_on_eval
         self.transform_on_fantasize = transform_on_fantasize
@@ -877,14 +877,17 @@ class InputPerturbation(InputTransform, Module):
         super().__init__()
         if perturbation_set.dim() != 2:
             raise ValueError("`perturbation_set` must be an `n_p x d`-dim tensor!")
-        self.perturbation_set = perturbation_set
-        if bounds is not None and bounds.shape[-1] != perturbation_set.shape[-1]:
-            raise ValueError(
-                "`bounds` must have the same number of columns (last dimension) as "
-                f"the `perturbation_set`! Got {bounds.shape[-1]} and "
-                f"{perturbation_set.shape[-1]}."
-            )
-        self.bounds = bounds
+        self.register_buffer("perturbation_set", perturbation_set)
+        if bounds is not None:
+            if bounds.shape[-1] != perturbation_set.shape[-1]:
+                raise ValueError(
+                    "`bounds` must have the same number of columns (last dimension) as "
+                    f"the `perturbation_set`! Got {bounds.shape[-1]} and "
+                    f"{perturbation_set.shape[-1]}."
+                )
+            self.register_buffer("bounds", bounds)
+        else:
+            self.bounds = None
         self.multiplicative = multiplicative
         self.transform_on_train = transform_on_train
         self.transform_on_eval = transform_on_eval

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -626,6 +626,11 @@ class TestAppendFeatures(BotorchTestCase):
                 transformed_X = transform(X)
             self.assertTrue(torch.equal(X, transformed_X))
 
+            # Make sure .to calls work.
+            transform.to(device=torch.device("cpu"), dtype=torch.half)
+            self.assertEqual(transform.feature_set.device.type, "cpu")
+            self.assertEqual(transform.feature_set.dtype, torch.half)
+
 
 class TestInputPerturbation(BotorchTestCase):
     def test_input_perturbation(self):
@@ -711,6 +716,13 @@ class TestInputPerturbation(BotorchTestCase):
             )
             transformed = transform(X)
             self.assertTrue(torch.allclose(transformed, expected))
+
+            # Make sure .to calls work.
+            transform.to(device=torch.device("cpu"), dtype=torch.half)
+            self.assertEqual(transform.perturbation_set.device.type, "cpu")
+            self.assertEqual(transform.perturbation_set.dtype, torch.half)
+            self.assertEqual(transform.bounds.device.type, "cpu")
+            self.assertEqual(transform.bounds.dtype, torch.half)
 
             # multiplicative
             perturbation_set = torch.tensor(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

If we store the tensor attributes as `self.attr = tensor_attr`, the `Module.to(...)` calls don't affect these attributes. To actually change the device / dtype of this attribute, we manually need to call `module.attr.to(...)`, which is less than ideal particularly if the `module` is a sub-module of a `Model`. Registering the attribute as a buffer solves this issue.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

Unit tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)