### PR TITLE
low-rank cholesky updates for NEI

### DIFF
--- a/botorch/acquisition/cached_cholesky.py
+++ b/botorch/acquisition/cached_cholesky.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+Abstract class for acquisition functions leveraging a cached Cholesky
+decomposition of the posterior covaiance over f(X_baseline).
+"""
+from __future__ import annotations
+
+import warnings
+from abc import ABC
+from typing import Optional
+
+import torch
+from botorch.exceptions.errors import UnsupportedError
+from botorch.exceptions.warnings import BotorchWarning
+from botorch.models import HigherOrderGP
+from botorch.models.deterministic import DeterministicModel
+from botorch.models.model import ModelList, Model
+from botorch.models.multitask import KroneckerMultiTaskGP, MultiTaskGP
+from botorch.posteriors.gpytorch import GPyTorchPosterior
+from botorch.posteriors.posterior import Posterior
+from botorch.sampling.samplers import MCSampler
+from botorch.utils.low_rank import extract_batch_covar, sample_cached_cholesky
+from gpytorch import settings as gpt_settings
+from gpytorch.distributions.multitask_multivariate_normal import (
+    MultitaskMultivariateNormal,
+)
+from gpytorch.utils.errors import NotPSDError, NanError
+from torch import Tensor
+
+
+class CachedCholeskyMCAcquisitionFunction(ABC):
+    r"""Abstract class for acquisition functions using a cached Cholesky.
+
+    Specifically, this is for acquisition functions that require sampling from
+    the posterior P(f(X_baseline, X) | D). The Cholesky of the posterior
+    covariance over f(X_baseline) is cached.
+    """
+
+    def _check_sampler(self) -> None:
+        r"""Check compatibility of sampler and model with a cached Cholesky."""
+        if not self.sampler.collapse_batch_dims:
+            raise UnsupportedError(
+                "Expected sampler to use `collapse_batch_dims=True`."
+            )
+        elif self.sampler.base_samples is not None:
+            warnings.warn(
+                message=(
+                    "sampler.base_samples is not None. The base_samples must be "
+                    "initialized to None. Resetting sampler.base_samples to None."
+                ),
+                category=BotorchWarning,
+            )
+            self.sampler.base_samples = None
+        elif self._uses_matheron and self.sampler.batch_range != (0, -1):
+            raise RuntimeError(
+                "sampler.batch_range is not (0, -1). This check requires that the "
+                "sampler.batch_range is (0, -1) with GPs that use Matheron's rule "
+                "for sampling, in order to properly collapse batch dimensions. "
+            )
+
+    def _setup(
+        self,
+        model: Model,
+        sampler: Optional[MCSampler] = None,
+        cache_root: bool = False,
+        check_sampler: bool = False,
+    ) -> None:
+        r"""Set class attributes and perform compatibility checks.
+
+        Args:
+            model: A model.
+            sampler: A sampler.
+            cache_root: A boolean indicating whether to cache the Cholesky.
+                This might be overridden in the model is not compatible.
+            check_sampler: A boolean indicating whether to check the sampler.
+                The sampler is always checked if cache_root is True.
+        """
+        models = model.models if isinstance(model, ModelList) else [model]
+        self._is_mt = any(
+            isinstance(m, (MultiTaskGP, KroneckerMultiTaskGP, HigherOrderGP))
+            for m in models
+        )
+        self._is_deterministic = any(isinstance(m, DeterministicModel) for m in models)
+        self._uses_matheron = any(
+            isinstance(m, (KroneckerMultiTaskGP, HigherOrderGP)) for m in models
+        )
+        if check_sampler or cache_root:
+            self._check_sampler()
+        if self._is_deterministic or self._is_mt:
+            cache_root = False
+        self._cache_root = cache_root
+
+    def _cache_root_decomposition(
+        self,
+        posterior: Posterior,
+    ) -> None:
+        r"""Cache Cholesky of the posterior covariance over f(X_baseline).
+
+        Args:
+            posterior: The posterior over f(X_baseline).
+        """
+        if isinstance(posterior.mvn, MultitaskMultivariateNormal):
+            lazy_covar = extract_batch_covar(posterior.mvn)
+        else:
+            lazy_covar = posterior.mvn.lazy_covariance_matrix
+        with gpt_settings.fast_computations.covar_root_decomposition(False):
+            lazy_covar_root = lazy_covar.root_decomposition()
+            baseline_L = lazy_covar_root.root.evaluate()
+        self.register_buffer("_baseline_L", baseline_L)
+
+    def _get_f_X_samples(self, posterior: GPyTorchPosterior, q_in: int) -> Tensor:
+        r"""Get posterior samples at the `q_in` new points from the joint posterior.
+
+        Args:
+            posterior: The joint posterior is over (X_baseline, X).
+            q_in: The number of new points in the posterior. See `_set_sampler` for
+                more information.
+
+        Returns:
+            A `sample_shape x batch_shape x q x m`-dim tensor of posterior
+                samples at the new points.
+        """
+        # Technically we should make sure that we add a consistent nugget to the
+        # cached covariance (and box decompositions) and the new block.
+        # But recomputing box decompositions every time the jitter changes would
+        # be quite slow.
+        if not self._is_mt and self._cache_root and hasattr(self, "_baseline_L"):
+            try:
+                return sample_cached_cholesky(
+                    posterior=posterior,
+                    baseline_L=self._baseline_L,
+                    q=q_in,
+                    base_samples=self.sampler.base_samples,
+                    sample_shape=self.sampler.sample_shape,
+                )
+            except (NanError, NotPSDError):
+                warnings.warn(
+                    "Low-rank cholesky updates failed due NaNs or due to an "
+                    "ill-conditioned covariance matrix. "
+                    "Falling back to standard sampling.",
+                    BotorchWarning,
+                )
+
+        # TODO: improve efficiency for multi-task models
+        samples = self.sampler(posterior)
+        if isinstance(self.model, HigherOrderGP):
+            # Select the correct q-batch dimension for HOGP.
+            q_dim = -self.model._num_dimensions
+            q_idcs = (
+                torch.arange(-q_in, 0, device=samples.device) + samples.shape[q_dim]
+            )
+            return samples.index_select(q_dim, q_idcs)
+        else:
+            return samples[..., -q_in:, :]

--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -22,10 +22,12 @@ from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from typing import Any, Optional, Union
 
 import torch
 from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.cached_cholesky import CachedCholeskyMCAcquisitionFunction
 from botorch.acquisition.objective import (
     IdentityMCObjective,
     MCAcquisitionObjective,
@@ -34,6 +36,7 @@ from botorch.acquisition.objective import (
 from botorch.acquisition.utils import prune_inferior_points
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.model import Model
+from botorch.posteriors.posterior import Posterior
 from botorch.sampling.samplers import MCSampler, SobolQMCNormalSampler
 from botorch.utils.transforms import (
     concatenate_pending_points,
@@ -178,7 +181,9 @@ class qExpectedImprovement(MCAcquisitionFunction):
         return q_ei
 
 
-class qNoisyExpectedImprovement(MCAcquisitionFunction):
+class qNoisyExpectedImprovement(
+    MCAcquisitionFunction, CachedCholeskyMCAcquisitionFunction
+):
     r"""MC-based batch Noisy Expected Improvement.
 
     This function does not assume a `best_f` is known (which would require
@@ -205,6 +210,7 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
         posterior_transform: Optional[PosteriorTransform] = None,
         X_pending: Optional[Tensor] = None,
         prune_baseline: bool = False,
+        cache_root: bool = True,
         **kwargs: Any,
     ) -> None:
         r"""q-Noisy Expected Improvement.
@@ -229,6 +235,13 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
                 customize pruning parameters, instead manually call
                 `botorch.acquisition.utils.prune_inferior_points` on `X_baseline`
                 before instantiating the acquisition function.
+            cache_root: A boolean indicating whether to cache the root
+                decomposition over `X_baseline` and use low-rank updates.
+
+        TODO: similar to qNEHVI, when we are using sequential greedy candidate
+        selection, we could incorporate pending points X_baseline and compute
+        the incremental qNEI from the new point. This would greatly increase
+        efficiency for large batches.
         """
         super().__init__(
             model=model,
@@ -237,6 +250,8 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
             posterior_transform=posterior_transform,
             X_pending=X_pending,
         )
