### PR TITLE
Make Normalize input transform input column specific

### DIFF
--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -344,9 +344,7 @@ class Normalize(ReversibleInputTransform, Module):
         """
         super().__init__()
         if (indices is None) or (len(indices) == 0):
-            self.register_buffer(
-                "indices", torch.tensor(list(range(d)), dtype=torch.long)
-            )
+            self.register_buffer("indices", torch.arange(d))
         else:
             indices = torch.tensor(indices, dtype=torch.long)
             if len(indices) > d:

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -348,9 +348,7 @@ class Normalize(ReversibleInputTransform, Module):
         else:
             indices = torch.tensor(indices, dtype=torch.long)
             if len(indices) > d:
-                raise ValueError(
-                    "Dimensions of provided `indices` are incompatible with `d`!"
-                )
+                raise ValueError("Can provide at most `d` indices!")
             if (indices > d - 1).any():
                 raise ValueError("Elements of `indices` have to be smaller than `d`!")
             if len(indices.unique()) != len(indices):

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -123,6 +123,7 @@ class TestInputTransforms(BotorchTestCase):
             self.assertTrue(torch.equal(ipt5(X), X))
 
     def test_normalize(self):
+
         for dtype in (torch.float, torch.double):
 
             # basic init, learned bounds
@@ -132,12 +133,17 @@ class TestInputTransforms(BotorchTestCase):
             self.assertEqual(nlz._d, 2)
             self.assertEqual(nlz.mins.shape, torch.Size([1, 2]))
             self.assertEqual(nlz.ranges.shape, torch.Size([1, 2]))
+            self.assertEqual(len(nlz.indices), 2)
             nlz = Normalize(d=2, batch_shape=torch.Size([3]))
             self.assertTrue(nlz.learn_bounds)
             self.assertTrue(nlz.training)
             self.assertEqual(nlz._d, 2)
             self.assertEqual(nlz.mins.shape, torch.Size([3, 1, 2]))
             self.assertEqual(nlz.ranges.shape, torch.Size([3, 1, 2]))
+            self.assertEqual(len(nlz.indices), 2)
+            self.assertTrue(
+                (nlz.indices == torch.tensor([0, 1], dtype=torch.long)).all()
+            )
 
             # basic init, fixed bounds
             bounds = torch.zeros(2, 2, device=self.device, dtype=dtype)
@@ -149,6 +155,23 @@ class TestInputTransforms(BotorchTestCase):
             self.assertTrue(
                 torch.equal(nlz.mins, bounds[..., 1:2, :] - bounds[..., 0:1, :])
             )
+
+            # basic init, provided indices
+            with self.assertRaises(ValueError):
+                nlz = Normalize(d=2, indices=[0, 1, 2])
+            with self.assertRaises(ValueError):
+                nlz = Normalize(d=2, indices=[0, 2])
+            with self.assertRaises(ValueError):
+                nlz = Normalize(d=2, indices=[0, 0])
+            nlz = Normalize(d=2, indices=[0])
+            self.assertTrue(nlz.learn_bounds)
+            self.assertTrue(nlz.training)
+            self.assertEqual(nlz._d, 2)
+            self.assertEqual(nlz.mins.shape, torch.Size([1, 2]))
+            self.assertEqual(nlz.ranges.shape, torch.Size([1, 2]))
+            self.assertEqual(len(nlz.indices), 1)
+            self.assertTrue((nlz.indices == torch.tensor([0], dtype=torch.long)).all())
+
             # test .to
             other_dtype = torch.float if dtype == torch.double else torch.double
             nlz.to(other_dtype)
@@ -231,7 +254,32 @@ class TestInputTransforms(BotorchTestCase):
                 X_nlzd2 = nlz.untransform(X2)
                 self.assertTrue(torch.allclose(X_nlzd, X_nlzd2, atol=1e-4, rtol=1e-4))
 
+                # test non complete indices
+                indices = [0, 2]
+                nlz = Normalize(d=3, batch_shape=batch_shape, indices=indices)
+                X = torch.randn(*batch_shape, 4, 3, device=self.device, dtype=dtype)
+                X_nlzd = nlz(X)
+                self.assertEqual(X_nlzd[..., indices].min().item(), 0.0)
+                self.assertEqual(X_nlzd[..., indices].max().item(), 1.0)
+                self.assertTrue(torch.allclose(X_nlzd[..., 1], X[..., 1]))
+                nlz.eval()
+                X_unnlzd = nlz.untransform(X_nlzd)
+                self.assertTrue(torch.allclose(X, X_unnlzd, atol=1e-4, rtol=1e-4))
+                expected_bounds = torch.cat(
+                    [X.min(dim=-2, keepdim=True)[0], X.max(dim=-2, keepdim=True)[0]],
+                    dim=-2,
+                )
+                self.assertTrue(torch.allclose(nlz.bounds, expected_bounds))
+                # test errors on wrong shape
+                nlz = Normalize(d=2, batch_shape=batch_shape)
+                X = torch.randn(*batch_shape, 2, 1, device=self.device, dtype=dtype)
+                with self.assertRaises(BotorchTensorDimensionError):
+                    nlz(X)
+
                 # test equals
+                nlz = Normalize(
+                    d=2, bounds=bounds, batch_shape=batch_shape, reverse=True
+                )
                 nlz2 = Normalize(
                     d=2, bounds=bounds, batch_shape=batch_shape, reverse=False
                 )
@@ -247,6 +295,10 @@ class TestInputTransforms(BotorchTestCase):
                 self.assertFalse(nlz.equals(nlz4))
                 nlz5 = Normalize(d=2, batch_shape=batch_shape)
                 self.assertFalse(nlz.equals(nlz5))
+                nlz6 = Normalize(d=2, batch_shape=batch_shape, indices=[0, 1])
+                self.assertTrue(nlz5.equals(nlz6))
+                nlz7 = Normalize(d=2, batch_shape=batch_shape, indices=[0])
+                self.assertFalse(nlz5.equals(nlz7))
 
     def test_chained_input_transform(self):
 

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -133,17 +133,12 @@ class TestInputTransforms(BotorchTestCase):
             self.assertEqual(nlz._d, 2)
             self.assertEqual(nlz.mins.shape, torch.Size([1, 2]))
             self.assertEqual(nlz.ranges.shape, torch.Size([1, 2]))
-            self.assertEqual(len(nlz.indices), 2)
             nlz = Normalize(d=2, batch_shape=torch.Size([3]))
             self.assertTrue(nlz.learn_bounds)
             self.assertTrue(nlz.training)
             self.assertEqual(nlz._d, 2)
             self.assertEqual(nlz.mins.shape, torch.Size([3, 1, 2]))
             self.assertEqual(nlz.ranges.shape, torch.Size([3, 1, 2]))
-            self.assertEqual(len(nlz.indices), 2)
-            self.assertTrue(
-                (nlz.indices == torch.tensor([0, 1], dtype=torch.long)).all()
-            )
 
             # basic init, fixed bounds
             bounds = torch.zeros(2, 2, device=self.device, dtype=dtype)
@@ -163,6 +158,8 @@ class TestInputTransforms(BotorchTestCase):
                 nlz = Normalize(d=2, indices=[0, 2])
             with self.assertRaises(ValueError):
                 nlz = Normalize(d=2, indices=[0, 0])
+            with self.assertRaises(ValueError):
+                nlz = Normalize(d=2, indices=[])
             nlz = Normalize(d=2, indices=[0])
             self.assertTrue(nlz.learn_bounds)
             self.assertTrue(nlz.training)
@@ -296,9 +293,14 @@ class TestInputTransforms(BotorchTestCase):
                 nlz5 = Normalize(d=2, batch_shape=batch_shape)
                 self.assertFalse(nlz.equals(nlz5))
                 nlz6 = Normalize(d=2, batch_shape=batch_shape, indices=[0, 1])
-                self.assertTrue(nlz5.equals(nlz6))
+                self.assertFalse(nlz5.equals(nlz6))
                 nlz7 = Normalize(d=2, batch_shape=batch_shape, indices=[0])
                 self.assertFalse(nlz5.equals(nlz7))
+                nlz8 = Normalize(d=2, batch_shape=batch_shape, indices=[0, 1])
+                self.assertTrue(nlz6.equals(nlz8))
+                nlz9 = Normalize(d=3, batch_shape=batch_shape, indices=[0, 1])
+                nlz10 = Normalize(d=3, batch_shape=batch_shape, indices=[0, 2])
+                self.assertFalse(nlz9.equals(nlz10))
 
     def test_chained_input_transform(self):
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR adds the possibility to apply a `Normalize` input transform only to specific input columns specified via a list of indices (in analogy to the `Log10` transform). This makes it possible to combine it with other transforms or intentionally ignore inputs in the transform.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
