### PR TITLE
Fix missing weights in VaR

### DIFF
--- a/botorch/acquisition/risk_measures.py
+++ b/botorch/acquisition/risk_measures.py
@@ -176,7 +176,7 @@ class VaR(CVaR):
             weights: An optional `m`-dim tensor of weights for scalarizing
                 multi-objective samples before calculating the risk measure.
         """
-        super().__init__(n_w=n_w, alpha=alpha)
+        super().__init__(n_w=n_w, alpha=alpha, weights=weights)
         self._q = 1 - self.alpha_idx / n_w
 
     def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:

--- a/test/acquisition/test_risk_measures.py
+++ b/test/acquisition/test_risk_measures.py
@@ -108,7 +108,8 @@ class TestCVaR(BotorchTestCase):
                 )
             )
             # w/ weights=-1
-            obj.weights = torch.tensor([-1.0], device=self.device, dtype=dtype)
+            weights = torch.tensor([-1.0], device=self.device, dtype=dtype)
+            obj = CVaR(alpha=0.5, n_w=3, weights=weights)
             rm_samples = obj(samples)
             self.assertTrue(
                 torch.equal(
@@ -135,7 +136,8 @@ class TestVaR(BotorchTestCase):
                 )
             )
             # w/ weights=-1.0
-            obj.weights = torch.tensor([-1.0], device=self.device, dtype=dtype)
+            weights = torch.tensor([-1.0], device=self.device, dtype=dtype)
+            obj = VaR(alpha=0.5, n_w=3, weights=weights)
             rm_samples = obj(samples)
             self.assertTrue(
                 torch.equal(
@@ -162,7 +164,8 @@ class TestWorstCase(BotorchTestCase):
                 )
             )
             # w/ weights = -1.0
-            obj.weights = torch.tensor([-1.0], device=self.device, dtype=dtype)
+            weights = torch.tensor([-1.0], device=self.device, dtype=dtype)
+            obj = WorstCase(n_w=3, weights=weights)
             rm_samples = obj(samples)
             self.assertTrue(
                 torch.equal(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

`VaR` was completely ignoring `weights` due to it not being passed into `super().__init__(...)` call.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

Fixed the `weights` unit tests for `VaR` and others.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)

cc @sdaulton 