### PR TITLE
Pad small diagonalization with zeros for KroneckerMultitaskGP

### DIFF
--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -585,13 +585,13 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
             cols_to_add = data_data_evecs.shape[-2] - data_data_evecs.shape[-1]
             zero_evecs = torch.zeros(
                 *data_data_evecs.shape[:-1],
-                rows_to_add,
+                cols_to_add,
                 dtype=data_data_evals.dtype,
                 device=data_data_evals.device,
             )
             zero_evals = torch.zeros(
                 *data_data_evecs.shape[:-2],
-                rows_to_add,
+                cols_to_add,
                 dtype=data_data_evals.dtype,
                 device=data_data_evals.device,
             )

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -582,7 +582,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
 
         # pad the eigenvalue and eigenvectors with zeros if we are using lanczos
         if data_data_evecs.shape[-1] < data_data_evecs.shape[-2]:
-            rows_to_add = data_data_evecs.shape[-2] - data_data_evecs.shape[-1]
+            cols_to_add = data_data_evecs.shape[-2] - data_data_evecs.shape[-1]
             zero_evecs = torch.zeros(
                 *data_data_evecs.shape[:-1],
                 rows_to_add,

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -583,9 +583,15 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
         # pad the eigenvalue and eigenvectors with zeros if we are using lanczos
         if data_data_evecs.shape[-1] < data_data_evecs.shape[-2]:
             rows_to_add = data_data_evecs.shape[-2] - data_data_evecs.shape[-1]
-            zero_evecs = torch.zeros(*data_data_evecs.shape[:-1], rows_to_add, dtype=data_data_evals.dtype, device=data_data_evals.device)
-            zero_evals = torch.zeros(*data_data_evecs.shape[:-2], rows_to_add, dtype=data_data_evals.dtype, device=data_data_evals.device)
-            data_data_evecs = CatLazyTensor(data_data_evecs, lazify(zero_evecs), dim=-1, output_device=data_data_evals.device)
+            zero_evecs = torch.zeros(
+                *data_data_evecs.shape[:-1], rows_to_add, dtype=data_data_evals.dtype, device=data_data_evals.device
+            )
+            zero_evals = torch.zeros(
+                *data_data_evecs.shape[:-2], rows_to_add, dtype=data_data_evals.dtype, device=data_data_evals.device
+            )
+            data_data_evecs = CatLazyTensor(
+                data_data_evecs, lazify(zero_evecs), dim=-1, output_device=data_data_evals.device
+            )
             data_data_evals = torch.cat((data_data_evals, zero_evals), dim=-1)
 
         # construct K_{xt, x}

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -584,13 +584,22 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
         if data_data_evecs.shape[-1] < data_data_evecs.shape[-2]:
             rows_to_add = data_data_evecs.shape[-2] - data_data_evecs.shape[-1]
             zero_evecs = torch.zeros(
-                *data_data_evecs.shape[:-1], rows_to_add, dtype=data_data_evals.dtype, device=data_data_evals.device
+                *data_data_evecs.shape[:-1],
+                rows_to_add,
+                dtype=data_data_evals.dtype,
+                device=data_data_evals.device,
             )
             zero_evals = torch.zeros(
-                *data_data_evecs.shape[:-2], rows_to_add, dtype=data_data_evals.dtype, device=data_data_evals.device
+                *data_data_evecs.shape[:-2],
+                rows_to_add,
+                dtype=data_data_evals.dtype,
+                device=data_data_evals.device,
             )
             data_data_evecs = CatLazyTensor(
-                data_data_evecs, lazify(zero_evecs), dim=-1, output_device=data_data_evals.device
+                data_data_evecs,
+                lazify(zero_evecs),
+                dim=-1,
+                output_device=data_data_evals.device,
             )
             data_data_evals = torch.cat((data_data_evals, zero_evals), dim=-1)
 

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -39,7 +39,7 @@ from gpytorch.means import ConstantMean, MultitaskMean
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from gpytorch.priors import GammaPrior, LogNormalPrior, SmoothedBoxPrior
 from gpytorch.priors.lkj_prior import LKJCovariancePrior
-from gpytorch.settings import max_cholesky_size
+from gpytorch.settings import max_cholesky_size, max_root_decomposition_size
 
 
 def _get_random_mt_data(**tkwargs):
@@ -737,7 +737,8 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
             for max_cholesky in max_cholesky_sizes:
                 model.train()
                 test_x = torch.rand(2, 2, **tkwargs)
-                with max_cholesky_size(max_cholesky):
+                # small root decomp to enforce zero padding
+                with max_cholesky_size(max_cholesky), max_root_decomposition_size(3):
                     posterior_f = model.posterior(test_x)
                     self.assertIsInstance(posterior_f, GPyTorchPosterior)
                     self.assertIsInstance(posterior_f.mvn, MultitaskMultivariateNormal)


### PR DESCRIPTION
Resolution of #956 



## Motivation

The following command from the linked issue now works:
```python
from botorch.models.multitask import KroneckerMultiTaskGP
import torch

train_X = torch.rand(801, 2)
train_Y = torch.cat([train_X, train_X**2], dim=-1)
model = KroneckerMultiTaskGP(train_X, train_Y)
model.posterior(torch.tensor([[0.5, 0.5]])).rsample(torch.Size((15,)))
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

unit test

## Related PRs

n/a
