### PR TITLE
make non-interleaved base samples use intuitive shape

### DIFF
--- a/botorch/posteriors/base_samples.py
+++ b/botorch/posteriors/base_samples.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import torch
+from gpytorch.distributions.multitask_multivariate_normal import (
+    MultitaskMultivariateNormal,
+)
+from torch import Tensor
+
+
+def _reshape_base_samples_non_interleaved(
+    mvn: MultitaskMultivariateNormal, base_samples: Tensor, sample_shape: torch.Size
+) -> Tensor:
+    r"""Reshape base samples to account for non-interleaved MT-MVNs.
+
+    This method is important for making sure that the `n`th base sample
+    only effects the posterior sample for the `p`th point if `p >= n`.
+    Without this reshaping, for M>=2, the posterior samples for all `n`
+    points.
+
+    Args:
+        mvn: A MultitaskMultivariateNormal distribution.
+        base_samples: A `sample_shape x `batch_shape` x n x m`-dim
+            tensor of base_samples.
+        sample_shape: The sample shape.
+
+    Returns:
+        A `sample_shape x `batch_shape` x n x m`-dim tensor of
+            base_samples suitable for a non-interleaved-multi-task
+            or single-task covariance matrix.
+    """
+    mvn
+    if not mvn._interleaved:
+        new_shape = sample_shape + mvn._output_shape[:-2] + mvn._output_shape[:-3:-1]
+        base_samples = (
+            base_samples.transpose(-1, -2)
+            .view(new_shape)
+            .reshape(sample_shape + mvn.loc.shape)
+            .view(base_samples.shape)
+        )
+    return base_samples

--- a/botorch/posteriors/gpytorch.py
+++ b/botorch/posteriors/gpytorch.py
@@ -15,6 +15,7 @@ from typing import Optional
 
 import torch
 from botorch.exceptions.errors import BotorchTensorDimensionError
+from botorch.posteriors.base_samples import _reshape_base_samples_non_interleaved
 from botorch.posteriors.posterior import Posterior
 from gpytorch import settings as gpt_settings
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
@@ -86,8 +87,12 @@ class GPyTorchPosterior(Posterior):
                 raise RuntimeError("sample_shape disagrees with shape of base_samples.")
             # get base_samples to the correct shape
             base_samples = base_samples.expand(sample_shape + self.event_shape)
+            if self._is_mt:
+                base_samples = _reshape_base_samples_non_interleaved(
+                    mvn=self.mvn, base_samples=base_samples, sample_shape=sample_shape
+                )
             # remove output dimension in single output case
-            if not self._is_mt:
+            else:
                 base_samples = base_samples.squeeze(-1)
         with ExitStack() as es:
             if gpt_settings._fast_covar_root_decomposition.is_default():

--- a/sphinx/source/posteriors.rst
+++ b/sphinx/source/posteriors.rst
@@ -43,3 +43,11 @@ Transformed Posterior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.posteriors.transformed
     :members:
+
+Utilities
+---------------------------------------------
+
+Base Samples
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.posteriors.base_samples
+		:members:

--- a/test/utils/test_low_rank.py
+++ b/test/utils/test_low_rank.py
@@ -70,6 +70,7 @@ class TestSampleCachedCholesky(BotorchTestCase):
                             train_Y[:, :m],
                         )
                     sampler = IIDNormalSampler(3)
+                    base_sampler = IIDNormalSampler(3)
                     for q in (1, 3, 9):
                         # test batched baseline_L
                         for train_batch_shape in (
@@ -139,6 +140,34 @@ class TestSampleCachedCholesky(BotorchTestCase):
                                     torch.allclose(
                                         test_X2.grad[..., -q:, :],
                                         test_X.grad[..., -q:, :],
+                                        **all_close_kwargs,
+                                    )
+                                )
+                                # Test that adding a new point and base_sample
+                                # did not change posterior samples for previous points.
+                                # This tests that we properly account for not
+                                # interleaving.
+                                base_sampler.base_samples = (
+                                    sampler.base_samples[..., :-q, :].detach().clone()
+                                )
+
+                                baseline_samples = base_sampler(base_posterior)
+                                new_batch_shape = samples.shape[
+                                    1 : -baseline_samples.ndim + 1
+                                ]
+                                expanded_baseline_samples = baseline_samples.view(
+                                    baseline_samples.shape[0],
+                                    *[1] * len(new_batch_shape),
+                                    *baseline_samples.shape[1:],
+                                ).expand(
+                                    baseline_samples.shape[0],
+                                    *new_batch_shape,
+                                    *baseline_samples.shape[1:],
+                                )
+                                self.assertTrue(
+                                    torch.allclose(
+                                        expanded_baseline_samples,
+                                        samples[..., :-q, :],
                                         **all_close_kwargs,
                                     )
                                 )


### PR DESCRIPTION
Summary: This was pretty subtle but pretty important. Previously, base_samples with shape: `sample_shape x n x m` would not actually be mapped to outcomes in the way that one would expect. Appending the base samples for a `n+1`th point would affect the posterior samples for the some of the `n` points due to not accounting for not interleaving. This update accounts for not interleaving, such that appending new base samples does not change the posterior samples for the previous points.

Differential Revision: D33532706

