### PR TITLE
Implement PosteriorTransform

### DIFF
--- a/botorch/acquisition/__init__.py
+++ b/botorch/acquisition/__init__.py
@@ -50,6 +50,7 @@ from botorch.acquisition.objective import (
     LinearMCObjective,
     MCAcquisitionObjective,
     ScalarizedObjective,
+    ScalarizedPosteriorTransform,
 )
 from botorch.acquisition.proximal import ProximalAcquisitionFunction
 from botorch.acquisition.utils import get_acquisition_function
@@ -88,6 +89,7 @@ __all__ = [
     "MCAcquisitionFunction",
     "MCAcquisitionObjective",
     "ScalarizedObjective",
+    "ScalarizedPosteriorTransform",
     "get_acquisition_function",
     "get_acqf_input_constructor",
 ]

--- a/botorch/acquisition/acquisition.py
+++ b/botorch/acquisition/acquisition.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 
 import warnings
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Callable
 
-from botorch.exceptions import BotorchWarning
+from botorch.exceptions import BotorchWarning, UnsupportedError
 from botorch.models.model import Model
+from botorch.posteriors.posterior import Posterior
 from torch import Tensor
 from torch.nn import Module
 
@@ -31,6 +32,35 @@ class AcquisitionFunction(Module, ABC):
         """
         super().__init__()
         self.add_module("model", model)
+
+    @classmethod
+    def _deprecate_acqf_objective(
+        cls,
+        posterior_transform: Optional[Callable[[Posterior], Posterior]],
+        objective: Optional[Module],
+    ) -> Optional[Callable[[Posterior], Posterior]]:
+        from botorch.acquisition.objective import (
+            ScalarizedObjective,
+            ScalarizedPosteriorTransform,
+        )
+
+        if objective is None:
+            return posterior_transform
+        warnings.warn(
+            f"{cls.__name__} got a non-MC `objective`. The non-MC "
+            "AcquisitionObjectives and the `objective` argument to"
+            "AnalyticAcquisitionFunctions are DEPRECATED and will be removed in the"
+            "next version. Use `posterior_transform` instead.",
+            DeprecationWarning,
+        )
+        if not isinstance(objective, ScalarizedObjective):
+            raise UnsupportedError(
+                f"{cls.__name__} only supports ScalarizedObjective "
+                "(DEPRECATED) type objectives."
+            )
+        return ScalarizedPosteriorTransform(
+            weights=objective.weights, offset=objective.offset
+        )
 
     def set_X_pending(self, X_pending: Optional[Tensor] = None) -> None:
         r"""Informs the acquisition function about pending design points.

--- a/botorch/acquisition/active_learning.py
+++ b/botorch/acquisition/active_learning.py
@@ -27,7 +27,7 @@ from typing import Optional
 
 from botorch import settings
 from botorch.acquisition.analytic import AnalyticAcquisitionFunction
-from botorch.acquisition.objective import ScalarizedObjective
+from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.model import Model
 from botorch.sampling.samplers import MCSampler, SobolQMCNormalSampler
 from botorch.utils.transforms import concatenate_pending_points, t_batch_mode_transform
@@ -51,8 +51,9 @@ class qNegIntegratedPosteriorVariance(AnalyticAcquisitionFunction):
         model: Model,
         mc_points: Tensor,
         sampler: Optional[MCSampler] = None,
-        objective: Optional[ScalarizedObjective] = None,
+        posterior_transform: Optional[PosteriorTransform] = None,
         X_pending: Optional[Tensor] = None,
+        **kwargs,
     ) -> None:
         r"""q-Integrated Negative Posterior Variance.
 
@@ -65,12 +66,12 @@ class qNegIntegratedPosteriorVariance(AnalyticAcquisitionFunction):
             sampler: The sampler used for drawing fantasy samples. In the basic setting
                 of a standard GP (default) this is a dummy, since the variance of the
                 model after conditioning does not actually depend on the sampled values.
-            objective: A ScalarizedObjective. Required for multi-output models.
+            posterior_transform: A PosteriorTransform. Required for multi-output models.
             X_pending: A `n' x d`-dim Tensor of `n'` design points that have
                 points that have been submitted for function evaluation but
                 have not yet been evaluated.
         """
-        super().__init__(model=model, objective=objective)
+        super().__init__(model=model, posterior_transform=posterior_transform, **kwargs)
         if sampler is None:
             # If no sampler is provided, we use the following dummy sampler for the
             # fantasize() method in forward. IMPORTANT: This assumes that the posterior
@@ -107,15 +108,13 @@ class qNegIntegratedPosteriorVariance(AnalyticAcquisitionFunction):
 
         # evaluate the posterior at the grid points
         with settings.propagate_grads(True):
-            posterior = fantasy_model.posterior(mc_points)
-
-        # transform with the scalarized objective
-        if self.objective is not None:
-            posterior = self.objective(posterior)
+            posterior = fantasy_model.posterior(
+                mc_points, posterior_transform=self.posterior_transform
+            )
 
         neg_variance = posterior.variance.mul(-1.0)
 
