### PR TITLE
Fix split chunks in sample_cached_cholesky

### DIFF
--- a/botorch/utils/low_rank.py
+++ b/botorch/utils/low_rank.py
@@ -109,7 +109,8 @@ def sample_cached_cholesky(
     # bl := K(X, X_baseline)
     # br := K(X, X)
     # Get bottom right block of new covariance
-    bl, br = torch.split(bottom_rows, bottom_rows.shape[-1] - q, dim=-1)
+    bl = bottom_rows[..., :bottom_rows.shape[-1] - q]
+    br = bottom_rows[..., bottom_rows.shape[-1] - q:]
     # Solve Ax = b
     # where A = K(X_baseline, X_baseline) and b = K(X, X_baseline)^T
     # and bl_chol := x^T

--- a/botorch/utils/low_rank.py
+++ b/botorch/utils/low_rank.py
@@ -109,8 +109,7 @@ def sample_cached_cholesky(
     # bl := K(X, X_baseline)
     # br := K(X, X)
     # Get bottom right block of new covariance
-    bl = bottom_rows[..., :bottom_rows.shape[-1] - q]
-    br = bottom_rows[..., bottom_rows.shape[-1] - q:]
+    bl, br = bottom_rows.split([bottom_rows.shape[-1] - q, q], dim=-1)
     # Solve Ax = b
     # where A = K(X_baseline, X_baseline) and b = K(X, X_baseline)^T
     # and bl_chol := x^T

--- a/test/utils/test_low_rank.py
+++ b/test/utils/test_low_rank.py
@@ -70,7 +70,7 @@ class TestSampleCachedCholesky(BotorchTestCase):
                             train_Y[:, :m],
                         )
                     sampler = IIDNormalSampler(3)
-                    for q in (1, 3):
+                    for q in (1, 3, 9):
                         # test batched baseline_L
                         for train_batch_shape in (
                             torch.Size([]),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

In `sample_cached_cholesky` if `bottom_rows.shape[-1] - q < bottom_rows.shape[-1] / 2`, the split call produces more than two tensors, which errors out during assignment. This happens if `q` is larger than the number of baseline points. This fixes the error by ~~replacing the `torch.split` call with explicit indexing.~~ using list of chunk sizes in `split`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)
Update units.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)

cc @sdaulton 
