### PR TITLE
Improve find_interior_point

### DIFF
--- a/test/utils/test_sampling.py
+++ b/test/utils/test_sampling.py
@@ -308,7 +308,7 @@ class TestSampleUtils(BotorchTestCase):
         A = np.array([[-1.0]])
         b = np.array([-3.0])
         x = find_interior_point(A=A, b=b)
-        self.assertAlmostEqual(x.item(), 3.0)
+        self.assertAlmostEqual(x.item(), 6.201544, places=4)
 
     def test_get_polytope_samples(self):
         tkwargs = {"device": self.device}


### PR DESCRIPTION
Summary:
Modifies the LP for finding an interior point to better deal with unbounded feasible sets by constraining the slack variable.

This change is necessary since if in the existing version (which essentially searches for the point “furthest away from the boundary”) the feasible set is unbounded, then LP will find a solution on the boundary (the one with minimal inf norm) which is not an interior point. This PR gets rid of that logic and caps the “furthest away to” some (arbitrary) max so that we don’t run into issues with unboundedness in that case. This also simplifies things relative to the previous fallback. We could of course also just always solve the bounded version, but that might cause some weird outcomes, so I am doing this as a fallback only.

Reviewed By: dme65

Differential Revision: D33325860

