### PR TITLE
Modify NEHVI to support MTGPs

### DIFF
--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -40,9 +40,11 @@ from botorch.acquisition.multi_objective.utils import (
 )
 from botorch.exceptions.errors import UnsupportedError
 from botorch.exceptions.warnings import BotorchWarning
+from botorch.models.deterministic import DeterministicModel
 from botorch.models.model import Model
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import MultiTaskGP
+from botorch.posteriors import DeterministicPosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.posterior import Posterior
 from botorch.sampling.samplers import MCSampler, SobolQMCNormalSampler
@@ -449,6 +451,8 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
             self.p_class = FastNondominatedPartitioning
         self.register_buffer("_X_baseline", X_baseline)
         self.register_buffer("_X_baseline_and_pending", X_baseline)
+        if isinstance(model, DeterministicModel):
+            cache_root = False
         self._cache_root = cache_root
         self.register_buffer(
             "cache_pending",
@@ -687,6 +691,7 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
             if (
                 self.X_baseline.shape[0] > 0
                 and self.base_sampler.base_samples is not None
+                and not isinstance(posterior, DeterministicPosterior)
             ):
                 current_base_samples = self.base_sampler.base_samples.detach().clone()
                 view_shape = (

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -735,7 +735,15 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
                     expanded_shape
                 )
                 if self._uses_matheron:
-                    self.sampler.base_samples[..., :end_idx] = expanded_samples
+                    n_train_samples = current_base_samples.shape[-1] // 2
+                    # The train base samples.
+                    self.sampler.base_samples[..., :n_train_samples] = expanded_samples[
+                        ..., :n_train_samples
+                    ]
+                    # The train noise base samples.
+                    self.sampler.base_samples[
+                        ..., -n_train_samples:
+                    ] = expanded_samples[..., -n_train_samples:]
                 else:
                     self.sampler.base_samples[..., :end_idx, :] = expanded_samples
                 # update cached subset indices

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -40,10 +40,11 @@ from botorch.acquisition.multi_objective.utils import (
 )
 from botorch.exceptions.errors import UnsupportedError
 from botorch.exceptions.warnings import BotorchWarning
+from botorch.models import HigherOrderGP
 from botorch.models.deterministic import DeterministicModel
 from botorch.models.model import Model
 from botorch.models.model_list_gp_regression import ModelListGP
-from botorch.models.multitask import MultiTaskGP
+from botorch.models.multitask import MultiTaskGP, KroneckerMultiTaskGP
 from botorch.posteriors import DeterministicPosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.posterior import Posterior
@@ -234,10 +235,10 @@ class qExpectedHypervolumeImprovement(MultiObjectiveMCAcquisitionFunction):
             A `batch_shape x (model_batch_shape)`-dim tensor of expected hypervolume
             improvement for each batch.
         """
-        q = samples.shape[-2]
         # Note that the objective may subset the outcomes (e.g. this will usually happen
         # if there are constraints present).
         obj = self.objective(samples, X=X)
+        q = obj.shape[-2]
         if self.constraints is not None:
             feas_weights = torch.ones(
                 obj.shape[:-1], device=obj.device, dtype=obj.dtype
@@ -249,7 +250,7 @@ class qExpectedHypervolumeImprovement(MultiObjectiveMCAcquisitionFunction):
                 eta=self.eta,
             )
         self._cache_q_subset_indices(q=q)
-        batch_shape = samples.shape[:-2]
+        batch_shape = obj.shape[:-2]
         # this is n_samples x input_batch_shape x
         areas_per_segment = torch.zeros(
             *batch_shape,
@@ -273,7 +274,7 @@ class qExpectedHypervolumeImprovement(MultiObjectiveMCAcquisitionFunction):
         )
         for i in range(1, q + 1):
             # TODO: we could use batches to compute (q choose i) and (q choose q-i)
-            # simulataneously since subsets of size i and q-i have the same number of
+            # simultaneously since subsets of size i and q-i have the same number of
             # elements. This would decrease the number of iterations, but increase
             # memory usage.
             q_choose_i = self.q_subset_indices[f"q_choose_{i}"]
@@ -402,6 +403,14 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
         super(qExpectedHypervolumeImprovement, self).__init__(
             model=model, sampler=sampler, objective=objective
         )
+        models = model.models if isinstance(model, ModelListGP) else [model]
+        self._is_mt = any(
+            isinstance(m, (MultiTaskGP, KroneckerMultiTaskGP, HigherOrderGP))
+            for m in models
+        )
+        self._uses_matheron = any(
+            isinstance(m, (KroneckerMultiTaskGP, HigherOrderGP)) for m in models
+        )
         if not self.sampler.collapse_batch_dims:
             raise UnsupportedError(
                 "qNoisyExpectedHypervolumeImprovement currently requires sampler "
@@ -417,6 +426,17 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
                 category=BotorchWarning,
             )
             self.sampler.base_samples = None
+        elif self._uses_matheron and sampler.batch_range != (0, -1):
+            warnings.warn(
+                message=(
+                    "sampler.batch_range is not (0, -1). qNEHVI requires that the "
+                    "sampler.batch_range is (0, -1) with GPs that use Matheron's rule "
+                    "for sampling, in order to properly collapse batch dimensions. "
+                    "Overwriting the batch_range with (0, -1)!"
+                ),
+                category=BotorchWarning,
+            )
+            self.sampler.batch_range = (0, -1)
         if X_baseline.ndim > 2:
             raise UnsupportedError(
                 "qNoisyExpectedHypervolumeImprovement does not support batched "
@@ -437,8 +457,6 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
         self.constraints = constraints
         self.alpha = alpha
         self.eta = eta
-        models = model.models if isinstance(model, ModelListGP) else [model]
-        self._is_mt = any(isinstance(m, MultiTaskGP) for m in models)
         self.q = -1
         self.q_subset_indices = BufferDict()
         self.partitioning = None
@@ -451,7 +469,7 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
             self.p_class = FastNondominatedPartitioning
         self.register_buffer("_X_baseline", X_baseline)
         self.register_buffer("_X_baseline_and_pending", X_baseline)
-        if isinstance(model, DeterministicModel):
+        if isinstance(model, DeterministicModel) or self._is_mt:
             cache_root = False
         self._cache_root = cache_root
         self.register_buffer(
@@ -694,13 +712,19 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
                 and not isinstance(posterior, DeterministicPosterior)
             ):
                 current_base_samples = self.base_sampler.base_samples.detach().clone()
+                # This is the # of non-`sample_shape` dimensions.
+                base_ndims = current_base_samples.dim() - 1
+                # Unsqueeze as many dimensions as needed to match base_sample_shape.
                 view_shape = (
-                    base_sample_shape[0:1]
-                    + torch.Size([1] * (len(base_sample_shape) - 3))
-                    + current_base_samples.shape[-2:]
+                    self.sampler.sample_shape
+                    + torch.Size(
+                        [1] * (len(base_sample_shape) - current_base_samples.dim())
+                    )
+                    + current_base_samples.shape[-base_ndims:]
                 )
                 expanded_shape = (
-                    base_sample_shape[:-2] + current_base_samples.shape[-2:]
+                    base_sample_shape[:-base_ndims]
+                    + current_base_samples.shape[-base_ndims:]
                 )
                 # Use stored base samples:
                 # Use all base_samples from the current sampler
@@ -709,10 +733,14 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
                 # For example, when using sequential greedy candidate generation
                 # then generate the new candidate point using last (-1) base_sample
                 # in sampler. This copies that base sample.
-                end_idx = current_base_samples.shape[-2]
-                self.sampler.base_samples[..., :end_idx, :] = current_base_samples.view(
-                    view_shape
-                ).expand(expanded_shape)
+                end_idx = current_base_samples.shape[-1 if self._uses_matheron else -2]
+                expanded_samples = current_base_samples.view(view_shape).expand(
+                    expanded_shape
+                )
+                if self._uses_matheron:
+                    self.sampler.base_samples[..., :end_idx] = expanded_samples
+                else:
+                    self.sampler.base_samples[..., :end_idx, :] = expanded_samples
                 # update cached subset indices
                 # Note: this also stores self.q = q
                 self._cache_q_subset_indices(q=q)
@@ -752,7 +780,13 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
 
         # TODO: improve efficiency for multi-task models
         samples = self.sampler(posterior)
-        return samples[..., -q:, :]
+        if isinstance(self.model, HigherOrderGP):
+            # Select the correct q-batch dimension for HOGP.
+            q_dim = -self.model._num_dimensions
+            q_idcs = torch.arange(-q, 0) + samples.shape[q_dim]
+            return samples.index_select(q_dim, q_idcs)
+        else:
+            return samples[..., -q:, :]
 
     @concatenate_pending_points
     @t_batch_mode_transform()

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -783,7 +783,7 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
         if isinstance(self.model, HigherOrderGP):
             # Select the correct q-batch dimension for HOGP.
             q_dim = -self.model._num_dimensions
-            q_idcs = torch.arange(-q, 0) + samples.shape[q_dim]
+            q_idcs = torch.arange(-q, 0, device=samples.device) + samples.shape[q_dim]
             return samples.index_select(q_dim, q_idcs)
         else:
             return samples[..., -q:, :]

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -424,16 +424,11 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
             )
             self.sampler.base_samples = None
         elif self._uses_matheron and self.sampler.batch_range != (0, -1):
-            warnings.warn(
-                message=(
-                    "sampler.batch_range is not (0, -1). qNEHVI requires that the "
-                    "sampler.batch_range is (0, -1) with GPs that use Matheron's rule "
-                    "for sampling, in order to properly collapse batch dimensions. "
-                    "Overwriting the batch_range with (0, -1)!"
-                ),
-                category=BotorchWarning,
+            raise RuntimeError(
+                "sampler.batch_range is not (0, -1). qNEHVI requires that the "
+                "sampler.batch_range is (0, -1) with GPs that use Matheron's rule "
+                "for sampling, in order to properly collapse batch dimensions. "
             )
-            self.sampler.batch_range = (0, -1)
         if X_baseline.ndim > 2:
             raise UnsupportedError(
                 "qNoisyExpectedHypervolumeImprovement does not support batched "

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -426,7 +426,7 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
                 category=BotorchWarning,
             )
             self.sampler.base_samples = None
-        elif self._uses_matheron and sampler.batch_range != (0, -1):
+        elif self._uses_matheron and self.sampler.batch_range != (0, -1):
             warnings.warn(
                 message=(
                     "sampler.batch_range is not (0, -1). qNEHVI requires that the "

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -730,7 +730,6 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
                 # For example, when using sequential greedy candidate generation
                 # then generate the new candidate point using last (-1) base_sample
                 # in sampler. This copies that base sample.
-                end_idx = current_base_samples.shape[-1 if self._uses_matheron else -2]
                 expanded_samples = current_base_samples.view(view_shape).expand(
                     expanded_shape
                 )
@@ -745,6 +744,7 @@ class qNoisyExpectedHypervolumeImprovement(qExpectedHypervolumeImprovement):
                         ..., -n_train_samples:
                     ] = expanded_samples[..., -n_train_samples:]
                 else:
+                    end_idx = current_base_samples.shape[-2]
                     self.sampler.base_samples[..., :end_idx, :] = expanded_samples
                 # update cached subset indices
                 # Note: this also stores self.q = q

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -44,7 +44,7 @@ from botorch.models import HigherOrderGP
 from botorch.models.deterministic import DeterministicModel
 from botorch.models.model import Model
 from botorch.models.model_list_gp_regression import ModelListGP
-from botorch.models.multitask import MultiTaskGP, KroneckerMultiTaskGP
+from botorch.models.multitask import KroneckerMultiTaskGP, MultiTaskGP
 from botorch.posteriors import DeterministicPosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.posterior import Posterior

--- a/botorch/acquisition/multi_objective/objective.py
+++ b/botorch/acquisition/multi_objective/objective.py
@@ -10,7 +10,7 @@ from abc import abstractmethod
 from typing import List, Optional
 
 import torch
-from botorch.acquisition.objective import AcquisitionObjective
+from botorch.acquisition.objective import AcquisitionObjective, GenericMCObjective
 from botorch.exceptions.errors import BotorchError, BotorchTensorDimensionError
 from botorch.models.transforms.outcome import Standardize
 from botorch.posteriors import GPyTorchPosterior
@@ -43,6 +43,16 @@ class MCMultiOutputObjective(AcquisitionObjective):
             >>> outcomes = multi_obj(samples)
         """
         pass  # pragma: no cover
+
+
+class GenericMCMultiOutputObjective(GenericMCObjective, MCMultiOutputObjective):
+    r"""Multi-output objective generated from a generic callable.
+
+    Allows to construct arbitrary MC-objective functions from a generic
+    callable. In order to be able to use gradient-based acquisition function
+    optimization it should be possible to backpropagate through the callable.
+    """
+    pass
 
 
 class IdentityMCMultiOutputObjective(MCMultiOutputObjective):

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -101,7 +101,8 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel):
             train_X: A `n x (d + 1)` or `b x n x (d + 1)` (batch mode) tensor
                 of training data. One of the columns should contain the task
                 features (see `task_feature` argument).
