### PR TITLE
Fix flaky test_with_multitask

### DIFF
--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -1448,7 +1448,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             matheron = isinstance(model, (KroneckerMultiTaskGP, HigherOrderGP))
             acqf = get_acqf(model, matheron)
             base_samples = acqf.base_sampler.base_samples
-            posterior = model.posterior(train_x)
+            posterior = model.posterior(acqf.X_baseline)
             base_evals = acqf.base_sampler(posterior)
             self.assertTrue(acqf._is_mt)
             self.assertEqual(acqf._uses_matheron, matheron)
@@ -1492,6 +1492,6 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                 torch.allclose(
                     base_evals.unsqueeze(1).repeat(*repeat_shape),
                     expected,
-                    atol=1e-2,
+                    atol=5e-2,
                 )
             )


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This test was failing on some runs due to i) the `base_samples` changing shape in the test script due to ignoring that `train_x` is pruned within the acqf ii) too small of a tolerance being allowed for numerical inaccuracies. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

`test_with_multitask` was ran with `seed in range(1000)` and passed.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