-        if self.objective is None:
+        if self.posterior_transform is None:
             # if single-output, shape is 1 x batch_shape x num_grid_points x 1
             return neg_variance.mean(dim=-2).squeeze(-1).squeeze(0)
         else:

--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -26,7 +26,11 @@ from typing import Any, Optional, Union
 
 import torch
 from botorch.acquisition.acquisition import AcquisitionFunction
-from botorch.acquisition.objective import IdentityMCObjective, MCAcquisitionObjective
+from botorch.acquisition.objective import (
+    IdentityMCObjective,
+    MCAcquisitionObjective,
+    PosteriorTransform,
+)
 from botorch.acquisition.utils import prune_inferior_points
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.model import Model
@@ -47,6 +51,7 @@ class MCAcquisitionFunction(AcquisitionFunction, ABC):
         model: Model,
         sampler: Optional[MCSampler] = None,
         objective: Optional[MCAcquisitionObjective] = None,
+        posterior_transform: Optional[PosteriorTransform] = None,
         X_pending: Optional[Tensor] = None,
     ) -> None:
         r"""Constructor for the MCAcquisitionFunction base class.
@@ -57,6 +62,7 @@ class MCAcquisitionFunction(AcquisitionFunction, ABC):
                 `SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)`.
             objective: The MCAcquisitionObjective under which the samples are
                 evaluated. Defaults to `IdentityMCObjective()`.
+            posterior_transform: A PosteriorTransform (optional).
             X_pending: A `batch_shape, m x d`-dim Tensor of `m` design points
                 that have points that have been submitted for function evaluation
                 but have not yet been evaluated.
@@ -65,17 +71,20 @@ class MCAcquisitionFunction(AcquisitionFunction, ABC):
         if sampler is None:
             sampler = SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)
         self.add_module("sampler", sampler)
-        if objective is None:
-            if model.num_outputs != 1:
+        if objective is None and model.num_outputs != 1:
+            if posterior_transform is None:
                 raise UnsupportedError(
-                    "Must specify an objective when using a multi-output model."
+                    "Must specify an objective or a posterior transform when using "
+                    "a multi-output model."
                 )
+            elif not posterior_transform.scalarize:
+                raise UnsupportedError(
+                    "If using a multi-output model without an objective, "
+                    "posterior_transform must scalarize the output."
+                )
+        if objective is None:
             objective = IdentityMCObjective()
-        elif not isinstance(objective, MCAcquisitionObjective):
-            raise UnsupportedError(
-                "Only objectives of type MCAcquisitionObjective are supported for "
-                "MC acquisition functions."
-            )
+        self.posterior_transform = posterior_transform
         self.add_module("objective", objective)
         self.set_X_pending(X_pending)
 
@@ -115,6 +124,7 @@ class qExpectedImprovement(MCAcquisitionFunction):
         best_f: Union[float, Tensor],
         sampler: Optional[MCSampler] = None,
         objective: Optional[MCAcquisitionObjective] = None,
+        posterior_transform: Optional[PosteriorTransform] = None,
         X_pending: Optional[Tensor] = None,
         **kwargs: Any,
     ) -> None:
@@ -129,13 +139,18 @@ class qExpectedImprovement(MCAcquisitionFunction):
                 `SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)`
             objective: The MCAcquisitionObjective under which the samples are evaluated.
                 Defaults to `IdentityMCObjective()`.
+            posterior_transform: A PosteriorTransform (optional).
             X_pending:  A `m x d`-dim Tensor of `m` design points that have been
                 submitted for function evaluation but have not yet been evaluated.
                 Concatenated into X upon forward call. Copied and set to have no
                 gradient.
         """
         super().__init__(
-            model=model, sampler=sampler, objective=objective, X_pending=X_pending
+            model=model,
+            sampler=sampler,
+            objective=objective,
+            posterior_transform=posterior_transform,
+            X_pending=X_pending,
         )
         self.register_buffer("best_f", torch.as_tensor(best_f, dtype=float))
 
@@ -153,7 +168,9 @@ class qExpectedImprovement(MCAcquisitionFunction):
             design points `X`, where `batch_shape'` is the broadcasted batch shape of
             model and input `X`.
         """
-        posterior = self.model.posterior(X)
+        posterior = self.model.posterior(
+            X=X, posterior_transform=self.posterior_transform
+        )
         samples = self.sampler(posterior)
         obj = self.objective(samples, X=X)
         obj = (obj - self.best_f.unsqueeze(-1).to(obj)).clamp_min(0)
@@ -185,6 +202,7 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
         X_baseline: Tensor,
         sampler: Optional[MCSampler] = None,
         objective: Optional[MCAcquisitionObjective] = None,
+        posterior_transform: Optional[PosteriorTransform] = None,
         X_pending: Optional[Tensor] = None,
         prune_baseline: bool = False,
         **kwargs: Any,
@@ -200,6 +218,7 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
                 `SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)`.
             objective: The MCAcquisitionObjective under which the samples are
                 evaluated. Defaults to `IdentityMCObjective()`.
+            posterior_transform: A PosteriorTransform (optional).
             X_pending: A `batch_shape x m x d`-dim Tensor of `m` design points
                 that have points that have been submitted for function evaluation
                 but have not yet been evaluated. Concatenated into `X` upon
@@ -212,13 +231,18 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
                 before instantiating the acquisition function.
         """
         super().__init__(
-            model=model, sampler=sampler, objective=objective, X_pending=X_pending
+            model=model,
+            sampler=sampler,
+            objective=objective,
+            posterior_transform=posterior_transform,
+            X_pending=X_pending,
         )
         if prune_baseline:
             X_baseline = prune_inferior_points(
                 model=model,
                 X=X_baseline,
                 objective=objective,
+                posterior_transform=posterior_transform,
                 marginalize_dim=kwargs.get("marginalize_dim"),
             )
         self.register_buffer("X_baseline", X_baseline)
