### PR TITLE
Transforms in MixedSingleTaskGP

### DIFF
--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -115,7 +115,6 @@ class MixedSingleTaskGP(SingleTaskGP):
                 batch_shape: torch.Size,
                 ard_num_dims: int,
                 active_dims: List[int],
-                **kwargs: Any,
             ) -> MaternKernel:
                 return MaternKernel(
                     nu=2.5,
@@ -139,10 +138,6 @@ class MixedSingleTaskGP(SingleTaskGP):
         d = train_X.shape[-1]
         cat_dims = normalize_indices(indices=cat_dims, d=d)
         ord_dims = sorted(set(range(d)) - set(cat_dims))
-        if any(idx in cat_dims for idx in ord_dims):
-            raise ValueError(
-                "Inputs cannot be defined both as categorical and ordinal."
-            )
         if len(ord_dims) == 0:
             covar_module = ScaleKernel(
                 CategoricalKernel(

--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -51,6 +51,7 @@ class MixedSingleTaskGP(SingleTaskGP):
         train_X: Tensor,
         train_Y: Tensor,
         cat_dims: List[int],
+        ord_dims: Optional[List[int]] = None,
         cont_kernel_factory: Optional[Callable[[int, List[int]], Kernel]] = None,
         cont_kernel_options: Optional[Dict[str, Union[bool, float, int, str]]] = None,
         likelihood: Optional[Likelihood] = None,
@@ -131,7 +132,9 @@ class MixedSingleTaskGP(SingleTaskGP):
 
         d = train_X.shape[-1]
         cat_dims = normalize_indices(indices=cat_dims, d=d)
-        ord_dims = sorted(set(range(d)) - set(cat_dims))
+        ord_dims = ord_dims or sorted(set(range(d)) - set(cat_dims))
+        if any(idx in cat_dims for idx in ord_dims):
+            raise ValueError("Inputs cannot be defined both as categorical and ordinal.")
         if len(ord_dims) == 0:
             covar_module = ScaleKernel(
                 CategoricalKernel(

--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -91,8 +91,8 @@ class MixedSingleTaskGP(SingleTaskGP):
         if input_transform is not None:
             if hasattr(input_transform, "indices") is False:
                 raise ValueError(
-                    "Only continuous inputs can be transformed. \
-                        Please use `indices` in the `input_transform`."
+                    "Only continuous inputs can be transformed. "
+                    "Please use `indices` in the `input_transform`."
                 )
             # check that no cat dim is in indices
             elif any(idx in input_transform.indices for idx in cat_dims):

--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -97,8 +97,8 @@ class MixedSingleTaskGP(SingleTaskGP):
             # check that no cat dim is in indices
             elif any(idx in input_transform.indices for idx in cat_dims):
                 raise ValueError(
-                    "Only continuous inputs can be transformed. \
-                        Categorical index found in `indices` of the `input_transform`."
+                    "Only continuous inputs can be transformed. "
+                    "Categorical index found in `indices` of the `input_transform`."
                 )
         if len(cat_dims) == 0:
             raise ValueError(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR adds the possibility to use input and output transforms in the `MixedSingleTaskGP`. Only those input transforms are allowed which are applied only  to the ordinal input dimensions. In a separate PR (or this one?) one should overhaul the input transforms and provide everywhere the `indices` argument. For further information have a look at issue https://github.com/pytorch/botorch/issues/1054.

I disregarded my original idea of adding someting like `cont_kernel_options` because a precise control of the continuous kernel is already possible via the `cont_kernel_factory`. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