+        self._setup(model=model, sampler=self.sampler, cache_root=cache_root)
+        self.base_sampler = deepcopy(self.sampler)
         if prune_baseline:
             X_baseline = prune_inferior_points(
                 model=model,
@@ -246,6 +261,92 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
                 marginalize_dim=kwargs.get("marginalize_dim"),
             )
         self.register_buffer("X_baseline", X_baseline)
+
+        if self._cache_root:
+            self.q = -1
+            # set baseline samples
+            with torch.no_grad():
+                posterior = self.model.posterior(X_baseline)
+                baseline_samples = self.base_sampler(posterior)
+            baseline_obj = self.objective(baseline_samples, X=X_baseline)
+            self.register_buffer("baseline_samples", baseline_samples)
+            self.register_buffer(
+                "baseline_obj_max_values", baseline_obj.max(dim=-1).values
+            )
+            self._cache_root_decomposition(posterior=posterior)
+
+    def _set_sampler(
+        self,
+        q: int,
+        posterior: Posterior,
+    ) -> None:
+        r"""Update the sampler to use the original base samples for X_baseline.
+
+        Args:
+            q: the batch size
+            posterior: the posterior
+
+        TODO: refactor some/all of this into the MCSampler.
+        """
+        if self.q != q:
+            # create new base_samples
+            base_sample_shape = self.sampler._get_base_sample_shape(posterior=posterior)
+            self.sampler._construct_base_samples(
+                posterior=posterior, shape=base_sample_shape
+            )
+            if (
+                self.X_baseline.shape[0] > 0
+                and self.base_sampler.base_samples is not None
+            ):
+                current_base_samples = self.base_sampler.base_samples.detach().clone()
+                view_shape = (
+                    base_sample_shape[:1]
+                    + torch.Size([1] * (len(base_sample_shape) - 3))
+                    + current_base_samples.shape[-2:]
+                )
+                expanded_shape = (
+                    base_sample_shape[:-2] + current_base_samples.shape[-2:]
+                )
+                # Use stored base samples:
+                # Use all base_samples from the current sampler
+                # this includes the base_samples from the base_sampler
+                # and any base_samples for the new points in the sampler.
+                # For example, when using sequential greedy candidate generation
+                # then generate the new candidate point using last (-1) base_sample
+                # in sampler. This copies that base sample.
+                end_idx = current_base_samples.shape[-2]
+                self.sampler.base_samples[..., :end_idx, :] = current_base_samples.view(
+                    view_shape
+                ).expand(expanded_shape)
+            self.q = q
+
+    def _forward_cached(self, posterior: Posterior, X_full: Tensor, q: int) -> Tensor:
+        r"""Compute difference objective using cached root decomposition.
+
+        Args:
+            posterior: The posterior.
+            X_full: A `batch_shape x n + q x d`-dim tensor of inputs
+            q: The batch size.
+
+        Returns:
+            A `sample_shape x batch_shape`-dim tensor containing the
+                difference in objective under each MC sample.
+        """
+        self._set_sampler(q=q, posterior=posterior)
+        # handle one-to-many input transforms
+        n_w = posterior.event_shape[-2] // X_full.shape[-2]
+        new_samples = self._get_f_X_samples(posterior=posterior, q_in=n_w * q)
+        new_obj = self.objective(new_samples, X=X_full[..., -q:, :])
+        new_obj_max_values = new_obj.max(dim=-1).values
+        n_sample_dims = len(self.base_sampler.sample_shape)
+        view_shape = torch.Size(
+            [
+                *self.baseline_obj_max_values.shape[:n_sample_dims],
+                *(1,) * (new_obj_max_values.ndim - self.baseline_obj_max_values.ndim),
+                *self.baseline_obj_max_values.shape[n_sample_dims:],
+            ]
+        )
+        return new_obj_max_values - self.baseline_obj_max_values.view(view_shape)
 
     @concatenate_pending_points
     @t_batch_mode_transform()