@@ -241,7 +265,9 @@ class qNoisyExpectedImprovement(MCAcquisitionFunction):
         X_full = torch.cat([X, match_batch_shape(self.X_baseline, X)], dim=-2)
         # TODO: Implement more efficient way to compute posterior over both training and
         # test points in GPyTorch (https://github.com/cornellius-gp/gpytorch/issues/567)
-        posterior = self.model.posterior(X_full)
+        posterior = self.model.posterior(
+            X=X_full, posterior_transform=self.posterior_transform
+        )
         samples = self.sampler(posterior)
         obj = self.objective(samples, X=X_full)
         diffs = obj[..., :q].max(dim=-1).values - obj[..., q:].max(dim=-1).values
@@ -273,6 +299,7 @@ class qProbabilityOfImprovement(MCAcquisitionFunction):
         best_f: Union[float, Tensor],
         sampler: Optional[MCSampler] = None,
         objective: Optional[MCAcquisitionObjective] = None,
+        posterior_transform: Optional[PosteriorTransform] = None,
         X_pending: Optional[Tensor] = None,
         tau: float = 1e-3,
     ) -> None:
@@ -287,6 +314,7 @@ class qProbabilityOfImprovement(MCAcquisitionFunction):
                 `SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)`
             objective: The MCAcquisitionObjective under which the samples are
                 evaluated. Defaults to `IdentityMCObjective()`.
+            posterior_transform: A PosteriorTransform (optional).
             X_pending:  A `m x d`-dim Tensor of `m` design points that have
                 points that have been submitted for function evaluation
                 but have not yet been evaluated.  Concatenated into X upon
@@ -297,7 +325,11 @@ class qProbabilityOfImprovement(MCAcquisitionFunction):
                 estimates with higher variance.
         """
         super().__init__(
-            model=model, sampler=sampler, objective=objective, X_pending=X_pending
+            model=model,
+            sampler=sampler,
+            objective=objective,
+            posterior_transform=posterior_transform,
+            X_pending=X_pending,
         )
         self.register_buffer("best_f", torch.as_tensor(best_f, dtype=float))
         self.register_buffer("tau", torch.as_tensor(tau, dtype=float))
@@ -316,7 +348,9 @@ class qProbabilityOfImprovement(MCAcquisitionFunction):
             given design points `X`, where `batch_shape'` is the broadcasted batch shape
             of model and input `X`.
         """
-        posterior = self.model.posterior(X)
+        posterior = self.model.posterior(
+            X=X, posterior_transform=self.posterior_transform
+        )
         samples = self.sampler(posterior)
         obj = self.objective(samples, X=X)
         max_obj = obj.max(dim=-1)[0]
@@ -353,7 +387,9 @@ class qSimpleRegret(MCAcquisitionFunction):
             points `X`, where `batch_shape'` is the broadcasted batch shape of model
             and input `X`.
         """
-        posterior = self.model.posterior(X)
+        posterior = self.model.posterior(
+            X=X, posterior_transform=self.posterior_transform
+        )
         samples = self.sampler(posterior)
         obj = self.objective(samples, X=X)
         val = obj.max(dim=-1)[0].mean(dim=0)
@@ -382,6 +418,7 @@ class qUpperConfidenceBound(MCAcquisitionFunction):
         beta: float,
         sampler: Optional[MCSampler] = None,
         objective: Optional[MCAcquisitionObjective] = None,
+        posterior_transform: Optional[PosteriorTransform] = None,
         X_pending: Optional[Tensor] = None,
     ) -> None:
         r"""q-Upper Confidence Bound.
@@ -393,13 +430,18 @@ class qUpperConfidenceBound(MCAcquisitionFunction):
                 `SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)`
             objective: The MCAcquisitionObjective under which the samples are
                 evaluated. Defaults to `IdentityMCObjective()`.