-            train_Y: A `n` or `b x n` (batch mode) tensor of training observations.
+            train_Y: A `n x 1` or `b x n x 1` (batch mode) tensor of training
+                observations.
             task_feature: The index of the task feature (`-d <= task_feature <= d`).
             output_tasks: A list of task indices for which to compute model
                 outputs for. If omitted, return outputs for all task indices.
@@ -316,7 +317,7 @@ class FixedNoiseMultiTaskGP(MultiTaskGP):
             train_X: A `n x (d + 1)` or `b x n x (d + 1)` (batch mode) tensor
                 of training data. One of the columns should contain the task
                 features (see `task_feature` argument).
-            train_Y: A `n` or `b x n` (batch mode) tensor of training
+            train_Y: A `n x 1` or `b x n x 1` (batch mode) tensor of training
                 observations.
             train_Yvar: A `n` or `b x n` (batch mode) tensor of observation
                 noise standard errors.

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+
 import warnings
 from copy import deepcopy
 from itertools import product

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -3,7 +3,6 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import itertools
 import warnings
 from copy import deepcopy
 from itertools import product

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -1460,5 +1460,5 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                 else torch.Size([2, 2, 3, 2])
             )
             self.assertEqual(
-                wrapped_compute.call_args.kwargs["samples"].shape, expected_shape
+                wrapped_compute.call_args[-1]["samples"].shape, expected_shape
             )

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -17,9 +17,9 @@ from botorch.acquisition.multi_objective.monte_carlo import (
     qNoisyExpectedHypervolumeImprovement,
 )
 from botorch.acquisition.multi_objective.objective import (
+    GenericMCMultiOutputObjective,
     IdentityMCMultiOutputObjective,
     MCMultiOutputObjective,
-    GenericMCMultiOutputObjective,
 )
 from botorch.acquisition.objective import IdentityMCObjective
 from botorch.exceptions.errors import BotorchError, UnsupportedError


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

As seen in #1036, qNEHVI currently does not support KroneckerMTGP, or any other GP that uses Matheron's rule sampling. This modifies the `_set_sampler` to add support for these.

With this, `HigherOrderGP` is also supported as long as it is coupled with an `objective` that reduces the `batch x q x output_shape` samples to `batch x q x m` (where `m` agrees with the `ref_point`, of course).

In addition, I sneaked in a `GenericMCMultiOutputObjective`.

Resolves #1036.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

Unittests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
#1026 

cc @wjmaddox 