@@ -262,15 +363,19 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
             of model and input `X`.
         """
         q = X.shape[-2]
-        X_full = torch.cat([X, match_batch_shape(self.X_baseline, X)], dim=-2)
+        X_full = torch.cat([match_batch_shape(self.X_baseline, X), X], dim=-2)
         # TODO: Implement more efficient way to compute posterior over both training and
         # test points in GPyTorch (https://github.com/cornellius-gp/gpytorch/issues/567)
         posterior = self.model.posterior(
-            X=X_full, posterior_transform=self.posterior_transform
+            X_full, posterior_transform=self.posterior_transform
         )
-        samples = self.sampler(posterior)
-        obj = self.objective(samples, X=X_full)
-        diffs = obj[..., :q].max(dim=-1).values - obj[..., q:].max(dim=-1).values
+        if self._cache_root:
+            diffs = self._forward_cached(posterior=posterior, X_full=X_full, q=q)
+        else:
+            samples = self.sampler(posterior)
+            obj = self.objective(samples, X=X_full)
+            diffs = obj[..., -q:].max(dim=-1).values - obj[..., :-q].max(dim=-1).values
+
         return diffs.clamp_min(0).mean(dim=0)
 
 

--- a/sphinx/source/acquisition.rst
+++ b/sphinx/source/acquisition.rst
@@ -21,6 +21,11 @@ Analytic Acquisition Function API
 .. autoclass:: AnalyticAcquisitionFunction
     :members:
 
+Cached Cholesky Acquisition Function API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.acquisition.cached_cholesky
+    :members:
+
 Monte-Carlo Acquisition Function API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. currentmodule:: botorch.acquisition.monte_carlo

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -1299,7 +1299,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
 
     def test_cache_root(self):
         sample_cached_path = (
-            "botorch.acquisition.multi_objective.monte_carlo." "sample_cached_cholesky"
+            "botorch.acquisition.cached_cholesky.sample_cached_cholesky"
         )
         state_dict = {
             "likelihood.noise_covar.raw_noise": torch.tensor(

--- a/test/acquisition/test_cached_cholesky.py
+++ b/test/acquisition/test_cached_cholesky.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import warnings
+from unittest import mock
+
+import torch
+from botorch import settings
+from botorch.acquisition.cached_cholesky import CachedCholeskyMCAcquisitionFunction
+from botorch.acquisition.monte_carlo import MCAcquisitionFunction
+from botorch.acquisition.objective import GenericMCObjective
+from botorch.exceptions.errors import UnsupportedError
+from botorch.exceptions.warnings import BotorchWarning
+from botorch.models import SingleTaskGP
+from botorch.models.deterministic import GenericDeterministicModel
+from botorch.models.higher_order_gp import HigherOrderGP
+from botorch.sampling.samplers import IIDNormalSampler
+from botorch.utils.low_rank import extract_batch_covar
+from botorch.utils.testing import MockPosterior, MockModel, BotorchTestCase
+from gpytorch.utils.errors import NanError, NotPSDError
+
+CHOLESKY_PATH = "gpytorch.lazy.lazy_tensor.psd_safe_cholesky"
+EXTRACT_BATCH_COVAR_PATH = "botorch.acquisition.cached_cholesky.extract_batch_covar"
+
+
+class DummyCachedCholeskyAcqf(
+    MCAcquisitionFunction, CachedCholeskyMCAcquisitionFunction
+):
+    def forward(self, X):
+        return X
+
+
+class TestCachedCholeskyMCAcquisitionFunction(BotorchTestCase):
+    def test_setup(self):
+        mean = torch.zeros(1, 1)
+        variance = torch.ones(1, 1)
+        mm = MockModel(MockPosterior(mean=mean, variance=variance))
+        # basic test
+        sampler = IIDNormalSampler(1)
+        acqf = DummyCachedCholeskyAcqf(model=mm, sampler=sampler)
+        acqf._setup(model=mm, sampler=sampler)
+        self.assertFalse(acqf._is_mt)
+        self.assertFalse(acqf._is_deterministic)
+        self.assertFalse(acqf._uses_matheron)
+        self.assertFalse(acqf._cache_root)
+        acqf._setup(model=mm, sampler=sampler, cache_root=True)
+        self.assertTrue(acqf._cache_root)
+
+        # test check_sampler
+        with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            acqf._setup(model=mm, sampler=sampler, check_sampler=True)
+            self.assertEqual(len(ws), 0)
+
+        # test collapse_batch_dims=False
+        sampler = IIDNormalSampler(1, collapse_batch_dims=False)
+        acqf = DummyCachedCholeskyAcqf(model=mm, sampler=sampler)
+        with self.assertRaises(UnsupportedError):
+            acqf._setup(model=mm, sampler=sampler, check_sampler=True)
+        # test warning if base_samples is not None
+        sampler = IIDNormalSampler(1)
+        sampler.base_samples = torch.zeros(1, 1)
+        acqf = DummyCachedCholeskyAcqf(model=mm, sampler=sampler)
+        with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            acqf._setup(model=mm, sampler=sampler, check_sampler=True)
+            self.assertTrue(issubclass(ws[-1].category, BotorchWarning))
+        # test the base_samples are set to None
+        self.assertIsNone(acqf.sampler.base_samples)
+        # test model that uses matheron's rule and sampler.batch_range != (0, -1)
+        hogp = HigherOrderGP(torch.zeros(1, 1), torch.zeros(1, 1, 1)).eval()
+        acqf = DummyCachedCholeskyAcqf(model=hogp, sampler=sampler)
+        with self.assertRaises(RuntimeError):
+            acqf._setup(model=hogp, sampler=sampler, cache_root=True)
+        self.assertTrue(acqf._uses_matheron)
+        self.assertTrue(acqf._is_mt)
+        self.assertFalse(acqf._is_deterministic)
+
+        # test deterministic model
+        model = GenericDeterministicModel(f=lambda X: X)
+        acqf = DummyCachedCholeskyAcqf(model=model, sampler=sampler)
+        acqf._setup(model=model, sampler=sampler, cache_root=True)
+        self.assertTrue(acqf._is_deterministic)
+        self.assertFalse(acqf._uses_matheron)
+        self.assertFalse(acqf._is_mt)
+        self.assertFalse(acqf._cache_root)
+
+    def test_cache_root_decomposition(self):
+        tkwargs = {"device": self.device}
+        for dtype in (torch.float, torch.double):
+            tkwargs["dtype"] = dtype
+            # test mt-mvn
+            train_x = torch.rand(2, 1, **tkwargs)
+            train_y = torch.rand(2, 2, **tkwargs)
+            test_x = torch.rand(2, 1, **tkwargs)
+            model = SingleTaskGP(train_x, train_y)
+            sampler = IIDNormalSampler(1)
+            with torch.no_grad():
+                posterior = model.posterior(test_x)
+            acqf = DummyCachedCholeskyAcqf(
+                model=model,
+                sampler=sampler,
+                objective=GenericMCObjective(lambda Y: Y[..., 0]),
+            )
+            baseline_L = torch.eye(2, **tkwargs)
+            with mock.patch(
+                EXTRACT_BATCH_COVAR_PATH, wraps=extract_batch_covar
+            ) as mock_extract_batch_covar:
+                with mock.patch(
+                    CHOLESKY_PATH, return_value=baseline_L
+                ) as mock_cholesky:
+                    acqf._cache_root_decomposition(posterior=posterior)
+                    mock_extract_batch_covar.assert_called_once_with(posterior.mvn)
+                    mock_cholesky.assert_called_once()
+            # test mvn
+            model = SingleTaskGP(train_x, train_y[:, :1])
+            with torch.no_grad():
+                posterior = model.posterior(test_x)
+            with mock.patch(EXTRACT_BATCH_COVAR_PATH) as mock_extract_batch_covar:
+                with mock.patch(
+                    CHOLESKY_PATH, return_value=baseline_L
+                ) as mock_cholesky:
+                    acqf._cache_root_decomposition(posterior=posterior)
+                    mock_extract_batch_covar.assert_not_called()
+                    mock_cholesky.assert_called_once()
+            self.assertTrue(torch.equal(acqf._baseline_L, baseline_L))
+
+    def test_get_f_X_samples(self):
+        tkwargs = {"device": self.device}
+        for dtype in (torch.float, torch.double):
+            tkwargs["dtype"] = dtype
+            mean = torch.zeros(5, 1, **tkwargs)
+            variance = torch.ones(5, 1, **tkwargs)
+            mm = MockModel(
+                MockPosterior(
+                    mean=mean, variance=variance, samples=torch.rand(5, 1, **tkwargs)
+                )
+            )
+            # basic test
+            sampler = IIDNormalSampler(1)
+            acqf = DummyCachedCholeskyAcqf(model=mm, sampler=sampler)
+            acqf._setup(model=mm, sampler=sampler, cache_root=True)
+            q = 3
+            baseline_L = torch.eye(5 - q, **tkwargs)
+            acqf._baseline_L = baseline_L
+            posterior = mm.posterior(torch.rand(5, 1, **tkwargs))
+            # basic test
+            rv = torch.rand(1, 5, 1, **tkwargs)
+            with mock.patch(
+                "botorch.acquisition.cached_cholesky.sample_cached_cholesky",
+                return_value=rv,
+            ) as mock_sample_cached_cholesky:
+                samples = acqf._get_f_X_samples(posterior=posterior, q_in=q)
+                mock_sample_cached_cholesky.assert_called_once_with(
+                    posterior=posterior,
+                    baseline_L=acqf._baseline_L,
+                    q=q,
+                    base_samples=acqf.sampler.base_samples,
+                    sample_shape=acqf.sampler.sample_shape,
+                )
+            self.assertTrue(torch.equal(rv, samples))
+
+            # test fall back when sampling from cached cholesky fails
+            for error_cls in (NanError, NotPSDError):
+                base_samples = torch.rand(1, 5, 1, **tkwargs)
+                acqf.sampler.base_samples = base_samples
+                acqf._baseline_L = baseline_L
+                with mock.patch(
+                    "botorch.acquisition.cached_cholesky.sample_cached_cholesky",
+                    side_effect=error_cls,
+                ) as mock_sample_cached_cholesky:
+                    with warnings.catch_warnings(record=True) as ws, settings.debug(
+                        True
+                    ):
+                        samples = acqf._get_f_X_samples(posterior=posterior, q_in=q)
+                        mock_sample_cached_cholesky.assert_called_once_with(
+                            posterior=posterior,
+                            baseline_L=acqf._baseline_L,
+                            q=q,
+                            base_samples=base_samples,
+                            sample_shape=acqf.sampler.sample_shape,
+                        )
+                        self.assertTrue(issubclass(ws[0].category, BotorchWarning))
+                        self.assertTrue(samples.shape, torch.Size([1, q, 1]))
+            # test HOGP
+            hogp = HigherOrderGP(torch.zeros(2, 1), torch.zeros(2, 1, 1)).eval()
+            acqf = DummyCachedCholeskyAcqf(model=hogp, sampler=sampler)
+            acqf._setup(model=hogp, sampler=sampler, cache_root=True)
+            mock_samples = torch.rand(5, 1, 1, **tkwargs)
+            posterior = MockPosterior(
+                mean=mean, variance=variance, samples=mock_samples
+            )
+            samples = acqf._get_f_X_samples(posterior=posterior, q_in=q)
+            self.assertTrue(torch.equal(samples, mock_samples[2:].unsqueeze(0)))

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -572,7 +572,9 @@ class TestSampleAroundBest(BotorchTestCase):
                 MockPosterior(mean=(2 * X_train + 1).sum(dim=-1, keepdim=True))
             )
             # test NEI with X_baseline
-            acqf = qNoisyExpectedImprovement(model, X_baseline=X_train)
+            acqf = qNoisyExpectedImprovement(
+                model, X_baseline=X_train, cache_root=False
+            )
             with mock.patch(
                 "botorch.optim.initializers.sample_perturbed_subset_dims"
             ) as mock_subset_dims:
@@ -592,7 +594,9 @@ class TestSampleAroundBest(BotorchTestCase):
                     mean=(2 * X_train + 1).sum(dim=-1, keepdim=True).unsqueeze(0)
                 )
             )
-            acqf = qNoisyExpectedImprovement(model, X_baseline=X_train)
+            acqf = qNoisyExpectedImprovement(
+                model, X_baseline=X_train, cache_root=False
+            )
             X_rnd = sample_points_around_best(
                 acq_function=acqf,
                 n_discrete_points=4,
@@ -714,7 +718,9 @@ class TestSampleAroundBest(BotorchTestCase):
             bounds = torch.ones(2, 21, **tkwargs)
             bounds[1] = 2
             # test NEI with X_baseline
-            acqf = qNoisyExpectedImprovement(model, X_baseline=X_train)
+            acqf = qNoisyExpectedImprovement(
+                model, X_baseline=X_train, cache_root=False
+            )
             with mock.patch(
                 "botorch.optim.initializers.sample_perturbed_subset_dims",
                 wraps=sample_perturbed_subset_dims,

--- a/test/optim/test_utils.py
+++ b/test/optim/test_utils.py
@@ -322,7 +322,9 @@ class TestGetXBaseline(BotorchTestCase):
                 MockPosterior(mean=(2 * X_train + 1).sum(dim=-1, keepdim=True))
             )
             # test NEI with X_baseline
-            acqf = qNoisyExpectedImprovement(model, X_baseline=X_train[:2])
+            acqf = qNoisyExpectedImprovement(
+                model, X_baseline=X_train[:2], cache_root=False
+            )
             X = get_X_baseline(acq_function=acqf)
             self.assertTrue(torch.equal(X, acqf.X_baseline))
             # test EI without X_baseline


### PR DESCRIPTION
Summary:
This uses low-rank cholesky updates in NEI. Using SAA this allows us to cache the objectives values for the in-sample points and only compute the objectives for the new test points. This is much faster when there are lots of baseline points.

However, this makes the acquisition function harder to read, so I am curious to hear what folks think.

Moreover, this is a prototype that I am using for research, but many common components with NEHVI should be refactored into a shared utility or base class.

Differential Revision: D32668278