+            posterior_transform: A PosteriorTransform (optional).
             X_pending: A `batch_shape x m x d`-dim Tensor of `m` design points that have
                 points that have been submitted for function evaluation but have not yet
                 been evaluated. Concatenated into X upon forward call. Copied and set to
                 have no gradient.
         """
         super().__init__(
-            model=model, sampler=sampler, objective=objective, X_pending=X_pending
+            model=model,
+            sampler=sampler,
+            objective=objective,
+            posterior_transform=posterior_transform,
+            X_pending=X_pending,
         )
         self.beta_prime = math.sqrt(beta * math.pi / 2)
 
@@ -417,7 +459,9 @@ class qUpperConfidenceBound(MCAcquisitionFunction):
             design points `X`, where `batch_shape'` is the broadcasted batch shape of
             model and input `X`.
         """
-        posterior = self.model.posterior(X)
+        posterior = self.model.posterior(
+            X=X, posterior_transform=self.posterior_transform
+        )
         samples = self.sampler(posterior)
         obj = self.objective(samples, X=X)
         mean = obj.mean(dim=0)

--- a/botorch/acquisition/multi_objective/objective.py
+++ b/botorch/acquisition/multi_objective/objective.py
@@ -10,7 +10,11 @@ from abc import abstractmethod
 from typing import List, Optional
 
 import torch
-from botorch.acquisition.objective import AcquisitionObjective, GenericMCObjective
+from botorch.acquisition.objective import (
+    AcquisitionObjective,
+    GenericMCObjective,
+    MCAcquisitionObjective,
+)
 from botorch.exceptions.errors import BotorchError, BotorchTensorDimensionError
 from botorch.models.transforms.outcome import Standardize
 from botorch.posteriors import GPyTorchPosterior
@@ -18,7 +22,7 @@ from botorch.utils.transforms import normalize_indices
 from torch import Tensor
 
 
-class MCMultiOutputObjective(AcquisitionObjective):
+class MCMultiOutputObjective(MCAcquisitionObjective):
     r"""Abstract base class for MC multi-output objectives."""
 
     @abstractmethod
@@ -184,6 +188,7 @@ class UnstandardizeMCMultiOutputObjective(IdentityMCMultiOutputObjective):
 
 class AnalyticMultiOutputObjective(AcquisitionObjective):
     r"""Abstract base class for multi-output analyic objectives."""
+    # TODO: Refactor these as PosteriorTransform as well.
 
     @abstractmethod
     def forward(self, posterior: GPyTorchPosterior) -> GPyTorchPosterior:

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -17,19 +17,52 @@ from typing import Callable, List, Optional
 
 import torch
 from botorch.posteriors.gpytorch import GPyTorchPosterior, scalarize_posterior
+from botorch.posteriors.posterior import Posterior
 from botorch.utils import apply_constraints
 from torch import Tensor
 from torch.nn import Module
 
 
 class AcquisitionObjective(Module, ABC):
-    r"""Abstract base class for objectives."""
+    r"""Abstract base class for objectives.
 
+    DEPRECATED - This will be removed in the next version.
+    """
     ...
 
 
-class ScalarizedObjective(AcquisitionObjective):
-    r"""Affine objective to be used with analytic acquisition functions.
+class PosteriorTransform(Module, ABC):
+    r"""Abstract base class for objectives that transform the posterior."""
+
+    scalarize: bool  # True if the transform reduces to single-output
+
+    @abstractmethod
+    def evaluate(self, Y: Tensor) -> Tensor:
+        r"""Evaluate the transform on a set of outcomes.
+
+        Args:
+            Y: A `batch_shape x q x m`-dim tensor of outcomes.
+
+        Returns:
+            A `batch_shape x q' [x m']`-dim tensor of transformed outcomes.
+        """
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def forward(self, posterior: Posterior) -> Posterior:
+        r"""Compute the transformed posterior.
+
+        Args:
+            posterior: The posterior to be transformed.
+
+        Returns:
+            The transformed posterior object.
+        """
+        pass  # pragma: no cover
+
+
+class ScalarizedPosteriorTransform(PosteriorTransform):
+    r"""An affine posterior transform for scalarizing multi-output posteriors.
 
     For a Gaussian posterior at a single point (`q=1`) with mean `mu` and
     covariance matrix `Sigma`, this yields a single-output posterior with mean
@@ -39,12 +72,16 @@ class ScalarizedObjective(AcquisitionObjective):
         Example for a model with two outcomes:
 
         >>> weights = torch.tensor([0.5, 0.25])
-        >>> objective = ScalarizedObjective(weights)
-        >>> EI = ExpectedImprovement(model, best_f=0.1, objective=objective)
+        >>> posterior_transform = ScalarizedPosteriorTransform(weights)
+        >>> EI = ExpectedImprovement(
+        ... model, best_f=0.1, posterior_transform=posterior_transform
+        ... )
     """
 
+    scalarize: bool = True
+
     def __init__(self, weights: Tensor, offset: float = 0.0) -> None:
-        r"""Affine objective.
+        r"""Affine posterior transform.
 
         Args:
             weights: A one-dimensional tensor with `m` elements representing the
@@ -58,13 +95,13 @@ class ScalarizedObjective(AcquisitionObjective):
         self.offset = offset
 
     def evaluate(self, Y: Tensor) -> Tensor:
-        r"""Evaluate the objective on a set of outcomes.
+        r"""Evaluate the transform on a set of outcomes.
 
         Args:
             Y: A `batch_shape x q x m`-dim tensor of outcomes.
 
         Returns:
-            A `batch_shape x q`-dim tensor of objective values.
+            A `batch_shape x q`-dim tensor of transformed outcomes.
         """
         return self.offset + Y @ self.weights
 
