### PR TITLE
Remove windows os from min req tests

### DIFF
--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: [3.7, 3.9]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This caused issue with unix shell specific commands. We don't need to test this on windows, so we can just remove this.