### PR TITLE
Avoid costly application of posterior transform im Kronecker&HOGP models

### DIFF
--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -413,8 +413,10 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         self.eval()  # make sure we're calling a posterior
 
         if posterior_transform is not None:
+            # this could be very costly, disallow for now
             raise NotImplementedError(
-                "Posteriror transform currently not supported for HOGP"
+                "Posterior transforms currently not supported for "
+                f"{self.__class__.__name__}"
             )
 
         # input transforms are applied at `posterior` in `eval` mode, and at

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -560,6 +560,13 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
     ) -> MultitaskGPPosterior:
         self.eval()
 
+        if posterior_transform is not None:
+            # this could be very costly, disallow for now
+            raise NotImplementedError(
+                "Posterior transforms currently not supported for "
+                f"{self.__class__.__name__}"
+            )
+
         X = self.transform_inputs(X)
         train_x = self.transform_inputs(self.train_inputs[0])
 
@@ -745,10 +752,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
 
         if hasattr(self, "outcome_transform"):
             posterior = self.outcome_transform.untransform_posterior(posterior)
-        if posterior_transform is not None:
-            return posterior_transform(posterior)
-        else:
-            return posterior
+        return posterior
 
     def train(self, val=True, *args, **kwargs):
         if val:

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -682,18 +682,10 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
             self.assertEqual(posterior_f.mean.shape, torch.Size([3, 2, 2]))
             self.assertEqual(posterior_f.variance.shape, torch.Size([3, 2, 2]))
 
-            # test posterior_tf
-            if not use_octf:
-                # Note that if a `Standardize` outcome transform is used this
-                # (currently) returns a `TransformedPosterior` which is incompatible
-                # with PosteriorTransform
-                post_tf = ScalarizedPosteriorTransform(weights=torch.ones(2, **tkwargs))
-                posterior_f_tf = model.posterior(test_x, posterior_transform=post_tf)
-                self.assertTrue(
-                    torch.equal(
-                        posterior_f.mean.sum(dim=-1, keepdim=True), posterior_f_tf.mean
-                    )
-                )
+            # test that using a posterior transform throws error
+            post_tf = ScalarizedPosteriorTransform(weights=torch.ones(2, **tkwargs))
+            with self.assertRaises(NotImplementedError):
+                model.posterior(test_x, posterior_transform=post_tf)
 
     def test_KroneckerMultiTaskGP_custom(self):
         for batch_shape, dtype in itertools.product(


### PR DESCRIPTION
As suggested in https://github.com/pytorch/botorch/pull/890#discussion_r802771369