@@ -83,7 +120,18 @@ class ScalarizedObjective(AcquisitionObjective):
         )
 
 
-class MCAcquisitionObjective(AcquisitionObjective):
+class ScalarizedObjective(ScalarizedPosteriorTransform, AcquisitionObjective):
+    """DEPRECATED - Use ScalarizedPosteriorTransform instead."""
+
+    def __init__(self, weights: Tensor, offset: float = 0.0) -> None:
+        warnings.warn(
+            "ScalarizedObjective is deprecated and will be removed in the next "
+            "version. Use ScalarizedPosteriorTransform instead."
+        )
+        super().__init__(weights=weights, offset=offset)
+
+
+class MCAcquisitionObjective(Module, ABC):
     r"""Abstract base class for MC-based objectives."""
 
     @abstractmethod

--- a/botorch/generation/sampling.py
+++ b/botorch/generation/sampling.py
@@ -22,9 +22,10 @@ from typing import Any, Optional
 import torch
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.objective import (
-    AcquisitionObjective,
+    MCAcquisitionObjective,
     IdentityMCObjective,
-    ScalarizedObjective,
+    PosteriorTransform,
+    ScalarizedPosteriorTransform,
 )
 from botorch.generation.utils import _flip_sub_unique
 from botorch.models.model import Model
@@ -67,23 +68,38 @@ class MaxPosteriorSampling(SamplingStrategy):
     def __init__(
         self,
         model: Model,
-        objective: Optional[AcquisitionObjective] = None,
+        objective: Optional[MCAcquisitionObjective] = None,
+        posterior_transform: Optional[PosteriorTransform] = None,
         replacement: bool = True,
     ) -> None:
         r"""Constructor for the SamplingStrategy base class.
 
         Args:
             model: A fitted model.
-            objective: The objective. Typically, the AcquisitionObjective under which
-                the samples are evaluated. If a ScalarizedObjective, samples from the
-                scalarized posterior are used. Defaults to `IdentityMCObjective()`.
+            objective: The MCAcquisitionObjective under which the samples are
+                evaluated. Defaults to `IdentityMCObjective()`.
+            posterior_transform: An optional PosteriorTransform.
             replacement: If True, sample with replacement.
         """
         super().__init__()
         self.model = model
         if objective is None:
             objective = IdentityMCObjective()
+        elif not isinstance(objective, MCAcquisitionObjective):
+            # TODO: Clean up once ScalarizedObjective is removed.
+            if posterior_transform is not None:
+                raise RuntimeError(
+                    "A ScalarizedObjective (DEPRECATED) and a posterior transform "
+                    "are not supported at the same time. Use only a posterior "
+                    "transform instead."
+                )
+            else:
+                posterior_transform = ScalarizedPosteriorTransform(
+                    weights=objective.weights, offset=objective.offset
+                )
+                objective = IdentityMCObjective()
         self.objective = objective
+        self.posterior_transform = posterior_transform
         self.replacement = replacement
 
     def forward(
@@ -101,16 +117,15 @@ class MaxPosteriorSampling(SamplingStrategy):
             A `batch_shape x num_samples x d`-dim Tensor of samples from `X`, where
             `X[..., i, :]` is the `i`-th sample.
         """
-        posterior = self.model.posterior(X, observation_noise=observation_noise)
-        if isinstance(self.objective, ScalarizedObjective):
-            posterior = self.objective(posterior)
+        posterior = self.model.posterior(
+            X,
+            observation_noise=observation_noise,
+            posterior_transform=self.posterior_transform,
+        )
 
         # num_samples x batch_shape x N x m
         samples = posterior.rsample(sample_shape=torch.Size([num_samples]))
-        if isinstance(self.objective, ScalarizedObjective):
-            obj = samples.squeeze(-1)  # num_samples x batch_shape x N
-        else:
-            obj = self.objective(samples, X=X)  # num_samples x batch_shape x N
+        obj = self.objective(samples, X=X)  # num_samples x batch_shape x N
         if self.replacement:
             # if we allow replacement then things are simple(r)
             idcs = torch.argmax(obj, dim=-1)

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -19,6 +19,7 @@ from contextlib import ExitStack
 from typing import Any, List, Optional, Tuple, Union
 
 import torch
+from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform, Standardize
@@ -406,9 +407,16 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         X: Tensor,
         output_indices: Optional[List[int]] = None,
         observation_noise: Union[bool, Tensor] = False,
+        posterior_transform: Optional[PosteriorTransform] = None,
         **kwargs: Any,
     ) -> GPyTorchPosterior:
         self.eval()  # make sure we're calling a posterior
+
+        if posterior_transform is not None:
+            raise NotImplementedError(
+                "Posteriror transform currently not supported for HOGP"
+            )
+
         # input transforms are applied at `posterior` in `eval` mode, and at
         # `model.forward()` at the training time
         X = self.transform_inputs(X)
@@ -499,7 +507,6 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
             )
             if hasattr(self, "outcome_transform"):
                 posterior = self.outcome_transform.untransform_posterior(posterior)
-
             return posterior
 
     def make_posterior_variances(self, joint_covariance_matrix: LazyTensor) -> Tensor:

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -14,7 +14,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Callable
 
 import numpy as np
 import torch
@@ -48,6 +48,7 @@ class Model(Module, ABC):
         X: Tensor,
         output_indices: Optional[List[int]] = None,
         observation_noise: bool = False,
+        posterior_transform: Optional[Callable[[Posterior], Posterior]] = None,
         **kwargs: Any,
     ) -> Posterior:
         r"""Computes the posterior over model outputs at the provided points.
@@ -66,6 +67,7 @@ class Model(Module, ABC):
                 model's outputs are required for optimization. If omitted,
                 computes the posterior over all model outputs.
             observation_noise: If True, add observation noise to the posterior.
+            posterior_transform: An optional PosteriorTransform.
 
         Returns:
             A `Posterior` object, representing a batch of `b` joint distributions

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -25,6 +25,7 @@ import math
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
+from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.gp_regression import MIN_INFERRED_NOISE_LEVEL
 from botorch.models.gpytorch import GPyTorchModel, MultiTaskGPyTorchModel
 from botorch.models.transforms.input import InputTransform
@@ -554,6 +555,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
         X: Tensor,
         output_indices: Optional[List[int]] = None,
         observation_noise: Union[bool, Tensor] = False,
+        posterior_transform: Optional[PosteriorTransform] = None,
         **kwargs: Any,
     ) -> MultitaskGPPosterior:
         self.eval()
@@ -743,8 +745,10 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
 
         if hasattr(self, "outcome_transform"):
             posterior = self.outcome_transform.untransform_posterior(posterior)
-
-        return posterior
+        if posterior_transform is not None:
+            return posterior_transform(posterior)
+        else:
+            return posterior
 
     def train(self, val=True, *args, **kwargs):
         if val:

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -394,7 +394,8 @@ def gen_value_function_initial_conditions(
     # compute maximizer of the current value function
     value_function = _get_value_function(
         model=current_model,
-        objective=acq_function.objective,
+        objective=getattr(acq_function, "objective", None),
+        posterior_transform=acq_function.posterior_transform,
         sampler=getattr(acq_function, "sampler", None),
         project=getattr(acq_function, "project", None),
     )

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -14,6 +14,7 @@ from unittest import TestCase
 
 import torch
 from botorch import settings
+from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.model import Model
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.posterior import Posterior
@@ -160,9 +161,13 @@ class MockModel(Model):
         self,
         X: Tensor,
         output_indices: Optional[List[int]] = None,
+        posterior_transform: Optional[PosteriorTransform] = None,
         observation_noise: bool = False,
     ) -> MockPosterior:
-        return self._posterior
+        if posterior_transform is not None:
+            return posterior_transform(self._posterior)
+        else:
+            return self._posterior
 
     @property
     def num_outputs(self) -> int:

--- a/test/acquisition/test_objective.py
+++ b/test/acquisition/test_objective.py
@@ -15,7 +15,8 @@ from botorch.acquisition.objective import (
     IdentityMCObjective,
     LinearMCObjective,
     MCAcquisitionObjective,
-    ScalarizedObjective,
+    PosteriorTransform,
+    ScalarizedPosteriorTransform,
 )
 from botorch.utils import apply_constraints
 from botorch.utils.testing import _get_test_posterior, BotorchTestCase
@@ -40,14 +41,20 @@ def feasible_con(samples: Tensor) -> Tensor:
     )
 
 
-class TestScalarizedObjective(BotorchTestCase):
-    def test_affine_acquisition_objective(self):
+class TestPosteriorTransform(BotorchTestCase):
+    def test_abstract_raises(self):
+        with self.assertRaises(TypeError):
+            PosteriorTransform()
+
+
+class TestScalarizedPosteriorTransform(BotorchTestCase):
+    def test_scalarized_posterior_transform(self):
         for batch_shape, m, dtype in itertools.product(
             ([], [3]), (1, 2), (torch.float, torch.double)
         ):
             offset = torch.rand(1).item()
             weights = torch.randn(m, device=self.device, dtype=dtype)
-            obj = ScalarizedObjective(weights=weights, offset=offset)
+            obj = ScalarizedPosteriorTransform(weights=weights, offset=offset)
             posterior = _get_test_posterior(
                 batch_shape, m=m, device=self.device, dtype=dtype
             )
@@ -64,7 +71,7 @@ class TestScalarizedObjective(BotorchTestCase):
             )
             # test error
             with self.assertRaises(ValueError):
-                ScalarizedObjective(weights=torch.rand(2, m))
+                ScalarizedPosteriorTransform(weights=torch.rand(2, m))
             # test evaluate
             Y = torch.rand(2, m, device=self.device, dtype=dtype)
             val = obj.evaluate(Y)

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -16,7 +16,11 @@ from botorch.acquisition.multi_objective import (
     MCMultiOutputObjective,
     monte_carlo as moo_monte_carlo,
 )
-from botorch.acquisition.objective import GenericMCObjective, MCAcquisitionObjective
+from botorch.acquisition.objective import (
+    GenericMCObjective,
+    MCAcquisitionObjective,
+    ScalarizedPosteriorTransform,
+)
 from botorch.acquisition.utils import (
     expand_trace_observations,
     get_acquisition_function,
@@ -80,6 +84,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
             best_f=best_f,
             sampler=mock.ANY,
             objective=self.objective,
+            posterior_transform=None,
             X_pending=self.X_pending,
         )
         # test batched model
@@ -123,6 +128,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
             best_f=best_f,
             sampler=mock.ANY,
             objective=self.objective,
+            posterior_transform=None,
             X_pending=self.X_pending,
             tau=1e-3,
         )
@@ -241,6 +247,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
             model=self.model,
             sampler=mock.ANY,
             objective=self.objective,
+            posterior_transform=None,
             X_pending=self.X_pending,
         )
         args, kwargs = mock_acqf.call_args
@@ -299,6 +306,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
             beta=0.3,
             sampler=mock.ANY,
             objective=self.objective,
+            posterior_transform=None,
             X_pending=self.X_pending,
         )
         args, kwargs = mock_acqf.call_args
@@ -350,6 +358,19 @@ class TestGetAcquisitionFunction(BotorchTestCase):
                 acquisition_function_name="qEHVI",
                 model=self.model,
                 objective=self.mo_objective,
+                X_observed=self.X_observed,
+                X_pending=self.X_pending,
+                mc_samples=self.mc_samples,
+                seed=self.seed,
+                ref_point=self.ref_point,
+            )
+        # posterior transforms are not supported
+        with self.assertRaises(NotImplementedError):
+            acqf = get_acquisition_function(
+                acquisition_function_name="qEHVI",
+                model=self.model,
+                objective=self.mo_objective,
+                posterior_transform=ScalarizedPosteriorTransform(weights=torch.rand(2)),
                 X_observed=self.X_observed,
                 X_pending=self.X_pending,
                 mc_samples=self.mc_samples,

--- a/test/models/test_deterministic.py
+++ b/test/models/test_deterministic.py
@@ -7,6 +7,7 @@
 import warnings
 
 import torch
+from botorch.acquisition.objective import ScalarizedPosteriorTransform
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.deterministic import (
     AffineDeterministicModel,
@@ -119,3 +120,14 @@ class TestDeterministicModels(BotorchTestCase):
         model.train()
         with self.assertWarns(RuntimeWarning):
             model.eval()
+
+    def test_posterior_transform(self):
+        def f(X):
+            return X
+
+        model = GenericDeterministicModel(f)
+        test_X = torch.rand(3, 2)
+        post_tf = ScalarizedPosteriorTransform(weights=torch.rand(2))
+        # expect error due to post_tf expecting an MVN
+        with self.assertRaises(AttributeError):
+            model.posterior(test_X, posterior_transform=post_tf)

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -9,6 +9,7 @@ import warnings
 
 import torch
 from botorch import fit_gpytorch_model, settings
+from botorch.acquisition.objective import ScalarizedPosteriorTransform
 from botorch.exceptions import (
     BotorchTensorDimensionError,
     BotorchTensorDimensionWarning,
@@ -262,6 +263,15 @@ class TestGPyTorchModel(BotorchTestCase):
                 )
             )
 
+    def test_posterior_transform(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        train_X = torch.rand(5, 1, **tkwargs)
+        train_Y = torch.sin(train_X)
+        model = SimpleGPyTorchModel(train_X, train_Y)
+        post_tf = ScalarizedPosteriorTransform(weights=torch.zeros(1, **tkwargs))
+        post = model.posterior(torch.rand(3, 1, **tkwargs), posterior_transform=post_tf)
+        self.assertTrue(torch.equal(post.mean, torch.zeros(3, 1, **tkwargs)))
+
 
 class TestBatchedMultiOutputGPyTorchModel(BotorchTestCase):
     def test_batched_multi_output_gpytorch_model(self):
@@ -333,6 +343,15 @@ class TestBatchedMultiOutputGPyTorchModel(BotorchTestCase):
                         if num_outputs == 1
                         else expected_input_batch_shape + torch.Size([2]),
                     )
+
+    def test_posterior_transform(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        train_X = torch.rand(5, 2, **tkwargs)
+        train_Y = torch.sin(train_X)
+        model = SimpleBatchedMultiOutputGPyTorchModel(train_X, train_Y)
+        post_tf = ScalarizedPosteriorTransform(weights=torch.zeros(2, **tkwargs))
+        post = model.posterior(torch.rand(3, 2, **tkwargs), posterior_transform=post_tf)
+        self.assertTrue(torch.equal(post.mean, torch.zeros(3, 1, **tkwargs)))
 
 
 class TestModelListGPyTorchModel(BotorchTestCase):
@@ -471,3 +490,19 @@ class TestModelListGPyTorchModel(BotorchTestCase):
                         torch.cat([expected_train, expected_test], dim=0),
                     )
                 )
+
+    def test_posterior_transform(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        train_X1, train_X2 = (
+            torch.rand(5, 1, **tkwargs),
+            torch.rand(5, 1, **tkwargs),
+        )
+        train_Y1 = torch.sin(train_X1)
+        train_Y2 = torch.cos(train_X2)
+        # test different batch shapes
+        m1 = SimpleGPyTorchModel(train_X1, train_Y1)
+        m2 = SimpleGPyTorchModel(train_X2, train_Y2)
+        model = SimpleModelListGPyTorchModel(m1, m2)
+        post_tf = ScalarizedPosteriorTransform(torch.ones(2, **tkwargs))
+        post = model.posterior(torch.rand(3, 1, **tkwargs), posterior_transform=post_tf)
+        self.assertEqual(post.mean.shape, torch.Size([3, 1]))

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -9,6 +9,7 @@ import math
 import warnings
 
 import torch
+from botorch.acquisition.objective import ScalarizedPosteriorTransform
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.fit import fit_gpytorch_model
 from botorch.models.multitask import (
@@ -318,6 +319,11 @@ class TestMultiTaskGP(BotorchTestCase):
             posterior_f = model.posterior(test_x)
             self.assertIsInstance(posterior_f, GPyTorchPosterior)
             self.assertIsInstance(posterior_f.mvn, MultivariateNormal)
+
+            # test posterior transform
+            post_tf = ScalarizedPosteriorTransform(weights=torch.ones(1, **tkwargs))
+            posterior_f_tf = model.posterior(test_x, posterior_transform=post_tf)
+            self.assertTrue(torch.equal(posterior_f.mean, posterior_f_tf.mean))
 
     def test_MultiTaskGP_fixed_prior(self):
         for dtype in (torch.float, torch.double):
@@ -675,6 +681,19 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
                 )
             self.assertEqual(posterior_f.mean.shape, torch.Size([3, 2, 2]))
             self.assertEqual(posterior_f.variance.shape, torch.Size([3, 2, 2]))
+
+            # test posterior_tf
+            if not use_octf:
+                # Note that if a `Standardize` outcome transform is used this
+                # (currently) returns a `TransformedPosterior` which is incompatible
+                # with PosteriorTransform
+                post_tf = ScalarizedPosteriorTransform(weights=torch.ones(2, **tkwargs))
+                posterior_f_tf = model.posterior(test_x, posterior_transform=post_tf)
+                self.assertTrue(
+                    torch.equal(
+                        posterior_f.mean.sum(dim=-1, keepdim=True), posterior_f_tf.mean
+                    )
+                )
 
     def test_KroneckerMultiTaskGP_custom(self):
         for batch_shape, dtype in itertools.product(

--- a/test/models/test_pairwise_gp.py
+++ b/test/models/test_pairwise_gp.py
@@ -9,6 +9,7 @@ import warnings
 
 import torch
 from botorch import fit_gpytorch_model
+from botorch.acquisition.objective import ScalarizedPosteriorTransform
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.models.pairwise_gp import PairwiseGP, PairwiseLaplaceMarginalLogLikelihood
 from botorch.models.transforms.input import Normalize
@@ -129,6 +130,11 @@ class TestPairwiseGP(BotorchTestCase):
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertEqual(posterior.mean.shape, expected_shape)
             self.assertEqual(posterior.variance.shape, expected_shape)
+
+            # test posterior transform
+            post_tf = ScalarizedPosteriorTransform(weights=torch.ones(1))
+            posterior_tf = model.posterior(X, posterior_transform=post_tf)
+            self.assertTrue(torch.equal(posterior.mean, posterior_tf.mean))
 
             # expect to raise error when output_indices is not None
             with self.assertRaises(RuntimeError):

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -630,10 +630,10 @@ class TestSampleAroundBest(BotorchTestCase):
             self.assertTrue((X_rnd >= 1).all())
             self.assertTrue((X_rnd <= 2).all())
 
-            # test an acquisition function that has objective=None
+            # test an acquisition function that has no posterior_transform
             # and maximize=False
             pm = PosteriorMean(model, maximize=False)
-            self.assertIsNone(pm.objective)
+            self.assertIsNone(pm.posterior_transform)
             self.assertFalse(pm.maximize)
             X_rnd = sample_points_around_best(
                 acq_function=pm,


### PR DESCRIPTION
Summary:
Implements PosteriorTransform for analytic transforms on the posteriors. This replaces the existing analytic objectives, e.g., `ScalarizedObjective`, and adds support for use of other analytic posterior transforms within the MC acquisition functions, such as an expectation over the `q` batch.

Pull Request resolved: https://github.com/pytorch/botorch/pull/890

Test Plan:
Unit tests

(ax test failures fixed in stacked diffs)

Differential Revision: D30003828

Pulled By: Balandat

