### PR TITLE
Use BOTORCH_MODULAR in tutorials with Ax

### DIFF
--- a/tutorials/custom_acquisition.ipynb
+++ b/tutorials/custom_acquisition.ipynb
@@ -1,390 +1,2269 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    "## Writing a custom acquisition function and interfacing with Ax\n",
-    "\n",
-    "As seen in the [custom BoTorch model in Ax](./custom_botorch_model_in_ax) tutorial, Ax's `BotorchModel` is flexible in allowing different components of the Bayesian optimization loop to be specified through a functional API. This tutorial walks through the steps of writing a custom acquisition function and then inserting it into Ax. \n",
-    "\n",
-    "\n",
-    "### Upper Confidence Bound (UCB)\n",
-    "\n",
-    "The Upper Confidence Bound (UCB) acquisition function balances exploration and exploitation by assigning a score of $\\mu + \\sqrt{\\beta} \\cdot \\sigma$ if the posterior distribution is normal with mean $\\mu$ and variance $\\sigma^2$. This \"analytic\" version is implemented in the `UpperConfidenceBound` class. The Monte Carlo version of UCB is implemented in the `qUpperConfidenceBound` class, which also allows for q-batches of size greater than one. (The derivation of q-UCB is given in Appendix A of [Wilson et. al., 2017](https://arxiv.org/pdf/1712.00424.pdf))."
-   ]
+  "metadata": {
+    "kernelspec": {
+      "display_name": "python3",
+      "language": "python",
+      "name": "python3",
+      "metadata": {
+        "kernel_name": "bento_kernel_ae",
+        "nightly_builds": false,
+        "fbpkg_supported": true,
+        "is_prebuilt": true
+      }
+    },
+    "last_server_session_id": "2baef851-0b83-461d-a13a-55031180a4e3",
+    "last_kernel_id": "c639787b-ec07-49bc-b91b-8fe06aa9b0d0",
+    "last_base_url": "https://10601.od.fbinfra.net:443/",
+    "last_msg_id": "68579f90-eb9b7aec3051a3df474af652_278",
+    "outputWidgetContext": {}
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    "### A scalarized version of q-UCB\n",
-    "\n",
-    "Suppose now that we are in a multi-output setting, where, e.g., we model the effects of a design on multiple metrics. We first show a simple extension of the q-UCB acquisition function that accepts a multi-output model and performs q-UCB on a scalarized version of the multiple outputs, achieved via a vector of weights. Implementing a new acquisition function in botorch is easy; one simply needs to implement the constructor and a `forward` method."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import math\n",
-    "\n",
-    "from torch import Tensor\n",
-    "from typing import Optional\n",
-    "\n",
-    "from botorch.acquisition import MCAcquisitionObjective\n",
-    "from botorch.acquisition.acquisition import AcquisitionFunction\n",
-    "from botorch.acquisition.monte_carlo import MCAcquisitionFunction\n",
-    "from botorch.models.model import Model\n",
-    "from botorch.sampling.samplers import MCSampler, SobolQMCNormalSampler\n",
-    "from botorch.utils import t_batch_mode_transform\n",
-    "\n",
-    "\n",
-    "class qScalarizedUpperConfidenceBound(MCAcquisitionFunction):\n",
-    "    def __init__(\n",
-    "        self,\n",
-    "        model: Model,\n",
-    "        beta: Tensor,\n",
-    "        weights: Tensor,\n",
-    "        sampler: Optional[MCSampler] = None,\n",
-    "    ) -> None:\n",
-    "        # we use the AcquisitionFunction constructor, since that of \n",
-    "        # MCAcquisitionFunction performs some validity checks that we don't want here\n",
-    "        super(MCAcquisitionFunction, self).__init__(model=model)\n",
-    "        if sampler is None:\n",
-    "            sampler = SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)\n",
-    "        self.sampler = sampler\n",
-    "        self.register_buffer(\"beta\", torch.as_tensor(beta))\n",
-    "        self.register_buffer(\"weights\", torch.as_tensor(weights))\n",
-    "\n",
-    "    @t_batch_mode_transform()\n",
-    "    def forward(self, X: Tensor) -> Tensor:\n",
-    "        \"\"\"Evaluate scalarized qUCB on the candidate set `X`.\n",
-    "\n",
-    "        Args:\n",
-    "            X: A `(b) x q x d`-dim Tensor of `(b)` t-batches with `q` `d`-dim\n",
-    "                design points each.\n",
-    "\n",
-    "        Returns:\n",
-    "            Tensor: A `(b)`-dim Tensor of Upper Confidence Bound values at the\n",
-    "                given design points `X`.\n",
-    "        \"\"\"\n",
-    "        posterior = self.model.posterior(X)\n",
-    "        samples = self.sampler(posterior)  # n x b x q x o\n",
-    "        scalarized_samples = samples.matmul(self.weights)  # n x b x q\n",
-    "        mean = posterior.mean  # b x q x o\n",
-    "        scalarized_mean = mean.matmul(self.weights)  # b x q\n",
-    "        ucb_samples = (\n",
-    "            scalarized_mean\n",
-    "            + math.sqrt(self.beta * math.pi / 2)\n",
-    "            * (scalarized_samples - scalarized_mean).abs()\n",
-    "        )\n",
-    "        return ucb_samples.max(dim=-1)[0].mean(dim=0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that `qScalarizedUpperConfidenceBound` is very similar to `qUpperConfidenceBound` and only requires a few lines of new code to accomodate scalarization of multiple outputs. The `@t_batch_mode_transform` decorator ensures that the input `X` has an explicit t-batch dimension (code comments are added with shapes for clarity)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Ad-hoc testing q-Scalarized-UCB\n",
-    "\n",
-    "Before hooking the newly defined acquisition function into a Bayesian Optimization loop, we should test it. For this we'll just make sure that it properly evaluates on a compatible multi-output model. Here we just define a basic multi-output `SingleTaskGP` model trained on synthetic data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import torch\n",
-    "\n",
-    "from botorch.fit import fit_gpytorch_model\n",
-    "from botorch.models import SingleTaskGP\n",
-    "from botorch.utils import standardize\n",
-    "from gpytorch.mlls import ExactMarginalLogLikelihood\n",
-    "\n",
-    "\n",
-    "# generate synthetic data\n",
-    "X = torch.rand(20, 2)\n",
-    "Y = torch.stack([torch.sin(X[:, 0]), torch.cos(X[:, 1])], -1)\n",
-    "Y = standardize(Y)  # standardize to zero mean unit variance\n",
-    "\n",
-    "# construct and fit the multi-output model\n",
-    "gp = SingleTaskGP(X, Y)\n",
-    "mll = ExactMarginalLogLikelihood(gp.likelihood, gp)\n",
-    "fit_gpytorch_model(mll);\n",
-    "\n",
-    "# construct the acquisition function\n",
-    "qSUCB = qScalarizedUpperConfidenceBound(gp, beta=0.1, weights=torch.tensor([0.1, 0.5]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
+  "nbformat": 4,
+  "nbformat_minor": 2,
+  "cells": [
     {
-     "data": {
-      "text/plain": [
-       "tensor([-0.1354], grad_fn=<MeanBackward1>)"
+      "cell_type": "markdown",
+      "metadata": {
+        "collapsed": true,
+        "originalKey": "4c6694a4-a6f8-4fc6-a9a7-4a29617406cb",
+        "showInput": true,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "## Writing a custom acquisition function and interfacing with Ax\n",
+        "\n",
+        "As seen in the [custom BoTorch model in Ax](./custom_botorch_model_in_ax) tutorial, Ax's `BotorchModel` is flexible in allowing different components of the Bayesian optimization loop to be specified through a functional API. This tutorial walks through the steps of writing a custom acquisition function and then inserting it into Ax. \n",
+        "\n",
+        "Next cell sets up a decorator solely to speed up the testing of the notebook. You can safely ignore this cell and use of the decorator throughout the tutorial."
       ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# evaluate on single q-batch with q=3\n",
-    "qSUCB(torch.rand(3, 2))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "tensor([-0.0566,  0.2893], grad_fn=<MeanBackward1>)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# batch-evaluate on two q-batches with q=3\n",
-    "qSUCB(torch.rand(2, 3, 2))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    "### A scalarized version of analytic UCB (`q=1` only)\n",
-    "\n",
-    "We can also write an *analytic* version of UCB for a multi-output model, assuming a multivariate normal posterior and `q=1`. The new class `ScalarizedUpperConfidenceBound` subclasses `AnalyticAcquisitionFunction` instead of `MCAcquisitionFunction`. In contrast to the MC version, instead of using the weights on the MC samples, we directly scalarize the mean vector $\\mu$ and covariance matrix $\\Sigma$ and apply standard UCB on the univariate normal distribution, which has mean $w^T \\mu$ and variance $w^T \\Sigma w$. In addition to the `@t_batch_transform` decorator, here we are also using `expected_q=1` to ensure the input `X` has a `q=1`.\n",
-    "\n",
-    "*Note:* BoTorch also provides a `ScalarizedObjective` abstraction that can be used with any existing analytic acqusition functions and automatically performs the scalarization we implement manually below. See the end of this tutorial for a usage example."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from botorch.acquisition import AnalyticAcquisitionFunction\n",
-    "\n",
-    "\n",
-    "class ScalarizedUpperConfidenceBound(AnalyticAcquisitionFunction):\n",
-    "    def __init__(\n",
-    "        self,\n",
-    "        model: Model,\n",
-    "        beta: Tensor,\n",
-    "        weights: Tensor,\n",
-    "        maximize: bool = True,\n",
-    "    ) -> None:\n",
-    "        # we use the AcquisitionFunction constructor, since that of \n",
-    "        # AnalyticAcquisitionFunction performs some validity checks that we don't want here\n",
-    "        super(AnalyticAcquisitionFunction, self).__init__(model)\n",
-    "        self.maximize = maximize\n",
-    "        self.register_buffer(\"beta\", torch.as_tensor(beta))\n",
-    "        self.register_buffer(\"weights\", torch.as_tensor(weights))\n",
-    "\n",
-    "    @t_batch_mode_transform(expected_q=1)\n",
-    "    def forward(self, X: Tensor) -> Tensor:\n",
-    "        \"\"\"Evaluate the Upper Confidence Bound on the candidate set X using scalarization\n",
-    "\n",
-    "        Args:\n",
-    "            X: A `(b) x d`-dim Tensor of `(b)` t-batches of `d`-dim design\n",
-    "                points each.\n",
-    "\n",
-    "        Returns:\n",
-    "            A `(b)`-dim Tensor of Upper Confidence Bound values at the given\n",
-    "                design points `X`.\n",
-    "        \"\"\"\n",
-    "        self.beta = self.beta.to(X)\n",
-    "        batch_shape = X.shape[:-2]\n",
-    "        posterior = self.model.posterior(X)\n",
-    "        means = posterior.mean.squeeze(dim=-2)  # b x o\n",
-    "        scalarized_mean = means.matmul(self.weights)  # b\n",
-    "        covs = posterior.mvn.covariance_matrix  # b x o x o\n",
-    "        weights = self.weights.view(1, -1, 1)  # 1 x o x 1 (assume single batch dimension)\n",
-    "        weights = weights.expand(batch_shape + weights.shape[1:])  # b x o x 1\n",
-    "        weights_transpose = weights.permute(0, 2, 1)  # b x 1 x o\n",
-    "        scalarized_variance = torch.bmm(\n",
-    "            weights_transpose, torch.bmm(covs, weights)\n",
-    "        ).view(batch_shape)  # b\n",
-    "        delta = (self.beta.expand_as(scalarized_mean) * scalarized_variance).sqrt()\n",
-    "        if self.maximize:\n",
-    "            return scalarized_mean + delta\n",
-    "        else:\n",
-    "            return scalarized_mean - delta"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Ad-hoc testing Scalarized-UCB\n",
-    "\n",
-    "Notice that we pass in an explicit q-batch dimension for consistency, even though `q=1`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# construct the acquisition function\n",
-    "SUCB = ScalarizedUpperConfidenceBound(gp, beta=0.1, weights=torch.tensor([0.1, 0.5]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "2d340028-46d5-44a6-bbb5-174dc137fe98",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "2d340028-46d5-44a6-bbb5-174dc137fe98",
+        "executionStartTime": 1646671915465,
+        "executionStopTime": 1646671916654
+      },
+      "source": [
+        "import os\n",
+        "from contextlib import contextmanager\n",
+        "\n",
+        "from ax.utils.testing.mock import fast_botorch_optimize_context_manager\n",
+        "\n",
+        "\n",
+        "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")\n",
+        "\n",
+        "\n",
+        "@contextmanager\n",
+        "def dummy_context_manager():\n",
+        "    yield\n",
+        "\n",
+        "\n",
+        "if SMOKE_TEST:\n",
+        "    fast_smoke_test = fast_botorch_optimize_context_manager\n",
+        "else:\n",
+        "    fast_smoke_test = dummy_context_manager"
+      ],
+      "execution_count": 1,
+      "outputs": []
+    },
     {
-     "data": {
-      "text/plain": [
-       "tensor([0.3753], grad_fn=<AddBackward0>)"
+      "cell_type": "markdown",
+      "metadata": {
+        "collapsed": true,
+        "originalKey": "c901c723-b2f3-4f75-96c0-6555954209f5",
+        "showInput": true,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Upper Confidence Bound (UCB)\n",
+        "\n",
+        "The Upper Confidence Bound (UCB) acquisition function balances exploration and exploitation by assigning a score of $\\mu + \\sqrt{\\beta} \\cdot \\sigma$ if the posterior distribution is normal with mean $\\mu$ and variance $\\sigma^2$. This \"analytic\" version is implemented in the `UpperConfidenceBound` class. The Monte Carlo version of UCB is implemented in the `qUpperConfidenceBound` class, which also allows for q-batches of size greater than one. (The derivation of q-UCB is given in Appendix A of [Wilson et. al., 2017](https://arxiv.org/pdf/1712.00424.pdf)).\n",
+        "\n",
+        "### A scalarized version of q-UCB\n",
+        "\n",
+        "Suppose now that we are in a multi-output setting, where, e.g., we model the effects of a design on multiple metrics. We first show a simple extension of the q-UCB acquisition function that accepts a multi-output model and performs q-UCB on a scalarized version of the multiple outputs, achieved via a vector of weights. Implementing a new acquisition function in botorch is easy; one simply needs to implement the constructor and a `forward` method."
       ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# evaluate on single point\n",
-    "SUCB(torch.rand(1, 2))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "tensor([-0.2374, -0.0187,  0.0905], grad_fn=<AddBackward0>)"
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "75503e22-bf3b-49d6-87a8-cb9c741e941e",
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "75503e22-bf3b-49d6-87a8-cb9c741e941e",
+        "executionStartTime": 1646671916688,
+        "executionStopTime": 1646671916982
+      },
+      "source": [
+        "import math\n",
+        "from typing import Optional\n",
+        "\n",
+        "from botorch.acquisition.monte_carlo import MCAcquisitionFunction\n",
+        "from botorch.models.model import Model\n",
+        "from botorch.sampling.samplers import MCSampler, SobolQMCNormalSampler\n",
+        "from botorch.utils import t_batch_mode_transform\n",
+        "from torch import Tensor\n",
+        "\n",
+        "\n",
+        "class qScalarizedUpperConfidenceBound(MCAcquisitionFunction):\n",
+        "    def __init__(\n",
+        "        self,\n",
+        "        model: Model,\n",
+        "        beta: Tensor,\n",
+        "        weights: Tensor,\n",
+        "        sampler: Optional[MCSampler] = None,\n",
+        "    ) -> None:\n",
+        "        # we use the AcquisitionFunction constructor, since that of\n",
+        "        # MCAcquisitionFunction performs some validity checks that we don't want here\n",
+        "        super(MCAcquisitionFunction, self).__init__(model=model)\n",
+        "        if sampler is None:\n",
+        "            sampler = SobolQMCNormalSampler(num_samples=512, collapse_batch_dims=True)\n",
+        "        self.sampler = sampler\n",
+        "        self.register_buffer(\"beta\", torch.as_tensor(beta))\n",
+        "        self.register_buffer(\"weights\", torch.as_tensor(weights))\n",
+        "\n",
+        "    @t_batch_mode_transform()\n",
+        "    def forward(self, X: Tensor) -> Tensor:\n",
+        "        \"\"\"Evaluate scalarized qUCB on the candidate set `X`.\n",
+        "\n",
+        "        Args:\n",
+        "            X: A `(b) x q x d`-dim Tensor of `(b)` t-batches with `q` `d`-dim\n",
+        "                design points each.\n",
+        "\n",
+        "        Returns:\n",
+        "            Tensor: A `(b)`-dim Tensor of Upper Confidence Bound values at the\n",
+        "                given design points `X`.\n",
+        "        \"\"\"\n",
+        "        posterior = self.model.posterior(X)\n",
+        "        samples = self.sampler(posterior)  # n x b x q x o\n",
+        "        scalarized_samples = samples.matmul(self.weights)  # n x b x q\n",
+        "        mean = posterior.mean  # b x q x o\n",
+        "        scalarized_mean = mean.matmul(self.weights)  # b x q\n",
+        "        ucb_samples = (\n",
+        "            scalarized_mean + math.sqrt(self.beta * math.pi / 2) * (scalarized_samples - scalarized_mean).abs()\n",
+        "        )\n",
+        "        return ucb_samples.max(dim=-1)[0].mean(dim=0)"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "b1d4ee8e-69e1-4914-b113-473add84f322",
+        "showInput": false,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "Note that `qScalarizedUpperConfidenceBound` is very similar to `qUpperConfidenceBound` and only requires a few lines of new code to accomodate scalarization of multiple outputs. The `@t_batch_mode_transform` decorator ensures that the input `X` has an explicit t-batch dimension (code comments are added with shapes for clarity).\n",
+        "\n",
+        "See the end of this tutorial for a quick and easy way of achieving the same scalarization effect using `ScalarizedPosteriorTransform`."
       ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "7122ce31-f5ee-4fdc-8962-73f692eaaac0"
+      },
+      "source": [
+        "#### Ad-hoc testing q-Scalarized-UCB\n",
+        "\n",
+        "Before hooking the newly defined acquisition function into a Bayesian Optimization loop, we should test it. For this we'll just make sure that it properly evaluates on a compatible multi-output model. Here we just define a basic multi-output `SingleTaskGP` model trained on synthetic data."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "4958d0f5-cce4-4fc8-8fa2-8b9d7fe2bd5d",
+        "collapsed": false,
+        "requestMsgId": "4958d0f5-cce4-4fc8-8fa2-8b9d7fe2bd5d",
+        "executionStartTime": 1646671917013,
+        "executionStopTime": 1646671917787,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "import torch\n",
+        "\n",
+        "from botorch.fit import fit_gpytorch_model\n",
+        "from botorch.models import SingleTaskGP\n",
+        "from botorch.utils import standardize\n",
+        "from gpytorch.mlls import ExactMarginalLogLikelihood\n",
+        "\n",
+        "\n",
+        "# generate synthetic data\n",
+        "X = torch.rand(20, 2)\n",
+        "Y = torch.stack([torch.sin(X[:, 0]), torch.cos(X[:, 1])], -1)\n",
+        "Y = standardize(Y)  # standardize to zero mean unit variance\n",
+        "\n",
+        "# construct and fit the multi-output model\n",
+        "with fast_smoke_test():\n",
+        "    gp = SingleTaskGP(X, Y)\n",
+        "    mll = ExactMarginalLogLikelihood(gp.likelihood, gp)\n",
+        "    fit_gpytorch_model(mll)\n",
+        "\n",
+        "# construct the acquisition function\n",
+        "qSUCB = qScalarizedUpperConfidenceBound(gp, beta=0.1, weights=torch.tensor([0.1, 0.5]))"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "5070d96c-5673-4bbf-ab72-781d1eabd1bf",
+        "collapsed": false,
+        "requestMsgId": "5070d96c-5673-4bbf-ab72-781d1eabd1bf",
+        "executionStartTime": 1646671917814,
+        "executionStopTime": 1646671917964
+      },
+      "source": [
+        "# evaluate on single q-batch with q=3\n",
+        "qSUCB(torch.rand(3, 2))"
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "tensor([-0.0703], grad_fn=<MeanBackward1>)"
+          },
+          "metadata": {
+            "bento_obj_id": "140262428718080"
+          },
+          "execution_count": 4
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "scrolled": true,
+        "originalKey": "b3e0a586-b362-4ab4-b4c1-7fc0c99a1be4",
+        "collapsed": false,
+        "requestMsgId": "b3e0a586-b362-4ab4-b4c1-7fc0c99a1be4",
+        "executionStartTime": 1646671918000,
+        "executionStopTime": 1646671918150
+      },
+      "source": [
+        "# batch-evaluate on two q-batches with q=3\n",
+        "qSUCB(torch.rand(2, 3, 2))"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "tensor([0.3681, 0.3131], grad_fn=<MeanBackward1>)"
+          },
+          "metadata": {
+            "bento_obj_id": "140262499108720"
+          },
+          "execution_count": 5
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "collapsed": true,
+        "originalKey": "aa45db76-36cb-42e9-9386-649d9ea5e741"
+      },
+      "source": [
+        "### A scalarized version of analytic UCB (`q=1` only)\n",
+        "\n",
+        "We can also write an *analytic* version of UCB for a multi-output model, assuming a multivariate normal posterior and `q=1`. The new class `ScalarizedUpperConfidenceBound` subclasses `AnalyticAcquisitionFunction` instead of `MCAcquisitionFunction`. In contrast to the MC version, instead of using the weights on the MC samples, we directly scalarize the mean vector $\\mu$ and covariance matrix $\\Sigma$ and apply standard UCB on the univariate normal distribution, which has mean $w^T \\mu$ and variance $w^T \\Sigma w$. In addition to the `@t_batch_transform` decorator, here we are also using `expected_q=1` to ensure the input `X` has a `q=1`.\n",
+        "\n",
+        "*Note:* BoTorch also provides a `ScalarizedObjective` abstraction that can be used with any existing analytic acqusition functions and automatically performs the scalarization we implement manually below. See the end of this tutorial for a usage example."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "5528fc1c-5cf1-4cab-9598-9a41e652d6ea",
+        "collapsed": false,
+        "requestMsgId": "5528fc1c-5cf1-4cab-9598-9a41e652d6ea",
+        "executionStartTime": 1646671918182,
+        "executionStopTime": 1646671918282
+      },
+      "source": [
+        "from botorch.acquisition import AnalyticAcquisitionFunction\n",
+        "\n",
+        "\n",
+        "class ScalarizedUpperConfidenceBound(AnalyticAcquisitionFunction):\n",
+        "    def __init__(\n",
+        "        self,\n",
+        "        model: Model,\n",
+        "        beta: Tensor,\n",
+        "        weights: Tensor,\n",
+        "        maximize: bool = True,\n",
+        "    ) -> None:\n",
+        "        # we use the AcquisitionFunction constructor, since that of \n",
+        "        # AnalyticAcquisitionFunction performs some validity checks that we don't want here\n",
+        "        super(AnalyticAcquisitionFunction, self).__init__(model)\n",
+        "        self.maximize = maximize\n",
+        "        self.register_buffer(\"beta\", torch.as_tensor(beta))\n",
+        "        self.register_buffer(\"weights\", torch.as_tensor(weights))\n",
+        "\n",
+        "    @t_batch_mode_transform(expected_q=1)\n",
+        "    def forward(self, X: Tensor) -> Tensor:\n",
+        "        \"\"\"Evaluate the Upper Confidence Bound on the candidate set X using scalarization\n",
+        "\n",
+        "        Args:\n",
+        "            X: A `(b) x d`-dim Tensor of `(b)` t-batches of `d`-dim design\n",
+        "                points each.\n",
+        "\n",
+        "        Returns:\n",
+        "            A `(b)`-dim Tensor of Upper Confidence Bound values at the given\n",
+        "                design points `X`.\n",
+        "        \"\"\"\n",
+        "        self.beta = self.beta.to(X)\n",
+        "        batch_shape = X.shape[:-2]\n",
+        "        posterior = self.model.posterior(X)\n",
+        "        means = posterior.mean.squeeze(dim=-2)  # b x o\n",
+        "        scalarized_mean = means.matmul(self.weights)  # b\n",
+        "        covs = posterior.mvn.covariance_matrix  # b x o x o\n",
+        "        weights = self.weights.view(1, -1, 1)  # 1 x o x 1 (assume single batch dimension)\n",
+        "        weights = weights.expand(batch_shape + weights.shape[1:])  # b x o x 1\n",
+        "        weights_transpose = weights.permute(0, 2, 1)  # b x 1 x o\n",
+        "        scalarized_variance = torch.bmm(\n",
+        "            weights_transpose, torch.bmm(covs, weights)\n",
+        "        ).view(batch_shape)  # b\n",
+        "        delta = (self.beta.expand_as(scalarized_mean) * scalarized_variance).sqrt()\n",
+        "        if self.maximize:\n",
+        "            return scalarized_mean + delta\n",
+        "        else:\n",
+        "            return scalarized_mean - delta"
+      ],
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "54811aec-bcad-4d24-8346-fa69c9e1d4c1"
+      },
+      "source": [
+        "#### Ad-hoc testing Scalarized-UCB\n",
+        "\n",
+        "Notice that we pass in an explicit q-batch dimension for consistency, even though `q=1`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "f7a98f13-7d87-4e87-afb8-a8ff087faeef",
+        "collapsed": false,
+        "requestMsgId": "f7a98f13-7d87-4e87-afb8-a8ff087faeef",
+        "executionStartTime": 1646671918364,
+        "executionStopTime": 1646671918383
+      },
+      "source": [
+        "# construct the acquisition function\n",
+        "SUCB = ScalarizedUpperConfidenceBound(gp, beta=0.1, weights=torch.tensor([0.1, 0.5]))"
+      ],
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "78de901c-d537-4b20-8ab2-f1161d12cca3",
+        "collapsed": false,
+        "requestMsgId": "78de901c-d537-4b20-8ab2-f1161d12cca3",
+        "executionStartTime": 1646671918404,
+        "executionStopTime": 1646671918535
+      },
+      "source": [
+        "# evaluate on single point\n",
+        "SUCB(torch.rand(1, 2))"
+      ],
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "tensor([-1.2662], grad_fn=<AddBackward0>)"
+          },
+          "metadata": {
+            "bento_obj_id": "140262413764544"
+          },
+          "execution_count": 8
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "3ffbd8b7-11e6-48d1-8d05-eddd3fc8221c",
+        "collapsed": false,
+        "requestMsgId": "3ffbd8b7-11e6-48d1-8d05-eddd3fc8221c",
+        "executionStartTime": 1646671918567,
+        "executionStopTime": 1646671918643
+      },
+      "source": [
+        "# batch-evaluate on 3 points\n",
+        "SUCB(torch.rand(3, 1, 2))"
+      ],
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "tensor([ 0.3431, -0.0833,  0.0702], grad_fn=<AddBackward0>)"
+          },
+          "metadata": {
+            "bento_obj_id": "140262412703120"
+          },
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "23509c96-6cab-4b3c-a8f6-ca87e607f642",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "## Using the custom acquisition function with Ax's Service API"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "636b7375-e46f-4bfb-bd38-724bcaae1b71",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Registering the new acquisition function\n",
+        "\n",
+        "In order to use an acquisition function, Ax needs to know how to generate inputs to construct the acquisition function."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "cd81abdf-050f-470c-be2a-432a52f911b5",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "cd81abdf-050f-470c-be2a-432a52f911b5",
+        "executionStartTime": 1646671918683,
+        "executionStopTime": 1646671918836
+      },
+      "source": [
+        "from typing import List\n",
+        "from typing import Any, Dict\n",
+        "\n",
+        "from botorch.acquisition.input_constructors import acqf_input_constructor\n",
+        "\n",
+        "\n",
+        "@acqf_input_constructor(ScalarizedUpperConfidenceBound)\n",
+        "def construct_inputs_scalarized_ucb(\n",
+        "    model: Model,\n",
+        "    beta: float,\n",
+        "    weights: List[float],\n",
+        "    **kwargs: Any,\n",
+        ") -> Dict[str, Any]:\n",
+        "    return {\n",
+        "        \"model\": model,\n",
+        "        \"beta\": torch.as_tensor(beta, dtype=torch.double),\n",
+        "        \"weights\": torch.as_tensor(weights, dtype=torch.double),\n",
+        "    }"
+      ],
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "71d0ade7-1341-4dda-b59e-b4f362d9991d",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Setting up a `GenerationStrategy` using `BOTORCH_MODULAR` with our custom acquistion function.\n",
+        "\n",
+        "`BOTORCH_MODULAR` is a convenient wrapper implemented in Ax that facilitates the use of custom BoTorch models and acquisition functions in Ax experiments. In order to customize the way the candidates are generated, we need to construct a new `GenerationStrategy` and pass it into the `AxClient`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "80c4b078-9787-46da-ac78-a574cc73a17d",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "80c4b078-9787-46da-ac78-a574cc73a17d",
+        "executionStartTime": 1646671918882,
+        "executionStopTime": 1646671919282
+      },
+      "source": [
+        "from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy\n",
+        "from ax.modelbridge.registry import Models\n",
+        "\n",
+        "\n",
+        "gs = GenerationStrategy(\n",
+        "    steps=[\n",
+        "        # Quasi-random initialization step\n",
+        "        GenerationStep(\n",
+        "            model=Models.SOBOL,\n",
+        "            num_trials=5,  # How many trials should be produced from this generation step\n",
+        "            model_kwargs={\"seed\": 999},  # Any kwargs you want passed into the model\n",
+        "        ),\n",
+        "        # Bayesian optimization step using the custom acquisition function\n",
+        "        GenerationStep(\n",
+        "            model=Models.BOTORCH_MODULAR,\n",
+        "            num_trials=-1,  # No limitation on how many trials should be produced from this step\n",
+        "            # For `BOTORCH_MODULAR`, we pass in kwargs to specify what surrogate or acquisition function to use.\n",
+        "            # `acquisition_options` specifies the set of additional arguments to pass into the input constructor.\n",
+        "            model_kwargs={\n",
+        "                \"botorch_acqf_class\": ScalarizedUpperConfidenceBound,\n",
+        "                \"acquisition_options\": {\"beta\": 0.1, \"weights\": [1.0, 1.0]},\n",
+        "            },\n",
+        "        ),\n",
+        "    ]\n",
+        ")"
+      ],
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "b7e98402-9d53-4d33-bfbf-230833edc121",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Setting up the experiment\n",
+        "\n",
+        "We will set up a simple experiment to optimize a simple scalarization of the BraninCurrin function (per the weights above). A detailed tutorial on Service API can be found [here](https://ax.dev/tutorials/gpei_hartmann_service.html).\n",
+        "\n",
+        "In order to use the `GenerationStrategy` we just created, we will pass it into the `AxClient`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "e1e4f622-4678-4ae1-98a5-02c770c51f87",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "e1e4f622-4678-4ae1-98a5-02c770c51f87",
+        "executionStartTime": 1646671919309,
+        "executionStopTime": 1646671919661
+      },
+      "source": [
+        "from ax.service.ax_client import AxClient\n",
+        "from ax.service.utils.instantiation import ObjectiveProperties\n",
+        "from botorch.test_functions import BraninCurrin\n",
+        "\n",
+        "\n",
+        "# Initialize the client - AxClient offers a convenient API to control the experiment\n",
+        "ax_client = AxClient(generation_strategy=gs)\n",
+        "# Setup the experiment\n",
+        "ax_client.create_experiment(\n",
+        "    name=\"branincurrin_test_experiment\",\n",
+        "    parameters=[\n",
+        "        {\n",
+        "            \"name\": f\"x{i+1}\",\n",
+        "            \"type\": \"range\",\n",
+        "            # It is crucial to use floats for the bounds, i.e., 0.0 rather than 0.\n",
+        "            # Otherwise, the parameter would \n",
+        "            \"bounds\": [0.0, 1.0],\n",
+        "        }\n",
+        "        for i in range(2)\n",
+        "    ],\n",
+        "    objectives={\n",
+        "        \"branin\": ObjectiveProperties(minimize=True),\n",
+        "        \"currin\": ObjectiveProperties(minimize=True),\n",
+        "    },\n",
+        ")\n",
+        "# Setup a function to evaluate the trials\n",
+        "branincurrin = BraninCurrin()\n",
+        "\n",
+        "\n",
+        "def evaluate(parameters):\n",
+        "    x = torch.tensor([[parameters.get(f\"x{i+1}\") for i in range(2)]])\n",
+        "    bc_eval = branincurrin(x).squeeze().tolist()\n",
+        "    # In our case, standard error is 0, since we are computing a synthetic function.\n",
+        "    return {\"branin\": (bc_eval[0], 0.0), \"currin\": (bc_eval[1], 0.0)}"
+      ],
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.ax_client: Starting optimization with verbose logging. To disable logging, set the `verbose_logging` argument to `False`. Note that float values in the logs are rounded to 6 decimal points.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.utils.instantiation: Due to non-specification, we will use the heuristic for selecting objective thresholds.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.utils.instantiation: Inferred value type of ParameterType.FLOAT for parameter x1. If that is not the expected value type, you can explicity specify 'value_type' ('int', 'float', 'bool' or 'str') in parameter dict.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.utils.instantiation: Inferred value type of ParameterType.FLOAT for parameter x2. If that is not the expected value type, you can explicity specify 'value_type' ('int', 'float', 'bool' or 'str') in parameter dict.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.utils.instantiation: Created search space: SearchSpace(parameters=[RangeParameter(name='x1', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x2', parameter_type=FLOAT, range=[0.0, 1.0])], parameter_constraints=[]).\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "ae279099-6f99-4d29-858b-d174d388e2d3",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Running the BO loop\n",
+        "\n",
+        "Ax makes this part super simple!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "11c29a68-56a5-4d48-888b-04dd69cfb0af",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "11c29a68-56a5-4d48-888b-04dd69cfb0af",
+        "executionStartTime": 1646671919688,
+        "executionStopTime": 1646671923283
+      },
+      "source": [
+        "with fast_smoke_test():\n",
+        "    for i in range(15):\n",
+        "        parameters, trial_index = ax_client.get_next_trial()\n",
+        "        # Local evaluation here can be replaced with deployment to external system.\n",
+        "        ax_client.complete_trial(trial_index=trial_index, raw_data=evaluate(parameters))"
+      ],
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.ax_client: Generated new trial 0 with parameters {'x1': 0.62873, 'x2': 0.51481}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.ax_client: Completed trial 0 with data: {'branin': (46.244598, 0.0), 'currin': (6.842319, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.ax_client: Generated new trial 1 with parameters {'x1': 0.434883, 'x2': 0.396266}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.ax_client: Completed trial 1 with data: {'branin': (14.735401, 0.0), 'currin': (8.740173, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.ax_client: Generated new trial 2 with parameters {'x1': 0.075645, 'x2': 0.934926}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.ax_client: Completed trial 2 with data: {'branin': (2.808084, 0.0), 'currin': (4.10731, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.ax_client: Generated new trial 3 with parameters {'x1': 0.863245, 'x2': 0.038764}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.ax_client: Completed trial 3 with data: {'branin': (9.956846, 0.0), 'currin': (10.342199, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.ax_client: Generated new trial 4 with parameters {'x1': 0.953918, 'x2': 0.808236}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:51:59] ax.service.ax_client: Completed trial 4 with data: {'branin': (95.420815, 0.0), 'currin': (4.715139, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:00] ax.service.ax_client: Generated new trial 5 with parameters {'x1': 1.0, 'x2': 0.343958}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:00] ax.service.ax_client: Completed trial 5 with data: {'branin': (6.59323, 0.0), 'currin': (7.800424, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:00] ax.service.ax_client: Generated new trial 6 with parameters {'x1': 0.545884, 'x2': 0.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:00] ax.service.ax_client: Completed trial 6 with data: {'branin': (5.420973, 0.0), 'currin': (11.428981, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:00] ax.service.ax_client: Generated new trial 7 with parameters {'x1': 0.123583, 'x2': 0.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:00] ax.service.ax_client: Completed trial 7 with data: {'branin': (151.348694, 0.0), 'currin': (12.425919, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:00] ax.service.ax_client: Generated new trial 8 with parameters {'x1': 0.04517, 'x2': 0.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:00] ax.service.ax_client: Completed trial 8 with data: {'branin': (240.225876, 0.0), 'currin': (7.476875, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:01] ax.service.ax_client: Generated new trial 9 with parameters {'x1': 0.120646, 'x2': 0.032783}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:01] ax.service.ax_client: Completed trial 9 with data: {'branin': (142.034271, 0.0), 'currin': (12.31697, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:01] ax.service.ax_client: Generated new trial 10 with parameters {'x1': 0.111548, 'x2': 0.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:01] ax.service.ax_client: Completed trial 10 with data: {'branin': (162.47403, 0.0), 'currin': (11.944614, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:02] ax.service.ax_client: Generated new trial 11 with parameters {'x1': 0.129161, 'x2': 0.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:02] ax.service.ax_client: Completed trial 11 with data: {'branin': (146.498032, 0.0), 'currin': (12.618309, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:02] ax.service.ax_client: Generated new trial 12 with parameters {'x1': 0.133428, 'x2': 0.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:02] ax.service.ax_client: Completed trial 12 with data: {'branin': (142.915176, 0.0), 'currin': (12.753123, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:02] ax.service.ax_client: Generated new trial 13 with parameters {'x1': 0.128619, 'x2': 0.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:02] ax.service.ax_client: Completed trial 13 with data: {'branin': (146.960831, 0.0), 'currin': (12.600433, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:03] ax.service.ax_client: Generated new trial 14 with parameters {'x1': 0.126961, 'x2': 0.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:03] ax.service.ax_client: Completed trial 14 with data: {'branin': (148.388519, 0.0), 'currin': (12.54465, 0.0)}.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "0e35aa1a-766a-4c5e-924f-852db76c3139",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Viewing trials and plotting the Pareto frontier\n",
+        "\n",
+        "View the trials attached to the experiment."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "e3299fb3-d9f7-45e3-ba34-8b5b0c29dea1",
+        "showInput": true,
+        "customInput": null,
+        "collapsed": false,
+        "requestMsgId": "e3299fb3-d9f7-45e3-ba34-8b5b0c29dea1",
+        "executionStopTime": 1646671923432,
+        "executionStartTime": 1646671923319
+      },
+      "source": [
+        "ax_client.generation_strategy.trials_as_df"
+      ],
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-07 08:52:03] ax.modelbridge.generation_strategy: Note that parameter values in dataframe are rounded to 2 decimal points; the values in the dataframe are thus not the exact ones suggested by Ax in trials.\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "    Generation Step  ...              Arm Parameterizations\n0                 0  ...  {'0_0': {'x1': 0.63, 'x2': 0.51}}\n1                 0  ...   {'1_0': {'x1': 0.43, 'x2': 0.4}}\n2                 0  ...  {'2_0': {'x1': 0.08, 'x2': 0.93}}\n3                 0  ...  {'3_0': {'x1': 0.86, 'x2': 0.04}}\n4                 0  ...  {'4_0': {'x1': 0.95, 'x2': 0.81}}\n5                 1  ...   {'5_0': {'x1': 1.0, 'x2': 0.34}}\n6                 1  ...   {'6_0': {'x1': 0.55, 'x2': 0.0}}\n7                 1  ...   {'7_0': {'x1': 0.12, 'x2': 0.0}}\n8                 1  ...   {'8_0': {'x1': 0.05, 'x2': 0.0}}\n9                 1  ...  {'9_0': {'x1': 0.12, 'x2': 0.03}}\n10                1  ...  {'10_0': {'x1': 0.11, 'x2': 0.0}}\n11                1  ...  {'11_0': {'x1': 0.13, 'x2': 0.0}}\n12                1  ...  {'12_0': {'x1': 0.13, 'x2': 0.0}}\n13                1  ...  {'13_0': {'x1': 0.13, 'x2': 0.0}}\n14                1  ...  {'14_0': {'x1': 0.13, 'x2': 0.0}}\n\n[15 rows x 5 columns]",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Generation Step</th>\n      <th>Generation Model</th>\n      <th>Trial Index</th>\n      <th>Trial Status</th>\n      <th>Arm Parameterizations</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>Sobol</td>\n      <td>0</td>\n      <td>COMPLETED</td>\n      <td>{'0_0': {'x1': 0.63, 'x2': 0.51}}</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>0</td>\n      <td>Sobol</td>\n      <td>1</td>\n      <td>COMPLETED</td>\n      <td>{'1_0': {'x1': 0.43, 'x2': 0.4}}</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>0</td>\n      <td>Sobol</td>\n      <td>2</td>\n      <td>COMPLETED</td>\n      <td>{'2_0': {'x1': 0.08, 'x2': 0.93}}</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>0</td>\n      <td>Sobol</td>\n      <td>3</td>\n      <td>COMPLETED</td>\n      <td>{'3_0': {'x1': 0.86, 'x2': 0.04}}</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0</td>\n      <td>Sobol</td>\n      <td>4</td>\n      <td>COMPLETED</td>\n      <td>{'4_0': {'x1': 0.95, 'x2': 0.81}}</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>1</td>\n      <td>BoTorch</td>\n      <td>5</td>\n      <td>COMPLETED</td>\n      <td>{'5_0': {'x1': 1.0, 'x2': 0.34}}</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>1</td>\n      <td>BoTorch</td>\n      <td>6</td>\n      <td>COMPLETED</td>\n      <td>{'6_0': {'x1': 0.55, 'x2': 0.0}}</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>1</td>\n      <td>BoTorch</td>\n      <td>7</td>\n      <td>COMPLETED</td>\n      <td>{'7_0': {'x1': 0.12, 'x2': 0.0}}</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>1</td>\n      <td>BoTorch</td>\n      <td>8</td>\n      <td>COMPLETED</td>\n      <td>{'8_0': {'x1': 0.05, 'x2': 0.0}}</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>1</td>\n      <td>BoTorch</td>\n      <td>9</td>\n      <td>COMPLETED</td>\n      <td>{'9_0': {'x1': 0.12, 'x2': 0.03}}</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>1</td>\n      <td>BoTorch</td>\n      <td>10</td>\n      <td>COMPLETED</td>\n      <td>{'10_0': {'x1': 0.11, 'x2': 0.0}}</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>1</td>\n      <td>BoTorch</td>\n      <td>11</td>\n      <td>COMPLETED</td>\n      <td>{'11_0': {'x1': 0.13, 'x2': 0.0}}</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>1</td>\n      <td>BoTorch</td>\n      <td>12</td>\n      <td>COMPLETED</td>\n      <td>{'12_0': {'x1': 0.13, 'x2': 0.0}}</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>1</td>\n      <td>BoTorch</td>\n      <td>13</td>\n      <td>COMPLETED</td>\n      <td>{'13_0': {'x1': 0.13, 'x2': 0.0}}</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>1</td>\n      <td>BoTorch</td>\n      <td>14</td>\n      <td>COMPLETED</td>\n      <td>{'14_0': {'x1': 0.13, 'x2': 0.0}}</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+            "application/vnd.dataresource+json": {
+              "schema": {
+                "fields": [
+                  {
+                    "name": "index",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "Generation Step",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "Generation Model",
+                    "type": "string"
+                  },
+                  {
+                    "name": "Trial Index",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "Trial Status",
+                    "type": "string"
+                  },
+                  {
+                    "name": "Arm Parameterizations",
+                    "type": "string"
+                  }
+                ],
+                "primaryKey": [
+                  "index"
+                ],
+                "pandas_version": "0.20.0"
+              },
+              "data": [
+                {
+                  "index": 0,
+                  "Generation Step": 0,
+                  "Generation Model": "Sobol",
+                  "Trial Index": 0,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "0_0": {
+                      "x1": 0.63,
+                      "x2": 0.51
+                    }
+                  }
+                },
+                {
+                  "index": 1,
+                  "Generation Step": 0,
+                  "Generation Model": "Sobol",
+                  "Trial Index": 1,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "1_0": {
+                      "x1": 0.43,
+                      "x2": 0.4
+                    }
+                  }
+                },
+                {
+                  "index": 2,
+                  "Generation Step": 0,
+                  "Generation Model": "Sobol",
+                  "Trial Index": 2,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "2_0": {
+                      "x1": 0.08,
+                      "x2": 0.93
+                    }
+                  }
+                },
+                {
+                  "index": 3,
+                  "Generation Step": 0,
+                  "Generation Model": "Sobol",
+                  "Trial Index": 3,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "3_0": {
+                      "x1": 0.86,
+                      "x2": 0.04
+                    }
+                  }
+                },
+                {
+                  "index": 4,
+                  "Generation Step": 0,
+                  "Generation Model": "Sobol",
+                  "Trial Index": 4,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "4_0": {
+                      "x1": 0.95,
+                      "x2": 0.81
+                    }
+                  }
+                },
+                {
+                  "index": 5,
+                  "Generation Step": 1,
+                  "Generation Model": "BoTorch",
+                  "Trial Index": 5,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "5_0": {
+                      "x1": 1,
+                      "x2": 0.34
+                    }
+                  }
+                },
+                {
+                  "index": 6,
+                  "Generation Step": 1,
+                  "Generation Model": "BoTorch",
+                  "Trial Index": 6,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "6_0": {
+                      "x1": 0.55,
+                      "x2": 0
+                    }
+                  }
+                },
+                {
+                  "index": 7,
+                  "Generation Step": 1,
+                  "Generation Model": "BoTorch",
+                  "Trial Index": 7,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "7_0": {
+                      "x1": 0.12,
+                      "x2": 0
+                    }
+                  }
+                },
+                {
+                  "index": 8,
+                  "Generation Step": 1,
+                  "Generation Model": "BoTorch",
+                  "Trial Index": 8,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "8_0": {
+                      "x1": 0.05,
+                      "x2": 0
+                    }
+                  }
+                },
+                {
+                  "index": 9,
+                  "Generation Step": 1,
+                  "Generation Model": "BoTorch",
+                  "Trial Index": 9,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "9_0": {
+                      "x1": 0.12,
+                      "x2": 0.03
+                    }
+                  }
+                },
+                {
+                  "index": 10,
+                  "Generation Step": 1,
+                  "Generation Model": "BoTorch",
+                  "Trial Index": 10,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "10_0": {
+                      "x1": 0.11,
+                      "x2": 0
+                    }
+                  }
+                },
+                {
+                  "index": 11,
+                  "Generation Step": 1,
+                  "Generation Model": "BoTorch",
+                  "Trial Index": 11,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "11_0": {
+                      "x1": 0.13,
+                      "x2": 0
+                    }
+                  }
+                },
+                {
+                  "index": 12,
+                  "Generation Step": 1,
+                  "Generation Model": "BoTorch",
+                  "Trial Index": 12,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "12_0": {
+                      "x1": 0.13,
+                      "x2": 0
+                    }
+                  }
+                },
+                {
+                  "index": 13,
+                  "Generation Step": 1,
+                  "Generation Model": "BoTorch",
+                  "Trial Index": 13,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "13_0": {
+                      "x1": 0.13,
+                      "x2": 0
+                    }
+                  }
+                },
+                {
+                  "index": 14,
+                  "Generation Step": 1,
+                  "Generation Model": "BoTorch",
+                  "Trial Index": 14,
+                  "Trial Status": "COMPLETED",
+                  "Arm Parameterizations": {
+                    "14_0": {
+                      "x1": 0.13,
+                      "x2": 0
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "metadata": {
+            "bento_obj_id": "140262297979728"
+          },
+          "execution_count": 14
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "ca47b562-3c01-4557-9c76-a7143a978dae",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "Plot the Pareto frontier.\n",
+        "\n",
+        "Note that we do not expect a good coverage of the Pareto frontier since our acquisition function naively optimizes the sum of the two objectives."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "5bbd1ba3-1f88-45d3-b4a9-c660a4ff9449",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "5bbd1ba3-1f88-45d3-b4a9-c660a4ff9449",
+        "executionStopTime": 1646671937133,
+        "executionStartTime": 1646671923463
+      },
+      "source": [
+        "from ax.plot.pareto_frontier import plot_pareto_frontier\n",
+        "from ax.utils.notebook.plotting import render\n",
+        "from ax.plot.pareto_utils import compute_posterior_pareto_frontier\n",
+        "objectives = ax_client.experiment.optimization_config.objective.objectives\n",
+        "with fast_smoke_test():\n",
+        "    frontier = compute_posterior_pareto_frontier(\n",
+        "        experiment=ax_client.experiment,\n",
+        "        data=ax_client.experiment.fetch_data(),\n",
+        "        primary_objective=objectives[1].metric,\n",
+        "        secondary_objective=objectives[0].metric,\n",
+        "        absolute_metrics=[\"branin\", \"currin\"],\n",
+        "        num_points=20,\n",
+        "    )\n",
+        "render(plot_pareto_frontier(frontier, CI_level=0.90)) "
+      ],
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.plotly.v1+json": {
+              "config": {
+                "linkText": "Export to plot.ly",
+                "plotlyServerURL": "https://plot.ly",
+                "showLink": false
+              },
+              "data": [
+                {
+                  "error_x": {
+                    "array": [
+                      2.1041476996943254,
+                      6.786010259991971,
+                      1.9656113401688824,
+                      4.423732739414581,
+                      0.053469934857209245,
+                      2.78694105198828,
+                      0.6898236525271969,
+                      0.9382302172266984,
+                      2.7732821025012337,
+                      0.8286482293982549,
+                      0.034751076827254826,
+                      2.3476668361744735,
+                      1.4979352627173559,
+                      0.06967102340856428,
+                      0.8953939354024776,
+                      4.59889063486126,
+                      3.3354967958939197,
+                      3.6932123296624937,
+                      4.221451769816604,
+                      0.031238075792602585
+                    ],
+                    "color": "rgba(128,177,211,0.4)",
+                    "thickness": 2,
+                    "type": "data"
+                  },
+                  "error_y": {
+                    "array": [
+                      0.17873377264041637,
+                      0.5515306718683937,
+                      0.17253745258952607,
+                      0.3751576343449705,
+                      0.002915780693328641,
+                      0.2410228815566845,
+                      0.0644407066074909,
+                      0.08878179657195737,
+                      0.23989919395858042,
+                      0.06689120025862685,
+                      0.0014881697544525598,
+                      0.1998204250555273,
+                      0.13264795654518274,
+                      0.0030433240864689635,
+                      0.08444141407318506,
+                      0.38959075548529154,
+                      0.2842421343096247,
+                      0.31436630497056933,
+                      0.3584212826999636,
+                      0.0013820652020805975
+                    ],
+                    "color": "rgba(128,177,211,0.4)",
+                    "thickness": 2,
+                    "type": "data"
+                  },
+                  "hoverinfo": "text",
+                  "legendgroup": "mean",
+                  "marker": {
+                    "color": "rgba(128,177,211,1)"
+                  },
+                  "mode": "markers",
+                  "name": "mean",
+                  "text": [
+                    "<b>Parameterization 0</b><br>currin: 13.465 [13.287, 13.644]<br>branin: 117.584 [115.480, 119.688]<br><br><em>Parameterization:</em><br>x1: 0.16767920184322185<br>x2: 0.0",
+                    "<b>Parameterization 1</b><br>currin: 4.58 [4.028, 5.131]<br>branin: 291.107 [284.321, 297.893]<br><br><em>Parameterization:</em><br>x1: 0.0<br>x2: 0.0",
+                    "<b>Parameterization 2</b><br>currin: 6.184 [6.012, 6.357]<br>branin: 261.934 [259.969, 263.900]<br><br><em>Parameterization:</em><br>x1: 0.027194891362803644<br>x2: 2.5185166380839053e-16",
+                    "<b>Parameterization 3</b><br>currin: 13.6 [13.225, 13.975]<br>branin: 106.514 [102.091, 110.938]<br><br><em>Parameterization:</em><br>x1: 0.18536860966736218<br>x2: 3.3443785963432355e-18",
+                    "<b>Parameterization 4</b><br>currin: 12.077 [12.074, 12.080]<br>branin: 159.55 [159.496, 159.603]<br><br><em>Parameterization:</em><br>x1: 0.11460868316283454<br>x2: 5.3303323434787666e-17",
+                    "<b>Parameterization 5</b><br>currin: 5.816 [5.575, 6.057]<br>branin: 268.351 [265.564, 271.138]<br><br><em>Parameterization:</em><br>x1: 0.02160336746884051<br>x2: 0.0",
+                    "<b>Parameterization 6</b><br>currin: 8.372 [8.307, 8.436]<br>branin: 225.605 [224.915, 226.295]<br><br><em>Parameterization:</em><br>x1: 0.05683632434773296<br>x2: 4.918922233951485e-16",
+                    "<b>Parameterization 7</b><br>currin: 9.325 [9.236, 9.414]<br>branin: 210.035 [209.097, 210.973]<br><br><em>Parameterization:</em><br>x1: 0.06925532709748217<br>x2: 1.5503707099545582e-16",
+                    "<b>Parameterization 8</b><br>currin: 5.821 [5.581, 6.061]<br>branin: 268.252 [265.478, 271.025]<br><br><em>Parameterization:</em><br>x1: 0.021691376056676585<br>x2: 3.2051296233652496e-17",
+                    "<b>Parameterization 9</b><br>currin: 13.243 [13.177, 13.310]<br>branin: 127.566 [126.737, 128.395]<br><br><em>Parameterization:</em><br>x1: 0.15325527390673868<br>x2: 1.773379865989145e-17",
+                    "<b>Parameterization 10</b><br>currin: 12.673 [12.671, 12.674]<br>branin: 145.076 [145.041, 145.111]<br><br><em>Parameterization:</em><br>x1: 0.13084181053123273<br>x2: 2.962376806316503e-16",
+                    "<b>Parameterization 11</b><br>currin: 13.49 [13.290, 13.690]<br>branin: 116.153 [113.805, 118.500]<br><br><em>Parameterization:</em><br>x1: 0.16985994621981024<br>x2: 2.9632435661937766e-18",
+                    "<b>Parameterization 12</b><br>currin: 6.425 [6.293, 6.558]<br>branin: 257.798 [256.300, 259.296]<br><br><em>Parameterization:</em><br>x1: 0.030717753467459964<br>x2: 0.0",
+                    "<b>Parameterization 13</b><br>currin: 11.898 [11.895, 11.901]<br>branin: 163.491 [163.421, 163.561]<br><br><em>Parameterization:</em><br>x1: 0.11051194919717217<br>x2: 1.072738325674222e-17",
+                    "<b>Parameterization 14</b><br>currin: 8.957 [8.872, 9.041]<br>branin: 216.076 [215.180, 216.971]<br><br><em>Parameterization:</em><br>x1: 0.06441505706513105<br>x2: 1.5792301613815218e-16",
+                    "<b>Parameterization 15</b><br>currin: 13.604 [13.214, 13.994]<br>branin: 105.838 [101.239, 110.437]<br><br><em>Parameterization:</em><br>x1: 0.18651341392393878<br>x2: 9.650520914440527e-19",
+                    "<b>Parameterization 16</b><br>currin: 13.559 [13.275, 13.844]<br>branin: 111.117 [107.782, 114.453]<br><br><em>Parameterization:</em><br>x1: 0.17777816466095842<br>x2: 3.439734827962657e-18",
+                    "<b>Parameterization 17</b><br>currin: 13.576 [13.262, 13.890]<br>branin: 109.518 [105.824, 113.211]<br><br><em>Parameterization:</em><br>x1: 0.18037637368600104<br>x2: 1.496325793153615e-17",
+                    "<b>Parameterization 18</b><br>currin: 13.595 [13.236, 13.953]<br>branin: 107.315 [103.093, 111.536]<br><br><em>Parameterization:</em><br>x1: 0.18402322384256978<br>x2: 4.938866169707718e-18",
+                    "<b>Parameterization 19</b><br>currin: 12.641 [12.640, 12.642]<br>branin: 145.905 [145.874, 145.936]<br><br><em>Parameterization:</em><br>x1: 0.12986019184125364<br>x2: 4.2280177997753536e-19"
+                  ],
+                  "type": "scatter",
+                  "x": [
+                    117.58389028667554,
+                    291.1067937435533,
+                    261.9341390131741,
+                    106.51430497393156,
+                    159.54982074893252,
+                    268.35108348668814,
+                    225.60472789080484,
+                    210.03477458396634,
+                    268.2515823601982,
+                    127.5659257867915,
+                    145.07590658746625,
+                    116.15282771282256,
+                    257.79795250639734,
+                    163.49083168058758,
+                    216.07584733390487,
+                    105.83823160563985,
+                    111.11717547592815,
+                    109.51765586973892,
+                    107.31479871719597,
+                    145.90475360323035
+                  ],
+                  "y": [
+                    13.46541893538193,
+                    4.579630552641066,
+                    6.184094471672527,
+                    13.59992686397306,
+                    12.07689179916785,
+                    5.815591848370005,
+                    8.371898089153662,
+                    9.325132431371747,
+                    5.821247624136068,
+                    13.243409084309496,
+                    12.672589873157278,
+                    13.489805244845972,
+                    6.425393170140941,
+                    11.897802484570782,
+                    8.956711548412214,
+                    13.603935231589551,
+                    13.559435420005158,
+                    13.576081782633128,
+                    13.59453002560557,
+                    12.64105232536555
+                  ]
+                }
+              ],
+              "layout": {
+                "height": 500,
+                "hovermode": "closest",
+                "legend": {
+                  "orientation": "h"
+                },
+                "margin": {
+                  "b": 75,
+                  "l": 225,
+                  "pad": 4,
+                  "t": 75
+                },
+                "template": {
+                  "data": {
+                    "bar": [
+                      {
+                        "error_x": {
+                          "color": "#2a3f5f"
+                        },
+                        "error_y": {
+                          "color": "#2a3f5f"
+                        },
+                        "marker": {
+                          "line": {
+                            "color": "#E5ECF6",
+                            "width": 0.5
+                          }
+                        },
+                        "type": "bar"
+                      }
+                    ],
+                    "barpolar": [
+                      {
+                        "marker": {
+                          "line": {
+                            "color": "#E5ECF6",
+                            "width": 0.5
+                          }
+                        },
+                        "type": "barpolar"
+                      }
+                    ],
+                    "carpet": [
+                      {
+                        "aaxis": {
+                          "endlinecolor": "#2a3f5f",
+                          "gridcolor": "white",
+                          "linecolor": "white",
+                          "minorgridcolor": "white",
+                          "startlinecolor": "#2a3f5f"
+                        },
+                        "baxis": {
+                          "endlinecolor": "#2a3f5f",
+                          "gridcolor": "white",
+                          "linecolor": "white",
+                          "minorgridcolor": "white",
+                          "startlinecolor": "#2a3f5f"
+                        },
+                        "type": "carpet"
+                      }
+                    ],
+                    "choropleth": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "choropleth"
+                      }
+                    ],
+                    "contour": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "contour"
+                      }
+                    ],
+                    "contourcarpet": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "contourcarpet"
+                      }
+                    ],
+                    "heatmap": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "heatmap"
+                      }
+                    ],
+                    "heatmapgl": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "heatmapgl"
+                      }
+                    ],
+                    "histogram": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "histogram"
+                      }
+                    ],
+                    "histogram2d": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "histogram2d"
+                      }
+                    ],
+                    "histogram2dcontour": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "histogram2dcontour"
+                      }
+                    ],
+                    "mesh3d": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "mesh3d"
+                      }
+                    ],
+                    "parcoords": [
+                      {
+                        "line": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "parcoords"
+                      }
+                    ],
+                    "pie": [
+                      {
+                        "automargin": true,
+                        "type": "pie"
+                      }
+                    ],
+                    "scatter": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatter"
+                      }
+                    ],
+                    "scatter3d": [
+                      {
+                        "line": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatter3d"
+                      }
+                    ],
+                    "scattercarpet": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattercarpet"
+                      }
+                    ],
+                    "scattergeo": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattergeo"
+                      }
+                    ],
+                    "scattergl": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattergl"
+                      }
+                    ],
+                    "scattermapbox": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattermapbox"
+                      }
+                    ],
+                    "scatterpolar": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterpolar"
+                      }
+                    ],
+                    "scatterpolargl": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterpolargl"
+                      }
+                    ],
+                    "scatterternary": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterternary"
+                      }
+                    ],
+                    "surface": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "surface"
+                      }
+                    ],
+                    "table": [
+                      {
+                        "cells": {
+                          "fill": {
+                            "color": "#EBF0F8"
+                          },
+                          "line": {
+                            "color": "white"
+                          }
+                        },
+                        "header": {
+                          "fill": {
+                            "color": "#C8D4E3"
+                          },
+                          "line": {
+                            "color": "white"
+                          }
+                        },
+                        "type": "table"
+                      }
+                    ]
+                  },
+                  "layout": {
+                    "annotationdefaults": {
+                      "arrowcolor": "#2a3f5f",
+                      "arrowhead": 0,
+                      "arrowwidth": 1
+                    },
+                    "autotypenumbers": "strict",
+                    "coloraxis": {
+                      "colorbar": {
+                        "outlinewidth": 0,
+                        "ticks": ""
+                      }
+                    },
+                    "colorscale": {
+                      "diverging": [
+                        [
+                          0,
+                          "#8e0152"
+                        ],
+                        [
+                          0.1,
+                          "#c51b7d"
+                        ],
+                        [
+                          0.2,
+                          "#de77ae"
+                        ],
+                        [
+                          0.3,
+                          "#f1b6da"
+                        ],
+                        [
+                          0.4,
+                          "#fde0ef"
+                        ],
+                        [
+                          0.5,
+                          "#f7f7f7"
+                        ],
+                        [
+                          0.6,
+                          "#e6f5d0"
+                        ],
+                        [
+                          0.7,
+                          "#b8e186"
+                        ],
+                        [
+                          0.8,
+                          "#7fbc41"
+                        ],
+                        [
+                          0.9,
+                          "#4d9221"
+                        ],
+                        [
+                          1,
+                          "#276419"
+                        ]
+                      ],
+                      "sequential": [
+                        [
+                          0,
+                          "#0d0887"
+                        ],
+                        [
+                          0.1111111111111111,
+                          "#46039f"
+                        ],
+                        [
+                          0.2222222222222222,
+                          "#7201a8"
+                        ],
+                        [
+                          0.3333333333333333,
+                          "#9c179e"
+                        ],
+                        [
+                          0.4444444444444444,
+                          "#bd3786"
+                        ],
+                        [
+                          0.5555555555555556,
+                          "#d8576b"
+                        ],
+                        [
+                          0.6666666666666666,
+                          "#ed7953"
+                        ],
+                        [
+                          0.7777777777777778,
+                          "#fb9f3a"
+                        ],
+                        [
+                          0.8888888888888888,
+                          "#fdca26"
+                        ],
+                        [
+                          1,
+                          "#f0f921"
+                        ]
+                      ],
+                      "sequentialminus": [
+                        [
+                          0,
+                          "#0d0887"
+                        ],
+                        [
+                          0.1111111111111111,
+                          "#46039f"
+                        ],
+                        [
+                          0.2222222222222222,
+                          "#7201a8"
+                        ],
+                        [
+                          0.3333333333333333,
+                          "#9c179e"
+                        ],
+                        [
+                          0.4444444444444444,
+                          "#bd3786"
+                        ],
+                        [
+                          0.5555555555555556,
+                          "#d8576b"
+                        ],
+                        [
+                          0.6666666666666666,
+                          "#ed7953"
+                        ],
+                        [
+                          0.7777777777777778,
+                          "#fb9f3a"
+                        ],
+                        [
+                          0.8888888888888888,
+                          "#fdca26"
+                        ],
+                        [
+                          1,
+                          "#f0f921"
+                        ]
+                      ]
+                    },
+                    "colorway": [
+                      "#636efa",
+                      "#EF553B",
+                      "#00cc96",
+                      "#ab63fa",
+                      "#FFA15A",
+                      "#19d3f3",
+                      "#FF6692",
+                      "#B6E880",
+                      "#FF97FF",
+                      "#FECB52"
+                    ],
+                    "font": {
+                      "color": "#2a3f5f"
+                    },
+                    "geo": {
+                      "bgcolor": "white",
+                      "lakecolor": "white",
+                      "landcolor": "#E5ECF6",
+                      "showlakes": true,
+                      "showland": true,
+                      "subunitcolor": "white"
+                    },
+                    "hoverlabel": {
+                      "align": "left"
+                    },
+                    "hovermode": "closest",
+                    "mapbox": {
+                      "style": "light"
+                    },
+                    "paper_bgcolor": "white",
+                    "plot_bgcolor": "#E5ECF6",
+                    "polar": {
+                      "angularaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "bgcolor": "#E5ECF6",
+                      "radialaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      }
+                    },
+                    "scene": {
+                      "xaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      },
+                      "yaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      },
+                      "zaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      }
+                    },
+                    "shapedefaults": {
+                      "line": {
+                        "color": "#2a3f5f"
+                      }
+                    },
+                    "ternary": {
+                      "aaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "baxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "bgcolor": "#E5ECF6",
+                      "caxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      }
+                    },
+                    "title": {
+                      "x": 0.05
+                    },
+                    "xaxis": {
+                      "automargin": true,
+                      "gridcolor": "white",
+                      "linecolor": "white",
+                      "ticks": "",
+                      "title": {
+                        "standoff": 15
+                      },
+                      "zerolinecolor": "white",
+                      "zerolinewidth": 2
+                    },
+                    "yaxis": {
+                      "automargin": true,
+                      "gridcolor": "white",
+                      "linecolor": "white",
+                      "ticks": "",
+                      "title": {
+                        "standoff": 15
+                      },
+                      "zerolinecolor": "white",
+                      "zerolinewidth": 2
+                    }
+                  }
+                },
+                "title": {
+                  "text": "Pareto Frontier"
+                },
+                "width": 750,
+                "xaxis": {
+                  "ticksuffix": "",
+                  "title": {
+                    "text": "branin"
+                  },
+                  "zeroline": true,
+                  "type": "linear",
+                  "range": [
+                    90.31414858006933,
+                    308.8179963942545
+                  ],
+                  "autorange": true
+                },
+                "yaxis": {
+                  "ticksuffix": "",
+                  "title": {
+                    "text": "currin"
+                  },
+                  "zeroline": true,
+                  "type": "linear",
+                  "range": [
+                    3.474465097089219,
+                    14.547160770758298
+                  ],
+                  "autorange": true
+                }
+              }
+            },
+            "text/html": "<div>                            <div id=\"e7710b14-3b74-4cc5-86d6-8afa7dd15961\" class=\"plotly-graph-div\" style=\"height:500px; width:750px;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"e7710b14-3b74-4cc5-86d6-8afa7dd15961\")) {                    Plotly.newPlot(                        \"e7710b14-3b74-4cc5-86d6-8afa7dd15961\",                        [{\"error_x\": {\"array\": [2.1041476996943254, 6.786010259991971, 1.9656113401688824, 4.423732739414581, 0.053469934857209245, 2.78694105198828, 0.6898236525271969, 0.9382302172266984, 2.7732821025012337, 0.8286482293982549, 0.034751076827254826, 2.3476668361744735, 1.4979352627173559, 0.06967102340856428, 0.8953939354024776, 4.59889063486126, 3.3354967958939197, 3.6932123296624937, 4.221451769816604, 0.031238075792602585], \"color\": \"rgba(128,177,211,0.4)\", \"thickness\": 2, \"type\": \"data\"}, \"error_y\": {\"array\": [0.17873377264041637, 0.5515306718683937, 0.17253745258952607, 0.3751576343449705, 0.002915780693328641, 0.2410228815566845, 0.0644407066074909, 0.08878179657195737, 0.23989919395858042, 0.06689120025862685, 0.0014881697544525598, 0.1998204250555273, 0.13264795654518274, 0.0030433240864689635, 0.08444141407318506, 0.38959075548529154, 0.2842421343096247, 0.31436630497056933, 0.3584212826999636, 0.0013820652020805975], \"color\": \"rgba(128,177,211,0.4)\", \"thickness\": 2, \"type\": \"data\"}, \"hoverinfo\": \"text\", \"legendgroup\": \"mean\", \"marker\": {\"color\": \"rgba(128,177,211,1)\"}, \"mode\": \"markers\", \"name\": \"mean\", \"text\": [\"<b>Parameterization 0</b><br>currin: 13.465 [13.287, 13.644]<br>branin: 117.584 [115.480, 119.688]<br><br><em>Parameterization:</em><br>x1: 0.16767920184322185<br>x2: 0.0\", \"<b>Parameterization 1</b><br>currin: 4.58 [4.028, 5.131]<br>branin: 291.107 [284.321, 297.893]<br><br><em>Parameterization:</em><br>x1: 0.0<br>x2: 0.0\", \"<b>Parameterization 2</b><br>currin: 6.184 [6.012, 6.357]<br>branin: 261.934 [259.969, 263.900]<br><br><em>Parameterization:</em><br>x1: 0.027194891362803644<br>x2: 2.5185166380839053e-16\", \"<b>Parameterization 3</b><br>currin: 13.6 [13.225, 13.975]<br>branin: 106.514 [102.091, 110.938]<br><br><em>Parameterization:</em><br>x1: 0.18536860966736218<br>x2: 3.3443785963432355e-18\", \"<b>Parameterization 4</b><br>currin: 12.077 [12.074, 12.080]<br>branin: 159.55 [159.496, 159.603]<br><br><em>Parameterization:</em><br>x1: 0.11460868316283454<br>x2: 5.3303323434787666e-17\", \"<b>Parameterization 5</b><br>currin: 5.816 [5.575, 6.057]<br>branin: 268.351 [265.564, 271.138]<br><br><em>Parameterization:</em><br>x1: 0.02160336746884051<br>x2: 0.0\", \"<b>Parameterization 6</b><br>currin: 8.372 [8.307, 8.436]<br>branin: 225.605 [224.915, 226.295]<br><br><em>Parameterization:</em><br>x1: 0.05683632434773296<br>x2: 4.918922233951485e-16\", \"<b>Parameterization 7</b><br>currin: 9.325 [9.236, 9.414]<br>branin: 210.035 [209.097, 210.973]<br><br><em>Parameterization:</em><br>x1: 0.06925532709748217<br>x2: 1.5503707099545582e-16\", \"<b>Parameterization 8</b><br>currin: 5.821 [5.581, 6.061]<br>branin: 268.252 [265.478, 271.025]<br><br><em>Parameterization:</em><br>x1: 0.021691376056676585<br>x2: 3.2051296233652496e-17\", \"<b>Parameterization 9</b><br>currin: 13.243 [13.177, 13.310]<br>branin: 127.566 [126.737, 128.395]<br><br><em>Parameterization:</em><br>x1: 0.15325527390673868<br>x2: 1.773379865989145e-17\", \"<b>Parameterization 10</b><br>currin: 12.673 [12.671, 12.674]<br>branin: 145.076 [145.041, 145.111]<br><br><em>Parameterization:</em><br>x1: 0.13084181053123273<br>x2: 2.962376806316503e-16\", \"<b>Parameterization 11</b><br>currin: 13.49 [13.290, 13.690]<br>branin: 116.153 [113.805, 118.500]<br><br><em>Parameterization:</em><br>x1: 0.16985994621981024<br>x2: 2.9632435661937766e-18\", \"<b>Parameterization 12</b><br>currin: 6.425 [6.293, 6.558]<br>branin: 257.798 [256.300, 259.296]<br><br><em>Parameterization:</em><br>x1: 0.030717753467459964<br>x2: 0.0\", \"<b>Parameterization 13</b><br>currin: 11.898 [11.895, 11.901]<br>branin: 163.491 [163.421, 163.561]<br><br><em>Parameterization:</em><br>x1: 0.11051194919717217<br>x2: 1.072738325674222e-17\", \"<b>Parameterization 14</b><br>currin: 8.957 [8.872, 9.041]<br>branin: 216.076 [215.180, 216.971]<br><br><em>Parameterization:</em><br>x1: 0.06441505706513105<br>x2: 1.5792301613815218e-16\", \"<b>Parameterization 15</b><br>currin: 13.604 [13.214, 13.994]<br>branin: 105.838 [101.239, 110.437]<br><br><em>Parameterization:</em><br>x1: 0.18651341392393878<br>x2: 9.650520914440527e-19\", \"<b>Parameterization 16</b><br>currin: 13.559 [13.275, 13.844]<br>branin: 111.117 [107.782, 114.453]<br><br><em>Parameterization:</em><br>x1: 0.17777816466095842<br>x2: 3.439734827962657e-18\", \"<b>Parameterization 17</b><br>currin: 13.576 [13.262, 13.890]<br>branin: 109.518 [105.824, 113.211]<br><br><em>Parameterization:</em><br>x1: 0.18037637368600104<br>x2: 1.496325793153615e-17\", \"<b>Parameterization 18</b><br>currin: 13.595 [13.236, 13.953]<br>branin: 107.315 [103.093, 111.536]<br><br><em>Parameterization:</em><br>x1: 0.18402322384256978<br>x2: 4.938866169707718e-18\", \"<b>Parameterization 19</b><br>currin: 12.641 [12.640, 12.642]<br>branin: 145.905 [145.874, 145.936]<br><br><em>Parameterization:</em><br>x1: 0.12986019184125364<br>x2: 4.2280177997753536e-19\"], \"type\": \"scatter\", \"x\": [117.58389028667554, 291.1067937435533, 261.9341390131741, 106.51430497393156, 159.54982074893252, 268.35108348668814, 225.60472789080484, 210.03477458396634, 268.2515823601982, 127.5659257867915, 145.07590658746625, 116.15282771282256, 257.79795250639734, 163.49083168058758, 216.07584733390487, 105.83823160563985, 111.11717547592815, 109.51765586973892, 107.31479871719597, 145.90475360323035], \"y\": [13.46541893538193, 4.579630552641066, 6.184094471672527, 13.59992686397306, 12.07689179916785, 5.815591848370005, 8.371898089153662, 9.325132431371747, 5.821247624136068, 13.243409084309496, 12.672589873157278, 13.489805244845972, 6.425393170140941, 11.897802484570782, 8.956711548412214, 13.603935231589551, 13.559435420005158, 13.576081782633128, 13.59453002560557, 12.64105232536555]}],                        {\"height\": 500, \"hovermode\": \"closest\", \"legend\": {\"orientation\": \"h\"}, \"margin\": {\"b\": 75, \"l\": 225, \"pad\": 4, \"t\": 75}, \"template\": {\"data\": {\"bar\": [{\"error_x\": {\"color\": \"#2a3f5f\"}, \"error_y\": {\"color\": \"#2a3f5f\"}, \"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"bar\"}], \"barpolar\": [{\"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"barpolar\"}], \"carpet\": [{\"aaxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"baxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"type\": \"carpet\"}], \"choropleth\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"choropleth\"}], \"contour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"contour\"}], \"contourcarpet\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"contourcarpet\"}], \"heatmap\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmap\"}], \"heatmapgl\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmapgl\"}], \"histogram\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"histogram\"}], \"histogram2d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2d\"}], \"histogram2dcontour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2dcontour\"}], \"mesh3d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"mesh3d\"}], \"parcoords\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"parcoords\"}], \"pie\": [{\"automargin\": true, \"type\": \"pie\"}], \"scatter\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter\"}], \"scatter3d\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter3d\"}], \"scattercarpet\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattercarpet\"}], \"scattergeo\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergeo\"}], \"scattergl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergl\"}], \"scattermapbox\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattermapbox\"}], \"scatterpolar\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolar\"}], \"scatterpolargl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolargl\"}], \"scatterternary\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterternary\"}], \"surface\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"surface\"}], \"table\": [{\"cells\": {\"fill\": {\"color\": \"#EBF0F8\"}, \"line\": {\"color\": \"white\"}}, \"header\": {\"fill\": {\"color\": \"#C8D4E3\"}, \"line\": {\"color\": \"white\"}}, \"type\": \"table\"}]}, \"layout\": {\"annotationdefaults\": {\"arrowcolor\": \"#2a3f5f\", \"arrowhead\": 0, \"arrowwidth\": 1}, \"autotypenumbers\": \"strict\", \"coloraxis\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"colorscale\": {\"diverging\": [[0, \"#8e0152\"], [0.1, \"#c51b7d\"], [0.2, \"#de77ae\"], [0.3, \"#f1b6da\"], [0.4, \"#fde0ef\"], [0.5, \"#f7f7f7\"], [0.6, \"#e6f5d0\"], [0.7, \"#b8e186\"], [0.8, \"#7fbc41\"], [0.9, \"#4d9221\"], [1, \"#276419\"]], \"sequential\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"sequentialminus\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]]}, \"colorway\": [\"#636efa\", \"#EF553B\", \"#00cc96\", \"#ab63fa\", \"#FFA15A\", \"#19d3f3\", \"#FF6692\", \"#B6E880\", \"#FF97FF\", \"#FECB52\"], \"font\": {\"color\": \"#2a3f5f\"}, \"geo\": {\"bgcolor\": \"white\", \"lakecolor\": \"white\", \"landcolor\": \"#E5ECF6\", \"showlakes\": true, \"showland\": true, \"subunitcolor\": \"white\"}, \"hoverlabel\": {\"align\": \"left\"}, \"hovermode\": \"closest\", \"mapbox\": {\"style\": \"light\"}, \"paper_bgcolor\": \"white\", \"plot_bgcolor\": \"#E5ECF6\", \"polar\": {\"angularaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"radialaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"scene\": {\"xaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"yaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"zaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}}, \"shapedefaults\": {\"line\": {\"color\": \"#2a3f5f\"}}, \"ternary\": {\"aaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"baxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"caxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"title\": {\"x\": 0.05}, \"xaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}, \"yaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}}}, \"title\": {\"text\": \"Pareto Frontier\"}, \"width\": 750, \"xaxis\": {\"ticksuffix\": \"\", \"title\": {\"text\": \"branin\"}, \"zeroline\": true}, \"yaxis\": {\"ticksuffix\": \"\", \"title\": {\"text\": \"currin\"}, \"zeroline\": true}},                        {\"responsive\": true}                    ).then(function(){\n                            \nvar gd = document.getElementById('e7710b14-3b74-4cc5-86d6-8afa7dd15961');\nvar x = new MutationObserver(function (mutations, observer) {{\n        var display = window.getComputedStyle(gd).display;\n        if (!display || display === 'none') {{\n            console.log([gd, 'removed!']);\n            Plotly.purge(gd);\n            observer.disconnect();\n        }}\n}});\n\n// Listen for the removal of the full notebook cells\nvar notebookContainer = gd.closest('#notebook-container');\nif (notebookContainer) {{\n    x.observe(notebookContainer, {childList: true});\n}}\n\n// Listen for the clearing of the current output cell\nvar outputEl = gd.closest('.output');\nif (outputEl) {{\n    x.observe(outputEl, {childList: true});\n}}\n\n                        })                };                });            </script>        </div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "b9127c73-b1b6-4e46-b593-43068d5015a8",
+        "showInput": true,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Appendix: Using `ScalarizedPosteriorTransform`\n",
+        "\n",
+        "Using the `ScalarizedPosteriorTransform` abstraction, the functionality of `ScalarizedUpperConfidenceBound` implemented above can be easily achieved in just a few lines of code. `PosteriorTransform`s can be used with both the MC and analytic acquisition functions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "79a4b36f-4b14-4a62-9dc6-883931ceb5d3",
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "79a4b36f-4b14-4a62-9dc6-883931ceb5d3",
+        "executionStopTime": 1646671937283,
+        "executionStartTime": 1646671937206
+      },
+      "source": [
+        "from botorch.acquisition.objective import ScalarizedPosteriorTransform\n",
+        "from botorch.acquisition.analytic import UpperConfidenceBound\n",
+        "\n",
+        "pt = ScalarizedPosteriorTransform(weights=torch.tensor([0.1, 0.5]))\n",
+        "SUCB = UpperConfidenceBound(gp, beta=0.1, posterior_transform=pt)"
+      ],
+      "execution_count": 16,
+      "outputs": []
     }
-   ],
-   "source": [
-    "# batch-evaluate on 3 points\n",
-    "SUCB(torch.rand(3, 1, 2))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To use our newly minted acquisition function within Ax, we need to write a custom factory function and pass it to the constructor of Ax's `BotorchModel` as the `acqf_constructor`, which has the call signature:\n",
-    "\n",
-    "```python\n",
-    "def acqf_constructor(\n",
-    "    model: Model,\n",
-    "    objective_weights: Tensor,\n",
-    "    outcome_constraints: Optional[Tuple[Tensor, Tensor]],\n",
-    "    X_observed: Optional[Tensor] = None,\n",
-    "    X_pending: Optional[Tensor] = None,\n",
-    "    **kwargs: Any,\n",
-    ") -> AcquisitionFunction:\n",
-    "```\n",
-    "\n",
-    "The argument `objective_weights` allows for scalarization of multiple objectives, `outcome_constraints` is used to define constraints on multi-output models, `X_observed` contains previously observed points (useful for acquisition functions such as Noisy Expected Improvement), and `X_pending` are the points that are awaiting observations. By default, Ax uses the Noisy Expected Improvement (`qNoisyExpectedImprovement`) acquisition function and so the default value of `acqf_constructor` is `get_NEI` (see documentation for additional details and context).\n",
-    "\n",
-    "Note that there is ample flexibility to how the arguments of `acqf_constructor` are used. In `get_NEI`, they are used in some preprocessing steps *before* constructing the acquisition function. They could also be directly passed to the botorch acquisition function, or not used at all --  all we need to do is return an `AcquisitionFunction`. We now give a bare-bones example of a custom factory function that returns our analytic scalarized-UCB acquisition.\n",
-    "\n",
-    "```python\n",
-    "def get_scalarized_UCB(\n",
-    "    model: Model,\n",
-    "    objective_weights: Tensor,\n",
-    "    **kwargs: Any,\n",
-    ") -> AcquisitionFunction:\n",
-    "    return ScalarizedUpperConfidenceBound(model=model, beta=0.2, weights=objective_weights)\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "By following the example shown in the [custom botorch model in ax](./custom_botorch_model_in_ax) tutorial, a `BotorchModel` can be instantiated with `get_scalarized_UCB` and then run in Ax."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Using `ScalarizedObjective`\n",
-    "\n",
-    "Using the `ScalarizedObjective` abstraction, the functionality of `ScalarizedUpperConfidenceBound` implemented above can be easily achieved in just a few lines of code:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from botorch.acquisition.objective import ScalarizedObjective\n",
-    "from botorch.acquisition.analytic import UpperConfidenceBound\n",
-    "\n",
-    "obj = ScalarizedObjective(weights=torch.tensor([0.1, 0.5]))\n",
-    "SUCB = UpperConfidenceBound(gp, beta=0.1, objective=obj)"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.6"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  ]
 }

--- a/tutorials/custom_botorch_model_in_ax.ipynb
+++ b/tutorials/custom_botorch_model_in_ax.ipynb
@@ -1,300 +1,10909 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Using a custom botorch model with Ax\n",
-    "\n",
-    "In this tutorial, we illustrate how to use a custom BoTorch model within Ax's `SimpleExperiment` API. This allows us to harness the convenience of Ax for running Bayesian Optimization loops, while at the same time maintaining full flexibility in terms of the modeling.\n",
-    "\n",
-    "Acquisition functions and strategies for optimizing acquisitions can be swapped out in much the same fashion. See for example the tutorial for [Implementing a custom acquisition function](./custom_acquisition).\n",
-    "\n",
-    "If you want to do something non-standard, or would like to have full insight into every aspect of the implementation, please see [this tutorial](./closed_loop_botorch_only) for how to write your own full optimization loop in BoTorch."
-   ]
+  "metadata": {
+    "kernelspec": {
+      "display_name": "python3",
+      "language": "python",
+      "name": "python3",
+      "metadata": {
+        "is_prebuilt": false,
+        "kernel_name": "ae_local"
+      }
+    },
+    "last_server_session_id": "2b3f36cb-8a35-4d8f-8081-fd8cce11a6d8",
+    "last_kernel_id": "e8ff816f-46bf-4a21-8b69-2acd322374a8",
+    "last_base_url": "https://devvm7832.prn0.facebook.com:8090/",
+    "last_msg_id": "a8ee827c-8065665572a287dbef6b078a_155",
+    "outputWidgetContext": {}
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Implementing the custom model\n",
-    "\n",
-    "For this tutorial, we implement a very simple gpytorch Exact GP Model that uses an RBF kernel (with ARD) and infers a (homoskedastic) noise level.\n",
-    "\n",
-    "Model definition is straightforward - here we implement a gpytorch `ExactGP` that also inherits from `GPyTorchModel` -- this adds all the api calls that botorch expects in its various modules. \n",
-    "\n",
-    "*Note:* botorch also allows implementing other custom models as long as they follow the minimal `Model` API. For more information, please see the [Model Documentation](../docs/models)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from botorch.models.gpytorch import GPyTorchModel\n",
-    "from gpytorch.distributions import MultivariateNormal\n",
-    "from gpytorch.means import ConstantMean\n",
-    "from gpytorch.models import ExactGP\n",
-    "from gpytorch.kernels import RBFKernel, ScaleKernel\n",
-    "from gpytorch.likelihoods import GaussianLikelihood\n",
-    "from gpytorch.mlls import ExactMarginalLogLikelihood\n",
-    "from gpytorch.priors import GammaPrior\n",
-    "\n",
-    "\n",
-    "class SimpleCustomGP(ExactGP, GPyTorchModel):\n",
-    "\n",
-    "    _num_outputs = 1  # to inform GPyTorchModel API\n",
-    "    \n",
-    "    def __init__(self, train_X, train_Y):\n",
-    "        # squeeze output dim before passing train_Y to ExactGP\n",
-    "        super().__init__(train_X, train_Y.squeeze(-1), GaussianLikelihood())\n",
-    "        self.mean_module = ConstantMean()\n",
-    "        self.covar_module = ScaleKernel(\n",
-    "            base_kernel=RBFKernel(ard_num_dims=train_X.shape[-1]),\n",
-    "        )\n",
-    "        self.to(train_X)  # make sure we're on the right device/dtype\n",
-    "        \n",
-    "    def forward(self, x):\n",
-    "        mean_x = self.mean_module(x)\n",
-    "        covar_x = self.covar_module(x)\n",
-    "        return MultivariateNormal(mean_x, covar_x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Define a factory function to be used with Ax's BotorchModel\n",
-    "\n",
-    "Ax's `BotorchModel` internally breaks down the different components of Bayesian Optimization (model generation & fitting, defining acquisition functions, and optimizing them) into a functional api. \n",
-    "\n",
-    "Depending on which of these components we want to modify, we can pass in an associated custom factory function to the `BotorchModel` constructor. In order to use a custom model, we have to implement a model factory function that, given data according to Ax's api specification, instantiates and fits a BoTorch Model object.\n",
-    "\n",
-    "The call signature of this factory function is the following: \n",
-    "\n",
-    "```python\n",
-    "def get_and_fit_gpytorch_model(\n",
-    "    Xs: List[Tensor],\n",
-    "    Ys: List[Tensor],\n",
-    "    Yvars: List[Tensor],\n",
-    "    state_dict: Optional[Dict[str, Tensor]] = None,\n",
-    "    **kwargs: Any,\n",
-    ") -> Model:\n",
-    "```\n",
-    "\n",
-    "where\n",
-    "- the `i`-th element of `Xs` are the training features for the i-th outcome as an `n_i x d` tensor (in our simple example, we only have one outcome)\n",
-    "- similarly, the `i`-th element of `Ys` and `Yvars` are the observations and associated observation variances for the `i`-th outcome as `n_i x 1` tensors\n",
-    "- `state_dict` is an optional PyTorch module state dict that can be used to initialize the model's parameters to pre-specified values\n",
-    "\n",
-    "The function must return a botorch `Model` object. What happens inside the function is up to you.\n",
-    "\n",
-    "Using botorch's `fit_gpytorch_model` utility function, model-fitting is straightforward for this simple model (you may have to use your own custom model fitting loop when working with more complex models - see the tutorial for [Fitting a model with torch.optim](fit_model_with_torch_optimizer)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from botorch.fit import fit_gpytorch_model\n",
-    "\n",
-    "def _get_and_fit_simple_custom_gp(Xs, Ys, **kwargs):\n",
-    "    model = SimpleCustomGP(Xs[0], Ys[0])\n",
-    "    mll = ExactMarginalLogLikelihood(model.likelihood, model)\n",
-    "    fit_gpytorch_model(mll)\n",
-    "    return model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Set up the optimization problem in Ax"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Ax's `SimpleExperiment` API requires an evaluation function that is able to compute all the metrics required in the experiment. This function needs to accept a set of parameter values as a dictionary. It should produce a dictionary of metric names to tuples of mean and standard error for those metrics.\n",
-    "\n",
-    "For this tutorial, we use the Branin function, a simple synthetic benchmark function in two dimensions. In an actual application, this could be arbitrarily complicated - e.g. this function could run some costly simulation, conduct some A/B tests, or kick off some ML model training job with the given parameters). "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import random\n",
-    "import numpy as np\n",
-    "\n",
-    "def branin(parameterization, *args):\n",
-    "    x1, x2 = parameterization[\"x1\"], parameterization[\"x2\"]\n",
-    "    y = (x2 - 5.1 / (4 * np.pi ** 2) * x1 ** 2 + 5 * x1 / np.pi - 6) ** 2\n",
-    "    y += 10 * (1 - 1 / (8 * np.pi)) * np.cos(x1) + 10\n",
-    "    # let's add some synthetic observation noise\n",
-    "    y += random.normalvariate(0, 0.1)\n",
-    "    return {\"branin\": (y, 0.0)}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We need to define a search space for our experiment that defines the parameters and the set of feasible values."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ax import ParameterType, RangeParameter, SearchSpace\n",
-    "\n",
-    "search_space = SearchSpace(\n",
-    "    parameters=[\n",
-    "        RangeParameter(\n",
-    "            name=\"x1\", parameter_type=ParameterType.FLOAT, lower=-5, upper=10\n",
-    "        ),\n",
-    "        RangeParameter(\n",
-    "            name=\"x2\", parameter_type=ParameterType.FLOAT, lower=0, upper=15\n",
-    "        ),\n",
-    "    ]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Third, we make a `SimpleExperiment` — note that the `objective_name` needs to be one of the metric names returned by the evaluation function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ax import SimpleExperiment\n",
-    "\n",
-    "exp = SimpleExperiment(\n",
-    "    name=\"test_branin\",\n",
-    "    search_space=search_space,\n",
-    "    evaluation_function=branin,\n",
-    "    objective_name=\"branin\",\n",
-    "    minimize=True,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We use the Sobol generator to create 5 (quasi-) random initial point in the search space. Calling `batch_trial` will cause Ax to evaluate the underlying `branin` function at the generated points, and automatically keep track of the results."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
+  "nbformat": 4,
+  "nbformat_minor": 2,
+  "cells": [
     {
-     "data": {
-      "text/plain": [
-       "BatchTrial(experiment_name='test_branin', index=0, status=TrialStatus.CANDIDATE)"
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "8760cbbb-0419-4ddd-b16d-360a0f8efb23",
+        "showInput": true,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "## Using a custom BoTorch model with Ax\n",
+        "\n",
+        "In this tutorial, we illustrate how to use a custom BoTorch model within Ax's `botorch_modular` API. This allows us to harness the convenience of Ax for running Bayesian Optimization loops, while at the same time maintaining full flexibility in terms of the modeling.\n",
+        "\n",
+        "Acquisition functions and strategies for optimizing acquisitions can be swapped out in much the same fashion. See for example the tutorial for [Implementing a custom acquisition function](./custom_acquisition).\n",
+        "\n",
+        "If you want to do something non-standard, or would like to have full insight into every aspect of the implementation, please see [this tutorial](./closed_loop_botorch_only) for how to write your own full optimization loop in BoTorch.\n",
+        "\n",
+        "Next cell sets up a decorator solely to speed up the testing of the notebook. You can safely ignore this cell and the use of the decorator throughout the tutorial."
       ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from ax.modelbridge import get_sobol\n",
-    "\n",
-    "sobol = get_sobol(exp.search_space)\n",
-    "exp.new_batch_trial(generator_run=sobol.gen(5))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To run our custom botorch model inside the Ax optimization loop, we can use the `get_botorch` factory function from `ax.modelbridge.factory`. Any keyword arguments given to this function are passed through to the `BotorchModel` constructor. To use our custom model, we just need to pass our newly minted `_get_and_fit_simple_custom_gp` function to `get_botorch` using the `model_constructor` argument.\n",
-    "\n",
-    "**Note:** `get_botorch` by default automatically applies a number of parameter transformations (e.g. to normalize input data or standardize output data). This is typically what you want for standard use cases with continuous parameters. If your model expects raw parameters, make sure to pass in `transforms=[]` to avoid any transformations to take place. See the [Ax documentation](https://ax.dev/docs/models.html#transforms) for additional information on how transformations in Ax work."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Run the optimization loop\n",
-    "\n",
-    "We're ready to run the Bayesian Optimization loop."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running optimization batch 1/5...\n",
-      "Running optimization batch 2/5...\n",
-      "Running optimization batch 3/5...\n",
-      "Running optimization batch 4/5...\n",
-      "Running optimization batch 5/5...\n",
-      "Done!\n"
-     ]
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "0b364288-7551-4ebb-9f96-719361878af3",
+        "showInput": true,
+        "customInput": null,
+        "collapsed": false,
+        "requestMsgId": "4c7bff19-2eca-4be8-8d92-f4f3b9f23d85",
+        "executionStartTime": 1646802598883,
+        "executionStopTime": 1646802598888
+      },
+      "source": [
+        "import os\n",
+        "from contextlib import contextmanager\n",
+        "\n",
+        "from ax.utils.testing.mock import fast_botorch_optimize_context_manager\n",
+        "\n",
+        "\n",
+        "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")\n",
+        "\n",
+        "\n",
+        "@contextmanager\n",
+        "def dummy_context_manager():\n",
+        "    yield\n",
+        "\n",
+        "\n",
+        "if SMOKE_TEST:\n",
+        "    fast_smoke_test = fast_botorch_optimize_context_manager\n",
+        "else:\n",
+        "    fast_smoke_test = dummy_context_manager"
+      ],
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "007adb71-ee1b-407c-9a61-ff948c104fce",
+        "showInput": true
+      },
+      "source": [
+        "### Implementing the custom model\n",
+        "\n",
+        "For this tutorial, we implement a very simple gpytorch Exact GP Model that uses an RBF kernel (with ARD) and infers a (homoskedastic) noise level.\n",
+        "\n",
+        "Model definition is straightforward - here we implement a gpytorch `ExactGP` that also inherits from `GPyTorchModel` -- this adds all the api calls that botorch expects in its various modules. \n",
+        "\n",
+        "*Note:* botorch also allows implementing other custom models as long as they follow the minimal `Model` API. For more information, please see the [Model Documentation](../docs/models)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "63288450-0e06-4487-857e-9e1e9d85a343",
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "d9929043-08ac-41b5-9268-2a1bef0676c8",
+        "executionStartTime": 1646802598911,
+        "executionStopTime": 1646802598919
+      },
+      "source": [
+        "from botorch.models.gpytorch import GPyTorchModel\n",
+        "from botorch.utils.containers import TrainingData\n",
+        "from gpytorch.distributions import MultivariateNormal\n",
+        "from gpytorch.kernels import RBFKernel, ScaleKernel\n",
+        "from gpytorch.likelihoods import GaussianLikelihood\n",
+        "from gpytorch.means import ConstantMean\n",
+        "from gpytorch.models import ExactGP\n",
+        "\n",
+        "\n",
+        "class SimpleCustomGP(ExactGP, GPyTorchModel):\n",
+        "\n",
+        "    _num_outputs = 1  # to inform GPyTorchModel API\n",
+        "\n",
+        "    def __init__(self, train_X, train_Y):\n",
+        "        # squeeze output dim before passing train_Y to ExactGP\n",
+        "        super().__init__(train_X, train_Y.squeeze(-1), GaussianLikelihood())\n",
+        "        self.mean_module = ConstantMean()\n",
+        "        self.covar_module = ScaleKernel(\n",
+        "            base_kernel=RBFKernel(ard_num_dims=train_X.shape[-1]),\n",
+        "        )\n",
+        "        self.to(train_X)  # make sure we're on the right device/dtype\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        mean_x = self.mean_module(x)\n",
+        "        covar_x = self.covar_module(x)\n",
+        "        return MultivariateNormal(mean_x, covar_x)\n",
+        "\n",
+        "    @classmethod\n",
+        "    def construct_inputs(cls, training_data: TrainingData, **kwargs):\n",
+        "        r\"\"\"Construct kwargs for the `SimpleCustomGP` from `TrainingData` and other options.\n",
+        "\n",
+        "        Args:\n",
+        "            training_data: `TrainingData` container with data for single outcome\n",
+        "                or for multiple outcomes for batched multi-output case.\n",
+        "            **kwargs: None expected for this class.\n",
+        "        \"\"\"\n",
+        "        return {\"train_X\": training_data.X, \"train_Y\": training_data.Y}"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "0f22b707-cec8-43a1-9152-503a1904fbd5",
+        "showInput": false,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Instantiate a `BoTorchModel` in Ax\n",
+        "\n",
+        "A `BoTorchModel` in Ax encapsulates both the surrogate (commonly referred to as `Model` in BoTorch) and an acquisition function. Here, we will only specify the custom surrogate and let Ax choose the default acquisition function.\n",
+        "\n",
+        "Most models should work with the base `Surrogate` in Ax, except for BoTorch `ModelListGP`, which works with `ListSurrogate`.\n",
+        "Note that the `Model` (e.g., the `SimpleCustomGP`) must implement `construct_inputs`, as this is used to construct the inputs required for instantiating a `Model` instance from the experiment data.\n",
+        "\n",
+        "In case the `Model` requires a complex set of arguments that cannot be constructed using a `construct_inputs` method, one can initialize the `model` and supply it via `Surrogate.from_botorch(model=model, mll_class=<Optional>)`, replacing the `Surrogate(...)` below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "e848d43f-cee5-4d6f-a930-2559554582d6",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "f55bab2a-3462-4377-82d3-8ea107d2551b",
+        "executionStartTime": 1646802598937,
+        "executionStopTime": 1646802598969
+      },
+      "source": [
+        "from ax.models.torch.botorch_modular.model import BoTorchModel\n",
+        "from ax.models.torch.botorch_modular.surrogate import Surrogate\n",
+        "\n",
+        "\n",
+        "ax_model = BoTorchModel(\n",
+        "    surrogate=Surrogate(\n",
+        "        # The model class to use\n",
+        "        botorch_model_class=SimpleCustomGP,\n",
+        "        # Optional, MLL class with which to optimize model parameters\n",
+        "        # mll_class=ExactMarginalLogLikelihood,\n",
+        "        # Optional, dictionary of keyword arguments to model constructor\n",
+        "        # model_options={}\n",
+        "    ),\n",
+        "    # Optional, acquisition function class to use - see custom acquisition tutorial\n",
+        "    # botorch_acqf_class=qExpectedImprovement,\n",
+        ")"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "4254a19d-cf71-4a88-a00f-608331cd9f54",
+        "showInput": false,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Combine with a `ModelBridge`\n",
+        "\n",
+        "`Model`s in Ax require a `ModelBridge` to interface with `Experiment`s. A `ModelBridge` takes the inputs supplied by the `Experiment` and converts them to the inputs expected by the `Model`. For a `BoTorchModel`, we use `TorchModelBridge`. The usage is as follows:\n",
+        "\n",
+        "```\n",
+        "from ax.modelbridge import TorchModelBridge\n",
+        "model_bridge = TorchModelBridge(\n",
+        "    experiment: Experiment,\n",
+        "    search_space: SearchSpace,\n",
+        "    data: Data,\n",
+        "    model: TorchModel,\n",
+        "    transforms: List[Type[Transform]],\n",
+        "    # And additional optional arguments.\n",
+        ")\n",
+        "# To generate a trial\n",
+        "trial = model_bridge.gen(1)\n",
+        "```\n",
+        "\n",
+        "For Modular BoTorch interface, we can combine the creation of the `BoTorchModel` and the `TorchModelBridge` into a single step as follows:\n",
+        "\n",
+        "```\n",
+        "from ax.modelbridge.registry import Models\n",
+        "model_bridge = Models.BOTORCH_MODULAR(\n",
+        "    experiment=experiment,\n",
+        "    data=data,\n",
+        "    surrogate=Surrogate(SimpleCustomGP),  # Optional, will use default if unspecified\n",
+        "    # Optional, will use default if unspecified\n",
+        "    # botorch_acqf_class=qNoisyExpectedImprovement,  \n",
+        ")\n",
+        "# To generate a trial\n",
+        "trial = model_bridge.gen(1)\n",
+        "```\n",
+        ""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "40d38579-279d-49fd-b2aa-e8c1fcab2a61",
+        "showInput": false,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "# Using the custom model in Ax to optimize the Branin function\n",
+        "\n",
+        "We will demonstrate this with both the Service API (simpler, easier to use) and the Developer API (advanced, more customizable)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "f4553323-645d-40f9-b1d5-b549e5265eb9",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "## Optimization with the Service API\n",
+        "\n",
+        "A detailed tutorial on the Service API can be found [here](https://ax.dev/tutorials/gpei_hartmann_service.html).\n",
+        "\n",
+        "In order to customize the way the candidates are created in Service API, we need to construct a new `GenerationStrategy` and pass it into `AxClient`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "906806a1-8b77-4719-82cb-4b86cc696271",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "5d74fa60-f595-4e7a-bbbc-e91f42b934d1",
+        "executionStartTime": 1646802598995,
+        "executionStopTime": 1646802599053
+      },
+      "source": [
+        "from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy\n",
+        "from ax.modelbridge.registry import Models\n",
+        "\n",
+        "\n",
+        "gs = GenerationStrategy(\n",
+        "    steps=[\n",
+        "        # Quasi-random initialization step\n",
+        "        GenerationStep(\n",
+        "            model=Models.SOBOL,\n",
+        "            num_trials=5,  # How many trials should be produced from this generation step\n",
+        "        ),\n",
+        "        # Bayesian optimization step using the custom acquisition function\n",
+        "        GenerationStep(\n",
+        "            model=Models.BOTORCH_MODULAR,\n",
+        "            num_trials=-1,  # No limitation on how many trials should be produced from this step\n",
+        "            # For `BOTORCH_MODULAR`, we pass in kwargs to specify what surrogate or acquisition function to use.\n",
+        "            model_kwargs={\n",
+        "                \"surrogate\": Surrogate(SimpleCustomGP),\n",
+        "            },\n",
+        "        ),\n",
+        "    ]\n",
+        ")"
+      ],
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "24e0fd52-cf2f-4c5a-8130-82e3b133c7df",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Setting up the experiment\n",
+        "\n",
+        "In order to use the `GenerationStrategy` we just created, we will pass it into the `AxClient`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "84dad757-0494-4fc3-9acd-7262367b2671",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "a3e2cc43-6913-4c70-bd5c-9d867c95b8ed",
+        "executionStartTime": 1646802599081,
+        "executionStopTime": 1646802599411
+      },
+      "source": [
+        "import torch\n",
+        "from ax.service.ax_client import AxClient\n",
+        "from ax.service.utils.instantiation import ObjectiveProperties\n",
+        "from botorch.test_functions import Branin\n",
+        "\n",
+        "\n",
+        "# Initialize the client - AxClient offers a convenient API to control the experiment\n",
+        "ax_client = AxClient(generation_strategy=gs)\n",
+        "# Setup the experiment\n",
+        "ax_client.create_experiment(\n",
+        "    name=\"branin_test_experiment\",\n",
+        "    parameters=[\n",
+        "        {\n",
+        "            \"name\": \"x1\",\n",
+        "            \"type\": \"range\",\n",
+        "            # It is crucial to use floats for the bounds, i.e., 0.0 rather than 0.\n",
+        "            # Otherwise, the parameter would be inferred as an integer range.\n",
+        "            \"bounds\": [-5.0, 10.0],\n",
+        "        },\n",
+        "        {\n",
+        "            \"name\": \"x2\",\n",
+        "            \"type\": \"range\",\n",
+        "            \"bounds\": [0.0, 15.0],\n",
+        "        },\n",
+        "    ],\n",
+        "    objectives={\n",
+        "        \"branin\": ObjectiveProperties(minimize=True),\n",
+        "    },\n",
+        ")\n",
+        "# Setup a function to evaluate the trials\n",
+        "branin = Branin()\n",
+        "\n",
+        "\n",
+        "def evaluate(parameters):\n",
+        "    x = torch.tensor([[parameters.get(f\"x{i+1}\") for i in range(2)]])\n",
+        "    # In our case, standard error is 0, since we are computing a synthetic function.\n",
+        "    # Our custom model does not utilize the SEM, so this (passing 0) has no effect.\n",
+        "    return {\"branin\": (branin(x).item(), 0.0)}"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.ax_client: Starting optimization with verbose logging. To disable logging, set the `verbose_logging` argument to `False`. Note that float values in the logs are rounded to 6 decimal points.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.utils.instantiation: Inferred value type of ParameterType.FLOAT for parameter x1. If that is not the expected value type, you can explicity specify 'value_type' ('int', 'float', 'bool' or 'str') in parameter dict.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.utils.instantiation: Inferred value type of ParameterType.FLOAT for parameter x2. If that is not the expected value type, you can explicity specify 'value_type' ('int', 'float', 'bool' or 'str') in parameter dict.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.utils.instantiation: Created search space: SearchSpace(parameters=[RangeParameter(name='x1', parameter_type=FLOAT, range=[-5.0, 10.0]), RangeParameter(name='x2', parameter_type=FLOAT, range=[0.0, 15.0])], parameter_constraints=[]).\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "25ac5ba7-291b-466f-bed0-f8cb5f842605",
+        "showInput": true,
+        "customInput": null
+      },
+      "source": [
+        "### Running the BO loop"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "84f831d3-a148-4872-8ca6-2413d3c75b9c",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "10bccad3-09b6-4711-8221-5fa0f75e7bdc",
+        "executionStartTime": 1646802599439,
+        "executionStopTime": 1646802636908
+      },
+      "source": [
+        "with fast_smoke_test():\n",
+        "    for i in range(30):\n",
+        "        parameters, trial_index = ax_client.get_next_trial()\n",
+        "        # Local evaluation here can be replaced with deployment to external system.\n",
+        "        ax_client.complete_trial(trial_index=trial_index, raw_data=evaluate(parameters))"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.ax_client: Generated new trial 0 with parameters {'x1': 1.053491, 'x2': 9.695006}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.ax_client: Completed trial 0 with data: {'branin': (42.0839, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.ax_client: Generated new trial 1 with parameters {'x1': 9.673876, 'x2': 5.031455}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.ax_client: Completed trial 1 with data: {'branin': (6.161984, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.ax_client: Generated new trial 2 with parameters {'x1': -2.698363, 'x2': 13.092639}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.ax_client: Completed trial 2 with data: {'branin': (4.775831, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.ax_client: Generated new trial 3 with parameters {'x1': 4.255731, 'x2': 5.362701}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.ax_client: Completed trial 3 with data: {'branin': (20.177181, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.ax_client: Generated new trial 4 with parameters {'x1': 9.896219, 'x2': 4.347518}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:09:59] ax.service.ax_client: Completed trial 4 with data: {'branin': (3.536641, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:00] ax.service.ax_client: Generated new trial 5 with parameters {'x1': -3.947539, 'x2': 12.530772}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:00] ax.service.ax_client: Completed trial 5 with data: {'branin': (6.466525, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:02] ax.service.ax_client: Generated new trial 6 with parameters {'x1': 10.0, 'x2': 1.062917}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:02] ax.service.ax_client: Completed trial 6 with data: {'branin': (5.706899, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:03] ax.service.ax_client: Generated new trial 7 with parameters {'x1': 7.218442, 'x2': 0.418715}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:03] ax.service.ax_client: Completed trial 7 with data: {'branin': (16.378994, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:04] ax.service.ax_client: Generated new trial 8 with parameters {'x1': -3.19908, 'x2': 0.113994}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:04] ax.service.ax_client: Completed trial 8 with data: {'branin': (151.693604, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:06] ax.service.ax_client: Generated new trial 9 with parameters {'x1': -5.0, 'x2': 15.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:06] ax.service.ax_client: Completed trial 9 with data: {'branin': (17.508297, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:08] ax.service.ax_client: Generated new trial 10 with parameters {'x1': 8.022765, 'x2': 3.542146}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:08] ax.service.ax_client: Completed trial 10 with data: {'branin': (12.370395, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:09] ax.service.ax_client: Generated new trial 11 with parameters {'x1': 5.533142, 'x2': 15.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:09] ax.service.ax_client: Completed trial 11 with data: {'branin': (208.881226, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:10] ax.service.ax_client: Generated new trial 12 with parameters {'x1': 2.911042, 'x2': 2.161366}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:10] ax.service.ax_client: Completed trial 12 with data: {'branin': (0.74213, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:11] ax.service.ax_client: Generated new trial 13 with parameters {'x1': 3.596695, 'x2': 0.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:11] ax.service.ax_client: Completed trial 13 with data: {'branin': (5.165417, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:13] ax.service.ax_client: Generated new trial 14 with parameters {'x1': 3.632046, 'x2': 2.031652}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:13] ax.service.ax_client: Completed trial 14 with data: {'branin': (1.541467, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:16] ax.service.ax_client: Generated new trial 15 with parameters {'x1': -2.117163, 'x2': 9.798724}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:16] ax.service.ax_client: Completed trial 15 with data: {'branin': (5.033342, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:20] ax.service.ax_client: Generated new trial 16 with parameters {'x1': 10.0, 'x2': 3.305778}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:20] ax.service.ax_client: Completed trial 16 with data: {'branin': (2.034841, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:22] ax.service.ax_client: Generated new trial 17 with parameters {'x1': 2.52183, 'x2': 2.546804}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:22] ax.service.ax_client: Completed trial 17 with data: {'branin': (2.251922, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:24] ax.service.ax_client: Generated new trial 18 with parameters {'x1': 3.258201, 'x2': 2.051793}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:24] ax.service.ax_client: Completed trial 18 with data: {'branin': (0.481058, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:26] ax.service.ax_client: Generated new trial 19 with parameters {'x1': 3.416109, 'x2': 2.004387}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:26] ax.service.ax_client: Completed trial 19 with data: {'branin': (0.761814, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:27] ax.service.ax_client: Generated new trial 20 with parameters {'x1': 3.143472, 'x2': 2.288195}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:27] ax.service.ax_client: Completed trial 20 with data: {'branin': (0.398119, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:29] ax.service.ax_client: Generated new trial 21 with parameters {'x1': 3.151661, 'x2': 1.988985}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:29] ax.service.ax_client: Completed trial 21 with data: {'branin': (0.475756, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:30] ax.service.ax_client: Generated new trial 22 with parameters {'x1': 3.320216, 'x2': 2.199366}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:30] ax.service.ax_client: Completed trial 22 with data: {'branin': (0.55421, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:31] ax.service.ax_client: Generated new trial 23 with parameters {'x1': 3.35505, 'x2': 1.886039}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:31] ax.service.ax_client: Completed trial 23 with data: {'branin': (0.66797, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:32] ax.service.ax_client: Generated new trial 24 with parameters {'x1': 2.995448, 'x2': 2.447697}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:32] ax.service.ax_client: Completed trial 24 with data: {'branin': (0.503379, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:32] ax.service.ax_client: Generated new trial 25 with parameters {'x1': -3.575003, 'x2': 15.0}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:32] ax.service.ax_client: Completed trial 25 with data: {'branin': (4.038473, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:33] ax.service.ax_client: Generated new trial 26 with parameters {'x1': 3.10412, 'x2': 2.184513}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:33] ax.service.ax_client: Completed trial 26 with data: {'branin': (0.419002, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:34] ax.service.ax_client: Generated new trial 27 with parameters {'x1': 3.409809, 'x2': 2.126092}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:34] ax.service.ax_client: Completed trial 27 with data: {'branin': (0.743807, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:35] ax.service.ax_client: Generated new trial 28 with parameters {'x1': 3.21861, 'x2': 2.25319}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:36] ax.service.ax_client: Completed trial 28 with data: {'branin': (0.427756, 0.0)}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:36] ax.service.ax_client: Generated new trial 29 with parameters {'x1': 3.133336, 'x2': 2.442237}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:36] ax.service.ax_client: Completed trial 29 with data: {'branin': (0.424067, 0.0)}.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "2794d041-6a39-483d-a603-cc5088bcd1b2",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Viewing the evaluated trials"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "db21dcbb-b74b-4a91-89c3-5ffbc8020220",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "71578ba1-7826-4c60-84a5-a14d5a10608c",
+        "executionStartTime": 1646802636942,
+        "executionStopTime": 1646802637202
+      },
+      "source": [
+        "ax_client.get_trials_data_frame()"
+      ],
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "        branin  trial_index arm_name  ...         x2  trial_status generation_method\n0    42.083900            0      0_0  ...   9.695006     COMPLETED             Sobol\n3     6.161984            1      1_0  ...   5.031455     COMPLETED             Sobol\n15    4.775831            2      2_0  ...  13.092639     COMPLETED             Sobol\n23   20.177181            3      3_0  ...   5.362701     COMPLETED             Sobol\n24    3.536641            4      4_0  ...   4.347518     COMPLETED             Sobol\n25    6.466525            5      5_0  ...  12.530772     COMPLETED           BoTorch\n26    5.706899            6      6_0  ...   1.062917     COMPLETED           BoTorch\n27   16.378994            7      7_0  ...   0.418715     COMPLETED           BoTorch\n28  151.693604            8      8_0  ...   0.113994     COMPLETED           BoTorch\n29   17.508297            9      9_0  ...  15.000000     COMPLETED           BoTorch\n1    12.370395           10     10_0  ...   3.542146     COMPLETED           BoTorch\n2   208.881226           11     11_0  ...  15.000000     COMPLETED           BoTorch\n4     0.742130           12     12_0  ...   2.161366     COMPLETED           BoTorch\n5     5.165417           13     13_0  ...   0.000000     COMPLETED           BoTorch\n6     1.541467           14     14_0  ...   2.031652     COMPLETED           BoTorch\n7     5.033342           15     15_0  ...   9.798724     COMPLETED           BoTorch\n8     2.034841           16     16_0  ...   3.305778     COMPLETED           BoTorch\n9     2.251922           17     17_0  ...   2.546804     COMPLETED           BoTorch\n10    0.481058           18     18_0  ...   2.051793     COMPLETED           BoTorch\n11    0.761814           19     19_0  ...   2.004387     COMPLETED           BoTorch\n12    0.398119           20     20_0  ...   2.288195     COMPLETED           BoTorch\n13    0.475756           21     21_0  ...   1.988985     COMPLETED           BoTorch\n14    0.554210           22     22_0  ...   2.199366     COMPLETED           BoTorch\n16    0.667970           23     23_0  ...   1.886039     COMPLETED           BoTorch\n17    0.503379           24     24_0  ...   2.447697     COMPLETED           BoTorch\n18    4.038473           25     25_0  ...  15.000000     COMPLETED           BoTorch\n19    0.419002           26     26_0  ...   2.184513     COMPLETED           BoTorch\n20    0.743807           27     27_0  ...   2.126092     COMPLETED           BoTorch\n21    0.427756           28     28_0  ...   2.253190     COMPLETED           BoTorch\n22    0.424067           29     29_0  ...   2.442237     COMPLETED           BoTorch\n\n[30 rows x 7 columns]",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>branin</th>\n      <th>trial_index</th>\n      <th>arm_name</th>\n      <th>x1</th>\n      <th>x2</th>\n      <th>trial_status</th>\n      <th>generation_method</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>42.083900</td>\n      <td>0</td>\n      <td>0_0</td>\n      <td>1.053491</td>\n      <td>9.695006</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>6.161984</td>\n      <td>1</td>\n      <td>1_0</td>\n      <td>9.673876</td>\n      <td>5.031455</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>4.775831</td>\n      <td>2</td>\n      <td>2_0</td>\n      <td>-2.698363</td>\n      <td>13.092639</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>23</th>\n      <td>20.177181</td>\n      <td>3</td>\n      <td>3_0</td>\n      <td>4.255731</td>\n      <td>5.362701</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>24</th>\n      <td>3.536641</td>\n      <td>4</td>\n      <td>4_0</td>\n      <td>9.896219</td>\n      <td>4.347518</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>25</th>\n      <td>6.466525</td>\n      <td>5</td>\n      <td>5_0</td>\n      <td>-3.947539</td>\n      <td>12.530772</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>26</th>\n      <td>5.706899</td>\n      <td>6</td>\n      <td>6_0</td>\n      <td>10.000000</td>\n      <td>1.062917</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>27</th>\n      <td>16.378994</td>\n      <td>7</td>\n      <td>7_0</td>\n      <td>7.218442</td>\n      <td>0.418715</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>28</th>\n      <td>151.693604</td>\n      <td>8</td>\n      <td>8_0</td>\n      <td>-3.199080</td>\n      <td>0.113994</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>29</th>\n      <td>17.508297</td>\n      <td>9</td>\n      <td>9_0</td>\n      <td>-5.000000</td>\n      <td>15.000000</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>12.370395</td>\n      <td>10</td>\n      <td>10_0</td>\n      <td>8.022765</td>\n      <td>3.542146</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>208.881226</td>\n      <td>11</td>\n      <td>11_0</td>\n      <td>5.533142</td>\n      <td>15.000000</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>0.742130</td>\n      <td>12</td>\n      <td>12_0</td>\n      <td>2.911042</td>\n      <td>2.161366</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>5.165417</td>\n      <td>13</td>\n      <td>13_0</td>\n      <td>3.596695</td>\n      <td>0.000000</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>1.541467</td>\n      <td>14</td>\n      <td>14_0</td>\n      <td>3.632046</td>\n      <td>2.031652</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>5.033342</td>\n      <td>15</td>\n      <td>15_0</td>\n      <td>-2.117163</td>\n      <td>9.798724</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2.034841</td>\n      <td>16</td>\n      <td>16_0</td>\n      <td>10.000000</td>\n      <td>3.305778</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2.251922</td>\n      <td>17</td>\n      <td>17_0</td>\n      <td>2.521830</td>\n      <td>2.546804</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>0.481058</td>\n      <td>18</td>\n      <td>18_0</td>\n      <td>3.258201</td>\n      <td>2.051793</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>0.761814</td>\n      <td>19</td>\n      <td>19_0</td>\n      <td>3.416109</td>\n      <td>2.004387</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>0.398119</td>\n      <td>20</td>\n      <td>20_0</td>\n      <td>3.143472</td>\n      <td>2.288195</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>0.475756</td>\n      <td>21</td>\n      <td>21_0</td>\n      <td>3.151661</td>\n      <td>1.988985</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>0.554210</td>\n      <td>22</td>\n      <td>22_0</td>\n      <td>3.320216</td>\n      <td>2.199366</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>0.667970</td>\n      <td>23</td>\n      <td>23_0</td>\n      <td>3.355050</td>\n      <td>1.886039</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>0.503379</td>\n      <td>24</td>\n      <td>24_0</td>\n      <td>2.995448</td>\n      <td>2.447697</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>18</th>\n      <td>4.038473</td>\n      <td>25</td>\n      <td>25_0</td>\n      <td>-3.575003</td>\n      <td>15.000000</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>19</th>\n      <td>0.419002</td>\n      <td>26</td>\n      <td>26_0</td>\n      <td>3.104120</td>\n      <td>2.184513</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>20</th>\n      <td>0.743807</td>\n      <td>27</td>\n      <td>27_0</td>\n      <td>3.409809</td>\n      <td>2.126092</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>21</th>\n      <td>0.427756</td>\n      <td>28</td>\n      <td>28_0</td>\n      <td>3.218610</td>\n      <td>2.253190</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n    <tr>\n      <th>22</th>\n      <td>0.424067</td>\n      <td>29</td>\n      <td>29_0</td>\n      <td>3.133336</td>\n      <td>2.442237</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+            "application/vnd.dataresource+json": {
+              "schema": {
+                "fields": [
+                  {
+                    "name": "index",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "branin",
+                    "type": "number"
+                  },
+                  {
+                    "name": "trial_index",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "arm_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "x1",
+                    "type": "number"
+                  },
+                  {
+                    "name": "x2",
+                    "type": "number"
+                  },
+                  {
+                    "name": "trial_status",
+                    "type": "string"
+                  },
+                  {
+                    "name": "generation_method",
+                    "type": "string"
+                  }
+                ],
+                "primaryKey": [
+                  "index"
+                ],
+                "pandas_version": "0.20.0"
+              },
+              "data": [
+                {
+                  "index": 0,
+                  "branin": 42.0839004517,
+                  "trial_index": 0,
+                  "arm_name": "0_0",
+                  "x1": 1.0534909368,
+                  "x2": 9.6950063109,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "Sobol"
+                },
+                {
+                  "index": 3,
+                  "branin": 6.1619844437,
+                  "trial_index": 1,
+                  "arm_name": "1_0",
+                  "x1": 9.6738758078,
+                  "x2": 5.0314545399,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "Sobol"
+                },
+                {
+                  "index": 15,
+                  "branin": 4.7758312225,
+                  "trial_index": 2,
+                  "arm_name": "2_0",
+                  "x1": -2.6983634615,
+                  "x2": 13.0926388828,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "Sobol"
+                },
+                {
+                  "index": 23,
+                  "branin": 20.1771812439,
+                  "trial_index": 3,
+                  "arm_name": "3_0",
+                  "x1": 4.2557313014,
+                  "x2": 5.3627007734,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "Sobol"
+                },
+                {
+                  "index": 24,
+                  "branin": 3.5366411209,
+                  "trial_index": 4,
+                  "arm_name": "4_0",
+                  "x1": 9.8962185998,
+                  "x2": 4.3475179235,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "Sobol"
+                },
+                {
+                  "index": 25,
+                  "branin": 6.4665250778,
+                  "trial_index": 5,
+                  "arm_name": "5_0",
+                  "x1": -3.947538999,
+                  "x2": 12.5307717314,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 26,
+                  "branin": 5.7068986893,
+                  "trial_index": 6,
+                  "arm_name": "6_0",
+                  "x1": 10,
+                  "x2": 1.062916555,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 27,
+                  "branin": 16.378993988,
+                  "trial_index": 7,
+                  "arm_name": "7_0",
+                  "x1": 7.2184418365,
+                  "x2": 0.418714845,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 28,
+                  "branin": 151.6936035156,
+                  "trial_index": 8,
+                  "arm_name": "8_0",
+                  "x1": -3.1990796261,
+                  "x2": 0.1139937445,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 29,
+                  "branin": 17.5082969666,
+                  "trial_index": 9,
+                  "arm_name": "9_0",
+                  "x1": -5,
+                  "x2": 15,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 1,
+                  "branin": 12.3703947067,
+                  "trial_index": 10,
+                  "arm_name": "10_0",
+                  "x1": 8.0227651134,
+                  "x2": 3.5421455118,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 2,
+                  "branin": 208.8812255859,
+                  "trial_index": 11,
+                  "arm_name": "11_0",
+                  "x1": 5.53314209,
+                  "x2": 15,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 4,
+                  "branin": 0.7421302795,
+                  "trial_index": 12,
+                  "arm_name": "12_0",
+                  "x1": 2.9110418816,
+                  "x2": 2.1613661316,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 5,
+                  "branin": 5.1654167175,
+                  "trial_index": 13,
+                  "arm_name": "13_0",
+                  "x1": 3.5966954968,
+                  "x2": 0,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 6,
+                  "branin": 1.541466713,
+                  "trial_index": 14,
+                  "arm_name": "14_0",
+                  "x1": 3.6320456772,
+                  "x2": 2.0316523416,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 7,
+                  "branin": 5.0333423615,
+                  "trial_index": 15,
+                  "arm_name": "15_0",
+                  "x1": -2.1171632044,
+                  "x2": 9.7987241983,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 8,
+                  "branin": 2.0348410606,
+                  "trial_index": 16,
+                  "arm_name": "16_0",
+                  "x1": 10,
+                  "x2": 3.3057777019,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 9,
+                  "branin": 2.2519216537,
+                  "trial_index": 17,
+                  "arm_name": "17_0",
+                  "x1": 2.5218296998,
+                  "x2": 2.546803576,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 10,
+                  "branin": 0.4810581207,
+                  "trial_index": 18,
+                  "arm_name": "18_0",
+                  "x1": 3.2582006156,
+                  "x2": 2.0517926488,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 11,
+                  "branin": 0.7618141174,
+                  "trial_index": 19,
+                  "arm_name": "19_0",
+                  "x1": 3.416108612,
+                  "x2": 2.0043870988,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 12,
+                  "branin": 0.3981189728,
+                  "trial_index": 20,
+                  "arm_name": "20_0",
+                  "x1": 3.1434719962,
+                  "x2": 2.2881945398,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 13,
+                  "branin": 0.4757556915,
+                  "trial_index": 21,
+                  "arm_name": "21_0",
+                  "x1": 3.151660615,
+                  "x2": 1.9889850619,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 14,
+                  "branin": 0.5542097092,
+                  "trial_index": 22,
+                  "arm_name": "22_0",
+                  "x1": 3.3202159894,
+                  "x2": 2.1993661125,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 16,
+                  "branin": 0.6679697037,
+                  "trial_index": 23,
+                  "arm_name": "23_0",
+                  "x1": 3.3550495493,
+                  "x2": 1.8860391985,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 17,
+                  "branin": 0.5033788681,
+                  "trial_index": 24,
+                  "arm_name": "24_0",
+                  "x1": 2.9954482957,
+                  "x2": 2.4476973195,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 18,
+                  "branin": 4.0384726524,
+                  "trial_index": 25,
+                  "arm_name": "25_0",
+                  "x1": -3.575002873,
+                  "x2": 15,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 19,
+                  "branin": 0.4190015793,
+                  "trial_index": 26,
+                  "arm_name": "26_0",
+                  "x1": 3.1041197799,
+                  "x2": 2.1845128334,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 20,
+                  "branin": 0.743806839,
+                  "trial_index": 27,
+                  "arm_name": "27_0",
+                  "x1": 3.4098088554,
+                  "x2": 2.1260921342,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 21,
+                  "branin": 0.4277563095,
+                  "trial_index": 28,
+                  "arm_name": "28_0",
+                  "x1": 3.2186100823,
+                  "x2": 2.2531901461,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                },
+                {
+                  "index": 22,
+                  "branin": 0.4240674973,
+                  "trial_index": 29,
+                  "arm_name": "29_0",
+                  "x1": 3.133335995,
+                  "x2": 2.442236968,
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch"
+                }
+              ]
+            }
+          },
+          "metadata": {
+            "bento_obj_id": "140418811196896"
+          },
+          "execution_count": 7
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "521e7082-5a4d-4110-b6ac-dd94fd674d3d",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "034baf37-374d-4281-8943-9356ee6f3e84",
+        "executionStartTime": 1646802637270,
+        "executionStopTime": 1646802637381
+      },
+      "source": [
+        "parameters, values = ax_client.get_best_parameters()\n",
+        "print(f\"Best parameters: {parameters}\")\n",
+        "print(f\"Corresponding mean: {values[0]}, covariance: {values[1]}\")"
+      ],
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Best parameters: {'x1': 3.143471996153947, 'x2': 2.2881945397553003}\nCorresponding mean: {'branin': 0.3981189727783203}, covariance: {'branin': {'branin': 0.0}}\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "10562d0a-5fc3-4771-91c3-f881bd211174",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Plotting the response surface and optimization progress"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "24bbc6f8-d9b7-45bc-ba2b-b92bbc9a3712",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "d0b78eb5-687f-48ac-b482-e5bc2a1203b3",
+        "executionStopTime": 1646802638565,
+        "executionStartTime": 1646802637385
+      },
+      "source": [
+        "from ax.utils.notebook.plotting import render\n",
+        "render(ax_client.get_contour_plot())"
+      ],
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-08 21:10:37] ax.service.ax_client: Retrieving contour plot with parameter 'x1' on X-axis and 'x2' on Y-axis, for metric 'branin'. Remaining parameters are affixed to the middle of their range.\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.plotly.v1+json": {
+              "config": {
+                "linkText": "Export to plot.ly",
+                "plotlyServerURL": "https://plot.ly",
+                "showLink": false
+              },
+              "data": [
+                {
+                  "autocolorscale": false,
+                  "autocontour": true,
+                  "colorbar": {
+                    "tickfont": {
+                      "size": 8
+                    },
+                    "ticksuffix": "",
+                    "x": 0.45,
+                    "y": 0.5
+                  },
+                  "colorscale": [
+                    [
+                      0,
+                      "rgb(247,252,253)"
+                    ],
+                    [
+                      0.125,
+                      "rgb(229,245,249)"
+                    ],
+                    [
+                      0.25,
+                      "rgb(204,236,230)"
+                    ],
+                    [
+                      0.375,
+                      "rgb(153,216,201)"
+                    ],
+                    [
+                      0.5,
+                      "rgb(102,194,164)"
+                    ],
+                    [
+                      0.625,
+                      "rgb(65,174,118)"
+                    ],
+                    [
+                      0.75,
+                      "rgb(35,139,69)"
+                    ],
+                    [
+                      0.875,
+                      "rgb(0,109,44)"
+                    ],
+                    [
+                      1,
+                      "rgb(0,68,27)"
+                    ]
+                  ],
+                  "contours": {
+                    "coloring": "heatmap",
+                    "start": 10,
+                    "end": 210,
+                    "size": 10
+                  },
+                  "hoverinfo": "x+y+z",
+                  "ncontours": 25,
+                  "type": "contour",
+                  "x": [
+                    -5,
+                    -4.6938775510204085,
+                    -4.387755102040816,
+                    -4.081632653061225,
+                    -3.7755102040816326,
+                    -3.4693877551020407,
+                    -3.163265306122449,
+                    -2.857142857142857,
+                    -2.5510204081632653,
+                    -2.2448979591836733,
+                    -1.9387755102040813,
+                    -1.6326530612244898,
+                    -1.3265306122448979,
+                    -1.020408163265306,
+                    -0.7142857142857144,
+                    -0.408163265306122,
+                    -0.1020408163265305,
+                    0.204081632653061,
+                    0.5102040816326534,
+                    0.8163265306122449,
+                    1.1224489795918373,
+                    1.4285714285714288,
+                    1.7346938775510203,
+                    2.0408163265306127,
+                    2.3469387755102042,
+                    2.6530612244897958,
+                    2.959183673469388,
+                    3.2653061224489797,
+                    3.571428571428571,
+                    3.8775510204081627,
+                    4.183673469387756,
+                    4.4897959183673475,
+                    4.795918367346939,
+                    5.1020408163265305,
+                    5.408163265306122,
+                    5.714285714285715,
+                    6.020408163265307,
+                    6.326530612244898,
+                    6.63265306122449,
+                    6.938775510204081,
+                    7.244897959183675,
+                    7.551020408163266,
+                    7.857142857142858,
+                    8.16326530612245,
+                    8.46938775510204,
+                    8.775510204081632,
+                    9.081632653061225,
+                    9.387755102040817,
+                    9.693877551020408,
+                    10
+                  ],
+                  "xaxis": "x",
+                  "y": [
+                    0,
+                    0.30612244897959184,
+                    0.6122448979591837,
+                    0.9183673469387755,
+                    1.2244897959183674,
+                    1.5306122448979593,
+                    1.836734693877551,
+                    2.142857142857143,
+                    2.4489795918367347,
+                    2.7551020408163267,
+                    3.0612244897959187,
+                    3.36734693877551,
+                    3.673469387755102,
+                    3.979591836734694,
+                    4.285714285714286,
+                    4.591836734693878,
+                    4.8979591836734695,
+                    5.204081632653061,
+                    5.510204081632653,
+                    5.816326530612245,
+                    6.122448979591837,
+                    6.428571428571429,
+                    6.73469387755102,
+                    7.040816326530613,
+                    7.346938775510204,
+                    7.653061224489796,
+                    7.959183673469388,
+                    8.26530612244898,
+                    8.571428571428571,
+                    8.877551020408163,
+                    9.183673469387756,
+                    9.489795918367347,
+                    9.795918367346939,
+                    10.10204081632653,
+                    10.408163265306122,
+                    10.714285714285715,
+                    11.020408163265307,
+                    11.326530612244898,
+                    11.63265306122449,
+                    11.938775510204081,
+                    12.244897959183675,
+                    12.551020408163266,
+                    12.857142857142858,
+                    13.16326530612245,
+                    13.46938775510204,
+                    13.775510204081632,
+                    14.081632653061225,
+                    14.387755102040817,
+                    14.693877551020408,
+                    15
+                  ],
+                  "yaxis": "y",
+                  "z": [
+                    [
+                      195.26892818586757,
+                      189.42126873277604,
+                      183.07116982761585,
+                      176.23012298196693,
+                      168.9158459328493,
+                      161.15310575768876,
+                      152.9744335208195,
+                      144.42067609659588,
+                      135.54133252229954,
+                      126.39462694726666,
+                      117.04727796973049,
+                      107.57393472749294,
+                      98.05626319585835,
+                      88.58168124618803,
+                      79.24175748011294,
+                      70.13030590802933,
+                      61.34122533267772,
+                      52.96614793464737,
+                      45.09197515215362,
+                      37.79838967573501,
+                      31.155439524762244,
+                      25.22129317370037,
+                      20.04026318631723,
+                      15.64118965033161,
+                      12.036263978580447,
+                      9.220358696850704,
+                      7.170910245531568,
+                      5.8483803644156165,
+                      5.197298266767962,
+                      5.147861616252605,
+                      5.61805045406734,
+                      6.5161858382902,
+                      7.743845158662456,
+                      9.19902986827346,
+                      10.779469546391104,
+                      12.385939383533007,
+                      13.92546671604188,
+                      15.314306223544735,
+                      16.48057265900931,
+                      17.366434060005734,
+                      17.92978661392414,
+                      18.145353837724205,
+                      18.005176454485603,
+                      17.518484180639184,
+                      16.71096541851712,
+                      15.623474448992942,
+                      14.310237086780738,
+                      12.83663398665627,
+                      11.27665513856564,
+                      9.710129038960876
+                    ],
+                    [
+                      189.52237621008516,
+                      183.5256219642262,
+                      177.0615279622794,
+                      170.1432223550338,
+                      162.78950512218728,
+                      155.0256408102269,
+                      146.884055184646,
+                      138.40488209362184,
+                      129.63630820326628,
+                      120.6346676219625,
+                      111.4642457988196,
+                      102.19676231011857,
+                      92.91051491039852,
+                      83.68918203167667,
+                      74.62029712211859,
+                      65.79342506374775,
+                      57.29808754688163,
+                      49.22149981797081,
+                      41.64619477323645,
+                      34.64762111841104,
+                      28.29180953495949,
+                      22.633203922946464,
+                      17.71275345625054,
+                      13.556355238213875,
+                      10.173726872770825,
+                      7.557773600746822,
+                      5.684496357880949,
+                      4.5134659653936176,
+                      3.988865614236973,
+                      4.041079920882776,
+                      4.588785262383851,
+                      5.54147398863404,
+                      6.8023255604381045,
+                      8.27132165665515,
+                      9.84849064616154,
+                      11.437160135711704,
+                      12.947094934438482,
+                      14.297401812093092,
+                      15.419091685456413,
+                      16.25720390374527,
+                      16.77241544092643,
+                      16.942079162009488,
+                      16.760658887254202,
+                      16.239553612234822,
+                      15.406327799234486,
+                      14.303388012000378,
+                      12.986167278369258,
+                      11.520896530647637,
+                      9.982056565375686,
+                      8.449613666083199
+                    ],
+                    [
+                      183.72475070325368,
+                      177.58180279800365,
+                      171.00751139648565,
+                      164.01666479858918,
+                      156.62915520500624,
+                      148.87073993480274,
+                      140.77371920749434,
+                      132.3774774834017,
+                      123.72883636818048,
+                      114.8821710796824,
+                      105.8992494769397,
+                      96.84876252204629,
+                      87.8055274714147,
+                      78.84935959297175,
+                      70.06362414763495,
+                      61.533497000924264,
+                      53.34397870318906,
+                      45.577722307319526,
+                      38.3127486990862,
+                      31.620133975516993,
+                      25.561760697013423,
+                      20.188228095325535,
+                      15.53701516328871,
+                      11.63098482773339,
+                      8.477307196102949,
+                      6.066865494378723,
+                      4.374190334945629,
+                      3.3579471360836965,
+                      2.961978795628509,
+                      3.1168821674541682,
+                      3.742073632314243,
+                      4.748277239308415,
+                      6.040349609909839,
+                      7.520340021574844,
+                      9.090672631712591,
+                      10.657331262862408,
+                      12.132925899831545,
+                      13.439524133425369,
+                      14.511140042662436,
+                      15.295786993672046,
+                      15.757018872903544,
+                      15.87490549108995,
+                      15.646411270922567,
+                      15.085170752087105,
+                      14.220678764627854,
+                      13.09693621821708,
+                      11.770613296436562,
+                      10.308809535363988,
+                      8.786504087554354,
+                      7.283798917882027
+                    ],
+                    [
+                      177.88910809259198,
+                      171.6032744802694,
+                      164.92293837221945,
+                      157.86456850716925,
+                      150.44915687754838,
+                      142.70294734326257,
+                      134.65809370928642,
+                      126.35319499988177,
+                      117.83365631851822,
+                      109.15182730268799,
+                      100.36687680820012,
+                      91.54437196101424,
+                      82.75554179058332,
+                      74.07621984044295,
+                      65.58547581234939,
+                      57.36396269649549,
+                      49.49202213333913,
+                      42.04760606374967,
+                      35.10408617276809,
+                      28.728033396071815,
+                      22.97705711607602,
+                      17.897797055437692,
+                      13.524159899667712,
+                      9.875887184729494,
+                      6.957531044570823,
+                      4.757900344584817,
+                      3.2500220761014766,
+                      2.3916424136793264,
+                      2.1262694674172344,
+                      2.3847365536615204,
+                      3.087241883504497,
+                      4.1457990633551365,
+                      5.467013798650063,
+                      6.955086661200335,
+                      8.514930525038594,
+                      10.055284890042227,
+                      11.491708144003704,
+                      12.749332948117786,
+                      13.765279182960214,
+                      14.490632822195575,
+                      14.891917033483276,
+                      14.952002871436331,
+                      14.670430110164887,
+                      14.063132953905889,
+                      13.161589426083903,
+                      12.011436056914869,
+                      10.670610045274955,
+                      9.207098472421007,
+                      7.696387684503717,
+                      6.218715140306511
+                    ],
+                    [
+                      172.02852640515917,
+                      165.6035209940268,
+                      158.82164539560452,
+                      151.701065763502,
+                      144.26387897863393,
+                      136.53680763925894,
+                      128.55183764327487,
+                      120.34674687665327,
+                      111.96547381581018,
+                      103.45827809352534,
+                      94.88165131910228,
+                      86.29794556770105,
+                      77.77469867102735,
+                      69.38364929032511,
+                      61.19945012149264,
+                      53.29810373309788,
+                      45.75516164072076,
+                      38.6437424015073,
+                      32.03243789483415,
+                      25.983187715714905,
+                      20.549209028138524,
+                      15.773072729588085,
+                      11.68501598358407,
+                      8.301575914856162,
+                      5.624619598343063,
+                      3.640831718666057,
+                      2.321703968068748,
+                      1.624050134831684,
+                      1.4910488317498825,
+                      1.8537929676084701,
+                      2.6333024904431905,
+                      3.7429357533272753,
+                      5.091116146573421,
+                      6.58427536639838,
+                      8.129903645823735,
+                      9.639591048993271,
+                      11.031942867553326,
+                      12.23525634143871,
+                      13.18985517143716,
+                      13.84999215760875,
+                      14.185248112789719,
+                      14.181376101524256,
+                      13.840563028635376,
+                      13.18110454873165,
+                      12.236513057557836,
+                      11.054101054879348,
+                      9.693102423129213,
+                      8.222411265616952,
+                      6.718031195837407,
+                      5.260336871971964
+                    ],
+                    [
+                      166.15604853017766,
+                      159.59598858229367,
+                      152.71742719110412,
+                      145.5402415059342,
+                      138.08763586254165,
+                      130.3868021953962,
+                      122.46953638067961,
+                      114.37275984366909,
+                      106.13889569274619,
+                      97.81605149827925,
+                      89.45796668365267,
+                      81.12369123253559,
+                      72.87697376232225,
+                      64.78535051994389,
+                      56.918941920235916,
+                      49.348979141506135,
+                      42.14609919306953,
+                      35.37846190964038,
+                      29.109755633403108,
+                      23.397169096085484,
+                      18.289414491623454,
+                      13.824890356175064,
+                      10.030072260652615,
+                      6.91821429623462,
+                      4.488434955662461,
+                      2.725247582470338,
+                      1.598578605755705,
+                      1.0642970357309203,
+                      1.0652570737472296,
+                      1.5328332239509344,
+                      2.3889050849773543,
+                      3.5482281660527892,
+                      4.9211086747727375,
+                      6.416285219327877,
+                      7.943909545483013,
+                      9.418512371035437,
+                      10.761839427967328,
+                      11.905447055925302,
+                      12.792955924946913,
+                      13.381875262109133,
+                      13.644927646620626,
+                      13.570825162030086,
+                      13.164470445997647,
+                      12.446579867606868,
+                      11.452749563547922,
+                      10.232007288292872,
+                      8.844912972146563,
+                      7.361287666910103,
+                      5.857663502882973,
+                      4.41455590018888
+                    ],
+                    [
+                      160.28462565403666,
+                      153.59402741874507,
+                      146.62397678070553,
+                      139.39607200177343,
+                      131.93462486202753,
+                      124.2672856092791,
+                      116.42563736708624,
+                      108.44571019272192,
+                      100.36836453491142,
+                      92.23949630640706,
+                      84.1100212358991,
+                      76.0356045043798,
+                      68.07611263572423,
+                      60.294777764133634,
+                      52.757079149077775,
+                      45.52936243392819,
+                      38.67723283276713,
+                      32.26377331830235,
+                      26.347652105197398,
+                      20.981194459751183,
+                      16.20850139697156,
+                      12.063701573731489,
+                      8.56942225870543,
+                      5.735560476325613,
+                      3.5584263369890863,
+                      2.0203174688154455,
+                      1.0895668774432643,
+                      0.7210872047657197,
+                      0.8574131331939014,
+                      1.4302216096357476,
+                      2.3622877376678186,
+                      3.569813709922597,
+                      4.965050079453807,
+                      6.4591139467699765,
+                      7.964898046038272,
+                      9.399958831254818,
+                      10.689270823301467,
+                      11.767738762572737,
+                      12.582368331389787,
+                      13.094009932014577,
+                      13.278607561098783,
+                      13.12790535674176,
+                      12.649586913137988,
+                      11.866845873292391,
+                      10.817409511086169,
+                      9.552058917398092,
+                      8.132709015003371,
+                      6.630128087869764,
+                      5.121389139654903,
+                      3.6871537254950635
+                    ],
+                    [
+                      154.4270612140372,
+                      147.61083378185978,
+                      140.55482605306372,
+                      133.28236399921005,
+                      125.81886422151084,
+                      118.1924226237368,
+                      110.43438624048667,
+                      102.57985930543069,
+                      94.66809382900124,
+                      86.74271702488824,
+                      78.85175296725708,
+                      71.04740379754378,
+                      63.385566373869906,
+                      55.92507304503015,
+                      48.72665965274708,
+                      41.85167921192384,
+                      35.360595183402346,
+                      29.311302982622944,
+                      23.757341494729516,
+                      18.74606708226295,
+                      14.31687014957641,
+                      10.499518194958089,
+                      7.3127090375157415,
+                      4.762913368166682,
+                      2.8435769874498575,
+                      1.5347403382394589,
+                      0.8031167302756863,
+                      0.6026516972350251,
+                      0.8755651135986113,
+                      1.5538560367344658,
+                      2.561228810265227,
+                      3.8153788612084885,
+                      5.23055888765902,
+                      6.72033170334687,
+                      8.200405652841013,
+                      9.591442807334571,
+                      10.821729428574542,
+                      11.829602520615161,
+                      12.565535493050962,
+                      12.993799597647756,
+                      13.093635212669465,
+                      12.859887385963269,
+                      12.303082319239909,
+                      11.44894460600543,
+                      10.337377921266162,
+                      9.020953430350716,
+                      7.562969454360411,
+                      6.03516205240747,
+                      4.515158488242406,
+                      3.083773579025843
+                    ],
+                    [
+                      148.59595571574067,
+                      141.65939308746476,
+                      134.52328718689716,
+                      127.21269473060366,
+                      119.75413187995639,
+                      112.17612589724192,
+                      104.5097638018562,
+                      96.7891900381388,
+                      89.05200397474891,
+                      81.33950972475053,
+                      73.69677540727653,
+                      66.17246649538959,
+                      58.818428071857966,
+                      51.689003228746024,
+                      44.84008893295419,
+                      38.32794573541696,
+                      32.20779293442585,
+                      26.532235360980913,
+                      21.349580982364046,
+                      16.702119205331602,
+                      12.624437383731753,
+                      9.141857018324089,
+                      6.269071078346078,
+                      4.009059584361491,
+                      2.3523521101266684,
+                      1.276693457652275,
+                      0.7471529353536148,
+                      0.7166991252787511,
+                      1.1272416366706253,
+                      1.9111201045420003,
+                      2.9929996749060006,
+                      4.29211249972802,
+                      5.724767379627444,
+                      7.207035564160435,
+                      8.657510615198307,
+                      10.000034721409076,
+                      11.166283247238685,
+                      12.098103682820032,
+                      12.74951434446124,
+                      13.088281725604158,
+                      13.097012659295224,
+                      12.77371758071694,
+                      12.1318231910229,
+                      11.19963565507462,
+                      10.019278023101656,
+                      8.645146789414659,
+                      7.141951418451038,
+                      5.582416443682877,
+                      4.0447377210635995,
+                      2.609892143708201
+                    ],
+                    [
+                      142.80365275491926,
+                      135.75242413129268,
+                      128.54239528963822,
+                      121.2003531364316,
+                      113.75390548060867,
+                      106.23199500776761,
+                      98.66542422657332,
+                      91.0873443564123,
+                      83.53365955595402,
+                      76.04329915745136,
+                      68.65831478587268,
+                      61.4237663477086,
+                      54.38737064509722,
+                      47.598898402641886,
+                      41.10931923486302,
+                      34.96970883864603,
+                      29.229947684914933,
+                      23.937254863122714,
+                      19.13461365145425,
+                      14.859156035992326,
+                      11.140581065911404,
+                      7.999686028995093,
+                      5.447089559038275,
+                      3.4822217478311845,
+                      2.0926481624801436,
+                      1.2537826236577239,
+                      0.9290281730245873,
+                      1.070367538216356,
+                      1.61940445096824,
+                      2.5088363739940114,
+                      3.664318598726604,
+                      5.0066603570666945,
+                      6.454276566004582,
+                      7.9258050094518655,
+                      9.342788912442527,
+                      10.632319536825158,
+                      11.729532944520084,
+                      12.579859507031946,
+                      13.140933899043809,
+                      13.384086772036387,
+                      13.295356404155491,
+                      12.875978531704607,
+                      12.142334310208454,
+                      11.125358873856058,
+                      9.86943517850175,
+                      8.430818678721648,
+                      6.875656942424749,
+                      5.277683724572535,
+                      3.7156786584932266,
+                      2.2707911373946317
+                    ],
+                    [
+                      137.0621865789978,
+                      129.9023248869848,
+                      122.62485260648009,
+                      115.25828267393226,
+                      107.83130397875598,
+                      100.37325706792745,
+                      92.91463490023395,
+                      85.48756260630532,
+                      78.12620826101711,
+                      70.8670775332618,
+                      63.7491488700751,
+                      56.8138125549287,
+                      50.104586335860716,
+                      43.66659196234597,
+                      37.545790354250386,
+                      31.787987575797974,
+                      26.437638525022912,
+                      21.536489442066284,
+                      17.122113142758714,
+                      13.226401493566701,
+                      9.874087343653004,
+                      7.081372339293395,
+                      4.854737358182504,
+                      3.190008517237029,
+                      2.0717438479712342,
+                      1.472994055998491,
+                      1.3554757583589598,
+                      1.670177907056722,
+                      2.3584026036572165,
+                      3.353221158423141,
+                      4.581306092322592,
+                      5.965080870905664,
+                      7.425112508181137,
+                      8.882658685388133,
+                      10.262271444260719,
+                      11.494354383842905,
+                      12.51756993106642,
+                      13.280997736747885,
+                      13.745954381827685,
+                      13.887397937580628,
+                      13.694857856294599,
+                      13.172850350343898,
+                      12.34076087876343,
+                      11.232197559805098,
+                      9.893841191377309,
+                      8.383838057824809,
+                      6.769799879833505,
+                      5.126490316074959,
+                      3.5332887160478883,
+                      2.071528920943935
+                    ],
+                    [
+                      131.3832315136994,
+                      124.12112019583296,
+                      116.78297464597412,
+                      109.3990260652171,
+                      101.9990312106591,
+                      94.61270932109397,
+                      87.27021825375346,
+                      80.00262480238669,
+                      72.84232183609576,
+                      65.82334534685405,
+                      58.981547861342506,
+                      52.35459092498778,
+                      45.98172830340836,
+                      39.90336279187154,
+                      34.160372545054365,
+                      28.793216973150145,
+                      23.840846727447286,
+                      19.339456297002933,
+                      15.32113041823801,
+                      11.812446061498655,
+                      8.833099491158897,
+                      6.394632213774811,
+                      4.499330128014158,
+                      3.13936666020558,
+                      2.2962531299615954,
+                      1.9406482832632719,
+                      2.0325643229847667,
+                      2.521989524709525,
+                      3.349928481376489,
+                      4.449841131617427,
+                      5.749442018161224,
+                      7.172802737078783,
+                      8.64268426919529,
+                      10.083012723061678,
+                      11.421402703225542,
+                      12.59162758764603,
+                      13.535935765258063,
+                      14.207116414239625,
+                      14.570227506390188,
+                      14.60391197639899,
+                      14.301244754092501,
+                      13.670072801101828,
+                      12.732831464268951,
+                      11.52584232404051,
+                      10.098119217079521,
+                      8.509729228301039,
+                      6.829773242289548,
+                      5.134065321954665,
+                      3.502601119036097,
+                      2.0169122988164307
+                    ],
+                    [
+                      125.77805356912435,
+                      118.42041167338317,
+                      111.028638557113,
+                      103.6346723288147,
+                      96.26932177497821,
+                      88.96266407676788,
+                      81.74449596196422,
+                      74.64479430096404,
+                      67.69413944269087,
+                      60.92405462463852,
+                      54.367217729356874,
+                      48.05750747916483,
+                      42.02985467295561,
+                      36.31987991000082,
+                      30.963311898497565,
+                      25.995194255112764,
+                      21.448902912407846,
+                      17.355010046596924,
+                      13.740042988763125,
+                      10.625197093126552,
+                      8.025069294932214,
+                      5.946483517050327,
+                      4.387479767960828,
+                      3.3365355012921736,
+                      2.77208058958335,
+                      2.662356336390763,
+                      2.9656547643048654,
+                      3.6309576272802975,
+                      4.598976021272035,
+                      5.803572049606375,
+                      7.173524751442564,
+                      8.634584447355806,
+                      10.111743778947954,
+                      11.531640896000004,
+                      12.825001205305266,
+                      13.929019369843392,
+                      14.78958314150796,
+                      15.363245188891746,
+                      15.61885815337248,
+                      15.538801311338855,
+                      15.119743797949937,
+                      14.372908545240021,
+                      13.32382195839402,
+                      12.011555876163039,
+                      10.487489490126901,
+                      8.813638622829421,
+                      7.060617167913234,
+                      5.3053097906889946,
+                      3.6283455659884254,
+                      2.1114686830796856
+                    ],
+                    [
+                      120.25746452579719,
+                      112.81133014384207,
+                      105.37323407844951,
+                      97.97680642412044,
+                      90.65388956436192,
+                      83.43489632968837,
+                      76.34923585612162,
+                      69.42576421349838,
+                      62.6932137786798,
+                      56.18055495477048,
+                      49.91724634464254,
+                      43.93333486953601,
+                      38.25937540580193,
+                      32.926149944156165,
+                      27.96417855237706,
+                      23.403027899830853,
+                      19.270437038390895,
+                      15.5912937203457,
+                      12.38650694890848,
+                      9.671831909580451,
+                      7.456711213036087,
+                      5.743200912006374,
+                      4.525050621968687,
+                      3.787004061946485,
+                      3.504379439483275,
+                      3.642978557596548,
+                      4.159359764173633,
+                      5.001493534854571,
+                      6.109801385784127,
+                      7.418559875728967,
+                      8.857632678602492,
+                      10.354476094689737,
+                      11.836347891715267,
+                      13.23263689020185,
+                      14.477221949085605,
+                      15.510764490593896,
+                      16.282838727289885,
+                      16.7538083789202,
+                      16.89636770455707,
+                      16.69667770435423,
+                      16.155044736074565,
+                      15.286107734032246,
+                      14.118520780534308,
+                      12.694138949472716,
+                      11.066736087641157,
+                      9.300302526531954,
+                      7.466987719564056,
+                      5.644766706784697,
+                      3.914919523378771,
+                      2.3594187933892545
+                    ],
+                    [
+                      114.83177878442862,
+                      107.30449089663554,
+                      99.82761736359899,
+                      92.43646182171588,
+                      85.16387926796486,
+                      78.04059439039357,
+                      71.09560188344743,
+                      64.35660689861754,
+                      57.85046030448053,
+                      51.60354264476514,
+                      45.64205275661464,
+                      39.99216195515396,
+                      34.68000233749026,
+                      29.731467777235856,
+                      25.171818074308817,
+                      21.025089865625837,
+                      17.313331556220394,
+                      14.055692902185395,
+                      11.26741214836819,
+                      8.95875401496902,
+                      7.133959628117088,
+                      5.790274124409823,
+                      4.917118709697101,
+                      4.495471198271487,
+                      4.497512494692417,
+                      4.886586321132571,
+                      5.617506169781567,
+                      6.637227599300626,
+                      7.885886385272633,
+                      9.298184589470356,
+                      10.805088310816233,
+                      12.335783719628196,
+                      13.819822906532742,
+                      15.1893789542044,
+                      16.381521167530686,
+                      17.340417092164795,
+                      18.01936810630511,
+                      18.382590040792962,
+                      18.406659282663252,
+                      18.08155772788655,
+                      17.41126614412131,
+                      16.413874186851377,
+                      15.121195555984064,
+                      13.57789758957789,
+                      11.840174945006947,
+                      9.974015939151245,
+                      8.053126713660777,
+                      6.1565919036632035,
+                      4.3663603346348445,
+                      2.764650066665121
+                    ],
+                    [
+                      109.51077324504882,
+                      101.90995204093036,
+                      94.40206796814016,
+                      87.02407629339083,
+                      79.8098211466228,
+                      72.7903138356516,
+                      65.99410742858251,
+                      59.44772685200635,
+                      53.17610989778758,
+                      47.20301333251669,
+                      41.55133994468966,
+                      36.243346865842035,
+                      31.30070271251963,
+                      26.744370694899423,
+                      22.594306344545288,
+                      18.868971311303095,
+                      15.584678047059052,
+                      12.754793343130164,
+                      10.388840813442162,
+                      8.491552738063337,
+                      7.061929498825407,
+                      6.092369573683616,
+                      5.567934288017632,
+                      5.465809028260404,
+                      5.755016387963289,
+                      6.396426948836718,
+                      7.343100515436831,
+                      8.540975235010858,
+                      9.929904920768037,
+                      11.44502694800504,
+                      13.018425278137894,
+                      14.58103646094004,
+                      16.064731810738472,
+                      17.404497186837023,
+                      18.540623627797807,
+                      19.420817996193804,
+                      20.002143077536903,
+                      20.252701292414514,
+                      20.15298513967803,
+                      19.696830276300346,
+                      18.891923133688053,
+                      17.759833384594526,
+                      16.335561493986155,
+                      14.666612026149926,
+                      12.811623336722683,
+                      10.838602784459336,
+                      8.822832778328227,
+                      6.844526088778517,
+                      4.98631832586973,
+                      3.3306909495337926
+                    ],
+                    [
+                      104.30365046005349,
+                      96.63717621257189,
+                      89.10624926176712,
+                      81.74945119430753,
+                      74.60158936043291,
+                      67.69393506557557,
+                      61.05457228909048,
+                      54.708817291470176,
+                      48.67966523777951,
+                      42.98821835507111,
+                      37.654051348685,
+                      32.69547386044839,
+                      28.12965652290974,
+                      23.972596340585287,
+                      20.238908244215526,
+                      16.941442114437958,
+                      14.090737645167994,
+                      11.694342340843857,
+                      9.756029912744758,
+                      8.274966590955747,
+                      7.244880696794386,
+                      6.65329565293203,
+                      6.4808880210048745,
+                      6.701029923006132,
+                      7.279569300098956,
+                      8.174892088196035,
+                      9.338297949580516,
+                      10.714706293576521,
+                      12.243692704820482,
+                      13.860838455845041,
+                      15.499358457470345,
+                      17.091956761465802,
+                      18.572844495511465,
+                      19.879843709322508,
+                      20.956492723459814,
+                      21.75406469732471,
+                      22.233411549966775,
+                      22.366550127812744,
+                      22.137916428385687,
+                      21.545226348977593,
+                      20.59989721747195,
+                      19.327002502236486,
+                      17.76475168475422,
+                      15.963507341384702,
+                      13.984371030689704,
+                      11.897387668685539,
+                      9.779433835849375,
+                      7.711868168578752,
+                      5.778031087712197,
+                      4.060686244873073
+                    ],
+                    [
+                      99.21900528330158,
+                      91.49499586516058,
+                      83.94917250619426,
+                      76.62171448562327,
+                      69.54836410506275,
+                      62.76062472999389,
+                      56.28608357368405,
+                      50.14882071048366,
+                      44.36986119647611,
+                      38.96762515528082,
+                      33.958331460873794,
+                      29.356314263504316,
+                      25.174217934966116,
+                      21.423044761247333,
+                      18.112040431295995,
+                      15.248414467825981,
+                      12.836905524259263,
+                      10.879214162359645,
+                      9.373337540400406,
+                      8.312850614684875,
+                      7.686186295057826,
+                      7.475971921169053,
+                      7.658481018400321,
+                      8.203257318308504,
+                      9.07296245895406,
+                      10.223489802414374,
+                      11.604374814039687,
+                      13.159518026343168,
+                      14.828220502480274,
+                      16.546514782509515,
+                      18.248757472249242,
+                      19.86943386479241,
+                      21.345111177756912,
+                      22.616465954667966,
+                      23.63030359046175,
+                      24.341484282814065,
+                      24.714670261499364,
+                      24.72581394967368,
+                      24.363315581591102,
+                      23.62879132676232,
+                      22.537408550270065,
+                      21.11776269578056,
+                      19.411289527008698,
+                      17.471226142713416,
+                      15.361153317983675,
+                      13.153169384466267,
+                      10.925761199691967,
+                      8.761450056832109,
+                      6.744299109635774,
+                      4.957373680862386
+                    ],
+                    [
+                      94.26479521285927,
+                      86.49158235178976,
+                      78.93916481395996,
+                      71.64928772104192,
+                      64.65859778675005,
+                      57.99880126071308,
+                      51.69696076517831,
+                      45.775893647191936,
+                      40.25462948761509,
+                      35.148881980155465,
+                      30.471490735663657,
+                      26.232791737499284,
+                      22.440881061872272,
+                      19.10174480260624,
+                      16.219238461817167,
+                      13.794910810924073,
+                      11.82767970150659,
+                      10.313379761779839,
+                      9.244213566074368,
+                      8.608147958318755,
+                      8.388305052163773,
+                      8.562402448365788,
+                      9.102298980050232,
+                      9.973700581308396,
+                      11.136075638336767,
+                      12.542820602462157,
+                      14.141705102610743,
+                      15.875611860540188,
+                      17.683571115690572,
+                      19.502072850057772,
+                      21.266623784429306,
+                      22.91350082318186,
+                      24.381639247065547,
+                      25.614583292362443,
+                      26.562419464158257,
+                      27.183609494491975,
+                      27.446640536879386,
+                      27.331415033493762,
+                      26.830311510929548,
+                      25.948859952064403,
+                      24.705990753359025,
+                      23.13383384916675,
+                      21.27706348817617,
+                      19.191803437796775,
+                      16.944126112269853,
+                      14.60819634942077,
+                      12.264125469776975,
+                      9.995613143858986,
+                      7.887462937680109,
+                      6.0230618663761195
+                    ],
+                    [
+                      89.44831459893302,
+                      81.63441897767846,
+                      74.08384117622509,
+                      66.83985719251334,
+                      59.939985438554565,
+                      53.41610471818784,
+                      47.29472516217291,
+                      41.597375887335204,
+                      36.341067795753425,
+                      31.538787096589424,
+                      27.199975044968667,
+                      23.330952120383124,
+                      19.935250312989538,
+                      17.013825083661068,
+                      14.565128486241354,
+                      12.585036324459947,
+                      11.066634386927277,
+                      9.9998810187364,
+                      9.371174775496822,
+                      9.162865913148101,
+                      9.352758310674988,
+                      9.913653529797594,
+                      10.812990660330048,
+                      12.012634144181373,
+                      13.468856867239356,
+                      15.13255762837098,
+                      16.949741005137607,
+                      18.862274193298532,
+                      20.808920314902124,
+                      22.726631793007414,
+                      24.552071580787732,
+                      26.22331521721398,
+                      27.68167373875348,
+                      28.87356718857197,
+                      29.75237147746947,
+                      30.28015813277679,
+                      30.429247284553792,
+                      30.18349912233933,
+                      29.539277824004515,
+                      28.5060342101023,
+                      27.106468518447734,
+                      25.376251974749877,
+                      23.36330438845185,
+                      21.12664390003531,
+                      18.734843303248766,
+                      16.264144159763838,
+                      13.796294401689345,
+                      11.416186597246963,
+                      9.209382020377463,
+                      7.259609791380898
+                    ],
+                    [
+                      84.77617286130709,
+                      76.93027817572437,
+                      69.39008071925566,
+                      62.20034940175453,
+                      55.39943955068497,
+                      49.01937113133877,
+                      43.08607388331123,
+                      37.61976428947482,
+                      32.63541357764589,
+                      28.143262719559175,
+                      24.149339876500754,
+                      20.655938027346075,
+                      17.66201551940319,
+                      15.16348975162854,
+                      13.153403721408477,
+                      11.621956188952371,
+                      10.55639807696651,
+                      9.940809695395501,
+                      9.755784697640173,
+                      9.978056595728896,
+                      10.58011150229331,
+                      11.529835960394482,
+                      12.790250841537759,
+                      14.319381091423574,
+                      16.07030653415628,
+                      17.99143116409099,
+                      20.02699771991126,
+                      22.117861385665094,
+                      24.202521898849106,
+                      26.218397971832722,
+                      28.10331263398225,
+                      29.797143768657744,
+                      31.243581614056296,
+                      32.39192508401978,
+                      33.198842082340406,
+                      33.63001598575496,
+                      33.66160141504167,
+                      33.28141733554926,
+                      32.4898142422208,
+                      31.30016429319528,
+                      29.7389381725146,
+                      27.845349447771987,
+                      25.670565387401986,
+                      23.276501701282225,
+                      20.73423653804704,
+                      18.122095429556012,
+                      15.523472916450839,
+                      13.024467656007948,
+                      10.711415399876895,
+                      8.668408023576015
+                    ],
+                    [
+                      80.25427683179419,
+                      72.38520292788735,
+                      64.86400731911965,
+                      57.736910993832666,
+                      51.04306945716908,
+                      44.81461147814444,
+                      39.076858586694165,
+                      33.848691389464356,
+                      29.143022696270805,
+                      24.967333816127915,
+                      21.324229441065846,
+                      18.211968384585095,
+                      15.624932005060252,
+                      13.553999186444184,
+                      11.98680586808933,
+                      10.907877775843401,
+                      10.298636561170042,
+                      10.137291279445531,
+                      10.39863828477995,
+                      11.05380244575657,
+                      12.069960423781911,
+                      13.41009203129422,
+                      15.032807977030226,
+                      16.89230136127951,
+                      18.938466045935876,
+                      21.117217644092825,
+                      23.371042692144755,
+                      25.639789114006263,
+                      27.861697040298353,
+                      29.974654197668094,
+                      31.917645297480085,
+                      33.632351005655764,
+                      35.064840007852794,
+                      36.16728815028087,
+                      36.89965225684059,
+                      37.23122344613008,
+                      37.14198584522354,
+                      36.623711555987754,
+                      35.680731385432324,
+                      34.33033281472086,
+                      32.6027513696777,
+                      30.540738240262133,
+                      28.198704837834576,
+                      25.64146307475023,
+                      22.942597591778775,
+                      20.182522074130738,
+                      17.44628540649595,
+                      14.821204070488456,
+                      12.394404396375975,
+                      10.250361744998266
+                    ],
+                    [
+                      75.88781730792816,
+                      68.0044925250246,
+                      60.51097467370741,
+                      53.45489325755527,
+                      46.8761653890281,
+                      40.806995422186674,
+                      35.272069024076785,
+                      30.288908907473875,
+                      25.868353014665146,
+                      22.015111915428758,
+                      18.728360821103028,
+                      16.00232302921141,
+                      13.826805738796713,
+                      12.187655791408634,
+                      11.067111610349556,
+                      10.444037908641656,
+                      10.29404097822772,
+                      10.58947384963075,
+                      11.299351581544862,
+                      12.389206672710106,
+                      13.820922417502361,
+                      15.552587381971602,
+                      17.53841663695321,
+                      19.728784692612948,
+                      22.070411172393094,
+                      24.506733283017965,
+                      26.978489410044023,
+                      29.424526210965073,
+                      31.78282805040884,
+                      33.991753301803776,
+                      35.991447768420215,
+                      37.72539211602921,
+                      39.14202858115108,
+                      40.1964030639224,
+                      40.85175263881653,
+                      41.08096595904166,
+                      40.867845232896755,
+                      40.20810344218978,
+                      39.110039070444124,
+                      37.59484242056093,
+                      35.69650205891654,
+                      33.46129630390551,
+                      30.946872155970837,
+                      28.220931756957327,
+                      25.35956347492668,
+                      22.445270183922226,
+                      19.564760481818965,
+                      16.806578829069625,
+                      14.258657423632592,
+                      12.005875762536096
+                    ],
+                    [
+                      71.68125987410559,
+                      63.79269272709802,
+                      56.335555899296715,
+                      49.35884126499418,
+                      42.903187271339036,
+                      37.00083988715436,
+                      31.675821515940555,
+                      26.944276247833656,
+                      22.8149530427047,
+                      19.28978402052336,
+                      16.364513258683928,
+                      14.029332475329852,
+                      12.2694836688239,
+                      11.065794972441058,
+                      10.395124300627558,
+                      10.230695297256537,
+                      10.54232102566059,
+                      11.296522067031665,
+                      12.456556485571031,
+                      13.982388755132309,
+                      15.830632559316143,
+                      17.954507810421635,
+                      20.303854858528144,
+                      22.825248420107823,
+                      25.462250179475046,
+                      28.155832431462443,
+                      30.844995862097903,
+                      33.467593100236776,
+                      35.96135666725449,
+                      38.265116157446,
+                      40.32017572784511,
+                      42.07181010029335,
+                      43.470826092089254,
+                      44.47512791417992,
+                      45.05121870397236,
+                      45.1755684212319,
+                      44.83577956452254,
+                      44.03148719027782,
+                      42.77493825071798,
+                      41.091206927423926,
+                      39.018016858645694,
+                      36.60515723358965,
+                      33.91349684093174,
+                      31.013617441525334,
+                      27.984104410134986,
+                      24.909547620583865,
+                      21.878318286887236,
+                      18.98019730067216,
+                      16.303937062548627,
+                      13.934841616405517
+                    ],
+                    [
+                      67.63834001530407,
+                      59.75359035393141,
+                      52.34153768664736,
+                      45.452487690154015,
+                      39.12775830823237,
+                      33.39960251723035,
+                      28.291352399119717,
+                      23.81775404631111,
+                      19.985455694610764,
+                      16.793606682409475,
+                      14.234522645790465,
+                      12.294372911148809,
+                      10.953849305791806,
+                      10.188781373377385,
+                      9.970670898341549,
+                      10.26712821485648,
+                      11.042203392072892,
+                      12.256616362283133,
+                      13.867900670669417,
+                      15.830485062188185,
+                      18.095744924213186,
+                      20.612061111946602,
+                      23.324926472316687,
+                      26.17714018918862,
+                      29.10912682326378,
+                      32.059410731426716,
+                      34.96526773048502,
+                      37.76356490201131,
+                      40.39178694716179,
+                      42.78923423416167,
+                      44.89836444120585,
+                      46.66623730955526,
+                      48.0460112735601,
+                      48.99843233547012,
+                      49.49325008335174,
+                      49.510493628969854,
+                      49.04154169679694,
+                      48.089926149381554,
+                      46.67181670347891,
+                      44.816146096866746,
+                      42.564348948991295,
+                      39.969703324859694,
+                      37.09628075777495,
+                      34.01752736070564,
+                      30.81451479505416,
+                      27.57391445197252,
+                      24.38576050486701,
+                      21.341076908522297,
+                      18.529449506528856,
+                      16.036626898698007
+                    ],
+                    [
+                      63.762062518653245,
+                      55.89021230547492,
+                      48.531919019487916,
+                      41.73875131280748,
+                      35.55266336578606,
+                      30.005880036845276,
+                      25.121016463810086,
+                      20.911402784732584,
+                      17.381577179882576,
+                      14.527905261513698,
+                      12.339281244007642,
+                      10.797866455746128,
+                      9.879823585058412,
+                      9.556010399206857,
+                      9.792604195239102,
+                      10.551637450963488,
+                      11.791435447032724,
+                      13.466957353875754,
+                      15.530052707615084,
+                      17.92965463422824,
+                      20.61193896714923,
+                      23.52048398494484,
+                      26.596468443534086,
+                      29.778945630831913,
+                      33.00522824657703,
+                      36.21141311451255,
+                      39.33306636581118,
+                      42.3060792560227,
+                      45.067692808652964,
+                      47.557676737517326,
+                      49.71963537454386,
+                      51.50240142716279,
+                      52.861468079681565,
+                      53.760401930565294,
+                      54.17217408897056,
+                      54.08034484796504,
+                      53.48003892872281,
+                      52.37865337103867,
+                      50.79624854854401,
+                      48.765584132392235,
+                      46.33177557253834,
+                      43.551562118455614,
+                      40.492193780068675,
+                      37.22996109228456,
+                      33.84840725030995,
+                      30.436276326586466,
+                      27.08526314992107,
+                      23.88763943640666,
+                      20.93383647984816,
+                      18.310066882206648
+                    ],
+                    [
+                      60.054705126598,
+                      52.20482897866417,
+                      44.90891442561966,
+                      38.219740181360464,
+                      32.179852129403635,
+                      26.821411489263838,
+                      22.166290361822618,
+                      18.226386457568246,
+                      15.00412101436176,
+                      12.493078365289454,
+                      10.67874262433677,
+                      9.539286668511545,
+                      9.046371002418283,
+                      9.165915022793598,
+                      9.858810324458739,
+                      11.081554539039052,
+                      12.786794187554495,
+                      14.923775497683206,
+                      17.438712384646365,
+                      20.275090125231436,
+                      23.37393102260291,
+                      26.674054008257436,
+                      30.112363234382414,
+                      33.62420100469518,
+                      37.143797788089856,
+                      40.60484665532384,
+                      43.94122155756129,
+                      47.08784887986532,
+                      49.981730249051864,
+                      52.563102357720545,
+                      54.77670735389236,
+                      56.573135925470346,
+                      57.910195336512004,
+                      58.75424702375892,
+                      59.08145349192985,
+                      58.87887255369923,
+                      58.14533865705682,
+                      56.89207614950296,
+                      55.14299765977009,
+                      52.934651965027285,
+                      50.315799212377556,
+                      47.34660650461395,
+                      44.09747286777922,
+                      40.64750867066735,
+                      37.082709834118816,
+                      33.493880870577414,
+                      29.97437223262567,
+                      26.617706053343788,
+                      23.515169715288824,
+                      20.75345854597577
+                    ],
+                    [
+                      56.517826375773055,
+                      48.69896201713211,
+                      41.47396169893344,
+                      34.896759374854454,
+                      29.010446978111858,
+                      23.847086298621345,
+                      19.42778093316792,
+                      15.762981239398147,
+                      12.85298710265402,
+                      10.688607415265313,
+                      9.25193178238275,
+                      8.517169267588306,
+                      8.4515109814266,
+                      9.015977835035546,
+                      10.166221514277503,
+                      11.85325522084473,
+                      14.024100405208703,
+                      16.622345933443533,
+                      19.58862619370563,
+                      22.861033874656194,
+                      26.37549089267756,
+                      30.0661066620915,
+                      33.86555616172155,
+                      37.705510785889125,
+                      41.51715268209358,
+                      45.23179826062688,
+                      48.781649084472164,
+                      52.10067884971875,
+                      55.1256542249407,
+                      57.79727562188633,
+                      60.06141226656703,
+                      61.87039500064356,
+                      63.18432080455443,
+                      63.97231575678565,
+                      64.2136985702808,
+                      63.898985363957195,
+                      63.0306781424662,
+                      61.62378458543381,
+                      59.706025006887124,
+                      57.317693369358864,
+                      54.51115249455295,
+                      51.34995843838255,
+                      47.907624635735274,
+                      44.26605206112625,
+                      40.51366648554437,
+                      36.74331717258467,
+                      33.05000236619135,
+                      29.52849512635131,
+                      26.270948062628783,
+                      23.36455707032954
+                    ],
+                    [
+                      53.15227752572945,
+                      45.373396298865245,
+                      38.22773399906,
+                      31.77032327242811,
+                      26.04475548570914,
+                      21.08295706688932,
+                      16.905238363923264,
+                      13.520589067858324,
+                      10.927185807871702,
+                      9.113071261056625,
+                      8.056960347743034,
+                      7.7291279783009195,
+                      8.092334394628146,
+                      9.102748261966086,
+                      10.710834012119363,
+                      12.862178074765115,
+                      15.498238002266286,
+                      18.55700845747819,
+                      21.97360791478594,
+                      25.68079904271623,
+                      29.60946345928761,
+                      33.68905732996577,
+                      37.84807768948508,
+                      42.014570138662634,
+                      46.116706595070134,
+                      50.0834571437455,
+                      53.84537299728955,
+                      57.33548855977501,
+                      60.49034015692193,
+                      63.25108781494672,
+                      65.56471527394928,
+                      67.38527296029875,
+                      68.67511963299856,
+                      69.40611151238576,
+                      69.56068341712552,
+                      69.1327651607422,
+                      68.12847838819567,
+                      66.56656418056187,
+                      64.47849994032208,
+                      61.90827492875705,
+                      58.9118068384514,
+                      55.55599629484273,
+                      51.91743144651344,
+                      48.08077003543615,
+                      44.13684073917841,
+                      40.18051840287079,
+                      36.30843836327992,
+                      32.61662287440195,
+                      29.198097283304627,
+                      26.140574858908963
+                    ],
+                    [
+                      49.9582184529957,
+                      42.228196037755815,
+                      35.170156204644826,
+                      28.84017220687037,
+                      23.282287425883304,
+                      18.528256983747543,
+                      14.59757405432053,
+                      11.497756022174727,
+                      9.224856890177648,
+                      7.764165723913864,
+                      7.091046771800363,
+                      7.171875396594759,
+                      7.965025125385214,
+                      9.42186483718967,
+                      11.487731068174048,
+                      14.102848199208754,
+                      17.203178350002,
+                      20.721192517914474,
+                      24.586564195201007,
+                      28.726795708657228,
+                      33.06779522277212,
+                      37.53442818669781,
+                      42.05107056429986,
+                      46.54219218771078,
+                      50.93299691291253,
+                      55.15014200190971,
+                      59.122552555854675,
+                      62.78233828685355,
+                      66.06580998946266,
+                      68.91458240482271,
+                      71.27673947686918,
+                      73.10802801012062,
+                      74.37303715761202,
+                      75.04631462349454,
+                      75.11336647300286,
+                      74.57148637056198,
+                      73.43036210749435,
+                      71.71241244556789,
+                      69.45281540811125,
+                      66.69919984443953,
+                      63.510984856279755,
+                      59.95836587081196,
+                      56.12096103984,
+                      52.08614646675563,
+                      47.9471227338814,
+                      43.80076759419244,
+                      39.745339855342635,
+                      35.87810689922753,
+                      32.29297257088001,
+                      29.07818313027137
+                    ],
+                    [
+                      46.93513735812171,
+                      39.262724845763465,
+                      32.30042536667471,
+                      26.105293348222403,
+                      20.7217761274922,
+                      16.18142169572648,
+                      12.502883043735661,
+                      9.692195344654511,
+                      7.743293161964523,
+                      6.638727918623847,
+                      6.350541343559028,
+                      6.841248718703188,
+                      8.064886522726521,
+                      9.968082383454131,
+                      12.491110834804703,
+                      15.56890580877014,
+                      19.132009548695663,
+                      23.107447092676228,
+                      27.41952498789466,
+                      31.99056179819364,
+                      36.74156563550208,
+                      41.59287984417506,
+                      46.46482166871509,
+                      51.278339965548,
+                      55.955716661438544,
+                      60.42133278298813,
+                      64.60251371151433,
+                      68.43046025570963,
+                      71.84126270641957,
+                      74.77698487816303,
+                      77.18679494501393,
+                      79.02811035727531,
+                      80.26771596591809,
+                      80.88280829791302,
+                      80.86191521892539,
+                      80.2056393468533,
+                      78.92717572976133,
+                      77.0525594780147,
+                      74.62060706806572,
+                      71.68252555878607,
+                      68.30117647822829,
+                      64.5499950167742,
+                      60.51157968883187,
+                      56.27598203968834,
+                      51.93873951756582,
+                      47.59870659192312,
+                      43.35574894729843,
+                      39.30837261074967,
+                      35.551363819267635,
+                      32.173516105471
+                    ],
+                    [
+                      44.08187410700364,
+                      36.475669575313674,
+                      29.617035079998374,
+                      23.563945634598113,
+                      18.361203996023107,
+                      14.040115450178018,
+                      10.618470808098046,
+                      8.100814920075067,
+                      6.478968675135251,
+                      5.732765169891959,
+                      5.830955850307502,
+                      6.732240154711997,
+                      8.386372567953362,
+                      10.735303923722022,
+                      13.714319002888129,
+                      17.25313956649537,
+                      21.276970414851682,
+                      25.70747527904959,
+                      30.46367867891128,
+                      35.462798673257566,
+                      40.62102306718141,
+                      45.854247594621555,
+                      51.0787984359446,
+                      56.212162883543066,
+                      61.17375091186221,
+                      65.88570689800423,
+                      70.2737849957054,
+                      74.26829407104222,
+                      77.80510917413153,
+                      80.82673686345804,
+                      83.283411993735,
+                      85.13419451971703,
+                      86.34802712567242,
+                      86.90470866154706,
+                      86.79573493990947,
+                      86.02495777144804,
+                      84.60901536944547,
+                      82.57749244200264,
+                      79.97277623443372,
+                      76.84958513918636,
+                      73.2741587574045,
+                      69.32311185967376,
+                      65.08196885046519,
+                      60.643409350324276,
+                      56.10526862951929,
+                      51.568348161390375,
+                      47.13410090145415,
+                      42.90226254700514,
+                      38.968503644266825,
+                      35.42217780198441
+                    ],
+                    [
+                      41.39664700304673,
+                      33.865067735731316,
+                      27.117803564384648,
+                      21.213688539493027,
+                      16.197831989171892,
+                      12.101261300489643,
+                      8.940884214759633,
+                      6.719748998190015,
+                      5.427571225270917,
+                      5.041488307675072,
+                      5.52699766826338,
+                      6.839031811602112,
+                      8.92312353996456,
+                      11.716617109512883,
+                      15.149885965214159,
+                      19.147524443890635,
+                      23.62948898923732,
+                      28.512173390750007,
+                      33.70941170339559,
+                      39.133411186350294,
+                      44.695625206816715,
+                      50.30758206048254,
+                      55.88168963864195,
+                      61.33203754341715,
+                      66.57521749229284,
+                      71.53117970538713,
+                      76.12413764620794,
+                      80.28352635332365,
+                      83.94501115425228,
+                      87.05153439073288,
+                      89.55437856353484,
+                      91.4142157038525,
+                      92.60210544586516,
+                      93.10039879593009,
+                      92.9035014426014,
+                      92.01844996578751,
+                      90.46525665671325,
+                      88.27698385561794,
+                      85.49951657309887,
+                      82.1910123444699,
+                      78.42101928410094,
+                      74.26926655463103,
+                      69.82414525641524,
+                      65.1809113496231,
+                      60.4396549209602,
+                      55.70309122030849,
+                      51.07423782570676,
+                      46.65404856993854,
+                      42.539078146077046,
+                      38.81925142780886
+                    ],
+                    [
+                      38.87708276351174,
+                      31.428338253298826,
+                      24.799905221621657,
+                      19.051414439168237,
+                      14.22823280749921,
+                      10.361075131754575,
+                      7.465946392977694,
+                      5.544393915658327,
+                      4.584038928184496,
+                      4.559349096897455,
+                      5.432608038350571,
+                      7.15503480172298,
+                      9.668005935445306,
+                      12.90433492440647,
+                      16.78956826577391,
+                      21.243263869749743,
+                      26.18022532926564,
+                      31.511674327969768,
+                      37.14635241809563,
+                      42.991551970788464,
+                      48.9540836767658,
+                      54.94119402944655,
+                      60.86145033477889,
+                      66.62561267678159,
+                      72.1475117981546,
+                      77.34494906490247,
+                      82.14062977422844,
+                      86.46313438720088,
+                      90.24792430192028,
+                      93.43837010913259,
+                      95.98678153018218,
+                      97.85541008521415,
+                      99.01738861199317,
+                      99.45756662020469,
+                      99.17319758417563,
+                      98.17443397753505,
+                      96.48458830287572,
+                      94.1401235683621,
+                      91.19034443555609,
+                      87.69677027268028,
+                      83.73218311678909,
+                      79.37935648075698,
+                      74.72948436755662,
+                      69.88034306194956,
+                      64.93423055375433,
+                      59.995739144201885,
+                      55.16942532153054,
+                      50.55744690051494,
+                      46.257240383360916,
+                      42.35931135309792
+                    ],
+                    [
+                      36.52024945221603,
+                      29.162315322822842,
+                      22.659905412202672,
+                      17.07338432020344,
+                      12.448327536970107,
+                      8.8151032407423,
+                      6.188795251105139,
+                      4.56944754713097,
+                      3.942600597425404,
+                      4.280081529235657,
+                      5.541004254588733,
+                      7.6729323038545925,
+                      10.613156372273679,
+                      14.290040391475138,
+                      18.624394065439493,
+                      23.530835899594017,
+                      28.91911831940121,
+                      34.69539495733634,
+                      40.763418970535554,
+                      47.0256697101608,
+                      53.38441260544374,
+                      59.74270322584551,
+                      66.00535072605683,
+                      72.07985797272767,
+                      77.87735546618521,
+                      83.31354373121172,
+                      88.30965434806927,
+                      92.79343356448587,
+                      96.70014493695896,
+                      99.97357925716912,
+                      102.5670517475618,
+                      104.44435880144917,
+                      105.58066001275446,
+                      105.96324644165333,
+                      105.59215344526135,
+                      104.48057628320325,
+                      102.65504925014295,
+                      100.15535428598932,
+                      97.0341326980041,
+                      93.35618346508863,
+                      89.19744311354009,
+                      84.64365477423564,
+                      79.78874709431574,
+                      74.73295648966271,
+                      69.58073809711662,
+                      64.4385210732423,
+                      59.41237202874233,
+                      54.60563593795395,
+                      50.11662651185186,
+                      46.03643762026861
+                    ],
+                    [
+                      34.322692101944135,
+                      27.063285078152518,
+                      20.69379817412115,
+                      15.275266544933366,
+                      10.853425457454982,
+                      7.45826318102441,
+                      5.103925348729902,
+                      3.7889521911549107,
+                      3.4968196265020186,
+                      4.196746679266553,
+                      5.844725466536556,
+                      8.384726278489806,
+                      11.750029177325068,
+                      15.864634987026706,
+                      20.644712327298105,
+                      26.000043111286796,
+                      31.83543620756094,
+                      38.052087211844565,
+                      44.54887087762705,
+                      51.22356110321423,
+                      57.97398087889123,
+                      64.69909074237813,
+                      71.30002865724495,
+                      77.68111652703844,
+                      83.75084865085731,
+                      89.42287533163773,
+                      94.61699074385103,
+                      99.26012837810168,
+                      103.28736035168035,
+                      106.64288915573675,
+                      109.28101259990925,
+                      111.16703544200178,
+                      112.27809505000712,
+                      112.60386397509387,
+                      112.14708995508227,
+                      110.92393392370636,
+                      108.96406923119227,
+                      106.31051047726854,
+                      103.01914794930252,
+                      99.15797331967303,
+                      94.80599352648628,
+                      90.05184207029305,
+                      84.99210966387014,
+                      79.72942859418694,
+                      74.37035662193476,
+                      69.02311612947994,
+                      63.79525198508986,
+                      58.79127679046826,
+                      54.11037452355453,
+                      49.84423293690493
+                    ],
+                    [
+                      32.28047074276672,
+                      25.127024791885336,
+                      18.897046588316872,
+                      13.65217837428083,
+                      9.438266711582743,
+                      6.284887563227601,
+                      4.205232810163636,
+                      3.1963405743910194,
+                      3.239641056895417,
+                      4.301780804502206,
+                      6.335681774153683,
+                      9.28178751469335,
+                      13.069447336701455,
+                      17.618390438800887,
+                      22.84024540137279,
+                      28.640065907362533,
+                      34.91783054988986,
+                      41.56989259594599,
+                      48.49036400203075,
+                      55.57242621592574,
+                      62.70956776652257,
+                      69.79675483199591,
+                      76.73154546107494,
+                      83.41516062209283,
+                      89.75352561789268,
+                      95.65829364837285,
+                      101.0478595895539,
+                      105.84836669985248,
+                      109.99470239411528,
+                      113.43147196992851,
+                      116.11393181745592,
+                      118.00885679576544,
+                      119.09531070122901,
+                      119.36528460842155,
+                      118.82416575473658,
+                      117.4909998671557,
+                      115.39851254165629,
+                      112.59286047540374,
+                      109.13309084934866,
+                      105.09029664504632,
+                      100.54646669984572,
+                      95.59304130446037,
+                      90.32919649456915,
+                      84.8598922239662,
+                      79.2937306730271,
+                      73.74068043471033,
+                      68.30972970076834,
+                      63.106536427066345,
+                      58.23114550563887,
+                      53.77584208010168
+                    ],
+                    [
+                      30.389200538498944,
+                      23.348844299152724,
+                      17.264625478835246,
+                      12.19872992991486,
+                      8.19706751070069,
+                      5.2887704826359165,
+                      3.4860629470671007,
+                      2.784484638448763,
+                      3.163441493355851,
+                      4.587046348472233,
+                      7.005206272742573,
+                      10.354908665435975,
+                      14.561656464262327,
+                      19.541003565031954,
+                      25.20014466520849,
+                      31.439518882758605,
+                      38.154393224703966,
+                      45.23639975878356,
+                      52.57500859223085,
+                      60.05892688986453,
+                      67.57742159443961,
+                      75.02156973724752,
+                      82.28544483041796,
+                      89.26725052484983,
+                      95.87041334711586,
+                      102.00464490315824,
+                      107.58698060616055,
+                      112.54279705222751,
+                      116.80680404415102,
+                      120.32400046404226,
+                      123.05057628669482,
+                      124.95473659576285,
+                      126.01741808165798,
+                      126.23286466962406,
+                      125.60902706227216,
+                      124.16775137186636,
+                      121.94472480787297,
+                      118.98915156503605,
+                      115.36313945903785,
+                      111.14078716564109,
+                      106.40697269248432,
+                      101.25585540442512,
+                      95.7891159188002,
+                      90.11396984067673,
+                      84.34100198129025,
+                      78.58187680100569,
+                      72.94698783021438,
+                      67.54311334320951,
+                      62.47114732191796,
+                      57.82397362493185
+                    ],
+                    [
+                      28.644093721234334,
+                      21.723629327642357,
+                      15.79106612275423,
+                      10.909070264017583,
+                      7.123567539993662,
+                      4.463216230504809,
+                      2.939260242158415,
+                      2.5457467570417887,
+                      3.2600815107148513,
+                      5.043885488206559,
+                      7.844109687084673,
+                      11.594359909074125,
+                      16.216381426064356,
+                      21.62165379181317,
+                      27.7130488591131,
+                      34.38650989711704,
+                      41.53271615627189,
+                      49.03870477890986,
+                      56.78943003202368,
+                      64.66924785650465,
+                      72.56332111911581,
+                      80.35894721429132,
+                      87.9468143797368,
+                      95.22219596924793,
+                      102.086092817007,
+                      108.44633272237138,
+                      114.21863313065953,
+                      119.32762856492457,
+                      123.70785867980175,
+                      127.30470645414016,
+                      130.07526956709032,
+                      131.9891419804754,
+                      133.02907773338714,
+                      133.19150543113676,
+                      132.48686028433013,
+                      130.93970110270087,
+                      128.58858251176287,
+                      125.48565782696195,
+                      121.69599532317756,
+                      117.29659976969594,
+                      112.37514162644064,
+                      107.02840768394165,
+                      101.36049857680234,
+                      95.48080987694823,
+                      89.50184375942757,
+                      83.53690694887513,
+                      77.69775730693635,
+                      72.09226561660111,
+                      66.8221606039495,
+                      61.980923894680174
+                    ],
+                    [
+                      27.04000300476337,
+                      20.245886406058112,
+                      14.470502633907351,
+                      9.776935193459222,
+                      6.211079212912315,
+                      3.801089933306649,
+                      2.5572203324745093,
+                      2.4720330173706007,
+                      3.520960182241309,
+                      5.663175853224699,
+                      8.842737219501299,
+                      12.9899468601217,
+                      18.022885242201195,
+                      23.84906296986631,
+                      30.367144736768836,
+                      37.46870147403712,
+                      45.03995337262461,
+                      52.963473786182476,
+                      61.11983192864333,
+                      69.38916018882325,
+                      77.65263923691914,
+                      85.79390039128964,
+                      93.70034953982164,
+                      101.26441997256407,
+                      108.38476262515698,
+                      114.96738144265666,
+                      120.92671898607182,
+                      126.18669328844615,
+                      130.6816817125527,
+                      134.3574416441025,
+                      137.17195180780703,
+                      139.09615237272254,
+                      140.11455735062296,
+                      140.2257095686668,
+                      139.44244709979105,
+                      137.79195073549124,
+                      135.3155450174696,
+                      132.0682304939012,
+                      128.11793206960414,
+                      123.54445727331273,
+                      118.43816854539412,
+                      112.89838473356994,
+                      107.03153828649371,
+                      100.9491255416763,
+                      94.76549740867824,
+                      88.59554609128423,
+                      82.55234979085787,
+                      76.74484121416572,
+                      71.27556692397181,
+                      66.23860301622251
+                    ],
+                    [
+                      25.57146615105904,
+                      18.90978901607694,
+                      13.296719676985681,
+                      8.79569654666085,
+                      5.45253841578427,
+                      3.2948697539827805,
+                      2.331943620638171,
+                      2.554848188992331,
+                      3.937071348237449,
+                      6.43538803082861,
+                      9.991027223824867,
+                      14.53107033879709,
+                      19.970029874578962,
+                      26.211557098618268,
+                      33.15022963972571,
+                      40.67337413585674,
+                      48.66288500710351,
+                      56.997007533128745,
+                      65.55206115331029,
+                      74.20408670798258,
+                      82.83040865072255,
+                      91.3111095858178,
+                      99.53041941528099,
+                      107.37802461949838,
+                      114.75030458404541,
+                      121.5515014018464,
+                      127.69482735006733,
+                      133.10351052174124,
+                      137.71177425557354,
+                      141.46574051560842,
+                      144.32424174184354,
+                      146.25952046129504,
+                      147.25779163399193,
+                      147.3196397758413,
+                      146.4602217254443,
+                      144.70924676824546,
+                      142.11070882682125,
+                      138.72235055462772,
+                      134.61484627186212,
+                      129.8706994579168,
+                      124.58286055058915,
+                      118.85308158631989,
+                      112.79003517867739,
+                      106.50723587322926,
+                      100.12081144818103,
+                      93.74717970679112,
+                      87.50069226308901,
+                      81.49131039650842,
+                      75.82237900756208,
+                      70.58856294997186
+                    ],
+                    [
+                      24.23275135974166,
+                      17.709224647884454,
+                      12.263201162856323,
+                      7.958412465844008,
+                      4.840556377273257,
+                      2.9367002829972826,
+                      2.2550901351839023,
+                      2.785351995528986,
+                      4.499061235474489,
+                      7.350644464283798,
+                      11.278571308314788,
+                      16.206787600233607,
+                      22.046338499498745,
+                      28.69712955538705,
+                      36.04977559283758,
+                      43.98749127170387,
+                      52.387982842430986,
+                      61.12530751574639,
+                      70.07167443719787,
+                      79.09916895030028,
+                      88.08138910181017,
+                      96.89498969409394,
+                      105.42113422117882,
+                      113.54685843536757,
+                      121.1663509184664,
+                      128.18215584695648,
+                      134.50630125904172,
+                      140.06135279739416,
+                      144.7813884743719,
+                      148.61288492902878,
+                      151.51550042143285,
+                      153.46273495641688,
+                      154.4424439526888,
+                      154.45717922137,
+                      153.52433005874752,
+                      151.67603824285752,
+                      148.95886377713862,
+                      145.43318332889072,
+                      141.17231030725267,
+                      136.26133412329156,
+                      130.7956859666758,
+                      124.87944892164518,
+                      118.62344087188009,
+                      112.14310882652634,
+                      105.55628246417609,
+                      98.98084231077178,
+                      92.53236358882467,
+                      86.32180005254267,
+                      80.45327283086169,
+                      75.02202735111845
+                    ],
+                    [
+                      23.017903149292284,
+                      16.637842417936596,
+                      11.363179574093675,
+                      7.2578784042752815,
+                      4.367472294373702,
+                      2.718446742655715,
+                      2.3180352569094893,
+                      3.154416299940653,
+                      5.197287032777737,
+                      8.398779344586812,
+                      12.694675464710478,
+                      18.005874617283137,
+                      24.240058856898475,
+                      31.293505420167286,
+                      39.05299451054758,
+                      47.39776512885181,
+                      56.201476988255706,
+                      65.334143236308,
+                      74.66400611673299,
+                      84.05933529125929,
+                      93.39013576714623,
+                      102.52975875493257,
+                      111.35641390633762,
+                      119.75458496014767,
+                      127.61635268079274,
+                      134.84262908078983,
+                      141.3443053750338,
+                      147.0433131573188,
+                      151.87359425923594,
+                      155.7819700801373,
+                      158.72889634691717,
+                      160.68908477858594,
+                      161.65196948157723,
+                      161.6219935236077,
+                      160.6186903806362,
+                      158.67653606901706,
+                      155.8445508815258,
+                      152.1856347226986,
+                      147.77562692980405,
+                      142.70208988545647,
+                      137.0628252776054,
+                      130.96414205829072,
+                      124.51890544842468,
+                      117.84440616634666,
+                      111.0600978635137,
+                      104.28525802093037,
+                      97.63663285666715,
+                      91.22612978485759,
+                      85.15862143483784,
+                      79.5299231070642
+                    ],
+                    [
+                      21.920788400084206,
+                      15.689100908320412,
+                      10.589685570122363,
+                      6.686678458621925,
+                      4.025406345659359,
+                      2.631749628041293,
+                      2.5119259267286633,
+                      3.6526828125485533,
+                      6.021876026133258,
+                      9.569399094384279,
+                      14.228421817538702,
+                      19.916889007960098,
+                      26.539227264619242,
+                      33.988206482617116,
+                      42.14690409989089,
+                      50.890723512712945,
+                      60.089423277655136,
+                      69.60912019458088,
+                      79.31423661700285,
+                      89.06936981711374,
+                      98.74106841535882,
+                      108.19950728542403,
+                      117.3200575636119,
+                      125.98475212786488,
+                      134.0836489936014,
+                      141.51609546101324,
+                      148.19189463453932,
+                      154.03237334360188,
+                      158.97134685001726,
+                      162.9559714500729,
+                      165.94747163273843,
+                      167.92172433089567,
+                      168.8696794703323,
+                      168.79759390733975,
+                      167.72705529125838,
+                      165.69477363126487,
+                      162.7521215013767,
+                      158.96440886280644,
+                      154.4098852662686,
+                      149.17847043763996,
+                      143.37022356049613,
+                      137.09357147477178,
+                      130.4633259816123,
+                      123.59852992858185,
+                      116.62018020432424,
+                      109.64888270186484,
+                      102.80249929124028,
+                      96.19384955484296,
+                      89.92853027839993,
+                      84.1029133851707
+                    ],
+                    [
+                      20.935142233041105,
+                      14.856315890785478,
+                      9.935597524428802,
+                      6.237236679038579,
+                      3.8063127258295033,
+                      2.6680794095443687,
+                      2.8277369527044875,
+                      4.270620932183386,
+                      6.962784897657084,
+                      10.851943042761762,
+                      15.86873058837585,
+                      21.928233198169075,
+                      28.931732885760432,
+                      36.76861651718042,
+                      45.31839404444891,
+                      54.452776779414485,
+                      64.03777096669995,
+                      73.93574819242772,
+                      84.00746125877666,
+                      94.1139815324162,
+                      104.11854091190679,
+                      113.88826798162239,
+                      123.29581322384126,
+                      132.2208620517321,
+                      140.55153672391404,
+                      148.18568886126977,
+                      155.03208339338627,
+                      161.01147252393244,
+                      166.05755503810323,
+                      170.1178123790063,
+                      173.15420884697187,
+                      175.1437394982699,
+                      176.07880629520787,
+                      175.96740120038592,
+                      174.83307454361764,
+                      172.7146683522453,
+                      169.66579753251972,
+                      165.75406680054536,
+                      161.06001793450181,
+                      155.67580998310277,
+                      149.70364413660963,
+                      143.25395458701612,
+                      136.4433963542654,
+                      129.3926702005707,
+                      122.22423286679603,
+                      115.05994746356853,
+                      108.01873352611312,
+                      101.21427868704413,
+                      94.75287394209423,
+                      88.73143201522129
+                    ],
+                    [
+                      20.0546134045833,
+                      14.13270760459272,
+                      9.39369065267079,
+                      5.901868005729222,
+                      3.702032340350204,
+                      2.818790927314506,
+                      3.2563270384411993,
+                      4.998585335614937,
+                      8.009858796951903,
+                      12.23574389407662,
+                      17.604421872698435,
+                      24.02821741370653,
+                      31.405381839619018,
+                      39.622046414268674,
+                      48.554292055800964,
+                      58.070284706069344,
+                      68.03243032221707,
+                      78.29950953719643,
+                      88.72875897630635,
+                      99.17787349091847,
+                      109.5069106634511,
+                      119.58008537677364,
+                      129.2674476292666,
+                      138.44644081450687,
+                      147.00334019222691,
+                      154.8345722009773,
+                      161.8479146792014,
+                      167.9635761679938,
+                      173.1151495670465,
+                      177.25043189052002,
+                      180.33209815773606,
+                      182.33821401257504,
+                      183.26256893852846,
+                      183.11481032200302,
+                      181.92035843451242,
+                      179.72008387907184,
+                      176.56973228006797,
+                      172.53908596843243,
+                      167.71085897656656,
+                      162.17932954145056,
+                      156.04872315080888,
+                      149.43136850469608,
+                      142.44565810071808,
+                      135.21385396384497,
+                      127.85978681883446,
+                      120.50650328032961,
+                      113.27392001557189,
+                      106.2765460235245,
+                      99.6213339857195,
+                      93.40571902276989
+                    ],
+                    [
+                      19.272808907146285,
+                      13.511447266501992,
+                      8.956685398840252,
+                      5.672828488803594,
+                      3.7043448077061374,
+                      3.07517711608698,
+                      3.788494162799541,
+                      5.826872937607032,
+                      9.152889800421688,
+                      13.710087600112148,
+                      19.42427683400069,
+                      26.20512210157481,
+                      33.94796075246054,
+                      42.53579876134785,
+                      51.84142938390124,
+                      61.729622829419604,
+                      72.05933968720144,
+                      82.68592673344179,
+                      93.46326053548606,
+                      104.24581144190094,
+                      114.89060759459113,
+                      125.25908505255165,
+                      135.21881558424798,
+                      144.6451078644969,
+                      153.4224805206419,
+                      161.44600665220935,
+                      168.6225291638045,
+                      174.87174469132208,
+                      180.12715135318177,
+                      184.33685239292012,
+                      187.4642044175949,
+                      189.4882958208554,
+                      190.40423853946746,
+                      190.223254913034,
+                      188.97254140922922,
+                      186.69489255654926,
+                      183.44807169282223,
+                      179.3039200685936,
+                      174.34720229409183,
+                      168.67419382512097,
+                      162.39102478537973,
+                      155.61180348205568,
+                      148.45655199869603,
+                      141.04899473627643,
+                      133.51424822466922,
+                      125.97646648974123,
+                      118.55650035687478,
+                      111.3696310121442,
+                      104.52343775640324,
+                      98.11585712214836
+                    ],
+                    [
+                      18.583337476136258,
+                      12.985702502195721,
+                      8.617294757972003,
+                      5.542364459600824,
+                      3.8050194273901106,
+                      3.428521709171415,
+                      4.41502995146219,
+                      6.745778854115443,
+                      10.381674384174783,
+                      15.264272255061954,
+                      21.31709792878309,
+                      28.447259389468613,
+                      36.54729935365853,
+                      45.497231475620794,
+                      55.16670538596989,
+                      65.41724785024323,
+                      76.10453162082098,
+                      87.08062925940345,
+                      98.19621584936948,
+                      109.30269158879892,
+                      120.25420225575917,
+                      130.90954200368154,
+                      141.1339284859282,
+                      150.80064462290315,
+                      159.7925442281801,
+                      168.0034201350042,
+                      175.3392334702848,
+                      181.71920148571056,
+                      187.07673914964346,
+                      191.36024688549725,
+                      194.53373381887627,
+                      196.5772630943667,
+                      197.4872036590167,
+                      197.2762717566247,
+                      195.97334553532264,
+                      193.62303784904717,
+                      190.28501562689567,
+                      186.03305906997082,
+                      180.9538602707492,
+                      175.14556837924388,
+                      168.71609681073326,
+                      161.78121677522478,
+                      154.46247013258107,
+                      146.88494274600686,
+                      139.17494663970743,
+                      131.45766492640738,
+                      123.85481728924634,
+                      116.48240550710258,
+                      109.44859793747926,
+                      102.85180897244274
+                    ],
+                    [
+                      17.979851717738633,
+                      12.548681402121803,
+                      8.368270227492728,
+                      5.502760334998294,
+                      3.995864785147603,
+                      3.8701505840325847,
+                      5.1267726937896345,
+                      7.745651014450798,
+                      11.686069548806264,
+                      16.887665645080865,
+                      23.27176778863892,
+                      30.743033204769592,
+                      39.191331733588505,
+                      48.49382010190128,
+                      58.51715076461461,
+                      69.11976171237345,
+                      80.15419772010344,
+                      91.4694190347295,
+                      102.91305999720578,
+                      114.33360706693193,
+                      125.58247266937431,
+                      136.5159477646833,
+                      146.9970216453282,
+                      156.8970619148054,
+                      166.09735068841593,
+                      174.49047471901778,
+                      181.9815674360882,
+                      188.48939996043623,
+                      193.94731628143626,
+                      198.30400530149922,
+                      201.5240997562814,
+                      203.5885895196662,
+                      204.495034905585,
+                      204.25756464119303,
+                      202.9066435027184,
+                      200.48859637462067,
+                      197.0648788079215,
+                      192.71108899103726,
+                      187.5157222663711,
+                      181.5786766774297,
+                      175.00952617382262,
+                      167.92558661598076,
+                      160.44980814825269,
+                      152.7085353667385,
+                      144.82918353193904,
+                      136.9378844416419,
+                      129.15715913236565,
+                      121.60367605605066,
+                      114.38615262487261,
+                      107.60345499509285
+                    ],
+                    [
+                      17.45608858757386,
+                      12.193674920710722,
+                      8.202446095105891,
+                      5.546384752115069,
+                      4.268776683197789,
+                      4.3914814275272605,
+                      5.914658674585844,
+                      8.816943083507294,
+                      13.056047249879967,
+                      18.56976109946502,
+                      25.277306400340333,
+                      33.08099768870276,
+                      41.86815589501538,
+                      51.5132184030786,
+                      61.87998909942983,
+                      72.82397397821836,
+                      84.19475174356936,
+                      95.83833419842182,
+                      107.59947756537753,
+                      119.3239127588235,
+                      130.86046953352522,
+                      142.0630759183903,
+                      152.79262001983258,
+                      162.91866584648548,
+                      172.32101807398703,
+                      180.89113255824557,
+                      188.5333699612872,
+                      195.16608922681777,
+                      200.72257608747955,
+                      205.15179962703823,
+                      208.41898753928072,
+                      210.50600851832544,
+                      211.4115485721231,
+                      211.15106732133162,
+                      209.75652081109277,
+                      207.2758392177953,
+                      203.77215116481378,
+                      199.32275114731007,
+                      194.0178126686537,
+                      187.95885686705822,
+                      181.25699432605577,
+                      174.0309660121906,
+                      166.40501741808316,
+                      158.50664754336563,
+                      150.4642808687454,
+                      142.4049155585686,
+                      134.45180442472295,
+                      126.72222644578915,
+                      119.32540571441857,
+                      112.36063154880972
+                    ]
+                  ],
+                  "zauto": true,
+                  "zmax": 211.4115485721231,
+                  "zmin": -211.4115485721231
+                },
+                {
+                  "autocolorscale": false,
+                  "autocontour": true,
+                  "colorbar": {
+                    "tickfont": {
+                      "size": 8
+                    },
+                    "ticksuffix": "",
+                    "x": 1,
+                    "y": 0.5
+                  },
+                  "colorscale": [
+                    [
+                      0,
+                      "rgb(255,247,251)"
+                    ],
+                    [
+                      0.14285714285714285,
+                      "rgb(236,231,242)"
+                    ],
+                    [
+                      0.2857142857142857,
+                      "rgb(208,209,230)"
+                    ],
+                    [
+                      0.42857142857142855,
+                      "rgb(166,189,219)"
+                    ],
+                    [
+                      0.5714285714285714,
+                      "rgb(116,169,207)"
+                    ],
+                    [
+                      0.7142857142857143,
+                      "rgb(54,144,192)"
+                    ],
+                    [
+                      0.8571428571428571,
+                      "rgb(5,112,176)"
+                    ],
+                    [
+                      1,
+                      "rgb(3,78,123)"
+                    ]
+                  ],
+                  "contours": {
+                    "coloring": "heatmap",
+                    "start": 2,
+                    "end": 28,
+                    "size": 2
+                  },
+                  "hoverinfo": "x+y+z",
+                  "ncontours": 25,
+                  "type": "contour",
+                  "x": [
+                    -5,
+                    -4.6938775510204085,
+                    -4.387755102040816,
+                    -4.081632653061225,
+                    -3.7755102040816326,
+                    -3.4693877551020407,
+                    -3.163265306122449,
+                    -2.857142857142857,
+                    -2.5510204081632653,
+                    -2.2448979591836733,
+                    -1.9387755102040813,
+                    -1.6326530612244898,
+                    -1.3265306122448979,
+                    -1.020408163265306,
+                    -0.7142857142857144,
+                    -0.408163265306122,
+                    -0.1020408163265305,
+                    0.204081632653061,
+                    0.5102040816326534,
+                    0.8163265306122449,
+                    1.1224489795918373,
+                    1.4285714285714288,
+                    1.7346938775510203,
+                    2.0408163265306127,
+                    2.3469387755102042,
+                    2.6530612244897958,
+                    2.959183673469388,
+                    3.2653061224489797,
+                    3.571428571428571,
+                    3.8775510204081627,
+                    4.183673469387756,
+                    4.4897959183673475,
+                    4.795918367346939,
+                    5.1020408163265305,
+                    5.408163265306122,
+                    5.714285714285715,
+                    6.020408163265307,
+                    6.326530612244898,
+                    6.63265306122449,
+                    6.938775510204081,
+                    7.244897959183675,
+                    7.551020408163266,
+                    7.857142857142858,
+                    8.16326530612245,
+                    8.46938775510204,
+                    8.775510204081632,
+                    9.081632653061225,
+                    9.387755102040817,
+                    9.693877551020408,
+                    10
+                  ],
+                  "xaxis": "x2",
+                  "y": [
+                    0,
+                    0.30612244897959184,
+                    0.6122448979591837,
+                    0.9183673469387755,
+                    1.2244897959183674,
+                    1.5306122448979593,
+                    1.836734693877551,
+                    2.142857142857143,
+                    2.4489795918367347,
+                    2.7551020408163267,
+                    3.0612244897959187,
+                    3.36734693877551,
+                    3.673469387755102,
+                    3.979591836734694,
+                    4.285714285714286,
+                    4.591836734693878,
+                    4.8979591836734695,
+                    5.204081632653061,
+                    5.510204081632653,
+                    5.816326530612245,
+                    6.122448979591837,
+                    6.428571428571429,
+                    6.73469387755102,
+                    7.040816326530613,
+                    7.346938775510204,
+                    7.653061224489796,
+                    7.959183673469388,
+                    8.26530612244898,
+                    8.571428571428571,
+                    8.877551020408163,
+                    9.183673469387756,
+                    9.489795918367347,
+                    9.795918367346939,
+                    10.10204081632653,
+                    10.408163265306122,
+                    10.714285714285715,
+                    11.020408163265307,
+                    11.326530612244898,
+                    11.63265306122449,
+                    11.938775510204081,
+                    12.244897959183675,
+                    12.551020408163266,
+                    12.857142857142858,
+                    13.16326530612245,
+                    13.46938775510204,
+                    13.775510204081632,
+                    14.081632653061225,
+                    14.387755102040817,
+                    14.693877551020408,
+                    15
+                  ],
+                  "yaxis": "y2",
+                  "z": [
+                    [
+                      16.575028679995533,
+                      13.045357280809945,
+                      9.787958112410214,
+                      6.821953204661192,
+                      4.165467206141658,
+                      1.854510698707561,
+                      0.6416146864526424,
+                      2.1027807804047858,
+                      3.501099783839739,
+                      4.624647588328975,
+                      5.473289110448883,
+                      6.062215614458349,
+                      6.412243750399299,
+                      6.547709042077872,
+                      6.495413098849659,
+                      6.283774979086636,
+                      5.942016819106485,
+                      5.499350440249589,
+                      4.984170807913547,
+                      4.42327854657468,
+                      3.8411647261010495,
+                      3.2594032613791284,
+                      2.696215249685746,
+                      2.1663070064424517,
+                      1.6811728101221024,
+                      1.2503073047612896,
+                      0.8845940074621941,
+                      0.6055277340803988,
+                      0.46113359389301056,
+                      0.48490143099795396,
+                      0.6041607312421873,
+                      0.7385634673278193,
+                      0.8534948117287061,
+                      0.934550376344165,
+                      0.9742397989065233,
+                      0.968762015528488,
+                      0.9183151553599883,
+                      0.8293364317455243,
+                      0.719370667740565,
+                      0.6259164366025604,
+                      0.6083332567174313,
+                      0.7025103466966202,
+                      0.8753135984814973,
+                      1.0685524317467758,
+                      1.2342633992202396,
+                      1.3350518933382713,
+                      1.3427028220243853,
+                      1.246682006057059,
+                      1.0909761044089583,
+                      1.081478181764701
+                    ],
+                    [
+                      16.440581814030374,
+                      12.971846143165324,
+                      9.776525835946083,
+                      6.873285915025536,
+                      4.280778357117699,
+                      2.038823165923997,
+                      0.6970307232806602,
+                      1.8992479916151566,
+                      3.231539363512329,
+                      4.310266621778727,
+                      5.1240539479497675,
+                      5.685960192340822,
+                      6.0161343445857325,
+                      6.138573443245237,
+                      6.07979900344678,
+                      5.867932831454112,
+                      5.531865513277298,
+                      5.100444970294054,
+                      4.6016755822899365,
+                      4.061941576087048,
+                      3.5052813033306123,
+                      2.952751397888984,
+                      2.4219384689337393,
+                      1.9267128575632226,
+                      1.4774067896840128,
+                      1.0818516578665902,
+                      0.748575752925397,
+                      0.49644094398620753,
+                      0.37415973103886757,
+                      0.4141248269377089,
+                      0.5360586919032101,
+                      0.66664301961728,
+                      0.7779286999840466,
+                      0.8578036941169072,
+                      0.8988350562287707,
+                      0.8961312484632808,
+                      0.8479740112623652,
+                      0.757933367574995,
+                      0.6394566483661,
+                      0.526555248062158,
+                      0.48684590232362573,
+                      0.5749412303071544,
+                      0.7524714574927417,
+                      0.9508141813118781,
+                      1.1195574073846686,
+                      1.220437818309363,
+                      1.2225341223003716,
+                      1.108018056092616,
+                      0.9061230052396354,
+                      0.8361865792797258
+                    ],
+                    [
+                      16.361124794894913,
+                      12.965949940271873,
+                      9.850522119712611,
+                      7.037887611106106,
+                      4.5602163486895,
+                      2.5066742661790022,
+                      1.3736320015557946,
+                      2.0109879756456257,
+                      3.1322973849504216,
+                      4.109866544025325,
+                      4.860010087854012,
+                      5.377773764805907,
+                      5.6769438485100645,
+                      5.7786371204430385,
+                      5.707771929253005,
+                      5.491399163616778,
+                      5.157583189180103,
+                      4.734471363416963,
+                      4.249441721230779,
+                      3.728300578124096,
+                      3.194535492937191,
+                      2.66864911006575,
+                      2.167621108266314,
+                      1.7045846880667193,
+                      1.2888974481490094,
+                      0.9270598363681031,
+                      0.6259193459707375,
+                      0.40335753964515164,
+                      0.31082523489893477,
+                      0.37144173250929186,
+                      0.49645647841890284,
+                      0.6247710371009005,
+                      0.7352362141070693,
+                      0.8175216777920612,
+                      0.8640215454831977,
+                      0.8688421486459023,
+                      0.8287680272125562,
+                      0.7452576001279956,
+                      0.6283319710836002,
+                      0.5060442574983907,
+                      0.4422275356622871,
+                      0.5076107106613241,
+                      0.6751171578364475,
+                      0.870053743769047,
+                      1.0381479884100608,
+                      1.139226938676373,
+                      1.139636941851658,
+                      1.0150068842136515,
+                      0.7774079554099962,
+                      0.642776001187437
+                    ],
+                    [
+                      16.3235251643392,
+                      13.010667589134822,
+                      9.98650240279972,
+                      7.279792098867444,
+                      4.936631751846471,
+                      3.074049909838645,
+                      2.066405602355589,
+                      2.326645259793255,
+                      3.173258313762015,
+                      4.007146508369033,
+                      4.669591545902855,
+                      5.1285628987810155,
+                      5.387194717758821,
+                      5.461617165582069,
+                      5.37399975323818,
+                      5.149634696742253,
+                      4.815310762304146,
+                      4.398161528542413,
+                      3.9247124136663007,
+                      3.4200294683637473,
+                      2.9069421227039354,
+                      2.40534585597554,
+                      1.931617875698996,
+                      1.4982219013572995,
+                      1.113682297253357,
+                      0.7834269050723239,
+                      0.5132238243281078,
+                      0.3220180399299505,
+                      0.26631921364851585,
+                      0.3489988660540653,
+                      0.4768579567934524,
+                      0.6044466270928625,
+                      0.7165024278513266,
+                      0.8038408584616011,
+                      0.8584503805740391,
+                      0.8734931599185124,
+                      0.8445821997510355,
+                      0.7717228648274894,
+                      0.6626018207578088,
+                      0.5399856185365792,
+                      0.45710009683467934,
+                      0.48797990213991804,
+                      0.6309369987519756,
+                      0.8144830545521695,
+                      0.9788145757201354,
+                      1.0803618566148414,
+                      1.0826895670362242,
+                      0.9564395838150115,
+                      0.6988351163971565,
+                      0.5043017687973534
+                    ],
+                    [
+                      16.315169344656088,
+                      13.089822808861832,
+                      10.16255396832098,
+                      7.5667363281914755,
+                      5.35659366035479,
+                      3.649992326052435,
+                      2.7066435538585596,
+                      2.725785755320671,
+                      3.310194569248184,
+                      3.9800479534466513,
+                      4.538606319964936,
+                      4.927891662394688,
+                      5.138674427342321,
+                      5.1808218692324,
+                      5.072938374370952,
+                      4.838022635030254,
+                      4.501217256189483,
+                      4.088371254454646,
+                      3.6249526801778416,
+                      3.135132332498915,
+                      2.6409704209368194,
+                      2.161688612707273,
+                      1.713043380423951,
+                      1.3068630819237874,
+                      0.9509279328766013,
+                      0.6497608580736125,
+                      0.4085524384677359,
+                      0.2499843635676529,
+                      0.2366417788229246,
+                      0.33900810051264907,
+                      0.4690791446499432,
+                      0.5972592797554422,
+                      0.7126512201825862,
+                      0.806582793446179,
+                      0.8704285276625666,
+                      0.8964198268483432,
+                      0.8791532939765317,
+                      0.8174734750039577,
+                      0.7172811549727319,
+                      0.5972050608079281,
+                      0.5003695477965999,
+                      0.4955665817932045,
+                      0.605836770077198,
+                      0.7726452012580686,
+                      0.9313011110118281,
+                      1.0338053374344085,
+                      1.0409410427699022,
+                      0.9200035331275385,
+                      0.6586534534079117,
+                      0.42252770493050573
+                    ],
+                    [
+                      16.32432516702727,
+                      13.188665772704018,
+                      10.35939032115288,
+                      7.8722854802504365,
+                      5.78317395238746,
+                      4.19581372618962,
+                      3.2834586410538638,
+                      3.1375001716547675,
+                      3.499677618273131,
+                      4.004616442020598,
+                      4.451711100325881,
+                      4.764729109242693,
+                      4.922886606081843,
+                      4.929453059394222,
+                      4.799047463430052,
+                      4.55202849244468,
+                      4.211621077269023,
+                      3.802174580837922,
+                      3.3479266937121293,
+                      2.8720143961211226,
+                      2.395622402391327,
+                      1.9372265880482216,
+                      1.5119291626916067,
+                      1.130930261170132,
+                      0.8013072843071307,
+                      0.5267499989266582,
+                      0.3122721708422022,
+                      0.18823039360522734,
+                      0.21942822054374606,
+                      0.3356158510664854,
+                      0.46678904615492156,
+                      0.5963483033601528,
+                      0.7160622448394035,
+                      0.8171880490434865,
+                      0.8903178645695434,
+                      0.9267601385425905,
+                      0.9201752226720586,
+                      0.8683650057154711,
+                      0.7756831043369726,
+                      0.6574677532631238,
+                      0.5491185757117689,
+                      0.5123127758287838,
+                      0.5878525041318945,
+                      0.7353502839495584,
+                      0.8875731046562584,
+                      0.9916511680458349,
+                      1.005599755609256,
+                      0.8946034080835221,
+                      0.6418359224832753,
+                      0.39065546064119316
+                    ],
+                    [
+                      16.34037727752671,
+                      13.294205012151581,
+                      10.560781318816263,
+                      8.176003883483597,
+                      6.1924075582621345,
+                      4.694453190476731,
+                      3.7945181527919263,
+                      3.5270293765206264,
+                      3.7076381429738903,
+                      4.0585672592556925,
+                      4.393935479543766,
+                      4.62823174051558,
+                      4.731517222156959,
+                      4.700913410423101,
+                      4.547006358828501,
+                      4.287357406664335,
+                      3.9431067435679603,
+                      3.536951520979752,
+                      3.091766223040784,
+                      2.6295425831175674,
+                      2.170502457019482,
+                      1.7323175145283647,
+                      1.329413148428598,
+                      0.9723806278943615,
+                      0.6676533969641053,
+                      0.4181838648451129,
+                      0.2293910436994568,
+                      0.14472219410088788,
+                      0.2140045106754834,
+                      0.33540519064489727,
+                      0.4658582131514624,
+                      0.5968702529851277,
+                      0.7211870966703491,
+                      0.829448749771769,
+                      0.9113232995591928,
+                      0.9572123186887537,
+                      0.9599070547959149,
+                      0.916251126184017,
+                      0.8292167394436942,
+                      0.7114600718197097,
+                      0.5925776840653828,
+                      0.5276411237525609,
+                      0.5691852220948734,
+                      0.6964912595489866,
+                      0.8422409351752593,
+                      0.9484672707384455,
+                      0.970360990488518,
+                      0.8717269789467025,
+                      0.634508462442286,
+                      0.3905457458038451
+                    ],
+                    [
+                      16.353951063749076,
+                      13.395322673133338,
+                      10.753528376270046,
+                      8.462680553184223,
+                      6.569145415596181,
+                      5.138076127621181,
+                      4.239859093051809,
+                      3.8777287712927584,
+                      3.9104949272046543,
+                      4.123346848795927,
+                      4.351847390495298,
+                      4.508403653813198,
+                      4.556843315421458,
+                      4.489080298894723,
+                      4.311907779814724,
+                      4.040095284376254,
+                      3.6926285103384893,
+                      3.2904635412786916,
+                      2.855025803335339,
+                      2.4070905182195896,
+                      1.9658699890445726,
+                      1.5482227265784592,
+                      1.1679472086916731,
+                      0.8351718944478214,
+                      0.5560068806487916,
+                      0.33341261472832845,
+                      0.17564915685714075,
+                      0.13631735983019128,
+                      0.2203779563680942,
+                      0.3368662213811005,
+                      0.4639391904241618,
+                      0.5957519664435919,
+                      0.7243919500651259,
+                      0.839337324289707,
+                      0.9291926988006033,
+                      0.9834693282015593,
+                      0.9941562224498581,
+                      0.9572251520975411,
+                      0.8744187998968981,
+                      0.7561547151472473,
+                      0.6274729265796899,
+                      0.5375178107176338,
+                      0.5463087741614547,
+                      0.6530298430634314,
+                      0.7924419626155282,
+                      0.9011349347918495,
+                      0.9312829036308129,
+                      0.8456500367845495,
+                      0.6265418390652617,
+                      0.40215379948652047
+                    ],
+                    [
+                      16.356949133306106,
+                      13.482739981892275,
+                      10.927192175016751,
+                      8.721300379191966,
+                      6.903970907622735,
+                      5.523200322881335,
+                      4.620493007002994,
+                      4.18166097625632,
+                      4.0930242985152425,
+                      4.184696391439506,
+                      4.314198238007676,
+                      4.396544444949058,
+                      4.3920364119045905,
+                      4.28851895644968,
+                      4.089412866578323,
+                      3.806823462974772,
+                      3.457594332215498,
+                      3.060912251720533,
+                      2.6367200397796977,
+                      2.204559775264497,
+                      1.7826562919348337,
+                      1.3871472912317033,
+                      1.0314239655184894,
+                      0.7256164461561047,
+                      0.4764945381870795,
+                      0.2891823689716218,
+                      0.17667339040848404,
+                      0.16812462400606626,
+                      0.23787542592149594,
+                      0.33961321022961205,
+                      0.45988167528345403,
+                      0.5912265509390845,
+                      0.7235272027216084,
+                      0.8445256934961884,
+                      0.9416058996691431,
+                      1.0033968709640646,
+                      1.0211509037006956,
+                      0.9900598942739633,
+                      0.9107856609182682,
+                      0.7918491634704099,
+                      0.6545333287061333,
+                      0.5424054860773792,
+                      0.5194752876566501,
+                      0.6047819176952208,
+                      0.7375924810836079,
+                      0.8485339324312229,
+                      0.886402456922661,
+                      0.8130071284035211,
+                      0.6116433913964392,
+                      0.41202089831441063
+                    ],
+                    [
+                      16.342525622780368,
+                      13.548893402651768,
+                      11.073722816123956,
+                      8.944089289552666,
+                      7.191192006277097,
+                      5.848629013869785,
+                      4.937967483739498,
+                      4.435298841694444,
+                      4.245863337038169,
+                      4.232310472404376,
+                      4.272107260037566,
+                      4.285472790533413,
+                      4.231344832211506,
+                      4.09462306801803,
+                      3.8758593086296456,
+                      3.5847012723365,
+                      3.2359262354567946,
+                      2.846977817697491,
+                      2.436337436607719,
+                      2.022363480504499,
+                      1.6224077353427675,
+                      1.2521208618064414,
+                      0.9249283799637673,
+                      0.651731006330607,
+                      0.4409791306822056,
+                      0.29911882378204524,
+                      0.22913818843252806,
+                      0.22308542737559972,
+                      0.2646172101599401,
+                      0.3437506223844929,
+                      0.4532762893441261,
+                      0.5824374802571667,
+                      0.7175329119746315,
+                      0.843944522926791,
+                      0.947649358908161,
+                      1.01639167557552,
+                      1.040752296314507,
+                      1.0152430216464,
+                      0.9396000627490244,
+                      0.8207496352658765,
+                      0.6768112111888155,
+                      0.545923890623597,
+                      0.49247303819747273,
+                      0.5544738624270636,
+                      0.6793075499965314,
+                      0.7913170115957177,
+                      0.8353775286270846,
+                      0.7722473270134377,
+                      0.5864121608631372,
+                      0.41366217580657694
+                    ],
+                    [
+                      16.305020621242832,
+                      13.587767306262963,
+                      11.187080959200985,
+                      9.125738646711998,
+                      7.427585223787781,
+                      6.114492660829098,
+                      5.194193465417992,
+                      4.637525402927724,
+                      4.363581540505196,
+                      4.259148812138378,
+                      4.218942072763114,
+                      4.169566703626262,
+                      4.070165558381105,
+                      3.9036850644437777,
+                      3.6683223693331874,
+                      3.3715155832283576,
+                      3.0260956742956275,
+                      2.647834144710804,
+                      2.2538229270736947,
+                      1.8613501556008232,
+                      1.4870923699351009,
+                      1.1465383750817615,
+                      0.8535830338842685,
+                      0.6200375653291091,
+                      0.45391135170811553,
+                      0.3540715664863073,
+                      0.3048785296022001,
+                      0.2870370337102998,
+                      0.29800875496755835,
+                      0.3494854531872619,
+                      0.44419264370878025,
+                      0.5691995123258174,
+                      0.7061860304026731,
+                      0.8374939408927635,
+                      0.9474760005916669,
+                      1.0229825312036778,
+                      1.0539927384233523,
+                      1.0344507940225323,
+                      0.9633405740884398,
+                      0.8463041850979574,
+                      0.6988666079107789,
+                      0.5540146326475212,
+                      0.47266375207920874,
+                      0.5082768818153568,
+                      0.621660617858532,
+                      0.7319106038244779,
+                      0.7793092241460637,
+                      0.7232551378508348,
+                      0.549463739818596,
+                      0.4054195337454816
+                    ],
+                    [
+                      16.239872233773422,
+                      13.594713689932252,
+                      11.262893165235123,
+                      9.262812527880007,
+                      7.611611743916994,
+                      6.321766028415922,
+                      5.391363527121862,
+                      4.788648437089632,
+                      4.443374682492646,
+                      4.2607229184181366,
+                      4.150048007172134,
+                      4.0446810085831455,
+                      3.905031009910128,
+                      3.712907790292911,
+                      3.4646345916400483,
+                      3.165700059272657,
+                      2.827134141123842,
+                      2.46313748387166,
+                      2.0895179812409714,
+                      1.7226380047726146,
+                      1.3786947991225285,
+                      1.0731855849263219,
+                      0.8202025393445942,
+                      0.6304147465027944,
+                      0.5057008706303958,
+                      0.4326505408777124,
+                      0.38732353825134835,
+                      0.3533181289500259,
+                      0.33544978954765,
+                      0.3569732126345937,
+                      0.4330971796774862,
+                      0.5519220239782361,
+                      0.6900006447016255,
+                      0.8259091307073447,
+                      0.9421325722527129,
+                      1.024620201787785,
+                      1.0628302404121217,
+                      1.0502680506982005,
+                      0.9853613891876001,
+                      0.8728087784356755,
+                      0.7261699835921427,
+                      0.5739454934447111,
+                      0.47037017754291655,
+                      0.47645997864109363,
+                      0.5717787097335207,
+                      0.6748049289541982,
+                      0.7208333994558718,
+                      0.6672748929907575,
+                      0.5010417735006186,
+                      0.3893424166867706
+                    ],
+                    [
+                      16.14351890740633,
+                      13.566277066838095,
+                      11.298157085781106,
+                      9.353307099330562,
+                      7.74292092212702,
+                      6.472005525060623,
+                      5.531906048361226,
+                      4.889882630360856,
+                      4.484218091974335,
+                      4.234487581802482,
+                      4.062432304988561,
+                      3.9079982268667064,
+                      3.733539677844199,
+                      3.5203733278941223,
+                      3.2633731781613644,
+                      2.9663288237227583,
+                      2.638619756085448,
+                      2.2929836045345167,
+                      1.9440441261644048,
+                      1.607331668627945,
+                      1.2985690871074493,
+                      1.0328578860069675,
+                      0.8228620501580269,
+                      0.6744257515615808,
+                      0.5802567863065214,
+                      0.5195637674993098,
+                      0.4694675230386267,
+                      0.41857707941987915,
+                      0.3747490979334429,
+                      0.36635060952000376,
+                      0.42092407395745235,
+                      0.5316831925882285,
+                      0.6702656162417151,
+                      0.8107522239956371,
+                      0.9335072986289229,
+                      1.0235846860367477,
+                      1.0700166437708496,
+                      1.0660116407971325,
+                      1.0096491341370233,
+                      0.9050303064419463,
+                      0.7643864198356423,
+                      0.6126910428166317,
+                      0.4959970004235353,
+                      0.47232393692871205,
+                      0.5402048088640864,
+                      0.6270476954902473,
+                      0.6645423151682212,
+                      0.6072744202153527,
+                      0.4433752555932958,
+                      0.3716053531128343
+                    ],
+                    [
+                      16.0133004199114,
+                      13.500033866714652,
+                      11.290997671029205,
+                      9.396326153177409,
+                      7.822028407076829,
+                      6.567195775140723,
+                      5.618455042383243,
+                      4.943059487338814,
+                      4.486321260229728,
+                      4.179364368469235,
+                      3.954461763226225,
+                      3.7578543790115653,
+                      3.554256118230394,
+                      3.324984698704964,
+                      3.0638247282488855,
+                      2.7730895199267707,
+                      2.460639609196815,
+                      2.137826464763065,
+                      1.8181163733076624,
+                      1.5161198429630405,
+                      1.2466656192065533,
+                      1.0232365164999748,
+                      0.8546379878773972,
+                      0.7397058422426311,
+                      0.6642741930560631,
+                      0.6065325666260781,
+                      0.5478393043034436,
+                      0.48080368754541786,
+                      0.41427648029797026,
+                      0.3778898115674594,
+                      0.40927038264733123,
+                      0.5104423874587027,
+                      0.6491952727238232,
+                      0.7944896975403175,
+                      0.9243413368246034,
+                      1.0229375979079618,
+                      1.0789903901368523,
+                      1.0855506182679282,
+                      1.0405349426556403,
+                      0.9477259603034351,
+                      0.8184951016790166,
+                      0.6750689870744091,
+                      0.5553921336692278,
+                      0.5068681056357354,
+                      0.539274655412107,
+                      0.598391688544714,
+                      0.6176771622034997,
+                      0.5489538150291551,
+                      0.38240438549036665,
+                      0.36387779992608393
+                    ],
+                    [
+                      15.847362667081176,
+                      13.394450085345499,
+                      11.240469140067056,
+                      9.391841884611129,
+                      7.850101600257562,
+                      6.609653593755998,
+                      5.653827326026365,
+                      4.950454345698774,
+                      4.45077234419318,
+                      4.09538293573226,
+                      3.8255990586561945,
+                      3.5935656841216193,
+                      3.366599490165715,
+                      3.126393713739429,
+                      2.865935886519627,
+                      2.586239461889384,
+                      2.2937253881612913,
+                      1.998349705338078,
+                      1.712283101844487,
+                      1.448813301261151,
+                      1.2209420434420204,
+                      1.0388767725001158,
+                      0.9059636724265699,
+                      0.8149509513669083,
+                      0.7490631344903781,
+                      0.6889524025029085,
+                      0.6203400174728999,
+                      0.5386869002298852,
+                      0.4530087065617374,
+                      0.39219985396407303,
+                      0.4006571239333915,
+                      0.49135113072081643,
+                      0.6301405607438287,
+                      0.7805892673447987,
+                      0.9182298472995308,
+                      1.0264401692432426,
+                      1.0937115838598626,
+                      1.1130440504900028,
+                      1.0823034631628625,
+                      1.0050738626901696,
+                      0.8919987909405923,
+                      0.7627891369814399,
+                      0.6479405381473079,
+                      0.5824911002416919,
+                      0.5780767230178483,
+                      0.5997818754663767,
+                      0.5905354756806566,
+                      0.5024710288854942,
+                      0.3321191260703884,
+                      0.3828366311509557
+                    ],
+                    [
+                      15.644569048360946,
+                      13.248757657630563,
+                      11.146395380057443,
+                      9.340517090348175,
+                      7.828812242563696,
+                      6.601963658155054,
+                      5.641003319794497,
+                      4.914676673833547,
+                      4.379301408472547,
+                      3.9834151963056867,
+                      3.676183983888949,
+                      3.4152700109741296,
+                      3.1707334502308444,
+                      2.9249249215506183,
+                      2.6702562111812416,
+                      2.406545977898602,
+                      2.138756818811805,
+                      1.8752839375505035,
+                      1.6266134899307096,
+                      1.4039585258848,
+                      1.2173029245143812,
+                      1.0723994747741574,
+                      0.9673983301404437,
+                      0.8916929340751794,
+                      0.8291531003465072,
+                      0.7639807121506957,
+                      0.685563724332227,
+                      0.5914284365864073,
+                      0.4905565635997936,
+                      0.4103993752985047,
+                      0.3987059137547118,
+                      0.4790143701254742,
+                      0.6177262685426492,
+                      0.7735171463363255,
+                      0.9195096875003177,
+                      1.0383500346220746,
+                      1.1183723040132922,
+                      1.1525613332429003,
+                      1.1387246084358629,
+                      1.0801609004027823,
+                      0.9865764696315731,
+                      0.8749706321264145,
+                      0.7691896715720011,
+                      0.6938376400662915,
+                      0.6578175485736167,
+                      0.6394218294745105,
+                      0.5950862238660434,
+                      0.48359551114356275,
+                      0.3195810637451353,
+                      0.4433882668054306
+                    ],
+                    [
+                      15.404419683719498,
+                      13.062848321686804,
+                      11.00924146063814,
+                      9.243571345642607,
+                      7.760231810859716,
+                      6.5469324530227375,
+                      5.583109730831207,
+                      4.838596137059915,
+                      4.274118449552691,
+                      3.844978642123844,
+                      3.507256811317122,
+                      3.2237889842324208,
+                      2.9674651117431456,
+                      2.721502329744604,
+                      2.477876631291497,
+                      2.2352083681234007,
+                      1.9968249048875408,
+                      1.7691713685949029,
+                      1.5603896237832773,
+                      1.3786888768093752,
+                      1.2301408878350903,
+                      1.1160418139263946,
+                      1.0310724037020316,
+                      0.9639829848502467,
+                      0.9009583022487673,
+                      0.8297168172411243,
+                      0.7425908466038579,
+                      0.6387182992914795,
+                      0.5271958839515521,
+                      0.4341869743557095,
+                      0.4079398985593621,
+                      0.47933226815745805,
+                      0.6176439161108256,
+                      0.7784563086867424,
+                      0.9329183667686592,
+                      1.0630307262687901,
+                      1.1569637317310992,
+                      1.2076238440984042,
+                      1.2126208359303796,
+                      1.1747120943288551,
+                      1.1022860854714929,
+                      1.0093899957627728,
+                      0.9141698219772424,
+                      0.833576155701682,
+                      0.7733372234812302,
+                      0.7192729754064038,
+                      0.6407072737076347,
+                      0.5098426577149362,
+                      0.37247753614662515,
+                      0.5506888953719113
+                    ],
+                    [
+                      15.126978707665428,
+                      12.837182991032936,
+                      10.830009827396248,
+                      9.102678690900852,
+                      7.646754781324672,
+                      6.447553172568748,
+                      5.483403279041962,
+                      4.725289740183577,
+                      4.137799233016003,
+                      3.6820899128982916,
+                      3.320417734985724,
+                      3.0205121525817944,
+                      2.758157263156464,
+                      2.5175826911821955,
+                      2.290363289314226,
+                      2.0737544712985563,
+                      1.8690472313486248,
+                      1.6800974029676774,
+                      1.5118891979012632,
+                      1.3688958836337024,
+                      1.2531859872737008,
+                      1.1627376366773485,
+                      1.0909011712996142,
+                      1.0276324534524754,
+                      0.9620088243469699,
+                      0.884874326118632,
+                      0.7909515310410632,
+                      0.6807759586453224,
+                      0.5638927194188957,
+                      0.4657482956726768,
+                      0.43293779797904647,
+                      0.49843804070668535,
+                      0.6357880526098107,
+                      0.8005957367763542,
+                      0.9629731422992214,
+                      1.1043891771700733,
+                      1.2127695302288366,
+                      1.2807846127078821,
+                      1.30561101224179,
+                      1.289139722406164,
+                      1.238091393903873,
+                      1.163515590013665,
+                      1.0788857289716667,
+                      0.9958689156368581,
+                      0.9180211273242199,
+                      0.8359477588422547,
+                      0.7301665272441187,
+                      0.5903916798954251,
+                      0.49157352154063516,
+                      0.7021107155443754
+                    ],
+                    [
+                      14.812809308179949,
+                      12.57271444906815,
+                      10.61015585354366,
+                      8.91988800839389,
+                      7.4910404163886435,
+                      6.306977450472138,
+                      5.345255078400558,
+                      4.5780019123663305,
+                      3.973202327189434,
+                      3.4971546218890284,
+                      3.117715966952449,
+                      2.807302541035944,
+                      2.5446559175099828,
+                      2.3150965099949588,
+                      2.1096821005089574,
+                      1.9239005876956645,
+                      1.7563341672618018,
+                      1.6074335116838625,
+                      1.478337723695068,
+                      1.369652615180439,
+                      1.2802671199795725,
+                      1.206540658364925,
+                      1.1422765386303029,
+                      1.0796180272741678,
+                      1.0105678385142827,
+                      0.9286714172129491,
+                      0.8306650546070891,
+                      0.7184203673667248,
+                      0.6022954175053394,
+                      0.5074854616230791,
+                      0.47707686221750417,
+                      0.540847014320356,
+                      0.6768012515630267,
+                      0.8440887928936134,
+                      1.0131959442958678,
+                      1.1652849562212542,
+                      1.2879369913299892,
+                      1.3733833120543857,
+                      1.4181034779693258,
+                      1.422828862370553,
+                      1.3924015354650743,
+                      1.3350342239358421,
+                      1.2604903086795949,
+                      1.176882598758452,
+                      1.0866879179321867,
+                      0.9843986788003204,
+                      0.8605242802484717,
+                      0.7224056939833696,
+                      0.6616832498119316,
+                      0.8937448080733684
+                    ],
+                    [
+                      14.462915873547054,
+                      12.270821264726104,
+                      10.351518502181637,
+                      8.697559870834194,
+                      7.29596713530568,
+                      6.128491528176521,
+                      5.172135528782209,
+                      4.400112912052367,
+                      3.7834070245122033,
+                      3.2928835335606994,
+                      2.9015629766978224,
+                      2.5864223766135384,
+                      2.329234131192955,
+                      2.116394985938338,
+                      1.938103658411862,
+                      1.7873616972284285,
+                      1.6591207645734023,
+                      1.5496545385194607,
+                      1.456054746967424,
+                      1.37571609662066,
+                      1.3057748259988073,
+                      1.2426198428198727,
+                      1.1816888024070331,
+                      1.1177174551134017,
+                      1.0454655709825855,
+                      0.9608319245564233,
+                      0.8623249147961947,
+                      0.7531460108720963,
+                      0.6446573911042102,
+                      0.5616404096313472,
+                      0.5417320857522692,
+                      0.6080960025062765,
+                      0.7428239049735164,
+                      0.9111493108710261,
+                      1.085494625171995,
+                      1.2471328557444965,
+                      1.383276290346479,
+                      1.4855439046200372,
+                      1.5494949568966463,
+                      1.5744978394718925,
+                      1.5634528091513753,
+                      1.522014199439066,
+                      1.45704721451049,
+                      1.3743143939729845,
+                      1.2760671656921299,
+                      1.1604853202025152,
+                      1.0271455666943559,
+                      0.898452248573799,
+                      0.8722238876025606,
+                      1.1232225670916698
+                    ],
+                    [
+                      14.078692478919399,
+                      11.93325104494296,
+                      10.056262777370021,
+                      8.438315474248942,
+                      7.064595635293894,
+                      5.915495461361654,
+                      4.967599719491858,
+                      4.195112900398258,
+                      3.5716657440031647,
+                      3.0722283291559562,
+                      2.6746657856568814,
+                      2.3604782380643106,
+                      2.114552367415123,
+                      1.9241968936074905,
+                      1.7780713512300086,
+                      1.665603785685442,
+                      1.5771032830407907,
+                      1.504289097373779,
+                      1.4407444812095158,
+                      1.3819482518913784,
+                      1.3248362897291017,
+                      1.267086573135857,
+                      1.206434433228919,
+                      1.1403186349042187,
+                      1.0660614994848236,
+                      0.9816600537296624,
+                      0.8872182944166632,
+                      0.7871779412654692,
+                      0.6936597035835861,
+                      0.6299555616139904,
+                      0.6264809716423345,
+                      0.6989928811821591,
+                      0.8333365489168079,
+                      1.0017996834738725,
+                      1.179986299324388,
+                      1.34984611845867,
+                      1.4983328731154149,
+                      1.6163707813017936,
+                      1.6984604357043387,
+                      1.742507559076801,
+                      1.7495166885213997,
+                      1.7228991063233718,
+                      1.667272242235688,
+                      1.5868908124405008,
+                      1.4844011120255811,
+                      1.3616516540059063,
+                      1.2263796329995322,
+                      1.1127322870308374,
+                      1.1187587178197052,
+                      1.3897628872684182
+                    ],
+                    [
+                      13.661876917672014,
+                      11.56207140077274,
+                      9.726831398016062,
+                      8.144994551239705,
+                      6.800138261200891,
+                      5.671484551732343,
+                      4.735273448564194,
+                      3.9665802022583225,
+                      3.3413670003313096,
+                      2.8383326020364166,
+                      2.4399778940765753,
+                      2.132386049151547,
+                      1.9036347253895658,
+                      1.7415224381476722,
+                      1.6320097443968555,
+                      1.5595469915192863,
+                      1.5090415155340464,
+                      1.468026063923613,
+                      1.4278362222603511,
+                      1.3835835681104325,
+                      1.3333113983092717,
+                      1.2768040174751694,
+                      1.2144326002625248,
+                      1.1463514606413687,
+                      1.0723008012259072,
+                      0.9921815485537059,
+                      0.9074686409186715,
+                      0.8234663411053643,
+                      0.7521318763212587,
+                      0.7134966636265004,
+                      0.7298820302715058,
+                      0.8108997240386747,
+                      0.9460075783201581,
+                      1.1143150263113253,
+                      1.2952781204131227,
+                      1.472083674515213,
+                      1.6316505434416626,
+                      1.76423216748249,
+                      1.8632278398370654,
+                      1.925071669524445,
+                      1.9489859036110817,
+                      1.936447271902777,
+                      1.8903409209213897,
+                      1.8140216156644358,
+                      1.7109785389581218,
+                      1.5867119333160953,
+                      1.4561763071276168,
+                      1.3621864821611485,
+                      1.4000916387741393,
+                      1.693629316686984
+                    ],
+                    [
+                      13.214509513693146,
+                      11.159627263196024,
+                      9.365903727022369,
+                      7.8206200625414315,
+                      6.505932981085221,
+                      5.400032559270266,
+                      4.478840054631446,
+                      3.718163031016344,
+                      3.0960067196212147,
+                      2.5944956842334412,
+                      2.200667370296005,
+                      1.9053580841911286,
+                      1.699857691183413,
+                      1.571589909228133,
+                      1.502051322086494,
+                      1.4692590694215586,
+                      1.4526909021851533,
+                      1.4369488870054679,
+                      1.4127878562465792,
+                      1.3763546156036541,
+                      1.3277137748809642,
+                      1.269239778219677,
+                      1.2041398439211726,
+                      1.1353213989272275,
+                      1.0648652322167176,
+                      0.9943558221043228,
+                      0.9261750426882169,
+                      0.8655718021369104,
+                      0.8227190037104548,
+                      0.812660135893612,
+                      0.8501462150820487,
+                      0.940838433160304,
+                      1.0777240321537829,
+                      1.2459482985972379,
+                      1.4289691708792904,
+                      1.6116330798946579,
+                      1.7810903053168214,
+                      1.9270286825689955,
+                      2.041783544129695,
+                      2.120375416441933,
+                      2.160393753387756,
+                      2.161665828141499,
+                      2.1257581949632725,
+                      2.055580861643957,
+                      1.9557886004800324,
+                      1.8354601070411398,
+                      1.7158000861167992,
+                      1.6457261438185073,
+                      1.716521496128125,
+                      2.035684961006405
+                    ],
+                    [
+                      12.73889601013706,
+                      10.728503419981719,
+                      8.976360453889093,
+                      7.468368102956879,
+                      6.1854208950721326,
+                      5.104776500306424,
+                      4.202028365596608,
+                      3.453564521992057,
+                      2.8391669850839083,
+                      2.3441487531795975,
+                      1.9601041804451154,
+                      1.6829162888501894,
+                      1.5069407811902291,
+                      1.417635714980974,
+                      1.3896782932769711,
+                      1.39371370049873,
+                      1.4048997597728854,
+                      1.406833204023422,
+                      1.3913088176719413,
+                      1.3565250530414497,
+                      1.305123376909981,
+                      1.2423816446104776,
+                      1.174559128445377,
+                      1.1074557612337341,
+                      1.0454436947399348,
+                      0.9913586920675931,
+                      0.947490973111072,
+                      0.9174045883101773,
+                      0.9075842281741211,
+                      0.9272960558550096,
+                      0.9854707490893962,
+                      1.085996839022995,
+                      1.2252534833061677,
+                      1.3935305956201878,
+                      1.5781176970263462,
+                      1.7657666129425313,
+                      1.9441032674576324,
+                      2.102394983242971,
+                      2.232002198385823,
+                      2.3266315162950977,
+                      2.3824041160121103,
+                      2.397755392108441,
+                      2.3732714277065488,
+                      2.31176738716189,
+                      2.219286962848143,
+                      2.1083378787508935,
+                      2.0054009984420387,
+                      1.963423672929011,
+                      2.069026696640017,
+                      2.4171057818748314
+                    ],
+                    [
+                      12.237573899055308,
+                      10.271491348005643,
+                      8.561252888823487,
+                      7.09154191534662,
+                      5.8421265979155335,
+                      4.789403032578766,
+                      3.908602219565758,
+                      3.176531454263801,
+                      2.5745025299698674,
+                      2.0908448425281665,
+                      1.7218725915915987,
+                      1.4689378084275968,
+                      1.3289110046555663,
+                      1.282606336688242,
+                      1.2953224594924906,
+                      1.3307032159090364,
+                      1.3618565735853367,
+                      1.37344205228245,
+                      1.3595039330551717,
+                      1.3208831481849543,
+                      1.263127997994639,
+                      1.1947292141419565,
+                      1.1253651541013918,
+                      1.0640122815161106,
+                      1.0171655283378367,
+                      0.9879009864655608,
+                      0.976545810447938,
+                      0.9828315053240504,
+                      1.0082310385425601,
+                      1.056861114841274,
+                      1.134133513054467,
+                      1.2438294997443868,
+                      1.3855086481824557,
+                      1.553811666831531,
+                      1.7395540092484139,
+                      1.9314926950235642,
+                      2.1179187233632573,
+                      2.287827936159046,
+                      2.431718011288895,
+                      2.5421003772053807,
+                      2.613792892868858,
+                      2.6440683908123708,
+                      2.632811543590434,
+                      2.5830119467294708,
+                      2.5022376108561803,
+                      2.406193341889385,
+                      2.325669694759317,
+                      2.3159812036415555,
+                      2.458877171804436,
+                      2.8392025575528215
+                    ],
+                    [
+                      11.713281623654613,
+                      9.791559585005231,
+                      8.123776004326354,
+                      6.693549241727865,
+                      5.479641005358064,
+                      4.4576366162027945,
+                      3.6023522521768205,
+                      2.890847697454866,
+                      2.3057368158477427,
+                      1.8382675782371747,
+                      1.4898204352858817,
+                      1.2677359976142717,
+                      1.1699776258868697,
+                      1.1686844094038555,
+                      1.2180324362347519,
+                      1.2769666297251003,
+                      1.3194304616182653,
+                      1.3327817166535159,
+                      1.313968717287475,
+                      1.266740825325361,
+                      1.19982136009302,
+                      1.1253922122679734,
+                      1.057216981336681,
+                      1.0078543998959468,
+                      0.9852307719211967,
+                      0.9904616790184078,
+                      1.0191004053744852,
+                      1.0652412897006398,
+                      1.1254764396928334,
+                      1.2005504672598464,
+                      1.2944851514263447,
+                      1.4120020037874441,
+                      1.5555866098063076,
+                      1.723594036236695,
+                      1.9100419615790085,
+                      2.1056998260022115,
+                      2.29965357458167,
+                      2.4807576983695467,
+                      2.6387592772100357,
+                      2.7650940654831966,
+                      2.8534309369734356,
+                      2.90007994494866,
+                      2.9044524864544523,
+                      2.869912014013269,
+                      2.8056022063978947,
+                      2.730111820197017,
+                      2.6775974044522566,
+                      2.7044132631079805,
+                      2.887435143779703,
+                      3.303308226434534
+                    ],
+                    [
+                      11.168930143967684,
+                      9.291827022996868,
+                      7.667244577201898,
+                      6.277882497812545,
+                      5.101606493871593,
+                      4.113229867843396,
+                      3.2870910453686144,
+                      2.6003344091163245,
+                      2.036671873592748,
+                      1.590268940542026,
+                      1.268166285228549,
+                      1.0841614371760186,
+                      1.034199483509994,
+                      1.076687581130935,
+                      1.155360963085094,
+                      1.2285274027145745,
+                      1.2735415481214447,
+                      1.281321261912072,
+                      1.2518829582021564,
+                      1.191982812285095,
+                      1.1139005511650553,
+                      1.0343802749309683,
+                      0.9724296821731522,
+                      0.9444653917262469,
+                      0.9576682482610082,
+                      1.0071761008512032,
+                      1.0809044811444786,
+                      1.1672090265535455,
+                      1.2595439621913638,
+                      1.357395097699114,
+                      1.464917516274885,
+                      1.5883087284478146,
+                      1.7327240104533428,
+                      1.8997547387636995,
+                      2.0863395232009356,
+                      2.28522316166316,
+                      2.4863665618042448,
+                      2.6785827649178082,
+                      2.850963900979606,
+                      2.993975807432661,
+                      3.1002727773691627,
+                      3.1653693857782685,
+                      3.188383075537131,
+                      3.1731838307734606,
+                      3.130459822444638,
+                      3.0812974061464553,
+                      3.062315498097379,
+                      3.1298581863495025,
+                      3.356044335463409,
+                      3.810704341990222
+                    ],
+                    [
+                      10.60757640364885,
+                      8.775538616581313,
+                      7.19507195788359,
+                      5.848101470305986,
+                      4.711704439933318,
+                      3.759956859217985,
+                      2.966653437323392,
+                      2.308860701174319,
+                      1.771220214239347,
+                      1.3509564641796599,
+                      1.0616970136913266,
+                      0.923640808153772,
+                      0.9247949181611943,
+                      1.0055290765672782,
+                      1.10358815572124,
+                      1.181174857146873,
+                      1.2205304314827674,
+                      1.2162187374530788,
+                      1.1711692547518844,
+                      1.0952357046939678,
+                      1.0049663805906002,
+                      0.9233110960563248,
+                      0.876386572883957,
+                      0.8835636648114451,
+                      0.9458202689559231,
+                      1.0470468756926956,
+                      1.166908112423786,
+                      1.2903670054961767,
+                      1.410215978477387,
+                      1.526331109264893,
+                      1.6438396125575148,
+                      1.7706088528444301,
+                      1.914239075758665,
+                      2.079222513840831,
+                      2.265206922827538,
+                      2.4668663784459213,
+                      2.6750805905628177,
+                      2.878686266217525,
+                      3.0661878955308417,
+                      3.2271615212511273,
+                      3.3533526735635446,
+                      3.439610639128441,
+                      3.4848877508172906,
+                      3.4936260884836416,
+                      3.477947252217839,
+                      3.4609896049405755,
+                      3.480989239736294,
+                      3.593463880403185,
+                      3.8659642594062644,
+                      4.362571771166891
+                    ],
+                    [
+                      10.032398267704485,
+                      8.246043086503981,
+                      6.710751141048985,
+                      5.407818438014,
+                      4.313645534388785,
+                      3.4016106628362546,
+                      2.6449050767272477,
+                      2.0203716037126873,
+                      1.5134749360404902,
+                      1.124868951094483,
+                      0.8760859937117218,
+                      0.791900284252755,
+                      0.8430672227320977,
+                      0.9520585852786055,
+                      1.0582780450009266,
+                      1.1310159925035008,
+                      1.157554028709025,
+                      1.13564505120176,
+                      1.0708362352509377,
+                      0.9763183299575919,
+                      0.8743187534684,
+                      0.797159057044121,
+                      0.7804161957939612,
+                      0.8409758177311538,
+                      0.9635860616029288,
+                      1.1184134788899092,
+                      1.280645552233343,
+                      1.43548947717222,
+                      1.5769929438323278,
+                      1.7062521484925033,
+                      1.82966956903134,
+                      1.9567892702556064,
+                      2.097486594673375,
+                      2.2589460915560853,
+                      2.443394023359463,
+                      2.64740253872615,
+                      2.8627901013941597,
+                      3.0784452358207246,
+                      3.2823141188387948,
+                      3.463126709490365,
+                      3.6117882929415237,
+                      3.7225700557452264,
+                      3.7943340854039773,
+                      3.8320921929340255,
+                      3.8492143277586424,
+                      3.8704048783055653,
+                      3.9347477470133017,
+                      4.096317317834237,
+                      4.418329618296932,
+                      4.959957181334081
+                    ],
+                    [
+                      9.446670516322813,
+                      7.706772266931905,
+                      6.21783794872651,
+                      4.960685846273909,
+                      3.911163673706807,
+                      3.042007429894602,
+                      2.3257647256307745,
+                      1.738946121891249,
+                      1.2678492848118663,
+                      0.9173098507432028,
+                      0.7182678756889844,
+                      0.6938608499553337,
+                      0.7873378638219827,
+                      0.9115306072705424,
+                      1.015056475649551,
+                      1.0750829096447254,
+                      1.0831139277468234,
+                      1.0393874778380086,
+                      0.9517813169846137,
+                      0.8374288990742743,
+                      0.7271607633691332,
+                      0.6687347596427148,
+                      0.7066445973487555,
+                      0.8385547289974389,
+                      1.0244611361163285,
+                      1.2272933310338128,
+                      1.42405718507098,
+                      1.6027114624261565,
+                      1.7592315751332124,
+                      1.8960543584625098,
+                      2.0208429938582135,
+                      2.144751958270328,
+                      2.279832062200786,
+                      2.435868589145449,
+                      2.617623727600597,
+                      2.8235680956536253,
+                      3.0464640036584947,
+                      3.2752400081425574,
+                      3.4972654163587555,
+                      3.700420324631646,
+                      3.8747917857583523,
+                      4.014110548414441,
+                      4.117165696204827,
+                      4.189469380978217,
+                      4.24539093314194,
+                      4.310696414077845,
+                      4.424638419718676,
+                      4.639400748300682,
+                      5.014124909922834,
+                      5.6037503417937975
+                    ],
+                    [
+                      8.853741476205029,
+                      7.161221797036316,
+                      5.719936284451209,
+                      4.510386975440647,
+                      3.5080149445691586,
+                      2.685001129114598,
+                      2.0132505437274473,
+                      1.4689098895785064,
+                      1.0393448794861562,
+                      0.7349262479183255,
+                      0.5963630368237659,
+                      0.6313247097069479,
+                      0.7527319610908966,
+                      0.8786507479674536,
+                      0.9705004375238454,
+                      1.0120879704430086,
+                      0.9979462821993306,
+                      0.930130406268554,
+                      0.8187810364562522,
+                      0.6865141811005987,
+                      0.5792543582566956,
+                      0.5691072664148615,
+                      0.6905816273097,
+                      0.8980023126587343,
+                      1.1374116081395755,
+                      1.3765945117463252,
+                      1.5977505926980844,
+                      1.7917818334980795,
+                      1.9562548963795612,
+                      2.0946800446381015,
+                      2.215836006793963,
+                      2.332421597105368,
+                      2.4586443382965038,
+                      2.6069128293387887,
+                      2.784578918620651,
+                      2.992057361378159,
+                      3.2230500831799094,
+                      3.4664679177453803,
+                      3.709024552509443,
+                      3.9376863584353616,
+                      4.141687820796444,
+                      4.314201063040715,
+                      4.453899565633377,
+                      4.566663595609177,
+                      4.667563528242584,
+                      4.7829275648414855,
+                      4.95159822042747,
+                      5.223564932556753,
+                      5.654168924010719,
+                      6.294669176058717
+                    ],
+                    [
+                      8.257009845015833,
+                      6.612932898140411,
+                      5.220685604343041,
+                      4.0606305361713755,
+                      3.107984523174686,
+                      2.3345167042619597,
+                      1.7115701186421943,
+                      1.2150496115641163,
+                      0.8340473636269674,
+                      0.586447957439296,
+                      0.5175844870566325,
+                      0.6005558425084162,
+                      0.732381319947685,
+                      0.8489075406167489,
+                      0.9231514913277894,
+                      0.9435591887545945,
+                      0.9067167758853557,
+                      0.8162988615480785,
+                      0.6856325704519486,
+                      0.5473825485145621,
+                      0.47553714488333676,
+                      0.5568118496703109,
+                      0.7664254404660349,
+                      1.0303866996925917,
+                      1.304935260970227,
+                      1.5665749226981465,
+                      1.8014792758964875,
+                      2.0022839727712936,
+                      2.1674380109221216,
+                      2.3011635823537886,
+                      2.413201256571244,
+                      2.517770179556992,
+                      2.6313047556012674,
+                      2.768978222399963,
+                      2.940895552644865,
+                      3.1495207270394188,
+                      3.3894840328029083,
+                      3.649563807887726,
+                      3.9156624205988395,
+                      4.173693502966909,
+                      4.4119380379826145,
+                      4.622930473970674,
+                      4.805126954796394,
+                      4.964589300301874,
+                      5.116759541859865,
+                      5.288055660805061,
+                      5.516436761211379,
+                      5.849513644455905,
+                      6.339106056203438,
+                      7.03325058128163
+                    ],
+                    [
+                      7.659901213019972,
+                      6.0654750116865275,
+                      4.723751027187445,
+                      3.6151509838924345,
+                      2.714906846777964,
+                      1.9946168816304866,
+                      1.4252936143306307,
+                      0.9830157147943068,
+                      0.6599256003374459,
+                      0.48240309296782635,
+                      0.48272739444971563,
+                      0.592544558522802,
+                      0.7195870707271821,
+                      0.8199611545990916,
+                      0.8748275604683773,
+                      0.8757230552744844,
+                      0.8212011070862854,
+                      0.7179421637541342,
+                      0.5869506185945381,
+                      0.4821017584106414,
+                      0.5014808789866544,
+                      0.6776703458113863,
+                      0.9406326601831362,
+                      1.2333044727057456,
+                      1.524749291333076,
+                      1.795967742844975,
+                      2.0346058250413246,
+                      2.2338002466888414,
+                      2.3922765156494936,
+                      2.5146812828726746,
+                      2.611615764250507,
+                      2.6988568023530872,
+                      2.7952311300145154,
+                      2.9189486110222598,
+                      3.0831622785233934,
+                      3.2925678143503805,
+                      3.542704853904137,
+                      3.8220291229586976,
+                      4.115375674119803,
+                      4.407373047379542,
+                      4.685171274009123,
+                      4.940524976668343,
+                      5.171517140116639,
+                      5.38416350413288,
+                      5.593938251291756,
+                      5.826923691645789,
+                      6.1198277544499184,
+                      6.517795870265609,
+                      7.069402528841316,
+                      7.819845667009168
+                    ],
+                    [
+                      7.065843703797758,
+                      5.522429108437491,
+                      4.232816960713828,
+                      3.1777179587782154,
+                      2.3327096266968734,
+                      1.6696339445101334,
+                      1.1596890874362262,
+                      0.7800338362205006,
+                      0.5274702573070345,
+                      0.4301031584961648,
+                      0.48185493529181805,
+                      0.596692167846189,
+                      0.7099923139814311,
+                      0.7931115396185541,
+                      0.8324434237520991,
+                      0.8223045333603646,
+                      0.7648345020293259,
+                      0.674066399702595,
+                      0.5864193239709435,
+                      0.571361254311335,
+                      0.6875671503012158,
+                      0.9135940679333352,
+                      1.1965459022855631,
+                      1.498037929459647,
+                      1.7927836232848617,
+                      2.0630121082528197,
+                      2.296435090420368,
+                      2.4860237827255602,
+                      2.6304435795985888,
+                      2.734605731951185,
+                      2.809939932041067,
+                      2.8738821573613573,
+                      2.947916264821972,
+                      3.0537105418085546,
+                      3.2079260951074806,
+                      3.417775781618325,
+                      3.6796778799699417,
+                      3.9814712547003985,
+                      4.306534892757551,
+                      4.637865063000556,
+                      4.961218775078507,
+                      5.267367975902661,
+                      5.553823198048249,
+                      5.826303278442141,
+                      6.099986902282284,
+                      6.400257887118891,
+                      6.762306413805384,
+                      7.228803391188459,
+                      7.845346254570828,
+                      8.65461845575444
+                    ],
+                    [
+                      6.478242037909815,
+                      4.987371530020369,
+                      3.75158593064313,
+                      2.7521614687202725,
+                      1.9655035908632708,
+                      1.3644336560830008,
+                      0.9213683776083379,
+                      0.615858193092314,
+                      0.4473937353174898,
+                      0.4236239883584543,
+                      0.49887810712748415,
+                      0.6049876134732317,
+                      0.7033453818938271,
+                      0.7749225434572026,
+                      0.8100013915376986,
+                      0.8065885088427889,
+                      0.7728887520501981,
+                      0.7324859026474055,
+                      0.728045447605788,
+                      0.8061621097873051,
+                      0.9808315500903917,
+                      1.228684383503298,
+                      1.5166181492542543,
+                      1.8162458745443109,
+                      2.105173489465996,
+                      2.366071528783107,
+                      2.5864100033956015,
+                      2.758830739529538,
+                      2.8818395853316003,
+                      2.960564232423622,
+                      3.007287336381485,
+                      3.0412583494374683,
+                      3.0869818964305584,
+                      3.1701821027163883,
+                      3.311703363976457,
+                      3.521702694861098,
+                      3.7974267982048118,
+                      4.125655151318191,
+                      4.487744536055219,
+                      4.864572792922593,
+                      5.240153400359479,
+                      5.604021355418042,
+                      5.9528890342282885,
+                      6.2919260292207735,
+                      6.635720923013521,
+                      7.0086696211035955,
+                      7.444271072143212,
+                      7.982772189219237,
+                      8.667049460552054,
+                      9.537547338084051
+                    ],
+                    [
+                      5.9004491661383796,
+                      4.46385831920223,
+                      3.283785821905864,
+                      2.342426183097009,
+                      1.617765839586842,
+                      1.0849586003876255,
+                      0.719428284072774,
+                      0.5025128132555073,
+                      0.4209714790666228,
+                      0.4434897778995846,
+                      0.5202544256040081,
+                      0.6145053624577516,
+                      0.7049376205062579,
+                      0.7784318523112163,
+                      0.8284687120081994,
+                      0.8567777432915853,
+                      0.8758645767408021,
+                      0.909863945624351,
+                      0.9885785897353865,
+                      1.1327278237036662,
+                      1.3427548559053666,
+                      1.602622834320445,
+                      1.8898945992947809,
+                      2.182058983705427,
+                      2.4589782746972233,
+                      2.7038953082770134,
+                      2.904207757274356,
+                      3.0523259340547826,
+                      3.1466361411476282,
+                      3.1925001983513135,
+                      3.203104892938486,
+                      3.1996955586975453,
+                      3.2102505771417005,
+                      3.2653535515725673,
+                      3.3909956223524804,
+                      3.6009059395643916,
+                      3.8930766795338076,
+                      4.252569901421405,
+                      4.657916135432533,
+                      5.087224921827532,
+                      5.522331526020035,
+                      5.951246883324925,
+                      6.36965682600895,
+                      6.78195177798325,
+                      7.201887181523706,
+                      7.652660373001636,
+                      8.165987748838846,
+                      8.779786587222253,
+                      9.534453429112315,
+                      10.468428741285866
+                    ],
+                    [
+                      5.335734425125917,
+                      3.9554101975052793,
+                      2.833191748673898,
+                      1.952683218111633,
+                      1.2947274533058046,
+                      0.8393552186923409,
+                      0.566694876830585,
+                      0.4479531867203381,
+                      0.43188046848887773,
+                      0.46988298625276126,
+                      0.5392866265547398,
+                      0.6286253172932713,
+                      0.7263285009320231,
+                      0.8218369924976364,
+                      0.9095757088310334,
+                      0.9916563377941816,
+                      1.0785038366328488,
+                      1.1864269302279211,
+                      1.331588956571933,
+                      1.522863115549938,
+                      1.7582489613560357,
+                      2.02639401900032,
+                      2.3104957228997733,
+                      2.5918351663496515,
+                      2.8522210692898997,
+                      3.0756766766430994,
+                      3.2497764841225116,
+                      3.3668709721277734,
+                      3.4253146139416866,
+                      3.430735525206582,
+                      3.397262548510346,
+                      3.348307702411333,
+                      3.3158398337316277,
+                      3.3363425361854033,
+                      3.4423099536785875,
+                      3.651965986240039,
+                      3.9639112157965104,
+                      4.360514051265792,
+                      4.81635632161815,
+                      5.3059449806575945,
+                      5.808435976686961,
+                      6.310026376468585,
+                      6.805174036475417,
+                      7.2973067107869865,
+                      7.7991693414014005,
+                      8.332628731661437,
+                      8.927596725263534,
+                      9.619785338655724,
+                      10.447334866090316,
+                      11.446882584976535
+                    ],
+                    [
+                      4.787246959512813,
+                      3.4654987952154466,
+                      2.4036749877424564,
+                      1.587563124043332,
+                      1.0032300797371416,
+                      0.6400733426408332,
+                      0.4773434378185419,
+                      0.44350227781673357,
+                      0.45624026028717385,
+                      0.491104929006748,
+                      0.5568508531466142,
+                      0.6574855198087232,
+                      0.783711553857342,
+                      0.922578047476529,
+                      1.0657417119273698,
+                      1.2120782585670438,
+                      1.3669260477538987,
+                      1.5392506714749035,
+                      1.737535239903515,
+                      1.9658472521948551,
+                      2.2216805541262654,
+                      2.4960935048783126,
+                      2.7754149261077536,
+                      3.0434725901818647,
+                      3.283711244412672,
+                      3.481023169620965,
+                      3.6233404837898058,
+                      3.70310027869976,
+                      3.7186981476673995,
+                      3.6760310365458855,
+                      3.590150699122652,
+                      3.486739488169817,
+                      3.402285224078049,
+                      3.380469076581762,
+                      3.4621841680498253,
+                      3.6715164641721088,
+                      4.007449310503803,
+                      4.448204815455905,
+                      4.962871233255256,
+                      5.521326457348789,
+                      6.099517847588886,
+                      6.68157913707772,
+                      7.260599172794241,
+                      7.838927285500608,
+                      8.428194483640842,
+                      9.04887863237251,
+                      9.72912042056793,
+                      10.502569085451368,
+                      11.405313513849833,
+                      12.47235917784082
+                    ],
+                    [
+                      4.2579729984097066,
+                      2.9975357420148745,
+                      1.99930486000785,
+                      1.2526609042670316,
+                      0.7536481793449502,
+                      0.5056157896563672,
+                      0.45350163629166834,
+                      0.4646108340270225,
+                      0.47635789550089397,
+                      0.5042485553782181,
+                      0.581534884007708,
+                      0.716539198659189,
+                      0.8926797316459372,
+                      1.0903728590615274,
+                      1.2972699075949554,
+                      1.5088871528893368,
+                      1.726589829754673,
+                      1.9548060837036234,
+                      2.1979402013593967,
+                      2.457610237089514,
+                      2.7309141817461455,
+                      3.0100621747571212,
+                      3.2831872486885834,
+                      3.535858105029551,
+                      3.7528484247764244,
+                      3.9198999685933074,
+                      4.0253900303079515,
+                      4.061927710711203,
+                      4.027975370433539,
+                      3.9296410976615563,
+                      3.7827819157903253,
+                      3.6153167519885736,
+                      3.4687017439607635,
+                      3.3953592428057506,
+                      3.4472178349391456,
+                      3.6562826162797575,
+                      4.021549290668828,
+                      4.514918079367601,
+                      5.097888376442375,
+                      5.734511158301789,
+                      6.397034563308884,
+                      7.067375112925517,
+                      7.737205508659046,
+                      8.407764239807383,
+                      9.089540279487688,
+                      9.801628185619917,
+                      10.570472028919033,
+                      11.42780874159495,
+                      12.40786069976052,
+                      13.544147268081305
+                    ],
+                    [
+                      3.7506856458836713,
+                      2.5548685173298655,
+                      1.6245597314866052,
+                      0.9556783118436948,
+                      0.563570253160712,
+                      0.4520165531242714,
+                      0.47334885998761284,
+                      0.4873321702483015,
+                      0.4838091657986721,
+                      0.5148825228187672,
+                      0.6288888127831517,
+                      0.8217786448654313,
+                      1.062621834220661,
+                      1.3262975633111178,
+                      1.5984458705314146,
+                      1.8727612755070902,
+                      2.1481909087910322,
+                      2.4263786947892294,
+                      2.7092022550802284,
+                      2.996622064404006,
+                      3.285220680673285,
+                      3.567681367006715,
+                      3.833187021394902,
+                      4.068505588139852,
+                      4.259463955927022,
+                      4.39257154929053,
+                      4.4566637012383845,
+                      4.444544809122103,
+                      4.354713618285788,
+                      4.193357492337918,
+                      3.976891170527788,
+                      3.7352201469934996,
+                      3.51499632567986,
+                      3.3790926853100047,
+                      3.394111584669905,
+                      3.6031322188450936,
+                      4.004554030202655,
+                      4.56066802256207,
+                      5.2225957592653645,
+                      5.9472669335250306,
+                      6.702881004402547,
+                      7.469142243526876,
+                      8.236382072720412,
+                      9.004785914655798,
+                      9.783742114283553,
+                      10.591018593002829,
+                      11.451464503271106,
+                      12.395054457248289,
+                      13.454308564291878,
+                      14.661383003390679
+                    ],
+                    [
+                      3.267886573568172,
+                      2.140792307813142,
+                      1.2847727902326052,
+                      0.708983503338063,
+                      0.4587490556681648,
+                      0.4675000148965506,
+                      0.505948685997131,
+                      0.49679372438509584,
+                      0.47861773578614786,
+                      0.5376117577472059,
+                      0.7172698519933647,
+                      0.9839983628754405,
+                      1.2959133839975066,
+                      1.6271231562565367,
+                      1.9633175263521783,
+                      2.2973671482780085,
+                      2.626623198230495,
+                      2.950767166779336,
+                      3.2698201466737893,
+                      3.5824006976451526,
+                      3.884480946132263,
+                      4.16884044629901,
+                      4.425258770197651,
+                      4.641330515440893,
+                      4.803704032324815,
+                      4.8995496587949505,
+                      4.918126666618157,
+                      4.852410956404158,
+                      4.700859507999616,
+                      4.469536880683887,
+                      4.175025620004479,
+                      3.8486781643150256,
+                      3.5421472923596147,
+                      3.330419769645971,
+                      3.299719699031499,
+                      3.5091468614859833,
+                      3.955498411037178,
+                      4.586436839641442,
+                      5.339095610917936,
+                      6.162059040751555,
+                      7.019410110926192,
+                      7.888866567834731,
+                      8.759631322121392,
+                      9.63098039450627,
+                      10.511299672434497,
+                      11.417122756668576,
+                      12.371819562678237,
+                      13.403744888390465,
+                      14.543859752542943,
+                      15.823059589059591
+                    ],
+                    [
+                      2.8117414137076135,
+                      1.7585999529995804,
+                      0.9870879829394973,
+                      0.5338568302751264,
+                      0.44950389350606196,
+                      0.5139372455233899,
+                      0.5289115858057916,
+                      0.48653763407826467,
+                      0.47035767627840164,
+                      0.594247078056261,
+                      0.8607788708580634,
+                      1.2071553364218168,
+                      1.5910899422876548,
+                      1.989111293969188,
+                      2.3876306966691407,
+                      2.7789741581220078,
+                      3.159222781084598,
+                      3.5264774468062545,
+                      3.8792300030174767,
+                      4.214916484763263,
+                      4.528847343810187,
+                      4.8136828150717355,
+                      5.05951611925403,
+                      5.254509020803324,
+                      5.385945279698135,
+                      5.441548559118388,
+                      5.410946183683638,
+                      5.287235484447721,
+                      5.068725082230586,
+                      4.761105884922342,
+                      4.380611444300572,
+                      3.959167937684818,
+                      3.5525676407402984,
+                      3.249092360030272,
+                      3.1611263521919253,
+                      3.3717291411247157,
+                      3.8744136943519782,
+                      4.59446519408499,
+                      5.45056558421315,
+                      6.382107300269944,
+                      7.3494391678531965,
+                      8.32878390495032,
+                      9.308563071050235,
+                      10.28735606327899,
+                      11.27268259580407,
+                      12.279953278112858,
+                      13.33117646974053,
+                      14.453216548313906,
+                      15.675597382918523,
+                      17.02803745807528
+                    ],
+                    [
+                      2.3840172327836004,
+                      1.411723745757455,
+                      0.7423963486018218,
+                      0.45660712880287907,
+                      0.5006017122334869,
+                      0.5583946791837796,
+                      0.5300437881284078,
+                      0.4578386254503126,
+                      0.48092943084306355,
+                      0.7054483016207524,
+                      1.0655044361919632,
+                      1.4909428181990216,
+                      1.9458055257332567,
+                      2.40942607848514,
+                      2.8687447885209214,
+                      3.31550297684979,
+                      3.744629592538417,
+                      4.152842388863525,
+                      4.537290588626224,
+                      4.894328243261239,
+                      5.218584315781008,
+                      5.502474917171515,
+                      5.736226515177422,
+                      5.908387212688185,
+                      6.00673283739162,
+                      6.019446163386579,
+                      5.936464650710291,
+                      5.750951913721275,
+                      5.460958515706414,
+                      5.071538423386265,
+                      4.597982063721764,
+                      4.0716002637030435,
+                      3.5505631694356636,
+                      3.1363837334585476,
+                      2.9757676875618473,
+                      3.1887777015499115,
+                      3.7627841301607847,
+                      4.588610082800039,
+                      5.5614134321931825,
+                      6.611419109680617,
+                      7.696238140495911,
+                      8.79136228915,
+                      9.884884422134057,
+                      10.974940278709695,
+                      12.068334921445176,
+                      13.179469615950175,
+                      14.329100378454697,
+                      15.542713056774604,
+                      16.848495130970843,
+                      18.27505478771865
+                    ],
+                    [
+                      1.9860475514070024,
+                      1.104102298353519,
+                      0.5678870684260635,
+                      0.4732184116780174,
+                      0.5649364075148547,
+                      0.5825829730249809,
+                      0.5043404471218041,
+                      0.4231088400701319,
+                      0.5411859479877464,
+                      0.8816145875187023,
+                      1.3317453864037374,
+                      1.8336991395616815,
+                      2.3581045139580605,
+                      2.886223099735167,
+                      3.405112481104562,
+                      3.9058158840130166,
+                      4.382156430424587,
+                      4.829587367046882,
+                      5.244037935357592,
+                      5.620854959021468,
+                      5.953986271765199,
+                      6.235533338032015,
+                      6.455741164092949,
+                      6.603420182516386,
+                      6.666733267361913,
+                      6.634249316335276,
+                      6.496170337484716,
+                      6.245684839485313,
+                      5.880499452692794,
+                      5.404801613113279,
+                      4.832350683435006,
+                      4.192448993016908,
+                      3.5428739322810037,
+                      2.9959248445710527,
+                      2.741650368835182,
+                      2.958999575766619,
+                      3.6242416556664416,
+                      4.574763681148608,
+                      5.677401594514254,
+                      6.854786942983826,
+                      8.063497103547409,
+                      9.279274838466081,
+                      10.490385645213138,
+                      11.694775974010925,
+                      12.898678089561415,
+                      14.115584232533632,
+                      15.365090095304776,
+                      16.671394133530665,
+                      18.0614272858326,
+                      19.562738213793434
+                    ],
+                    [
+                      1.6187953821810495,
+                      0.8410958020298777,
+                      0.48268692679637376,
+                      0.5360060184018726,
+                      0.6147501782250782,
+                      0.5778327288533585,
+                      0.4536381276879171,
+                      0.41376724230585077,
+                      0.6737101221046345,
+                      1.1233894966708162,
+                      1.6577357405191337,
+                      2.2338398045814225,
+                      2.8266462598964854,
+                      3.41837425461746,
+                      3.995837480626938,
+                      4.549280668023256,
+                      5.07144664762986,
+                      5.5566065190248395,
+                      5.999559861731997,
+                      6.39470820326574,
+                      6.73533167120778,
+                      7.013181051226552,
+                      7.218449612256408,
+                      7.340128671745546,
+                      7.366697004757727,
+                      7.287061765802324,
+                      7.091665970684164,
+                      6.7737103941888,
+                      6.330520319942069,
+                      5.765269470779986,
+                      5.089712392152595,
+                      4.329767973767747,
+                      3.5392319464201303,
+                      2.8350576997168804,
+                      2.457792681766291,
+                      2.682522228829283,
+                      3.4656208733216074,
+                      4.561296389979882,
+                      5.805707045582651,
+                      7.117739017325885,
+                      8.4552710885619,
+                      9.795363333101761,
+                      11.126922152385074,
+                      12.44791610098853,
+                      13.764112389302513,
+                      15.088167610966533,
+                      16.43858513178874,
+                      17.838344208705102,
+                      19.31317865382598,
+                      20.889613608488393
+                    ],
+                    [
+                      1.2832109694656535,
+                      0.631590620084501,
+                      0.48282746507205526,
+                      0.6018315573019006,
+                      0.6376055771921819,
+                      0.5416668708783894,
+                      0.3922039105019781,
+                      0.4760954039498783,
+                      0.8818349605673913,
+                      1.4277422382750393,
+                      2.0416647964416486,
+                      2.6902218533170768,
+                      3.350576582439567,
+                      4.005191133794124,
+                      4.6403784349264905,
+                      5.245515067606787,
+                      5.812285167570847,
+                      6.333841904933658,
+                      6.803927735637224,
+                      7.2160539348368,
+                      7.562855266459685,
+                      7.835719073408345,
+                      8.024748208079723,
+                      8.119066375811371,
+                      8.107426900466935,
+                      7.979053821438338,
+                      7.7246355191685465,
+                      7.337411612964015,
+                      6.814356242198931,
+                      6.157607496028207,
+                      5.3766685723678735,
+                      4.493030237023696,
+                      3.5527626981885905,
+                      2.666961005447635,
+                      2.125239108182398,
+                      2.3622187837431,
+                      3.2985084946864522,
+                      4.5594305375462705,
+                      5.954872639276322,
+                      7.4064343414198825,
+                      8.875902548256304,
+                      10.342593425782846,
+                      11.796392916729797,
+                      13.235415929465214,
+                      14.665016779063885,
+                      16.097052067958238,
+                      17.54897195655093,
+                      19.0425805443887,
+                      20.602454199063796,
+                      22.254116800799824
+                    ],
+                    [
+                      0.981471302980851,
+                      0.49123427685907617,
+                      0.5310567383032259,
+                      0.6499255880364928,
+                      0.6295685160910098,
+                      0.4787683927688833,
+                      0.3626646629919067,
+                      0.6336502448951785,
+                      1.1592902922524289,
+                      1.79171062215461,
+                      2.4822253405936476,
+                      3.2020980683441183,
+                      3.9293496758530355,
+                      4.646223750730481,
+                      5.338364235845712,
+                      5.994237396643089,
+                      6.604491230136531,
+                      7.161215394642454,
+                      7.657157388529064,
+                      8.084989509243147,
+                      8.436730019364331,
+                      8.703406652446464,
+                      8.87501663677318,
+                      8.94079377127681,
+                      8.889750684896569,
+                      8.711433113390992,
+                      8.396809698483777,
+                      7.93923033948167,
+                      7.3354272643951735,
+                      6.586635353470972,
+                      5.700179330956648,
+                      4.692738593799218,
+                      3.59991392996315,
+                      2.513625741588136,
+                      1.7497713873016074,
+                      2.00690114713408,
+                      3.1412971174194744,
+                      4.583367575928078,
+                      6.134605603669768,
+                      7.727499046395364,
+                      9.329923933013932,
+                      10.924003030714672,
+                      12.50071586168582,
+                      14.058323311073371,
+                      15.601747080028506,
+                      17.142034327173928,
+                      18.695589382059623,
+                      20.283060781894562,
+                      21.927888325026004,
+                      23.65460413079937
+                    ],
+                    [
+                      0.7210063989600407,
+                      0.4388875057333319,
+                      0.5917484242717466,
+                      0.6740391131714392,
+                      0.5937919399342271,
+                      0.40945195407996193,
+                      0.43355956085650493,
+                      0.8767329060167149,
+                      1.5000202242166993,
+                      2.2132978533948298,
+                      2.9785827773731595,
+                      3.7689830698820783,
+                      4.562584895349917,
+                      5.341127928444304,
+                      6.089481036082592,
+                      6.79517824412801,
+                      7.447855896842414,
+                      8.038588924125717,
+                      8.559185763427777,
+                      9.0015290404721,
+                      9.357054458896997,
+                      9.616446396293467,
+                      9.769599312108362,
+                      9.805856051174063,
+                      9.714496037852927,
+                      9.485416192982933,
+                      9.10993084878221,
+                      8.58161748557806,
+                      7.897157260162325,
+                      7.057178322749674,
+                      6.067265605568839,
+                      4.939806612565891,
+                      3.699511093259744,
+                      2.408692675079036,
+                      1.3505415885580319,
+                      1.639842853616874,
+                      3.02120537297048,
+                      4.649912690661791,
+                      6.355395124290967,
+                      8.087809581641634,
+                      9.821945261021584,
+                      11.542645964128402,
+                      13.241800895024145,
+                      14.917667098439136,
+                      16.5746325969987,
+                      18.22287685249351,
+                      19.877733045020683,
+                      21.558689847198558,
+                      23.288053714761194,
+                      25.089362740565075
+                    ],
+                    [
+                      0.5269933875209503,
+                      0.4731225239318607,
+                      0.649703161932789,
+                      0.677847651145479,
+                      0.5444907660651784,
+                      0.3896442984803875,
+                      0.6242598616781451,
+                      1.1911828670805469,
+                      1.900331260275082,
+                      2.691326364884734,
+                      3.5302198965240206,
+                      4.390533481576447,
+                      5.249967177071056,
+                      6.089581067419989,
+                      6.893403324798,
+                      7.6480276451268345,
+                      8.342104927351231,
+                      8.965740748788368,
+                      9.509856519529196,
+                      9.965593615683476,
+                      10.323843271584913,
+                      10.574972404137082,
+                      10.708789816169029,
+                      10.714763760136266,
+                      10.582467511252425,
+                      10.30220095413858,
+                      9.86571791675823,
+                      9.26698347918682,
+                      8.502894055843408,
+                      7.573920006848865,
+                      6.4846964740246635,
+                      5.244788822824131,
+                      3.870727703610876,
+                      2.3963715151471394,
+                      0.9921127586715343,
+                      1.322054310642688,
+                      2.974392557257832,
+                      4.7773555039668185,
+                      6.627959156664591,
+                      8.494238562725268,
+                      10.356533588252288,
+                      12.201533265532412,
+                      14.021521366930367,
+                      15.81444398108823,
+                      17.583971269302545,
+                      19.33930797244352,
+                      21.094658962518555,
+                      22.868326164812512,
+                      24.68146966066768,
+                      26.5566205162097
+                    ],
+                    [
+                      0.4619599345142945,
+                      0.5673741618816567,
+                      0.7064941640185186,
+                      0.6758466145365313,
+                      0.5169603784057789,
+                      0.49327634710289003,
+                      0.90662300999202,
+                      1.5690360278514803,
+                      2.3582788425166923,
+                      3.225139319117529,
+                      4.136797353248597,
+                      5.066461003167081,
+                      5.991181644809249,
+                      6.891229488037744,
+                      7.749751919192157,
+                      8.55240331064755,
+                      9.28687656720917,
+                      9.942351127913147,
+                      10.50891099990664,
+                      10.977004493637546,
+                      11.33701993342049,
+                      11.57904033350349,
+                      11.692817365548724,
+                      11.667975325559674,
+                      11.494424914966878,
+                      11.162940010421094,
+                      10.665832286553588,
+                      9.997650606146825,
+                      9.155834905358999,
+                      8.141268405386072,
+                      6.958703166126735,
+                      5.6171145839842795,
+                      4.130359821360208,
+                      2.5207145724445614,
+                      0.8706832655702641,
+                      1.1924966030666975,
+                      3.0408969919687183,
+                      4.983592219939879,
+                      6.9625846717704105,
+                      8.95338803883041,
+                      10.938092493634107,
+                      12.903574765224757,
+                      14.841684788036106,
+                      16.749604055279054,
+                      18.63002349672844,
+                      20.491020855651684,
+                      22.34558616709531,
+                      24.21078714689062,
+                      26.106609828060677,
+                      28.054555606636846
+                    ]
+                  ]
+                },
+                {
+                  "hoverinfo": "text",
+                  "legendgroup": "In-sample",
+                  "marker": {
+                    "color": "black",
+                    "opacity": 0.5,
+                    "symbol": 1
+                  },
+                  "mode": "markers",
+                  "name": "In-sample",
+                  "text": [
+                    "Arm 0_0<br>branin: 42.0839 (SEM: 0)<br>x1: 1.05349<br>x2: 9.69501",
+                    "Arm 1_0<br>branin: 6.16198 (SEM: 0)<br>x1: 9.67388<br>x2: 5.03145",
+                    "Arm 2_0<br>branin: 4.77583 (SEM: 0)<br>x1: -2.69836<br>x2: 13.0926",
+                    "Arm 3_0<br>branin: 20.1772 (SEM: 0)<br>x1: 4.25573<br>x2: 5.3627",
+                    "Arm 4_0<br>branin: 3.53664 (SEM: 0)<br>x1: 9.89622<br>x2: 4.34752",
+                    "Arm 5_0<br>branin: 6.46653 (SEM: 0)<br>x1: -3.94754<br>x2: 12.5308",
+                    "Arm 6_0<br>branin: 5.7069 (SEM: 0)<br>x1: 10<br>x2: 1.06292",
+                    "Arm 7_0<br>branin: 16.379 (SEM: 0)<br>x1: 7.21844<br>x2: 0.418715",
+                    "Arm 8_0<br>branin: 151.694 (SEM: 0)<br>x1: -3.19908<br>x2: 0.113994",
+                    "Arm 9_0<br>branin: 17.5083 (SEM: 0)<br>x1: -5<br>x2: 15",
+                    "Arm 10_0<br>branin: 12.3704 (SEM: 0)<br>x1: 8.02277<br>x2: 3.54215",
+                    "Arm 11_0<br>branin: 208.881 (SEM: 0)<br>x1: 5.53314<br>x2: 15",
+                    "Arm 12_0<br>branin: 0.74213 (SEM: 0)<br>x1: 2.91104<br>x2: 2.16137",
+                    "Arm 13_0<br>branin: 5.16542 (SEM: 0)<br>x1: 3.5967<br>x2: 0",
+                    "Arm 14_0<br>branin: 1.54147 (SEM: 0)<br>x1: 3.63205<br>x2: 2.03165",
+                    "Arm 15_0<br>branin: 5.03334 (SEM: 0)<br>x1: -2.11716<br>x2: 9.79872",
+                    "Arm 16_0<br>branin: 2.03484 (SEM: 0)<br>x1: 10<br>x2: 3.30578",
+                    "Arm 17_0<br>branin: 2.25192 (SEM: 0)<br>x1: 2.52183<br>x2: 2.5468",
+                    "Arm 18_0<br>branin: 0.481058 (SEM: 0)<br>x1: 3.2582<br>x2: 2.05179",
+                    "Arm 19_0<br>branin: 0.761814 (SEM: 0)<br>x1: 3.41611<br>x2: 2.00439",
+                    "Arm 20_0<br>branin: 0.398119 (SEM: 0)<br>x1: 3.14347<br>x2: 2.28819",
+                    "Arm 21_0<br>branin: 0.475756 (SEM: 0)<br>x1: 3.15166<br>x2: 1.98899",
+                    "Arm 22_0<br>branin: 0.55421 (SEM: 0)<br>x1: 3.32022<br>x2: 2.19937",
+                    "Arm 23_0<br>branin: 0.66797 (SEM: 0)<br>x1: 3.35505<br>x2: 1.88604",
+                    "Arm 24_0<br>branin: 0.503379 (SEM: 0)<br>x1: 2.99545<br>x2: 2.4477",
+                    "Arm 25_0<br>branin: 4.03847 (SEM: 0)<br>x1: -3.575<br>x2: 15",
+                    "Arm 26_0<br>branin: 0.419002 (SEM: 0)<br>x1: 3.10412<br>x2: 2.18451",
+                    "Arm 27_0<br>branin: 0.743807 (SEM: 0)<br>x1: 3.40981<br>x2: 2.12609",
+                    "Arm 28_0<br>branin: 0.427756 (SEM: 0)<br>x1: 3.21861<br>x2: 2.25319"
+                  ],
+                  "type": "scatter",
+                  "x": [
+                    1.053490936756134,
+                    9.673875807784498,
+                    -2.6983634615316987,
+                    4.255731301382184,
+                    9.896218599751592,
+                    -3.947538998984686,
+                    10,
+                    7.21844183648062,
+                    -3.1990796261421757,
+                    -5,
+                    8.0227651133701,
+                    5.533142090027264,
+                    2.911041881584141,
+                    3.5966954967872837,
+                    3.6320456772082554,
+                    -2.1171632044281883,
+                    10,
+                    2.521829699771833,
+                    3.2582006155846504,
+                    3.4161086120295376,
+                    3.143471996153947,
+                    3.1516606150486464,
+                    3.320215989374521,
+                    3.3550495492967194,
+                    2.9954482956770887,
+                    -3.575002873038719,
+                    3.1041197799343703,
+                    3.4098088553679933,
+                    3.218610082260776
+                  ],
+                  "xaxis": "x",
+                  "y": [
+                    9.695006310939789,
+                    5.031454539857805,
+                    13.092638882808387,
+                    5.3627007734030485,
+                    4.34751792345196,
+                    12.530771731366281,
+                    1.062916555044761,
+                    0.41871484495313804,
+                    0.11399374450743174,
+                    15,
+                    3.542145511842334,
+                    15,
+                    2.161366131603687,
+                    0,
+                    2.0316523415854526,
+                    9.798724198318416,
+                    3.305777701872517,
+                    2.5468035759843533,
+                    2.051792648782326,
+                    2.004387098830192,
+                    2.2881945397553003,
+                    1.9889850619156846,
+                    2.1993661124829935,
+                    1.8860391984524798,
+                    2.447697319486139,
+                    15,
+                    2.184512833398977,
+                    2.126092134213714,
+                    2.2531901460823534
+                  ],
+                  "yaxis": "y"
+                },
+                {
+                  "hoverinfo": "text",
+                  "legendgroup": "In-sample",
+                  "marker": {
+                    "color": "black",
+                    "opacity": 0.5,
+                    "symbol": 1
+                  },
+                  "mode": "markers",
+                  "name": "In-sample",
+                  "showlegend": false,
+                  "text": [
+                    "Arm 0_0<br>branin: 42.0839 (SEM: 0)<br>x1: 1.05349<br>x2: 9.69501",
+                    "Arm 1_0<br>branin: 6.16198 (SEM: 0)<br>x1: 9.67388<br>x2: 5.03145",
+                    "Arm 2_0<br>branin: 4.77583 (SEM: 0)<br>x1: -2.69836<br>x2: 13.0926",
+                    "Arm 3_0<br>branin: 20.1772 (SEM: 0)<br>x1: 4.25573<br>x2: 5.3627",
+                    "Arm 4_0<br>branin: 3.53664 (SEM: 0)<br>x1: 9.89622<br>x2: 4.34752",
+                    "Arm 5_0<br>branin: 6.46653 (SEM: 0)<br>x1: -3.94754<br>x2: 12.5308",
+                    "Arm 6_0<br>branin: 5.7069 (SEM: 0)<br>x1: 10<br>x2: 1.06292",
+                    "Arm 7_0<br>branin: 16.379 (SEM: 0)<br>x1: 7.21844<br>x2: 0.418715",
+                    "Arm 8_0<br>branin: 151.694 (SEM: 0)<br>x1: -3.19908<br>x2: 0.113994",
+                    "Arm 9_0<br>branin: 17.5083 (SEM: 0)<br>x1: -5<br>x2: 15",
+                    "Arm 10_0<br>branin: 12.3704 (SEM: 0)<br>x1: 8.02277<br>x2: 3.54215",
+                    "Arm 11_0<br>branin: 208.881 (SEM: 0)<br>x1: 5.53314<br>x2: 15",
+                    "Arm 12_0<br>branin: 0.74213 (SEM: 0)<br>x1: 2.91104<br>x2: 2.16137",
+                    "Arm 13_0<br>branin: 5.16542 (SEM: 0)<br>x1: 3.5967<br>x2: 0",
+                    "Arm 14_0<br>branin: 1.54147 (SEM: 0)<br>x1: 3.63205<br>x2: 2.03165",
+                    "Arm 15_0<br>branin: 5.03334 (SEM: 0)<br>x1: -2.11716<br>x2: 9.79872",
+                    "Arm 16_0<br>branin: 2.03484 (SEM: 0)<br>x1: 10<br>x2: 3.30578",
+                    "Arm 17_0<br>branin: 2.25192 (SEM: 0)<br>x1: 2.52183<br>x2: 2.5468",
+                    "Arm 18_0<br>branin: 0.481058 (SEM: 0)<br>x1: 3.2582<br>x2: 2.05179",
+                    "Arm 19_0<br>branin: 0.761814 (SEM: 0)<br>x1: 3.41611<br>x2: 2.00439",
+                    "Arm 20_0<br>branin: 0.398119 (SEM: 0)<br>x1: 3.14347<br>x2: 2.28819",
+                    "Arm 21_0<br>branin: 0.475756 (SEM: 0)<br>x1: 3.15166<br>x2: 1.98899",
+                    "Arm 22_0<br>branin: 0.55421 (SEM: 0)<br>x1: 3.32022<br>x2: 2.19937",
+                    "Arm 23_0<br>branin: 0.66797 (SEM: 0)<br>x1: 3.35505<br>x2: 1.88604",
+                    "Arm 24_0<br>branin: 0.503379 (SEM: 0)<br>x1: 2.99545<br>x2: 2.4477",
+                    "Arm 25_0<br>branin: 4.03847 (SEM: 0)<br>x1: -3.575<br>x2: 15",
+                    "Arm 26_0<br>branin: 0.419002 (SEM: 0)<br>x1: 3.10412<br>x2: 2.18451",
+                    "Arm 27_0<br>branin: 0.743807 (SEM: 0)<br>x1: 3.40981<br>x2: 2.12609",
+                    "Arm 28_0<br>branin: 0.427756 (SEM: 0)<br>x1: 3.21861<br>x2: 2.25319"
+                  ],
+                  "type": "scatter",
+                  "x": [
+                    1.053490936756134,
+                    9.673875807784498,
+                    -2.6983634615316987,
+                    4.255731301382184,
+                    9.896218599751592,
+                    -3.947538998984686,
+                    10,
+                    7.21844183648062,
+                    -3.1990796261421757,
+                    -5,
+                    8.0227651133701,
+                    5.533142090027264,
+                    2.911041881584141,
+                    3.5966954967872837,
+                    3.6320456772082554,
+                    -2.1171632044281883,
+                    10,
+                    2.521829699771833,
+                    3.2582006155846504,
+                    3.4161086120295376,
+                    3.143471996153947,
+                    3.1516606150486464,
+                    3.320215989374521,
+                    3.3550495492967194,
+                    2.9954482956770887,
+                    -3.575002873038719,
+                    3.1041197799343703,
+                    3.4098088553679933,
+                    3.218610082260776
+                  ],
+                  "xaxis": "x2",
+                  "y": [
+                    9.695006310939789,
+                    5.031454539857805,
+                    13.092638882808387,
+                    5.3627007734030485,
+                    4.34751792345196,
+                    12.530771731366281,
+                    1.062916555044761,
+                    0.41871484495313804,
+                    0.11399374450743174,
+                    15,
+                    3.542145511842334,
+                    15,
+                    2.161366131603687,
+                    0,
+                    2.0316523415854526,
+                    9.798724198318416,
+                    3.305777701872517,
+                    2.5468035759843533,
+                    2.051792648782326,
+                    2.004387098830192,
+                    2.2881945397553003,
+                    1.9889850619156846,
+                    2.1993661124829935,
+                    1.8860391984524798,
+                    2.447697319486139,
+                    15,
+                    2.184512833398977,
+                    2.126092134213714,
+                    2.2531901460823534
+                  ],
+                  "yaxis": "y2"
+                }
+              ],
+              "layout": {
+                "annotations": [
+                  {
+                    "font": {
+                      "size": 14
+                    },
+                    "showarrow": false,
+                    "text": "Mean",
+                    "x": 0.25,
+                    "xanchor": "center",
+                    "xref": "paper",
+                    "y": 1,
+                    "yanchor": "bottom",
+                    "yref": "paper"
+                  },
+                  {
+                    "font": {
+                      "size": 14
+                    },
+                    "showarrow": false,
+                    "text": "Standard Error",
+                    "x": 0.8,
+                    "xanchor": "center",
+                    "xref": "paper",
+                    "y": 1,
+                    "yanchor": "bottom",
+                    "yref": "paper"
+                  }
+                ],
+                "autosize": false,
+                "height": 450,
+                "hovermode": "closest",
+                "legend": {
+                  "orientation": "h",
+                  "x": 0,
+                  "y": -0.25
+                },
+                "margin": {
+                  "b": 100,
+                  "l": 35,
+                  "pad": 0,
+                  "r": 35,
+                  "t": 35
+                },
+                "template": {
+                  "data": {
+                    "bar": [
+                      {
+                        "error_x": {
+                          "color": "#2a3f5f"
+                        },
+                        "error_y": {
+                          "color": "#2a3f5f"
+                        },
+                        "marker": {
+                          "line": {
+                            "color": "#E5ECF6",
+                            "width": 0.5
+                          }
+                        },
+                        "type": "bar"
+                      }
+                    ],
+                    "barpolar": [
+                      {
+                        "marker": {
+                          "line": {
+                            "color": "#E5ECF6",
+                            "width": 0.5
+                          }
+                        },
+                        "type": "barpolar"
+                      }
+                    ],
+                    "carpet": [
+                      {
+                        "aaxis": {
+                          "endlinecolor": "#2a3f5f",
+                          "gridcolor": "white",
+                          "linecolor": "white",
+                          "minorgridcolor": "white",
+                          "startlinecolor": "#2a3f5f"
+                        },
+                        "baxis": {
+                          "endlinecolor": "#2a3f5f",
+                          "gridcolor": "white",
+                          "linecolor": "white",
+                          "minorgridcolor": "white",
+                          "startlinecolor": "#2a3f5f"
+                        },
+                        "type": "carpet"
+                      }
+                    ],
+                    "choropleth": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "choropleth"
+                      }
+                    ],
+                    "contour": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "contour"
+                      }
+                    ],
+                    "contourcarpet": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "contourcarpet"
+                      }
+                    ],
+                    "heatmap": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "heatmap"
+                      }
+                    ],
+                    "heatmapgl": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "heatmapgl"
+                      }
+                    ],
+                    "histogram": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "histogram"
+                      }
+                    ],
+                    "histogram2d": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "histogram2d"
+                      }
+                    ],
+                    "histogram2dcontour": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "histogram2dcontour"
+                      }
+                    ],
+                    "mesh3d": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "mesh3d"
+                      }
+                    ],
+                    "parcoords": [
+                      {
+                        "line": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "parcoords"
+                      }
+                    ],
+                    "pie": [
+                      {
+                        "automargin": true,
+                        "type": "pie"
+                      }
+                    ],
+                    "scatter": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatter"
+                      }
+                    ],
+                    "scatter3d": [
+                      {
+                        "line": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatter3d"
+                      }
+                    ],
+                    "scattercarpet": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattercarpet"
+                      }
+                    ],
+                    "scattergeo": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattergeo"
+                      }
+                    ],
+                    "scattergl": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattergl"
+                      }
+                    ],
+                    "scattermapbox": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattermapbox"
+                      }
+                    ],
+                    "scatterpolar": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterpolar"
+                      }
+                    ],
+                    "scatterpolargl": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterpolargl"
+                      }
+                    ],
+                    "scatterternary": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterternary"
+                      }
+                    ],
+                    "surface": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "surface"
+                      }
+                    ],
+                    "table": [
+                      {
+                        "cells": {
+                          "fill": {
+                            "color": "#EBF0F8"
+                          },
+                          "line": {
+                            "color": "white"
+                          }
+                        },
+                        "header": {
+                          "fill": {
+                            "color": "#C8D4E3"
+                          },
+                          "line": {
+                            "color": "white"
+                          }
+                        },
+                        "type": "table"
+                      }
+                    ]
+                  },
+                  "layout": {
+                    "annotationdefaults": {
+                      "arrowcolor": "#2a3f5f",
+                      "arrowhead": 0,
+                      "arrowwidth": 1
+                    },
+                    "autotypenumbers": "strict",
+                    "coloraxis": {
+                      "colorbar": {
+                        "outlinewidth": 0,
+                        "ticks": ""
+                      }
+                    },
+                    "colorscale": {
+                      "diverging": [
+                        [
+                          0,
+                          "#8e0152"
+                        ],
+                        [
+                          0.1,
+                          "#c51b7d"
+                        ],
+                        [
+                          0.2,
+                          "#de77ae"
+                        ],
+                        [
+                          0.3,
+                          "#f1b6da"
+                        ],
+                        [
+                          0.4,
+                          "#fde0ef"
+                        ],
+                        [
+                          0.5,
+                          "#f7f7f7"
+                        ],
+                        [
+                          0.6,
+                          "#e6f5d0"
+                        ],
+                        [
+                          0.7,
+                          "#b8e186"
+                        ],
+                        [
+                          0.8,
+                          "#7fbc41"
+                        ],
+                        [
+                          0.9,
+                          "#4d9221"
+                        ],
+                        [
+                          1,
+                          "#276419"
+                        ]
+                      ],
+                      "sequential": [
+                        [
+                          0,
+                          "#0d0887"
+                        ],
+                        [
+                          0.1111111111111111,
+                          "#46039f"
+                        ],
+                        [
+                          0.2222222222222222,
+                          "#7201a8"
+                        ],
+                        [
+                          0.3333333333333333,
+                          "#9c179e"
+                        ],
+                        [
+                          0.4444444444444444,
+                          "#bd3786"
+                        ],
+                        [
+                          0.5555555555555556,
+                          "#d8576b"
+                        ],
+                        [
+                          0.6666666666666666,
+                          "#ed7953"
+                        ],
+                        [
+                          0.7777777777777778,
+                          "#fb9f3a"
+                        ],
+                        [
+                          0.8888888888888888,
+                          "#fdca26"
+                        ],
+                        [
+                          1,
+                          "#f0f921"
+                        ]
+                      ],
+                      "sequentialminus": [
+                        [
+                          0,
+                          "#0d0887"
+                        ],
+                        [
+                          0.1111111111111111,
+                          "#46039f"
+                        ],
+                        [
+                          0.2222222222222222,
+                          "#7201a8"
+                        ],
+                        [
+                          0.3333333333333333,
+                          "#9c179e"
+                        ],
+                        [
+                          0.4444444444444444,
+                          "#bd3786"
+                        ],
+                        [
+                          0.5555555555555556,
+                          "#d8576b"
+                        ],
+                        [
+                          0.6666666666666666,
+                          "#ed7953"
+                        ],
+                        [
+                          0.7777777777777778,
+                          "#fb9f3a"
+                        ],
+                        [
+                          0.8888888888888888,
+                          "#fdca26"
+                        ],
+                        [
+                          1,
+                          "#f0f921"
+                        ]
+                      ]
+                    },
+                    "colorway": [
+                      "#636efa",
+                      "#EF553B",
+                      "#00cc96",
+                      "#ab63fa",
+                      "#FFA15A",
+                      "#19d3f3",
+                      "#FF6692",
+                      "#B6E880",
+                      "#FF97FF",
+                      "#FECB52"
+                    ],
+                    "font": {
+                      "color": "#2a3f5f"
+                    },
+                    "geo": {
+                      "bgcolor": "white",
+                      "lakecolor": "white",
+                      "landcolor": "#E5ECF6",
+                      "showlakes": true,
+                      "showland": true,
+                      "subunitcolor": "white"
+                    },
+                    "hoverlabel": {
+                      "align": "left"
+                    },
+                    "hovermode": "closest",
+                    "mapbox": {
+                      "style": "light"
+                    },
+                    "paper_bgcolor": "white",
+                    "plot_bgcolor": "#E5ECF6",
+                    "polar": {
+                      "angularaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "bgcolor": "#E5ECF6",
+                      "radialaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      }
+                    },
+                    "scene": {
+                      "xaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      },
+                      "yaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      },
+                      "zaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      }
+                    },
+                    "shapedefaults": {
+                      "line": {
+                        "color": "#2a3f5f"
+                      }
+                    },
+                    "ternary": {
+                      "aaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "baxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "bgcolor": "#E5ECF6",
+                      "caxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      }
+                    },
+                    "title": {
+                      "x": 0.05
+                    },
+                    "xaxis": {
+                      "automargin": true,
+                      "gridcolor": "white",
+                      "linecolor": "white",
+                      "ticks": "",
+                      "title": {
+                        "standoff": 15
+                      },
+                      "zerolinecolor": "white",
+                      "zerolinewidth": 2
+                    },
+                    "yaxis": {
+                      "automargin": true,
+                      "gridcolor": "white",
+                      "linecolor": "white",
+                      "ticks": "",
+                      "title": {
+                        "standoff": 15
+                      },
+                      "zerolinecolor": "white",
+                      "zerolinewidth": 2
+                    }
+                  }
+                },
+                "width": 950,
+                "xaxis": {
+                  "anchor": "y",
+                  "autorange": false,
+                  "domain": [
+                    0.05,
+                    0.45
+                  ],
+                  "exponentformat": "e",
+                  "range": [
+                    -5,
+                    10
+                  ],
+                  "tickfont": {
+                    "size": 11
+                  },
+                  "tickmode": "auto",
+                  "title": {
+                    "text": "x1"
+                  },
+                  "type": "linear"
+                },
+                "xaxis2": {
+                  "anchor": "y2",
+                  "autorange": false,
+                  "domain": [
+                    0.6,
+                    1
+                  ],
+                  "exponentformat": "e",
+                  "range": [
+                    -5,
+                    10
+                  ],
+                  "tickfont": {
+                    "size": 11
+                  },
+                  "tickmode": "auto",
+                  "title": {
+                    "text": "x1"
+                  },
+                  "type": "linear"
+                },
+                "yaxis": {
+                  "anchor": "x",
+                  "autorange": false,
+                  "domain": [
+                    0,
+                    1
+                  ],
+                  "exponentformat": "e",
+                  "range": [
+                    0,
+                    15
+                  ],
+                  "tickfont": {
+                    "size": 11
+                  },
+                  "tickmode": "auto",
+                  "title": {
+                    "text": "x2"
+                  },
+                  "type": "linear"
+                },
+                "yaxis2": {
+                  "anchor": "x2",
+                  "autorange": false,
+                  "domain": [
+                    0,
+                    1
+                  ],
+                  "exponentformat": "e",
+                  "range": [
+                    0,
+                    15
+                  ],
+                  "tickfont": {
+                    "size": 11
+                  },
+                  "tickmode": "auto",
+                  "type": "linear"
+                }
+              }
+            },
+            "text/html": "<div>                            <div id=\"c8a2ed18-9784-499f-aa4d-3cffa82a8ac9\" class=\"plotly-graph-div\" style=\"height:450px; width:950px;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"c8a2ed18-9784-499f-aa4d-3cffa82a8ac9\")) {                    Plotly.newPlot(                        \"c8a2ed18-9784-499f-aa4d-3cffa82a8ac9\",                        [{\"autocolorscale\": false, \"autocontour\": true, \"colorbar\": {\"tickfont\": {\"size\": 8}, \"ticksuffix\": \"\", \"x\": 0.45, \"y\": 0.5}, \"colorscale\": [[0.0, \"rgb(247,252,253)\"], [0.125, \"rgb(229,245,249)\"], [0.25, \"rgb(204,236,230)\"], [0.375, \"rgb(153,216,201)\"], [0.5, \"rgb(102,194,164)\"], [0.625, \"rgb(65,174,118)\"], [0.75, \"rgb(35,139,69)\"], [0.875, \"rgb(0,109,44)\"], [1.0, \"rgb(0,68,27)\"]], \"contours\": {\"coloring\": \"heatmap\"}, \"hoverinfo\": \"x+y+z\", \"ncontours\": 25, \"type\": \"contour\", \"x\": [-5.0, -4.6938775510204085, -4.387755102040816, -4.081632653061225, -3.7755102040816326, -3.4693877551020407, -3.163265306122449, -2.857142857142857, -2.5510204081632653, -2.2448979591836733, -1.9387755102040813, -1.6326530612244898, -1.3265306122448979, -1.020408163265306, -0.7142857142857144, -0.408163265306122, -0.1020408163265305, 0.204081632653061, 0.5102040816326534, 0.8163265306122449, 1.1224489795918373, 1.4285714285714288, 1.7346938775510203, 2.0408163265306127, 2.3469387755102042, 2.6530612244897958, 2.959183673469388, 3.2653061224489797, 3.571428571428571, 3.8775510204081627, 4.183673469387756, 4.4897959183673475, 4.795918367346939, 5.1020408163265305, 5.408163265306122, 5.714285714285715, 6.020408163265307, 6.326530612244898, 6.63265306122449, 6.938775510204081, 7.244897959183675, 7.551020408163266, 7.857142857142858, 8.16326530612245, 8.46938775510204, 8.775510204081632, 9.081632653061225, 9.387755102040817, 9.693877551020408, 10.0], \"xaxis\": \"x\", \"y\": [0.0, 0.30612244897959184, 0.6122448979591837, 0.9183673469387755, 1.2244897959183674, 1.5306122448979593, 1.836734693877551, 2.142857142857143, 2.4489795918367347, 2.7551020408163267, 3.0612244897959187, 3.36734693877551, 3.673469387755102, 3.979591836734694, 4.285714285714286, 4.591836734693878, 4.8979591836734695, 5.204081632653061, 5.510204081632653, 5.816326530612245, 6.122448979591837, 6.428571428571429, 6.73469387755102, 7.040816326530613, 7.346938775510204, 7.653061224489796, 7.959183673469388, 8.26530612244898, 8.571428571428571, 8.877551020408163, 9.183673469387756, 9.489795918367347, 9.795918367346939, 10.10204081632653, 10.408163265306122, 10.714285714285715, 11.020408163265307, 11.326530612244898, 11.63265306122449, 11.938775510204081, 12.244897959183675, 12.551020408163266, 12.857142857142858, 13.16326530612245, 13.46938775510204, 13.775510204081632, 14.081632653061225, 14.387755102040817, 14.693877551020408, 15.0], \"yaxis\": \"y\", \"z\": [[195.26892818586757, 189.42126873277604, 183.07116982761585, 176.23012298196693, 168.9158459328493, 161.15310575768876, 152.9744335208195, 144.42067609659588, 135.54133252229954, 126.39462694726666, 117.04727796973049, 107.57393472749294, 98.05626319585835, 88.58168124618803, 79.24175748011294, 70.13030590802933, 61.34122533267772, 52.96614793464737, 45.09197515215362, 37.79838967573501, 31.155439524762244, 25.22129317370037, 20.04026318631723, 15.64118965033161, 12.036263978580447, 9.220358696850704, 7.170910245531568, 5.8483803644156165, 5.197298266767962, 5.147861616252605, 5.61805045406734, 6.5161858382902, 7.743845158662456, 9.19902986827346, 10.779469546391104, 12.385939383533007, 13.92546671604188, 15.314306223544735, 16.48057265900931, 17.366434060005734, 17.92978661392414, 18.145353837724205, 18.005176454485603, 17.518484180639184, 16.71096541851712, 15.623474448992942, 14.310237086780738, 12.83663398665627, 11.27665513856564, 9.710129038960876], [189.52237621008516, 183.5256219642262, 177.0615279622794, 170.1432223550338, 162.78950512218728, 155.0256408102269, 146.884055184646, 138.40488209362184, 129.63630820326628, 120.6346676219625, 111.4642457988196, 102.19676231011857, 92.91051491039852, 83.68918203167667, 74.62029712211859, 65.79342506374775, 57.29808754688163, 49.22149981797081, 41.64619477323645, 34.64762111841104, 28.29180953495949, 22.633203922946464, 17.71275345625054, 13.556355238213875, 10.173726872770825, 7.557773600746822, 5.684496357880949, 4.5134659653936176, 3.988865614236973, 4.041079920882776, 4.588785262383851, 5.54147398863404, 6.8023255604381045, 8.27132165665515, 9.84849064616154, 11.437160135711704, 12.947094934438482, 14.297401812093092, 15.419091685456413, 16.25720390374527, 16.77241544092643, 16.942079162009488, 16.760658887254202, 16.239553612234822, 15.406327799234486, 14.303388012000378, 12.986167278369258, 11.520896530647637, 9.982056565375686, 8.449613666083199], [183.72475070325368, 177.58180279800365, 171.00751139648565, 164.01666479858918, 156.62915520500624, 148.87073993480274, 140.77371920749434, 132.3774774834017, 123.72883636818048, 114.8821710796824, 105.8992494769397, 96.84876252204629, 87.8055274714147, 78.84935959297175, 70.06362414763495, 61.533497000924264, 53.34397870318906, 45.577722307319526, 38.3127486990862, 31.620133975516993, 25.561760697013423, 20.188228095325535, 15.53701516328871, 11.63098482773339, 8.477307196102949, 6.066865494378723, 4.374190334945629, 3.3579471360836965, 2.961978795628509, 3.1168821674541682, 3.742073632314243, 4.748277239308415, 6.040349609909839, 7.520340021574844, 9.090672631712591, 10.657331262862408, 12.132925899831545, 13.439524133425369, 14.511140042662436, 15.295786993672046, 15.757018872903544, 15.87490549108995, 15.646411270922567, 15.085170752087105, 14.220678764627854, 13.09693621821708, 11.770613296436562, 10.308809535363988, 8.786504087554354, 7.283798917882027], [177.88910809259198, 171.6032744802694, 164.92293837221945, 157.86456850716925, 150.44915687754838, 142.70294734326257, 134.65809370928642, 126.35319499988177, 117.83365631851822, 109.15182730268799, 100.36687680820012, 91.54437196101424, 82.75554179058332, 74.07621984044295, 65.58547581234939, 57.36396269649549, 49.49202213333913, 42.04760606374967, 35.10408617276809, 28.728033396071815, 22.97705711607602, 17.897797055437692, 13.524159899667712, 9.875887184729494, 6.957531044570823, 4.757900344584817, 3.2500220761014766, 2.3916424136793264, 2.1262694674172344, 2.3847365536615204, 3.087241883504497, 4.1457990633551365, 5.467013798650063, 6.955086661200335, 8.514930525038594, 10.055284890042227, 11.491708144003704, 12.749332948117786, 13.765279182960214, 14.490632822195575, 14.891917033483276, 14.952002871436331, 14.670430110164887, 14.063132953905889, 13.161589426083903, 12.011436056914869, 10.670610045274955, 9.207098472421007, 7.696387684503717, 6.218715140306511], [172.02852640515917, 165.6035209940268, 158.82164539560452, 151.701065763502, 144.26387897863393, 136.53680763925894, 128.55183764327487, 120.34674687665327, 111.96547381581018, 103.45827809352534, 94.88165131910228, 86.29794556770105, 77.77469867102735, 69.38364929032511, 61.19945012149264, 53.29810373309788, 45.75516164072076, 38.6437424015073, 32.03243789483415, 25.983187715714905, 20.549209028138524, 15.773072729588085, 11.68501598358407, 8.301575914856162, 5.624619598343063, 3.640831718666057, 2.321703968068748, 1.624050134831684, 1.4910488317498825, 1.8537929676084701, 2.6333024904431905, 3.7429357533272753, 5.091116146573421, 6.58427536639838, 8.129903645823735, 9.639591048993271, 11.031942867553326, 12.23525634143871, 13.18985517143716, 13.84999215760875, 14.185248112789719, 14.181376101524256, 13.840563028635376, 13.18110454873165, 12.236513057557836, 11.054101054879348, 9.693102423129213, 8.222411265616952, 6.718031195837407, 5.260336871971964], [166.15604853017766, 159.59598858229367, 152.71742719110412, 145.5402415059342, 138.08763586254165, 130.3868021953962, 122.46953638067961, 114.37275984366909, 106.13889569274619, 97.81605149827925, 89.45796668365267, 81.12369123253559, 72.87697376232225, 64.78535051994389, 56.918941920235916, 49.348979141506135, 42.14609919306953, 35.37846190964038, 29.109755633403108, 23.397169096085484, 18.289414491623454, 13.824890356175064, 10.030072260652615, 6.91821429623462, 4.488434955662461, 2.725247582470338, 1.598578605755705, 1.0642970357309203, 1.0652570737472296, 1.5328332239509344, 2.3889050849773543, 3.5482281660527892, 4.9211086747727375, 6.416285219327877, 7.943909545483013, 9.418512371035437, 10.761839427967328, 11.905447055925302, 12.792955924946913, 13.381875262109133, 13.644927646620626, 13.570825162030086, 13.164470445997647, 12.446579867606868, 11.452749563547922, 10.232007288292872, 8.844912972146563, 7.361287666910103, 5.857663502882973, 4.41455590018888], [160.28462565403666, 153.59402741874507, 146.62397678070553, 139.39607200177343, 131.93462486202753, 124.2672856092791, 116.42563736708624, 108.44571019272192, 100.36836453491142, 92.23949630640706, 84.1100212358991, 76.0356045043798, 68.07611263572423, 60.294777764133634, 52.757079149077775, 45.52936243392819, 38.67723283276713, 32.26377331830235, 26.347652105197398, 20.981194459751183, 16.20850139697156, 12.063701573731489, 8.56942225870543, 5.735560476325613, 3.5584263369890863, 2.0203174688154455, 1.0895668774432643, 0.7210872047657197, 0.8574131331939014, 1.4302216096357476, 2.3622877376678186, 3.569813709922597, 4.965050079453807, 6.4591139467699765, 7.964898046038272, 9.399958831254818, 10.689270823301467, 11.767738762572737, 12.582368331389787, 13.094009932014577, 13.278607561098783, 13.12790535674176, 12.649586913137988, 11.866845873292391, 10.817409511086169, 9.552058917398092, 8.132709015003371, 6.630128087869764, 5.121389139654903, 3.6871537254950635], [154.4270612140372, 147.61083378185978, 140.55482605306372, 133.28236399921005, 125.81886422151084, 118.1924226237368, 110.43438624048667, 102.57985930543069, 94.66809382900124, 86.74271702488824, 78.85175296725708, 71.04740379754378, 63.385566373869906, 55.92507304503015, 48.72665965274708, 41.85167921192384, 35.360595183402346, 29.311302982622944, 23.757341494729516, 18.74606708226295, 14.31687014957641, 10.499518194958089, 7.3127090375157415, 4.762913368166682, 2.8435769874498575, 1.5347403382394589, 0.8031167302756863, 0.6026516972350251, 0.8755651135986113, 1.5538560367344658, 2.561228810265227, 3.8153788612084885, 5.23055888765902, 6.72033170334687, 8.200405652841013, 9.591442807334571, 10.821729428574542, 11.829602520615161, 12.565535493050962, 12.993799597647756, 13.093635212669465, 12.859887385963269, 12.303082319239909, 11.44894460600543, 10.337377921266162, 9.020953430350716, 7.562969454360411, 6.03516205240747, 4.515158488242406, 3.083773579025843], [148.59595571574067, 141.65939308746476, 134.52328718689716, 127.21269473060366, 119.75413187995639, 112.17612589724192, 104.5097638018562, 96.7891900381388, 89.05200397474891, 81.33950972475053, 73.69677540727653, 66.17246649538959, 58.818428071857966, 51.689003228746024, 44.84008893295419, 38.32794573541696, 32.20779293442585, 26.532235360980913, 21.349580982364046, 16.702119205331602, 12.624437383731753, 9.141857018324089, 6.269071078346078, 4.009059584361491, 2.3523521101266684, 1.276693457652275, 0.7471529353536148, 0.7166991252787511, 1.1272416366706253, 1.9111201045420003, 2.9929996749060006, 4.29211249972802, 5.724767379627444, 7.207035564160435, 8.657510615198307, 10.000034721409076, 11.166283247238685, 12.098103682820032, 12.74951434446124, 13.088281725604158, 13.097012659295224, 12.77371758071694, 12.1318231910229, 11.19963565507462, 10.019278023101656, 8.645146789414659, 7.141951418451038, 5.582416443682877, 4.0447377210635995, 2.609892143708201], [142.80365275491926, 135.75242413129268, 128.54239528963822, 121.2003531364316, 113.75390548060867, 106.23199500776761, 98.66542422657332, 91.0873443564123, 83.53365955595402, 76.04329915745136, 68.65831478587268, 61.4237663477086, 54.38737064509722, 47.598898402641886, 41.10931923486302, 34.96970883864603, 29.229947684914933, 23.937254863122714, 19.13461365145425, 14.859156035992326, 11.140581065911404, 7.999686028995093, 5.447089559038275, 3.4822217478311845, 2.0926481624801436, 1.2537826236577239, 0.9290281730245873, 1.070367538216356, 1.61940445096824, 2.5088363739940114, 3.664318598726604, 5.0066603570666945, 6.454276566004582, 7.9258050094518655, 9.342788912442527, 10.632319536825158, 11.729532944520084, 12.579859507031946, 13.140933899043809, 13.384086772036387, 13.295356404155491, 12.875978531704607, 12.142334310208454, 11.125358873856058, 9.86943517850175, 8.430818678721648, 6.875656942424749, 5.277683724572535, 3.7156786584932266, 2.2707911373946317], [137.0621865789978, 129.9023248869848, 122.62485260648009, 115.25828267393226, 107.83130397875598, 100.37325706792745, 92.91463490023395, 85.48756260630532, 78.12620826101711, 70.8670775332618, 63.7491488700751, 56.8138125549287, 50.104586335860716, 43.66659196234597, 37.545790354250386, 31.787987575797974, 26.437638525022912, 21.536489442066284, 17.122113142758714, 13.226401493566701, 9.874087343653004, 7.081372339293395, 4.854737358182504, 3.190008517237029, 2.0717438479712342, 1.472994055998491, 1.3554757583589598, 1.670177907056722, 2.3584026036572165, 3.353221158423141, 4.581306092322592, 5.965080870905664, 7.425112508181137, 8.882658685388133, 10.262271444260719, 11.494354383842905, 12.51756993106642, 13.280997736747885, 13.745954381827685, 13.887397937580628, 13.694857856294599, 13.172850350343898, 12.34076087876343, 11.232197559805098, 9.893841191377309, 8.383838057824809, 6.769799879833505, 5.126490316074959, 3.5332887160478883, 2.071528920943935], [131.3832315136994, 124.12112019583296, 116.78297464597412, 109.3990260652171, 101.9990312106591, 94.61270932109397, 87.27021825375346, 80.00262480238669, 72.84232183609576, 65.82334534685405, 58.981547861342506, 52.35459092498778, 45.98172830340836, 39.90336279187154, 34.160372545054365, 28.793216973150145, 23.840846727447286, 19.339456297002933, 15.32113041823801, 11.812446061498655, 8.833099491158897, 6.394632213774811, 4.499330128014158, 3.13936666020558, 2.2962531299615954, 1.9406482832632719, 2.0325643229847667, 2.521989524709525, 3.349928481376489, 4.449841131617427, 5.749442018161224, 7.172802737078783, 8.64268426919529, 10.083012723061678, 11.421402703225542, 12.59162758764603, 13.535935765258063, 14.207116414239625, 14.570227506390188, 14.60391197639899, 14.301244754092501, 13.670072801101828, 12.732831464268951, 11.52584232404051, 10.098119217079521, 8.509729228301039, 6.829773242289548, 5.134065321954665, 3.502601119036097, 2.0169122988164307], [125.77805356912435, 118.42041167338317, 111.028638557113, 103.6346723288147, 96.26932177497821, 88.96266407676788, 81.74449596196422, 74.64479430096404, 67.69413944269087, 60.92405462463852, 54.367217729356874, 48.05750747916483, 42.02985467295561, 36.31987991000082, 30.963311898497565, 25.995194255112764, 21.448902912407846, 17.355010046596924, 13.740042988763125, 10.625197093126552, 8.025069294932214, 5.946483517050327, 4.387479767960828, 3.3365355012921736, 2.77208058958335, 2.662356336390763, 2.9656547643048654, 3.6309576272802975, 4.598976021272035, 5.803572049606375, 7.173524751442564, 8.634584447355806, 10.111743778947954, 11.531640896000004, 12.825001205305266, 13.929019369843392, 14.78958314150796, 15.363245188891746, 15.61885815337248, 15.538801311338855, 15.119743797949937, 14.372908545240021, 13.32382195839402, 12.011555876163039, 10.487489490126901, 8.813638622829421, 7.060617167913234, 5.3053097906889946, 3.6283455659884254, 2.1114686830796856], [120.25746452579719, 112.81133014384207, 105.37323407844951, 97.97680642412044, 90.65388956436192, 83.43489632968837, 76.34923585612162, 69.42576421349838, 62.6932137786798, 56.18055495477048, 49.91724634464254, 43.93333486953601, 38.25937540580193, 32.926149944156165, 27.96417855237706, 23.403027899830853, 19.270437038390895, 15.5912937203457, 12.38650694890848, 9.671831909580451, 7.456711213036087, 5.743200912006374, 4.525050621968687, 3.787004061946485, 3.504379439483275, 3.642978557596548, 4.159359764173633, 5.001493534854571, 6.109801385784127, 7.418559875728967, 8.857632678602492, 10.354476094689737, 11.836347891715267, 13.23263689020185, 14.477221949085605, 15.510764490593896, 16.282838727289885, 16.7538083789202, 16.89636770455707, 16.69667770435423, 16.155044736074565, 15.286107734032246, 14.118520780534308, 12.694138949472716, 11.066736087641157, 9.300302526531954, 7.466987719564056, 5.644766706784697, 3.914919523378771, 2.3594187933892545], [114.83177878442862, 107.30449089663554, 99.82761736359899, 92.43646182171588, 85.16387926796486, 78.04059439039357, 71.09560188344743, 64.35660689861754, 57.85046030448053, 51.60354264476514, 45.64205275661464, 39.99216195515396, 34.68000233749026, 29.731467777235856, 25.171818074308817, 21.025089865625837, 17.313331556220394, 14.055692902185395, 11.26741214836819, 8.95875401496902, 7.133959628117088, 5.790274124409823, 4.917118709697101, 4.495471198271487, 4.497512494692417, 4.886586321132571, 5.617506169781567, 6.637227599300626, 7.885886385272633, 9.298184589470356, 10.805088310816233, 12.335783719628196, 13.819822906532742, 15.1893789542044, 16.381521167530686, 17.340417092164795, 18.01936810630511, 18.382590040792962, 18.406659282663252, 18.08155772788655, 17.41126614412131, 16.413874186851377, 15.121195555984064, 13.57789758957789, 11.840174945006947, 9.974015939151245, 8.053126713660777, 6.1565919036632035, 4.3663603346348445, 2.764650066665121], [109.51077324504882, 101.90995204093036, 94.40206796814016, 87.02407629339083, 79.8098211466228, 72.7903138356516, 65.99410742858251, 59.44772685200635, 53.17610989778758, 47.20301333251669, 41.55133994468966, 36.243346865842035, 31.30070271251963, 26.744370694899423, 22.594306344545288, 18.868971311303095, 15.584678047059052, 12.754793343130164, 10.388840813442162, 8.491552738063337, 7.061929498825407, 6.092369573683616, 5.567934288017632, 5.465809028260404, 5.755016387963289, 6.396426948836718, 7.343100515436831, 8.540975235010858, 9.929904920768037, 11.44502694800504, 13.018425278137894, 14.58103646094004, 16.064731810738472, 17.404497186837023, 18.540623627797807, 19.420817996193804, 20.002143077536903, 20.252701292414514, 20.15298513967803, 19.696830276300346, 18.891923133688053, 17.759833384594526, 16.335561493986155, 14.666612026149926, 12.811623336722683, 10.838602784459336, 8.822832778328227, 6.844526088778517, 4.98631832586973, 3.3306909495337926], [104.30365046005349, 96.63717621257189, 89.10624926176712, 81.74945119430753, 74.60158936043291, 67.69393506557557, 61.05457228909048, 54.708817291470176, 48.67966523777951, 42.98821835507111, 37.654051348685, 32.69547386044839, 28.12965652290974, 23.972596340585287, 20.238908244215526, 16.941442114437958, 14.090737645167994, 11.694342340843857, 9.756029912744758, 8.274966590955747, 7.244880696794386, 6.65329565293203, 6.4808880210048745, 6.701029923006132, 7.279569300098956, 8.174892088196035, 9.338297949580516, 10.714706293576521, 12.243692704820482, 13.860838455845041, 15.499358457470345, 17.091956761465802, 18.572844495511465, 19.879843709322508, 20.956492723459814, 21.75406469732471, 22.233411549966775, 22.366550127812744, 22.137916428385687, 21.545226348977593, 20.59989721747195, 19.327002502236486, 17.76475168475422, 15.963507341384702, 13.984371030689704, 11.897387668685539, 9.779433835849375, 7.711868168578752, 5.778031087712197, 4.060686244873073], [99.21900528330158, 91.49499586516058, 83.94917250619426, 76.62171448562327, 69.54836410506275, 62.76062472999389, 56.28608357368405, 50.14882071048366, 44.36986119647611, 38.96762515528082, 33.958331460873794, 29.356314263504316, 25.174217934966116, 21.423044761247333, 18.112040431295995, 15.248414467825981, 12.836905524259263, 10.879214162359645, 9.373337540400406, 8.312850614684875, 7.686186295057826, 7.475971921169053, 7.658481018400321, 8.203257318308504, 9.07296245895406, 10.223489802414374, 11.604374814039687, 13.159518026343168, 14.828220502480274, 16.546514782509515, 18.248757472249242, 19.86943386479241, 21.345111177756912, 22.616465954667966, 23.63030359046175, 24.341484282814065, 24.714670261499364, 24.72581394967368, 24.363315581591102, 23.62879132676232, 22.537408550270065, 21.11776269578056, 19.411289527008698, 17.471226142713416, 15.361153317983675, 13.153169384466267, 10.925761199691967, 8.761450056832109, 6.744299109635774, 4.957373680862386], [94.26479521285927, 86.49158235178976, 78.93916481395996, 71.64928772104192, 64.65859778675005, 57.99880126071308, 51.69696076517831, 45.775893647191936, 40.25462948761509, 35.148881980155465, 30.471490735663657, 26.232791737499284, 22.440881061872272, 19.10174480260624, 16.219238461817167, 13.794910810924073, 11.82767970150659, 10.313379761779839, 9.244213566074368, 8.608147958318755, 8.388305052163773, 8.562402448365788, 9.102298980050232, 9.973700581308396, 11.136075638336767, 12.542820602462157, 14.141705102610743, 15.875611860540188, 17.683571115690572, 19.502072850057772, 21.266623784429306, 22.91350082318186, 24.381639247065547, 25.614583292362443, 26.562419464158257, 27.183609494491975, 27.446640536879386, 27.331415033493762, 26.830311510929548, 25.948859952064403, 24.705990753359025, 23.13383384916675, 21.27706348817617, 19.191803437796775, 16.944126112269853, 14.60819634942077, 12.264125469776975, 9.995613143858986, 7.887462937680109, 6.0230618663761195], [89.44831459893302, 81.63441897767846, 74.08384117622509, 66.83985719251334, 59.939985438554565, 53.41610471818784, 47.29472516217291, 41.597375887335204, 36.341067795753425, 31.538787096589424, 27.199975044968667, 23.330952120383124, 19.935250312989538, 17.013825083661068, 14.565128486241354, 12.585036324459947, 11.066634386927277, 9.9998810187364, 9.371174775496822, 9.162865913148101, 9.352758310674988, 9.913653529797594, 10.812990660330048, 12.012634144181373, 13.468856867239356, 15.13255762837098, 16.949741005137607, 18.862274193298532, 20.808920314902124, 22.726631793007414, 24.552071580787732, 26.22331521721398, 27.68167373875348, 28.87356718857197, 29.75237147746947, 30.28015813277679, 30.429247284553792, 30.18349912233933, 29.539277824004515, 28.5060342101023, 27.106468518447734, 25.376251974749877, 23.36330438845185, 21.12664390003531, 18.734843303248766, 16.264144159763838, 13.796294401689345, 11.416186597246963, 9.209382020377463, 7.259609791380898], [84.77617286130709, 76.93027817572437, 69.39008071925566, 62.20034940175453, 55.39943955068497, 49.01937113133877, 43.08607388331123, 37.61976428947482, 32.63541357764589, 28.143262719559175, 24.149339876500754, 20.655938027346075, 17.66201551940319, 15.16348975162854, 13.153403721408477, 11.621956188952371, 10.55639807696651, 9.940809695395501, 9.755784697640173, 9.978056595728896, 10.58011150229331, 11.529835960394482, 12.790250841537759, 14.319381091423574, 16.07030653415628, 17.99143116409099, 20.02699771991126, 22.117861385665094, 24.202521898849106, 26.218397971832722, 28.10331263398225, 29.797143768657744, 31.243581614056296, 32.39192508401978, 33.198842082340406, 33.63001598575496, 33.66160141504167, 33.28141733554926, 32.4898142422208, 31.30016429319528, 29.7389381725146, 27.845349447771987, 25.670565387401986, 23.276501701282225, 20.73423653804704, 18.122095429556012, 15.523472916450839, 13.024467656007948, 10.711415399876895, 8.668408023576015], [80.25427683179419, 72.38520292788735, 64.86400731911965, 57.736910993832666, 51.04306945716908, 44.81461147814444, 39.076858586694165, 33.848691389464356, 29.143022696270805, 24.967333816127915, 21.324229441065846, 18.211968384585095, 15.624932005060252, 13.553999186444184, 11.98680586808933, 10.907877775843401, 10.298636561170042, 10.137291279445531, 10.39863828477995, 11.05380244575657, 12.069960423781911, 13.41009203129422, 15.032807977030226, 16.89230136127951, 18.938466045935876, 21.117217644092825, 23.371042692144755, 25.639789114006263, 27.861697040298353, 29.974654197668094, 31.917645297480085, 33.632351005655764, 35.064840007852794, 36.16728815028087, 36.89965225684059, 37.23122344613008, 37.14198584522354, 36.623711555987754, 35.680731385432324, 34.33033281472086, 32.6027513696777, 30.540738240262133, 28.198704837834576, 25.64146307475023, 22.942597591778775, 20.182522074130738, 17.44628540649595, 14.821204070488456, 12.394404396375975, 10.250361744998266], [75.88781730792816, 68.0044925250246, 60.51097467370741, 53.45489325755527, 46.8761653890281, 40.806995422186674, 35.272069024076785, 30.288908907473875, 25.868353014665146, 22.015111915428758, 18.728360821103028, 16.00232302921141, 13.826805738796713, 12.187655791408634, 11.067111610349556, 10.444037908641656, 10.29404097822772, 10.58947384963075, 11.299351581544862, 12.389206672710106, 13.820922417502361, 15.552587381971602, 17.53841663695321, 19.728784692612948, 22.070411172393094, 24.506733283017965, 26.978489410044023, 29.424526210965073, 31.78282805040884, 33.991753301803776, 35.991447768420215, 37.72539211602921, 39.14202858115108, 40.1964030639224, 40.85175263881653, 41.08096595904166, 40.867845232896755, 40.20810344218978, 39.110039070444124, 37.59484242056093, 35.69650205891654, 33.46129630390551, 30.946872155970837, 28.220931756957327, 25.35956347492668, 22.445270183922226, 19.564760481818965, 16.806578829069625, 14.258657423632592, 12.005875762536096], [71.68125987410559, 63.79269272709802, 56.335555899296715, 49.35884126499418, 42.903187271339036, 37.00083988715436, 31.675821515940555, 26.944276247833656, 22.8149530427047, 19.28978402052336, 16.364513258683928, 14.029332475329852, 12.2694836688239, 11.065794972441058, 10.395124300627558, 10.230695297256537, 10.54232102566059, 11.296522067031665, 12.456556485571031, 13.982388755132309, 15.830632559316143, 17.954507810421635, 20.303854858528144, 22.825248420107823, 25.462250179475046, 28.155832431462443, 30.844995862097903, 33.467593100236776, 35.96135666725449, 38.265116157446, 40.32017572784511, 42.07181010029335, 43.470826092089254, 44.47512791417992, 45.05121870397236, 45.1755684212319, 44.83577956452254, 44.03148719027782, 42.77493825071798, 41.091206927423926, 39.018016858645694, 36.60515723358965, 33.91349684093174, 31.013617441525334, 27.984104410134986, 24.909547620583865, 21.878318286887236, 18.98019730067216, 16.303937062548627, 13.934841616405517], [67.63834001530407, 59.75359035393141, 52.34153768664736, 45.452487690154015, 39.12775830823237, 33.39960251723035, 28.291352399119717, 23.81775404631111, 19.985455694610764, 16.793606682409475, 14.234522645790465, 12.294372911148809, 10.953849305791806, 10.188781373377385, 9.970670898341549, 10.26712821485648, 11.042203392072892, 12.256616362283133, 13.867900670669417, 15.830485062188185, 18.095744924213186, 20.612061111946602, 23.324926472316687, 26.17714018918862, 29.10912682326378, 32.059410731426716, 34.96526773048502, 37.76356490201131, 40.39178694716179, 42.78923423416167, 44.89836444120585, 46.66623730955526, 48.0460112735601, 48.99843233547012, 49.49325008335174, 49.510493628969854, 49.04154169679694, 48.089926149381554, 46.67181670347891, 44.816146096866746, 42.564348948991295, 39.969703324859694, 37.09628075777495, 34.01752736070564, 30.81451479505416, 27.57391445197252, 24.38576050486701, 21.341076908522297, 18.529449506528856, 16.036626898698007], [63.762062518653245, 55.89021230547492, 48.531919019487916, 41.73875131280748, 35.55266336578606, 30.005880036845276, 25.121016463810086, 20.911402784732584, 17.381577179882576, 14.527905261513698, 12.339281244007642, 10.797866455746128, 9.879823585058412, 9.556010399206857, 9.792604195239102, 10.551637450963488, 11.791435447032724, 13.466957353875754, 15.530052707615084, 17.92965463422824, 20.61193896714923, 23.52048398494484, 26.596468443534086, 29.778945630831913, 33.00522824657703, 36.21141311451255, 39.33306636581118, 42.3060792560227, 45.067692808652964, 47.557676737517326, 49.71963537454386, 51.50240142716279, 52.861468079681565, 53.760401930565294, 54.17217408897056, 54.08034484796504, 53.48003892872281, 52.37865337103867, 50.79624854854401, 48.765584132392235, 46.33177557253834, 43.551562118455614, 40.492193780068675, 37.22996109228456, 33.84840725030995, 30.436276326586466, 27.08526314992107, 23.88763943640666, 20.93383647984816, 18.310066882206648], [60.054705126598, 52.20482897866417, 44.90891442561966, 38.219740181360464, 32.179852129403635, 26.821411489263838, 22.166290361822618, 18.226386457568246, 15.00412101436176, 12.493078365289454, 10.67874262433677, 9.539286668511545, 9.046371002418283, 9.165915022793598, 9.858810324458739, 11.081554539039052, 12.786794187554495, 14.923775497683206, 17.438712384646365, 20.275090125231436, 23.37393102260291, 26.674054008257436, 30.112363234382414, 33.62420100469518, 37.143797788089856, 40.60484665532384, 43.94122155756129, 47.08784887986532, 49.981730249051864, 52.563102357720545, 54.77670735389236, 56.573135925470346, 57.910195336512004, 58.75424702375892, 59.08145349192985, 58.87887255369923, 58.14533865705682, 56.89207614950296, 55.14299765977009, 52.934651965027285, 50.315799212377556, 47.34660650461395, 44.09747286777922, 40.64750867066735, 37.082709834118816, 33.493880870577414, 29.97437223262567, 26.617706053343788, 23.515169715288824, 20.75345854597577], [56.517826375773055, 48.69896201713211, 41.47396169893344, 34.896759374854454, 29.010446978111858, 23.847086298621345, 19.42778093316792, 15.762981239398147, 12.85298710265402, 10.688607415265313, 9.25193178238275, 8.517169267588306, 8.4515109814266, 9.015977835035546, 10.166221514277503, 11.85325522084473, 14.024100405208703, 16.622345933443533, 19.58862619370563, 22.861033874656194, 26.37549089267756, 30.0661066620915, 33.86555616172155, 37.705510785889125, 41.51715268209358, 45.23179826062688, 48.781649084472164, 52.10067884971875, 55.1256542249407, 57.79727562188633, 60.06141226656703, 61.87039500064356, 63.18432080455443, 63.97231575678565, 64.2136985702808, 63.898985363957195, 63.0306781424662, 61.62378458543381, 59.706025006887124, 57.317693369358864, 54.51115249455295, 51.34995843838255, 47.907624635735274, 44.26605206112625, 40.51366648554437, 36.74331717258467, 33.05000236619135, 29.52849512635131, 26.270948062628783, 23.36455707032954], [53.15227752572945, 45.373396298865245, 38.22773399906, 31.77032327242811, 26.04475548570914, 21.08295706688932, 16.905238363923264, 13.520589067858324, 10.927185807871702, 9.113071261056625, 8.056960347743034, 7.7291279783009195, 8.092334394628146, 9.102748261966086, 10.710834012119363, 12.862178074765115, 15.498238002266286, 18.55700845747819, 21.97360791478594, 25.68079904271623, 29.60946345928761, 33.68905732996577, 37.84807768948508, 42.014570138662634, 46.116706595070134, 50.0834571437455, 53.84537299728955, 57.33548855977501, 60.49034015692193, 63.25108781494672, 65.56471527394928, 67.38527296029875, 68.67511963299856, 69.40611151238576, 69.56068341712552, 69.1327651607422, 68.12847838819567, 66.56656418056187, 64.47849994032208, 61.90827492875705, 58.9118068384514, 55.55599629484273, 51.91743144651344, 48.08077003543615, 44.13684073917841, 40.18051840287079, 36.30843836327992, 32.61662287440195, 29.198097283304627, 26.140574858908963], [49.9582184529957, 42.228196037755815, 35.170156204644826, 28.84017220687037, 23.282287425883304, 18.528256983747543, 14.59757405432053, 11.497756022174727, 9.224856890177648, 7.764165723913864, 7.091046771800363, 7.171875396594759, 7.965025125385214, 9.42186483718967, 11.487731068174048, 14.102848199208754, 17.203178350002, 20.721192517914474, 24.586564195201007, 28.726795708657228, 33.06779522277212, 37.53442818669781, 42.05107056429986, 46.54219218771078, 50.93299691291253, 55.15014200190971, 59.122552555854675, 62.78233828685355, 66.06580998946266, 68.91458240482271, 71.27673947686918, 73.10802801012062, 74.37303715761202, 75.04631462349454, 75.11336647300286, 74.57148637056198, 73.43036210749435, 71.71241244556789, 69.45281540811125, 66.69919984443953, 63.510984856279755, 59.95836587081196, 56.12096103984, 52.08614646675563, 47.9471227338814, 43.80076759419244, 39.745339855342635, 35.87810689922753, 32.29297257088001, 29.07818313027137], [46.93513735812171, 39.262724845763465, 32.30042536667471, 26.105293348222403, 20.7217761274922, 16.18142169572648, 12.502883043735661, 9.692195344654511, 7.743293161964523, 6.638727918623847, 6.350541343559028, 6.841248718703188, 8.064886522726521, 9.968082383454131, 12.491110834804703, 15.56890580877014, 19.132009548695663, 23.107447092676228, 27.41952498789466, 31.99056179819364, 36.74156563550208, 41.59287984417506, 46.46482166871509, 51.278339965548, 55.955716661438544, 60.42133278298813, 64.60251371151433, 68.43046025570963, 71.84126270641957, 74.77698487816303, 77.18679494501393, 79.02811035727531, 80.26771596591809, 80.88280829791302, 80.86191521892539, 80.2056393468533, 78.92717572976133, 77.0525594780147, 74.62060706806572, 71.68252555878607, 68.30117647822829, 64.5499950167742, 60.51157968883187, 56.27598203968834, 51.93873951756582, 47.59870659192312, 43.35574894729843, 39.30837261074967, 35.551363819267635, 32.173516105471], [44.08187410700364, 36.475669575313674, 29.617035079998374, 23.563945634598113, 18.361203996023107, 14.040115450178018, 10.618470808098046, 8.100814920075067, 6.478968675135251, 5.732765169891959, 5.830955850307502, 6.732240154711997, 8.386372567953362, 10.735303923722022, 13.714319002888129, 17.25313956649537, 21.276970414851682, 25.70747527904959, 30.46367867891128, 35.462798673257566, 40.62102306718141, 45.854247594621555, 51.0787984359446, 56.212162883543066, 61.17375091186221, 65.88570689800423, 70.2737849957054, 74.26829407104222, 77.80510917413153, 80.82673686345804, 83.283411993735, 85.13419451971703, 86.34802712567242, 86.90470866154706, 86.79573493990947, 86.02495777144804, 84.60901536944547, 82.57749244200264, 79.97277623443372, 76.84958513918636, 73.2741587574045, 69.32311185967376, 65.08196885046519, 60.643409350324276, 56.10526862951929, 51.568348161390375, 47.13410090145415, 42.90226254700514, 38.968503644266825, 35.42217780198441], [41.39664700304673, 33.865067735731316, 27.117803564384648, 21.213688539493027, 16.197831989171892, 12.101261300489643, 8.940884214759633, 6.719748998190015, 5.427571225270917, 5.041488307675072, 5.52699766826338, 6.839031811602112, 8.92312353996456, 11.716617109512883, 15.149885965214159, 19.147524443890635, 23.62948898923732, 28.512173390750007, 33.70941170339559, 39.133411186350294, 44.695625206816715, 50.30758206048254, 55.88168963864195, 61.33203754341715, 66.57521749229284, 71.53117970538713, 76.12413764620794, 80.28352635332365, 83.94501115425228, 87.05153439073288, 89.55437856353484, 91.4142157038525, 92.60210544586516, 93.10039879593009, 92.9035014426014, 92.01844996578751, 90.46525665671325, 88.27698385561794, 85.49951657309887, 82.1910123444699, 78.42101928410094, 74.26926655463103, 69.82414525641524, 65.1809113496231, 60.4396549209602, 55.70309122030849, 51.07423782570676, 46.65404856993854, 42.539078146077046, 38.81925142780886], [38.87708276351174, 31.428338253298826, 24.799905221621657, 19.051414439168237, 14.22823280749921, 10.361075131754575, 7.465946392977694, 5.544393915658327, 4.584038928184496, 4.559349096897455, 5.432608038350571, 7.15503480172298, 9.668005935445306, 12.90433492440647, 16.78956826577391, 21.243263869749743, 26.18022532926564, 31.511674327969768, 37.14635241809563, 42.991551970788464, 48.9540836767658, 54.94119402944655, 60.86145033477889, 66.62561267678159, 72.1475117981546, 77.34494906490247, 82.14062977422844, 86.46313438720088, 90.24792430192028, 93.43837010913259, 95.98678153018218, 97.85541008521415, 99.01738861199317, 99.45756662020469, 99.17319758417563, 98.17443397753505, 96.48458830287572, 94.1401235683621, 91.19034443555609, 87.69677027268028, 83.73218311678909, 79.37935648075698, 74.72948436755662, 69.88034306194956, 64.93423055375433, 59.995739144201885, 55.16942532153054, 50.55744690051494, 46.257240383360916, 42.35931135309792], [36.52024945221603, 29.162315322822842, 22.659905412202672, 17.07338432020344, 12.448327536970107, 8.8151032407423, 6.188795251105139, 4.56944754713097, 3.942600597425404, 4.280081529235657, 5.541004254588733, 7.6729323038545925, 10.613156372273679, 14.290040391475138, 18.624394065439493, 23.530835899594017, 28.91911831940121, 34.69539495733634, 40.763418970535554, 47.0256697101608, 53.38441260544374, 59.74270322584551, 66.00535072605683, 72.07985797272767, 77.87735546618521, 83.31354373121172, 88.30965434806927, 92.79343356448587, 96.70014493695896, 99.97357925716912, 102.5670517475618, 104.44435880144917, 105.58066001275446, 105.96324644165333, 105.59215344526135, 104.48057628320325, 102.65504925014295, 100.15535428598932, 97.0341326980041, 93.35618346508863, 89.19744311354009, 84.64365477423564, 79.78874709431574, 74.73295648966271, 69.58073809711662, 64.4385210732423, 59.41237202874233, 54.60563593795395, 50.11662651185186, 46.03643762026861], [34.322692101944135, 27.063285078152518, 20.69379817412115, 15.275266544933366, 10.853425457454982, 7.45826318102441, 5.103925348729902, 3.7889521911549107, 3.4968196265020186, 4.196746679266553, 5.844725466536556, 8.384726278489806, 11.750029177325068, 15.864634987026706, 20.644712327298105, 26.000043111286796, 31.83543620756094, 38.052087211844565, 44.54887087762705, 51.22356110321423, 57.97398087889123, 64.69909074237813, 71.30002865724495, 77.68111652703844, 83.75084865085731, 89.42287533163773, 94.61699074385103, 99.26012837810168, 103.28736035168035, 106.64288915573675, 109.28101259990925, 111.16703544200178, 112.27809505000712, 112.60386397509387, 112.14708995508227, 110.92393392370636, 108.96406923119227, 106.31051047726854, 103.01914794930252, 99.15797331967303, 94.80599352648628, 90.05184207029305, 84.99210966387014, 79.72942859418694, 74.37035662193476, 69.02311612947994, 63.79525198508986, 58.79127679046826, 54.11037452355453, 49.84423293690493], [32.28047074276672, 25.127024791885336, 18.897046588316872, 13.65217837428083, 9.438266711582743, 6.284887563227601, 4.205232810163636, 3.1963405743910194, 3.239641056895417, 4.301780804502206, 6.335681774153683, 9.28178751469335, 13.069447336701455, 17.618390438800887, 22.84024540137279, 28.640065907362533, 34.91783054988986, 41.56989259594599, 48.49036400203075, 55.57242621592574, 62.70956776652257, 69.79675483199591, 76.73154546107494, 83.41516062209283, 89.75352561789268, 95.65829364837285, 101.0478595895539, 105.84836669985248, 109.99470239411528, 113.43147196992851, 116.11393181745592, 118.00885679576544, 119.09531070122901, 119.36528460842155, 118.82416575473658, 117.4909998671557, 115.39851254165629, 112.59286047540374, 109.13309084934866, 105.09029664504632, 100.54646669984572, 95.59304130446037, 90.32919649456915, 84.8598922239662, 79.2937306730271, 73.74068043471033, 68.30972970076834, 63.106536427066345, 58.23114550563887, 53.77584208010168], [30.389200538498944, 23.348844299152724, 17.264625478835246, 12.19872992991486, 8.19706751070069, 5.2887704826359165, 3.4860629470671007, 2.784484638448763, 3.163441493355851, 4.587046348472233, 7.005206272742573, 10.354908665435975, 14.561656464262327, 19.541003565031954, 25.20014466520849, 31.439518882758605, 38.154393224703966, 45.23639975878356, 52.57500859223085, 60.05892688986453, 67.57742159443961, 75.02156973724752, 82.28544483041796, 89.26725052484983, 95.87041334711586, 102.00464490315824, 107.58698060616055, 112.54279705222751, 116.80680404415102, 120.32400046404226, 123.05057628669482, 124.95473659576285, 126.01741808165798, 126.23286466962406, 125.60902706227216, 124.16775137186636, 121.94472480787297, 118.98915156503605, 115.36313945903785, 111.14078716564109, 106.40697269248432, 101.25585540442512, 95.7891159188002, 90.11396984067673, 84.34100198129025, 78.58187680100569, 72.94698783021438, 67.54311334320951, 62.47114732191796, 57.82397362493185], [28.644093721234334, 21.723629327642357, 15.79106612275423, 10.909070264017583, 7.123567539993662, 4.463216230504809, 2.939260242158415, 2.5457467570417887, 3.2600815107148513, 5.043885488206559, 7.844109687084673, 11.594359909074125, 16.216381426064356, 21.62165379181317, 27.7130488591131, 34.38650989711704, 41.53271615627189, 49.03870477890986, 56.78943003202368, 64.66924785650465, 72.56332111911581, 80.35894721429132, 87.9468143797368, 95.22219596924793, 102.086092817007, 108.44633272237138, 114.21863313065953, 119.32762856492457, 123.70785867980175, 127.30470645414016, 130.07526956709032, 131.9891419804754, 133.02907773338714, 133.19150543113676, 132.48686028433013, 130.93970110270087, 128.58858251176287, 125.48565782696195, 121.69599532317756, 117.29659976969594, 112.37514162644064, 107.02840768394165, 101.36049857680234, 95.48080987694823, 89.50184375942757, 83.53690694887513, 77.69775730693635, 72.09226561660111, 66.8221606039495, 61.980923894680174], [27.04000300476337, 20.245886406058112, 14.470502633907351, 9.776935193459222, 6.211079212912315, 3.801089933306649, 2.5572203324745093, 2.4720330173706007, 3.520960182241309, 5.663175853224699, 8.842737219501299, 12.9899468601217, 18.022885242201195, 23.84906296986631, 30.367144736768836, 37.46870147403712, 45.03995337262461, 52.963473786182476, 61.11983192864333, 69.38916018882325, 77.65263923691914, 85.79390039128964, 93.70034953982164, 101.26441997256407, 108.38476262515698, 114.96738144265666, 120.92671898607182, 126.18669328844615, 130.6816817125527, 134.3574416441025, 137.17195180780703, 139.09615237272254, 140.11455735062296, 140.2257095686668, 139.44244709979105, 137.79195073549124, 135.3155450174696, 132.0682304939012, 128.11793206960414, 123.54445727331273, 118.43816854539412, 112.89838473356994, 107.03153828649371, 100.9491255416763, 94.76549740867824, 88.59554609128423, 82.55234979085787, 76.74484121416572, 71.27556692397181, 66.23860301622251], [25.57146615105904, 18.90978901607694, 13.296719676985681, 8.79569654666085, 5.45253841578427, 3.2948697539827805, 2.331943620638171, 2.554848188992331, 3.937071348237449, 6.43538803082861, 9.991027223824867, 14.53107033879709, 19.970029874578962, 26.211557098618268, 33.15022963972571, 40.67337413585674, 48.66288500710351, 56.997007533128745, 65.55206115331029, 74.20408670798258, 82.83040865072255, 91.3111095858178, 99.53041941528099, 107.37802461949838, 114.75030458404541, 121.5515014018464, 127.69482735006733, 133.10351052174124, 137.71177425557354, 141.46574051560842, 144.32424174184354, 146.25952046129504, 147.25779163399193, 147.3196397758413, 146.4602217254443, 144.70924676824546, 142.11070882682125, 138.72235055462772, 134.61484627186212, 129.8706994579168, 124.58286055058915, 118.85308158631989, 112.79003517867739, 106.50723587322926, 100.12081144818103, 93.74717970679112, 87.50069226308901, 81.49131039650842, 75.82237900756208, 70.58856294997186], [24.23275135974166, 17.709224647884454, 12.263201162856323, 7.958412465844008, 4.840556377273257, 2.9367002829972826, 2.2550901351839023, 2.785351995528986, 4.499061235474489, 7.350644464283798, 11.278571308314788, 16.206787600233607, 22.046338499498745, 28.69712955538705, 36.04977559283758, 43.98749127170387, 52.387982842430986, 61.12530751574639, 70.07167443719787, 79.09916895030028, 88.08138910181017, 96.89498969409394, 105.42113422117882, 113.54685843536757, 121.1663509184664, 128.18215584695648, 134.50630125904172, 140.06135279739416, 144.7813884743719, 148.61288492902878, 151.51550042143285, 153.46273495641688, 154.4424439526888, 154.45717922137, 153.52433005874752, 151.67603824285752, 148.95886377713862, 145.43318332889072, 141.17231030725267, 136.26133412329156, 130.7956859666758, 124.87944892164518, 118.62344087188009, 112.14310882652634, 105.55628246417609, 98.98084231077178, 92.53236358882467, 86.32180005254267, 80.45327283086169, 75.02202735111845], [23.017903149292284, 16.637842417936596, 11.363179574093675, 7.2578784042752815, 4.367472294373702, 2.718446742655715, 2.3180352569094893, 3.154416299940653, 5.197287032777737, 8.398779344586812, 12.694675464710478, 18.005874617283137, 24.240058856898475, 31.293505420167286, 39.05299451054758, 47.39776512885181, 56.201476988255706, 65.334143236308, 74.66400611673299, 84.05933529125929, 93.39013576714623, 102.52975875493257, 111.35641390633762, 119.75458496014767, 127.61635268079274, 134.84262908078983, 141.3443053750338, 147.0433131573188, 151.87359425923594, 155.7819700801373, 158.72889634691717, 160.68908477858594, 161.65196948157723, 161.6219935236077, 160.6186903806362, 158.67653606901706, 155.8445508815258, 152.1856347226986, 147.77562692980405, 142.70208988545647, 137.0628252776054, 130.96414205829072, 124.51890544842468, 117.84440616634666, 111.0600978635137, 104.28525802093037, 97.63663285666715, 91.22612978485759, 85.15862143483784, 79.5299231070642], [21.920788400084206, 15.689100908320412, 10.589685570122363, 6.686678458621925, 4.025406345659359, 2.631749628041293, 2.5119259267286633, 3.6526828125485533, 6.021876026133258, 9.569399094384279, 14.228421817538702, 19.916889007960098, 26.539227264619242, 33.988206482617116, 42.14690409989089, 50.890723512712945, 60.089423277655136, 69.60912019458088, 79.31423661700285, 89.06936981711374, 98.74106841535882, 108.19950728542403, 117.3200575636119, 125.98475212786488, 134.0836489936014, 141.51609546101324, 148.19189463453932, 154.03237334360188, 158.97134685001726, 162.9559714500729, 165.94747163273843, 167.92172433089567, 168.8696794703323, 168.79759390733975, 167.72705529125838, 165.69477363126487, 162.7521215013767, 158.96440886280644, 154.4098852662686, 149.17847043763996, 143.37022356049613, 137.09357147477178, 130.4633259816123, 123.59852992858185, 116.62018020432424, 109.64888270186484, 102.80249929124028, 96.19384955484296, 89.92853027839993, 84.1029133851707], [20.935142233041105, 14.856315890785478, 9.935597524428802, 6.237236679038579, 3.8063127258295033, 2.6680794095443687, 2.8277369527044875, 4.270620932183386, 6.962784897657084, 10.851943042761762, 15.86873058837585, 21.928233198169075, 28.931732885760432, 36.76861651718042, 45.31839404444891, 54.452776779414485, 64.03777096669995, 73.93574819242772, 84.00746125877666, 94.1139815324162, 104.11854091190679, 113.88826798162239, 123.29581322384126, 132.2208620517321, 140.55153672391404, 148.18568886126977, 155.03208339338627, 161.01147252393244, 166.05755503810323, 170.1178123790063, 173.15420884697187, 175.1437394982699, 176.07880629520787, 175.96740120038592, 174.83307454361764, 172.7146683522453, 169.66579753251972, 165.75406680054536, 161.06001793450181, 155.67580998310277, 149.70364413660963, 143.25395458701612, 136.4433963542654, 129.3926702005707, 122.22423286679603, 115.05994746356853, 108.01873352611312, 101.21427868704413, 94.75287394209423, 88.73143201522129], [20.0546134045833, 14.13270760459272, 9.39369065267079, 5.901868005729222, 3.702032340350204, 2.818790927314506, 3.2563270384411993, 4.998585335614937, 8.009858796951903, 12.23574389407662, 17.604421872698435, 24.02821741370653, 31.405381839619018, 39.622046414268674, 48.554292055800964, 58.070284706069344, 68.03243032221707, 78.29950953719643, 88.72875897630635, 99.17787349091847, 109.5069106634511, 119.58008537677364, 129.2674476292666, 138.44644081450687, 147.00334019222691, 154.8345722009773, 161.8479146792014, 167.9635761679938, 173.1151495670465, 177.25043189052002, 180.33209815773606, 182.33821401257504, 183.26256893852846, 183.11481032200302, 181.92035843451242, 179.72008387907184, 176.56973228006797, 172.53908596843243, 167.71085897656656, 162.17932954145056, 156.04872315080888, 149.43136850469608, 142.44565810071808, 135.21385396384497, 127.85978681883446, 120.50650328032961, 113.27392001557189, 106.2765460235245, 99.6213339857195, 93.40571902276989], [19.272808907146285, 13.511447266501992, 8.956685398840252, 5.672828488803594, 3.7043448077061374, 3.07517711608698, 3.788494162799541, 5.826872937607032, 9.152889800421688, 13.710087600112148, 19.42427683400069, 26.20512210157481, 33.94796075246054, 42.53579876134785, 51.84142938390124, 61.729622829419604, 72.05933968720144, 82.68592673344179, 93.46326053548606, 104.24581144190094, 114.89060759459113, 125.25908505255165, 135.21881558424798, 144.6451078644969, 153.4224805206419, 161.44600665220935, 168.6225291638045, 174.87174469132208, 180.12715135318177, 184.33685239292012, 187.4642044175949, 189.4882958208554, 190.40423853946746, 190.223254913034, 188.97254140922922, 186.69489255654926, 183.44807169282223, 179.3039200685936, 174.34720229409183, 168.67419382512097, 162.39102478537973, 155.61180348205568, 148.45655199869603, 141.04899473627643, 133.51424822466922, 125.97646648974123, 118.55650035687478, 111.3696310121442, 104.52343775640324, 98.11585712214836], [18.583337476136258, 12.985702502195721, 8.617294757972003, 5.542364459600824, 3.8050194273901106, 3.428521709171415, 4.41502995146219, 6.745778854115443, 10.381674384174783, 15.264272255061954, 21.31709792878309, 28.447259389468613, 36.54729935365853, 45.497231475620794, 55.16670538596989, 65.41724785024323, 76.10453162082098, 87.08062925940345, 98.19621584936948, 109.30269158879892, 120.25420225575917, 130.90954200368154, 141.1339284859282, 150.80064462290315, 159.7925442281801, 168.0034201350042, 175.3392334702848, 181.71920148571056, 187.07673914964346, 191.36024688549725, 194.53373381887627, 196.5772630943667, 197.4872036590167, 197.2762717566247, 195.97334553532264, 193.62303784904717, 190.28501562689567, 186.03305906997082, 180.9538602707492, 175.14556837924388, 168.71609681073326, 161.78121677522478, 154.46247013258107, 146.88494274600686, 139.17494663970743, 131.45766492640738, 123.85481728924634, 116.48240550710258, 109.44859793747926, 102.85180897244274], [17.979851717738633, 12.548681402121803, 8.368270227492728, 5.502760334998294, 3.995864785147603, 3.8701505840325847, 5.1267726937896345, 7.745651014450798, 11.686069548806264, 16.887665645080865, 23.27176778863892, 30.743033204769592, 39.191331733588505, 48.49382010190128, 58.51715076461461, 69.11976171237345, 80.15419772010344, 91.4694190347295, 102.91305999720578, 114.33360706693193, 125.58247266937431, 136.5159477646833, 146.9970216453282, 156.8970619148054, 166.09735068841593, 174.49047471901778, 181.9815674360882, 188.48939996043623, 193.94731628143626, 198.30400530149922, 201.5240997562814, 203.5885895196662, 204.495034905585, 204.25756464119303, 202.9066435027184, 200.48859637462067, 197.0648788079215, 192.71108899103726, 187.5157222663711, 181.5786766774297, 175.00952617382262, 167.92558661598076, 160.44980814825269, 152.7085353667385, 144.82918353193904, 136.9378844416419, 129.15715913236565, 121.60367605605066, 114.38615262487261, 107.60345499509285], [17.45608858757386, 12.193674920710722, 8.202446095105891, 5.546384752115069, 4.268776683197789, 4.3914814275272605, 5.914658674585844, 8.816943083507294, 13.056047249879967, 18.56976109946502, 25.277306400340333, 33.08099768870276, 41.86815589501538, 51.5132184030786, 61.87998909942983, 72.82397397821836, 84.19475174356936, 95.83833419842182, 107.59947756537753, 119.3239127588235, 130.86046953352522, 142.0630759183903, 152.79262001983258, 162.91866584648548, 172.32101807398703, 180.89113255824557, 188.5333699612872, 195.16608922681777, 200.72257608747955, 205.15179962703823, 208.41898753928072, 210.50600851832544, 211.4115485721231, 211.15106732133162, 209.75652081109277, 207.2758392177953, 203.77215116481378, 199.32275114731007, 194.0178126686537, 187.95885686705822, 181.25699432605577, 174.0309660121906, 166.40501741808316, 158.50664754336563, 150.4642808687454, 142.4049155585686, 134.45180442472295, 126.72222644578915, 119.32540571441857, 112.36063154880972]], \"zauto\": true, \"zmax\": 211.4115485721231, \"zmin\": -211.4115485721231}, {\"autocolorscale\": false, \"autocontour\": true, \"colorbar\": {\"tickfont\": {\"size\": 8}, \"ticksuffix\": \"\", \"x\": 1, \"y\": 0.5}, \"colorscale\": [[0.0, \"rgb(255,247,251)\"], [0.14285714285714285, \"rgb(236,231,242)\"], [0.2857142857142857, \"rgb(208,209,230)\"], [0.42857142857142855, \"rgb(166,189,219)\"], [0.5714285714285714, \"rgb(116,169,207)\"], [0.7142857142857143, \"rgb(54,144,192)\"], [0.8571428571428571, \"rgb(5,112,176)\"], [1.0, \"rgb(3,78,123)\"]], \"contours\": {\"coloring\": \"heatmap\"}, \"hoverinfo\": \"x+y+z\", \"ncontours\": 25, \"type\": \"contour\", \"x\": [-5.0, -4.6938775510204085, -4.387755102040816, -4.081632653061225, -3.7755102040816326, -3.4693877551020407, -3.163265306122449, -2.857142857142857, -2.5510204081632653, -2.2448979591836733, -1.9387755102040813, -1.6326530612244898, -1.3265306122448979, -1.020408163265306, -0.7142857142857144, -0.408163265306122, -0.1020408163265305, 0.204081632653061, 0.5102040816326534, 0.8163265306122449, 1.1224489795918373, 1.4285714285714288, 1.7346938775510203, 2.0408163265306127, 2.3469387755102042, 2.6530612244897958, 2.959183673469388, 3.2653061224489797, 3.571428571428571, 3.8775510204081627, 4.183673469387756, 4.4897959183673475, 4.795918367346939, 5.1020408163265305, 5.408163265306122, 5.714285714285715, 6.020408163265307, 6.326530612244898, 6.63265306122449, 6.938775510204081, 7.244897959183675, 7.551020408163266, 7.857142857142858, 8.16326530612245, 8.46938775510204, 8.775510204081632, 9.081632653061225, 9.387755102040817, 9.693877551020408, 10.0], \"xaxis\": \"x2\", \"y\": [0.0, 0.30612244897959184, 0.6122448979591837, 0.9183673469387755, 1.2244897959183674, 1.5306122448979593, 1.836734693877551, 2.142857142857143, 2.4489795918367347, 2.7551020408163267, 3.0612244897959187, 3.36734693877551, 3.673469387755102, 3.979591836734694, 4.285714285714286, 4.591836734693878, 4.8979591836734695, 5.204081632653061, 5.510204081632653, 5.816326530612245, 6.122448979591837, 6.428571428571429, 6.73469387755102, 7.040816326530613, 7.346938775510204, 7.653061224489796, 7.959183673469388, 8.26530612244898, 8.571428571428571, 8.877551020408163, 9.183673469387756, 9.489795918367347, 9.795918367346939, 10.10204081632653, 10.408163265306122, 10.714285714285715, 11.020408163265307, 11.326530612244898, 11.63265306122449, 11.938775510204081, 12.244897959183675, 12.551020408163266, 12.857142857142858, 13.16326530612245, 13.46938775510204, 13.775510204081632, 14.081632653061225, 14.387755102040817, 14.693877551020408, 15.0], \"yaxis\": \"y2\", \"z\": [[16.575028679995533, 13.045357280809945, 9.787958112410214, 6.821953204661192, 4.165467206141658, 1.854510698707561, 0.6416146864526424, 2.1027807804047858, 3.501099783839739, 4.624647588328975, 5.473289110448883, 6.062215614458349, 6.412243750399299, 6.547709042077872, 6.495413098849659, 6.283774979086636, 5.942016819106485, 5.499350440249589, 4.984170807913547, 4.42327854657468, 3.8411647261010495, 3.2594032613791284, 2.696215249685746, 2.1663070064424517, 1.6811728101221024, 1.2503073047612896, 0.8845940074621941, 0.6055277340803988, 0.46113359389301056, 0.48490143099795396, 0.6041607312421873, 0.7385634673278193, 0.8534948117287061, 0.934550376344165, 0.9742397989065233, 0.968762015528488, 0.9183151553599883, 0.8293364317455243, 0.719370667740565, 0.6259164366025604, 0.6083332567174313, 0.7025103466966202, 0.8753135984814973, 1.0685524317467758, 1.2342633992202396, 1.3350518933382713, 1.3427028220243853, 1.246682006057059, 1.0909761044089583, 1.081478181764701], [16.440581814030374, 12.971846143165324, 9.776525835946083, 6.873285915025536, 4.280778357117699, 2.038823165923997, 0.6970307232806602, 1.8992479916151566, 3.231539363512329, 4.310266621778727, 5.1240539479497675, 5.685960192340822, 6.0161343445857325, 6.138573443245237, 6.07979900344678, 5.867932831454112, 5.531865513277298, 5.100444970294054, 4.6016755822899365, 4.061941576087048, 3.5052813033306123, 2.952751397888984, 2.4219384689337393, 1.9267128575632226, 1.4774067896840128, 1.0818516578665902, 0.748575752925397, 0.49644094398620753, 0.37415973103886757, 0.4141248269377089, 0.5360586919032101, 0.66664301961728, 0.7779286999840466, 0.8578036941169072, 0.8988350562287707, 0.8961312484632808, 0.8479740112623652, 0.757933367574995, 0.6394566483661, 0.526555248062158, 0.48684590232362573, 0.5749412303071544, 0.7524714574927417, 0.9508141813118781, 1.1195574073846686, 1.220437818309363, 1.2225341223003716, 1.108018056092616, 0.9061230052396354, 0.8361865792797258], [16.361124794894913, 12.965949940271873, 9.850522119712611, 7.037887611106106, 4.5602163486895, 2.5066742661790022, 1.3736320015557946, 2.0109879756456257, 3.1322973849504216, 4.109866544025325, 4.860010087854012, 5.377773764805907, 5.6769438485100645, 5.7786371204430385, 5.707771929253005, 5.491399163616778, 5.157583189180103, 4.734471363416963, 4.249441721230779, 3.728300578124096, 3.194535492937191, 2.66864911006575, 2.167621108266314, 1.7045846880667193, 1.2888974481490094, 0.9270598363681031, 0.6259193459707375, 0.40335753964515164, 0.31082523489893477, 0.37144173250929186, 0.49645647841890284, 0.6247710371009005, 0.7352362141070693, 0.8175216777920612, 0.8640215454831977, 0.8688421486459023, 0.8287680272125562, 0.7452576001279956, 0.6283319710836002, 0.5060442574983907, 0.4422275356622871, 0.5076107106613241, 0.6751171578364475, 0.870053743769047, 1.0381479884100608, 1.139226938676373, 1.139636941851658, 1.0150068842136515, 0.7774079554099962, 0.642776001187437], [16.3235251643392, 13.010667589134822, 9.98650240279972, 7.279792098867444, 4.936631751846471, 3.074049909838645, 2.066405602355589, 2.326645259793255, 3.173258313762015, 4.007146508369033, 4.669591545902855, 5.1285628987810155, 5.387194717758821, 5.461617165582069, 5.37399975323818, 5.149634696742253, 4.815310762304146, 4.398161528542413, 3.9247124136663007, 3.4200294683637473, 2.9069421227039354, 2.40534585597554, 1.931617875698996, 1.4982219013572995, 1.113682297253357, 0.7834269050723239, 0.5132238243281078, 0.3220180399299505, 0.26631921364851585, 0.3489988660540653, 0.4768579567934524, 0.6044466270928625, 0.7165024278513266, 0.8038408584616011, 0.8584503805740391, 0.8734931599185124, 0.8445821997510355, 0.7717228648274894, 0.6626018207578088, 0.5399856185365792, 0.45710009683467934, 0.48797990213991804, 0.6309369987519756, 0.8144830545521695, 0.9788145757201354, 1.0803618566148414, 1.0826895670362242, 0.9564395838150115, 0.6988351163971565, 0.5043017687973534], [16.315169344656088, 13.089822808861832, 10.16255396832098, 7.5667363281914755, 5.35659366035479, 3.649992326052435, 2.7066435538585596, 2.725785755320671, 3.310194569248184, 3.9800479534466513, 4.538606319964936, 4.927891662394688, 5.138674427342321, 5.1808218692324, 5.072938374370952, 4.838022635030254, 4.501217256189483, 4.088371254454646, 3.6249526801778416, 3.135132332498915, 2.6409704209368194, 2.161688612707273, 1.713043380423951, 1.3068630819237874, 0.9509279328766013, 0.6497608580736125, 0.4085524384677359, 0.2499843635676529, 0.2366417788229246, 0.33900810051264907, 0.4690791446499432, 0.5972592797554422, 0.7126512201825862, 0.806582793446179, 0.8704285276625666, 0.8964198268483432, 0.8791532939765317, 0.8174734750039577, 0.7172811549727319, 0.5972050608079281, 0.5003695477965999, 0.4955665817932045, 0.605836770077198, 0.7726452012580686, 0.9313011110118281, 1.0338053374344085, 1.0409410427699022, 0.9200035331275385, 0.6586534534079117, 0.42252770493050573], [16.32432516702727, 13.188665772704018, 10.35939032115288, 7.8722854802504365, 5.78317395238746, 4.19581372618962, 3.2834586410538638, 3.1375001716547675, 3.499677618273131, 4.004616442020598, 4.451711100325881, 4.764729109242693, 4.922886606081843, 4.929453059394222, 4.799047463430052, 4.55202849244468, 4.211621077269023, 3.802174580837922, 3.3479266937121293, 2.8720143961211226, 2.395622402391327, 1.9372265880482216, 1.5119291626916067, 1.130930261170132, 0.8013072843071307, 0.5267499989266582, 0.3122721708422022, 0.18823039360522734, 0.21942822054374606, 0.3356158510664854, 0.46678904615492156, 0.5963483033601528, 0.7160622448394035, 0.8171880490434865, 0.8903178645695434, 0.9267601385425905, 0.9201752226720586, 0.8683650057154711, 0.7756831043369726, 0.6574677532631238, 0.5491185757117689, 0.5123127758287838, 0.5878525041318945, 0.7353502839495584, 0.8875731046562584, 0.9916511680458349, 1.005599755609256, 0.8946034080835221, 0.6418359224832753, 0.39065546064119316], [16.34037727752671, 13.294205012151581, 10.560781318816263, 8.176003883483597, 6.1924075582621345, 4.694453190476731, 3.7945181527919263, 3.5270293765206264, 3.7076381429738903, 4.0585672592556925, 4.393935479543766, 4.62823174051558, 4.731517222156959, 4.700913410423101, 4.547006358828501, 4.287357406664335, 3.9431067435679603, 3.536951520979752, 3.091766223040784, 2.6295425831175674, 2.170502457019482, 1.7323175145283647, 1.329413148428598, 0.9723806278943615, 0.6676533969641053, 0.4181838648451129, 0.2293910436994568, 0.14472219410088788, 0.2140045106754834, 0.33540519064489727, 0.4658582131514624, 0.5968702529851277, 0.7211870966703491, 0.829448749771769, 0.9113232995591928, 0.9572123186887537, 0.9599070547959149, 0.916251126184017, 0.8292167394436942, 0.7114600718197097, 0.5925776840653828, 0.5276411237525609, 0.5691852220948734, 0.6964912595489866, 0.8422409351752593, 0.9484672707384455, 0.970360990488518, 0.8717269789467025, 0.634508462442286, 0.3905457458038451], [16.353951063749076, 13.395322673133338, 10.753528376270046, 8.462680553184223, 6.569145415596181, 5.138076127621181, 4.239859093051809, 3.8777287712927584, 3.9104949272046543, 4.123346848795927, 4.351847390495298, 4.508403653813198, 4.556843315421458, 4.489080298894723, 4.311907779814724, 4.040095284376254, 3.6926285103384893, 3.2904635412786916, 2.855025803335339, 2.4070905182195896, 1.9658699890445726, 1.5482227265784592, 1.1679472086916731, 0.8351718944478214, 0.5560068806487916, 0.33341261472832845, 0.17564915685714075, 0.13631735983019128, 0.2203779563680942, 0.3368662213811005, 0.4639391904241618, 0.5957519664435919, 0.7243919500651259, 0.839337324289707, 0.9291926988006033, 0.9834693282015593, 0.9941562224498581, 0.9572251520975411, 0.8744187998968981, 0.7561547151472473, 0.6274729265796899, 0.5375178107176338, 0.5463087741614547, 0.6530298430634314, 0.7924419626155282, 0.9011349347918495, 0.9312829036308129, 0.8456500367845495, 0.6265418390652617, 0.40215379948652047], [16.356949133306106, 13.482739981892275, 10.927192175016751, 8.721300379191966, 6.903970907622735, 5.523200322881335, 4.620493007002994, 4.18166097625632, 4.0930242985152425, 4.184696391439506, 4.314198238007676, 4.396544444949058, 4.3920364119045905, 4.28851895644968, 4.089412866578323, 3.806823462974772, 3.457594332215498, 3.060912251720533, 2.6367200397796977, 2.204559775264497, 1.7826562919348337, 1.3871472912317033, 1.0314239655184894, 0.7256164461561047, 0.4764945381870795, 0.2891823689716218, 0.17667339040848404, 0.16812462400606626, 0.23787542592149594, 0.33961321022961205, 0.45988167528345403, 0.5912265509390845, 0.7235272027216084, 0.8445256934961884, 0.9416058996691431, 1.0033968709640646, 1.0211509037006956, 0.9900598942739633, 0.9107856609182682, 0.7918491634704099, 0.6545333287061333, 0.5424054860773792, 0.5194752876566501, 0.6047819176952208, 0.7375924810836079, 0.8485339324312229, 0.886402456922661, 0.8130071284035211, 0.6116433913964392, 0.41202089831441063], [16.342525622780368, 13.548893402651768, 11.073722816123956, 8.944089289552666, 7.191192006277097, 5.848629013869785, 4.937967483739498, 4.435298841694444, 4.245863337038169, 4.232310472404376, 4.272107260037566, 4.285472790533413, 4.231344832211506, 4.09462306801803, 3.8758593086296456, 3.5847012723365, 3.2359262354567946, 2.846977817697491, 2.436337436607719, 2.022363480504499, 1.6224077353427675, 1.2521208618064414, 0.9249283799637673, 0.651731006330607, 0.4409791306822056, 0.29911882378204524, 0.22913818843252806, 0.22308542737559972, 0.2646172101599401, 0.3437506223844929, 0.4532762893441261, 0.5824374802571667, 0.7175329119746315, 0.843944522926791, 0.947649358908161, 1.01639167557552, 1.040752296314507, 1.0152430216464, 0.9396000627490244, 0.8207496352658765, 0.6768112111888155, 0.545923890623597, 0.49247303819747273, 0.5544738624270636, 0.6793075499965314, 0.7913170115957177, 0.8353775286270846, 0.7722473270134377, 0.5864121608631372, 0.41366217580657694], [16.305020621242832, 13.587767306262963, 11.187080959200985, 9.125738646711998, 7.427585223787781, 6.114492660829098, 5.194193465417992, 4.637525402927724, 4.363581540505196, 4.259148812138378, 4.218942072763114, 4.169566703626262, 4.070165558381105, 3.9036850644437777, 3.6683223693331874, 3.3715155832283576, 3.0260956742956275, 2.647834144710804, 2.2538229270736947, 1.8613501556008232, 1.4870923699351009, 1.1465383750817615, 0.8535830338842685, 0.6200375653291091, 0.45391135170811553, 0.3540715664863073, 0.3048785296022001, 0.2870370337102998, 0.29800875496755835, 0.3494854531872619, 0.44419264370878025, 0.5691995123258174, 0.7061860304026731, 0.8374939408927635, 0.9474760005916669, 1.0229825312036778, 1.0539927384233523, 1.0344507940225323, 0.9633405740884398, 0.8463041850979574, 0.6988666079107789, 0.5540146326475212, 0.47266375207920874, 0.5082768818153568, 0.621660617858532, 0.7319106038244779, 0.7793092241460637, 0.7232551378508348, 0.549463739818596, 0.4054195337454816], [16.239872233773422, 13.594713689932252, 11.262893165235123, 9.262812527880007, 7.611611743916994, 6.321766028415922, 5.391363527121862, 4.788648437089632, 4.443374682492646, 4.2607229184181366, 4.150048007172134, 4.0446810085831455, 3.905031009910128, 3.712907790292911, 3.4646345916400483, 3.165700059272657, 2.827134141123842, 2.46313748387166, 2.0895179812409714, 1.7226380047726146, 1.3786947991225285, 1.0731855849263219, 0.8202025393445942, 0.6304147465027944, 0.5057008706303958, 0.4326505408777124, 0.38732353825134835, 0.3533181289500259, 0.33544978954765, 0.3569732126345937, 0.4330971796774862, 0.5519220239782361, 0.6900006447016255, 0.8259091307073447, 0.9421325722527129, 1.024620201787785, 1.0628302404121217, 1.0502680506982005, 0.9853613891876001, 0.8728087784356755, 0.7261699835921427, 0.5739454934447111, 0.47037017754291655, 0.47645997864109363, 0.5717787097335207, 0.6748049289541982, 0.7208333994558718, 0.6672748929907575, 0.5010417735006186, 0.3893424166867706], [16.14351890740633, 13.566277066838095, 11.298157085781106, 9.353307099330562, 7.74292092212702, 6.472005525060623, 5.531906048361226, 4.889882630360856, 4.484218091974335, 4.234487581802482, 4.062432304988561, 3.9079982268667064, 3.733539677844199, 3.5203733278941223, 3.2633731781613644, 2.9663288237227583, 2.638619756085448, 2.2929836045345167, 1.9440441261644048, 1.607331668627945, 1.2985690871074493, 1.0328578860069675, 0.8228620501580269, 0.6744257515615808, 0.5802567863065214, 0.5195637674993098, 0.4694675230386267, 0.41857707941987915, 0.3747490979334429, 0.36635060952000376, 0.42092407395745235, 0.5316831925882285, 0.6702656162417151, 0.8107522239956371, 0.9335072986289229, 1.0235846860367477, 1.0700166437708496, 1.0660116407971325, 1.0096491341370233, 0.9050303064419463, 0.7643864198356423, 0.6126910428166317, 0.4959970004235353, 0.47232393692871205, 0.5402048088640864, 0.6270476954902473, 0.6645423151682212, 0.6072744202153527, 0.4433752555932958, 0.3716053531128343], [16.0133004199114, 13.500033866714652, 11.290997671029205, 9.396326153177409, 7.822028407076829, 6.567195775140723, 5.618455042383243, 4.943059487338814, 4.486321260229728, 4.179364368469235, 3.954461763226225, 3.7578543790115653, 3.554256118230394, 3.324984698704964, 3.0638247282488855, 2.7730895199267707, 2.460639609196815, 2.137826464763065, 1.8181163733076624, 1.5161198429630405, 1.2466656192065533, 1.0232365164999748, 0.8546379878773972, 0.7397058422426311, 0.6642741930560631, 0.6065325666260781, 0.5478393043034436, 0.48080368754541786, 0.41427648029797026, 0.3778898115674594, 0.40927038264733123, 0.5104423874587027, 0.6491952727238232, 0.7944896975403175, 0.9243413368246034, 1.0229375979079618, 1.0789903901368523, 1.0855506182679282, 1.0405349426556403, 0.9477259603034351, 0.8184951016790166, 0.6750689870744091, 0.5553921336692278, 0.5068681056357354, 0.539274655412107, 0.598391688544714, 0.6176771622034997, 0.5489538150291551, 0.38240438549036665, 0.36387779992608393], [15.847362667081176, 13.394450085345499, 11.240469140067056, 9.391841884611129, 7.850101600257562, 6.609653593755998, 5.653827326026365, 4.950454345698774, 4.45077234419318, 4.09538293573226, 3.8255990586561945, 3.5935656841216193, 3.366599490165715, 3.126393713739429, 2.865935886519627, 2.586239461889384, 2.2937253881612913, 1.998349705338078, 1.712283101844487, 1.448813301261151, 1.2209420434420204, 1.0388767725001158, 0.9059636724265699, 0.8149509513669083, 0.7490631344903781, 0.6889524025029085, 0.6203400174728999, 0.5386869002298852, 0.4530087065617374, 0.39219985396407303, 0.4006571239333915, 0.49135113072081643, 0.6301405607438287, 0.7805892673447987, 0.9182298472995308, 1.0264401692432426, 1.0937115838598626, 1.1130440504900028, 1.0823034631628625, 1.0050738626901696, 0.8919987909405923, 0.7627891369814399, 0.6479405381473079, 0.5824911002416919, 0.5780767230178483, 0.5997818754663767, 0.5905354756806566, 0.5024710288854942, 0.3321191260703884, 0.3828366311509557], [15.644569048360946, 13.248757657630563, 11.146395380057443, 9.340517090348175, 7.828812242563696, 6.601963658155054, 5.641003319794497, 4.914676673833547, 4.379301408472547, 3.9834151963056867, 3.676183983888949, 3.4152700109741296, 3.1707334502308444, 2.9249249215506183, 2.6702562111812416, 2.406545977898602, 2.138756818811805, 1.8752839375505035, 1.6266134899307096, 1.4039585258848, 1.2173029245143812, 1.0723994747741574, 0.9673983301404437, 0.8916929340751794, 0.8291531003465072, 0.7639807121506957, 0.685563724332227, 0.5914284365864073, 0.4905565635997936, 0.4103993752985047, 0.3987059137547118, 0.4790143701254742, 0.6177262685426492, 0.7735171463363255, 0.9195096875003177, 1.0383500346220746, 1.1183723040132922, 1.1525613332429003, 1.1387246084358629, 1.0801609004027823, 0.9865764696315731, 0.8749706321264145, 0.7691896715720011, 0.6938376400662915, 0.6578175485736167, 0.6394218294745105, 0.5950862238660434, 0.48359551114356275, 0.3195810637451353, 0.4433882668054306], [15.404419683719498, 13.062848321686804, 11.00924146063814, 9.243571345642607, 7.760231810859716, 6.5469324530227375, 5.583109730831207, 4.838596137059915, 4.274118449552691, 3.844978642123844, 3.507256811317122, 3.2237889842324208, 2.9674651117431456, 2.721502329744604, 2.477876631291497, 2.2352083681234007, 1.9968249048875408, 1.7691713685949029, 1.5603896237832773, 1.3786888768093752, 1.2301408878350903, 1.1160418139263946, 1.0310724037020316, 0.9639829848502467, 0.9009583022487673, 0.8297168172411243, 0.7425908466038579, 0.6387182992914795, 0.5271958839515521, 0.4341869743557095, 0.4079398985593621, 0.47933226815745805, 0.6176439161108256, 0.7784563086867424, 0.9329183667686592, 1.0630307262687901, 1.1569637317310992, 1.2076238440984042, 1.2126208359303796, 1.1747120943288551, 1.1022860854714929, 1.0093899957627728, 0.9141698219772424, 0.833576155701682, 0.7733372234812302, 0.7192729754064038, 0.6407072737076347, 0.5098426577149362, 0.37247753614662515, 0.5506888953719113], [15.126978707665428, 12.837182991032936, 10.830009827396248, 9.102678690900852, 7.646754781324672, 6.447553172568748, 5.483403279041962, 4.725289740183577, 4.137799233016003, 3.6820899128982916, 3.320417734985724, 3.0205121525817944, 2.758157263156464, 2.5175826911821955, 2.290363289314226, 2.0737544712985563, 1.8690472313486248, 1.6800974029676774, 1.5118891979012632, 1.3688958836337024, 1.2531859872737008, 1.1627376366773485, 1.0909011712996142, 1.0276324534524754, 0.9620088243469699, 0.884874326118632, 0.7909515310410632, 0.6807759586453224, 0.5638927194188957, 0.4657482956726768, 0.43293779797904647, 0.49843804070668535, 0.6357880526098107, 0.8005957367763542, 0.9629731422992214, 1.1043891771700733, 1.2127695302288366, 1.2807846127078821, 1.30561101224179, 1.289139722406164, 1.238091393903873, 1.163515590013665, 1.0788857289716667, 0.9958689156368581, 0.9180211273242199, 0.8359477588422547, 0.7301665272441187, 0.5903916798954251, 0.49157352154063516, 0.7021107155443754], [14.812809308179949, 12.57271444906815, 10.61015585354366, 8.91988800839389, 7.4910404163886435, 6.306977450472138, 5.345255078400558, 4.5780019123663305, 3.973202327189434, 3.4971546218890284, 3.117715966952449, 2.807302541035944, 2.5446559175099828, 2.3150965099949588, 2.1096821005089574, 1.9239005876956645, 1.7563341672618018, 1.6074335116838625, 1.478337723695068, 1.369652615180439, 1.2802671199795725, 1.206540658364925, 1.1422765386303029, 1.0796180272741678, 1.0105678385142827, 0.9286714172129491, 0.8306650546070891, 0.7184203673667248, 0.6022954175053394, 0.5074854616230791, 0.47707686221750417, 0.540847014320356, 0.6768012515630267, 0.8440887928936134, 1.0131959442958678, 1.1652849562212542, 1.2879369913299892, 1.3733833120543857, 1.4181034779693258, 1.422828862370553, 1.3924015354650743, 1.3350342239358421, 1.2604903086795949, 1.176882598758452, 1.0866879179321867, 0.9843986788003204, 0.8605242802484717, 0.7224056939833696, 0.6616832498119316, 0.8937448080733684], [14.462915873547054, 12.270821264726104, 10.351518502181637, 8.697559870834194, 7.29596713530568, 6.128491528176521, 5.172135528782209, 4.400112912052367, 3.7834070245122033, 3.2928835335606994, 2.9015629766978224, 2.5864223766135384, 2.329234131192955, 2.116394985938338, 1.938103658411862, 1.7873616972284285, 1.6591207645734023, 1.5496545385194607, 1.456054746967424, 1.37571609662066, 1.3057748259988073, 1.2426198428198727, 1.1816888024070331, 1.1177174551134017, 1.0454655709825855, 0.9608319245564233, 0.8623249147961947, 0.7531460108720963, 0.6446573911042102, 0.5616404096313472, 0.5417320857522692, 0.6080960025062765, 0.7428239049735164, 0.9111493108710261, 1.085494625171995, 1.2471328557444965, 1.383276290346479, 1.4855439046200372, 1.5494949568966463, 1.5744978394718925, 1.5634528091513753, 1.522014199439066, 1.45704721451049, 1.3743143939729845, 1.2760671656921299, 1.1604853202025152, 1.0271455666943559, 0.898452248573799, 0.8722238876025606, 1.1232225670916698], [14.078692478919399, 11.93325104494296, 10.056262777370021, 8.438315474248942, 7.064595635293894, 5.915495461361654, 4.967599719491858, 4.195112900398258, 3.5716657440031647, 3.0722283291559562, 2.6746657856568814, 2.3604782380643106, 2.114552367415123, 1.9241968936074905, 1.7780713512300086, 1.665603785685442, 1.5771032830407907, 1.504289097373779, 1.4407444812095158, 1.3819482518913784, 1.3248362897291017, 1.267086573135857, 1.206434433228919, 1.1403186349042187, 1.0660614994848236, 0.9816600537296624, 0.8872182944166632, 0.7871779412654692, 0.6936597035835861, 0.6299555616139904, 0.6264809716423345, 0.6989928811821591, 0.8333365489168079, 1.0017996834738725, 1.179986299324388, 1.34984611845867, 1.4983328731154149, 1.6163707813017936, 1.6984604357043387, 1.742507559076801, 1.7495166885213997, 1.7228991063233718, 1.667272242235688, 1.5868908124405008, 1.4844011120255811, 1.3616516540059063, 1.2263796329995322, 1.1127322870308374, 1.1187587178197052, 1.3897628872684182], [13.661876917672014, 11.56207140077274, 9.726831398016062, 8.144994551239705, 6.800138261200891, 5.671484551732343, 4.735273448564194, 3.9665802022583225, 3.3413670003313096, 2.8383326020364166, 2.4399778940765753, 2.132386049151547, 1.9036347253895658, 1.7415224381476722, 1.6320097443968555, 1.5595469915192863, 1.5090415155340464, 1.468026063923613, 1.4278362222603511, 1.3835835681104325, 1.3333113983092717, 1.2768040174751694, 1.2144326002625248, 1.1463514606413687, 1.0723008012259072, 0.9921815485537059, 0.9074686409186715, 0.8234663411053643, 0.7521318763212587, 0.7134966636265004, 0.7298820302715058, 0.8108997240386747, 0.9460075783201581, 1.1143150263113253, 1.2952781204131227, 1.472083674515213, 1.6316505434416626, 1.76423216748249, 1.8632278398370654, 1.925071669524445, 1.9489859036110817, 1.936447271902777, 1.8903409209213897, 1.8140216156644358, 1.7109785389581218, 1.5867119333160953, 1.4561763071276168, 1.3621864821611485, 1.4000916387741393, 1.693629316686984], [13.214509513693146, 11.159627263196024, 9.365903727022369, 7.8206200625414315, 6.505932981085221, 5.400032559270266, 4.478840054631446, 3.718163031016344, 3.0960067196212147, 2.5944956842334412, 2.200667370296005, 1.9053580841911286, 1.699857691183413, 1.571589909228133, 1.502051322086494, 1.4692590694215586, 1.4526909021851533, 1.4369488870054679, 1.4127878562465792, 1.3763546156036541, 1.3277137748809642, 1.269239778219677, 1.2041398439211726, 1.1353213989272275, 1.0648652322167176, 0.9943558221043228, 0.9261750426882169, 0.8655718021369104, 0.8227190037104548, 0.812660135893612, 0.8501462150820487, 0.940838433160304, 1.0777240321537829, 1.2459482985972379, 1.4289691708792904, 1.6116330798946579, 1.7810903053168214, 1.9270286825689955, 2.041783544129695, 2.120375416441933, 2.160393753387756, 2.161665828141499, 2.1257581949632725, 2.055580861643957, 1.9557886004800324, 1.8354601070411398, 1.7158000861167992, 1.6457261438185073, 1.716521496128125, 2.035684961006405], [12.73889601013706, 10.728503419981719, 8.976360453889093, 7.468368102956879, 6.1854208950721326, 5.104776500306424, 4.202028365596608, 3.453564521992057, 2.8391669850839083, 2.3441487531795975, 1.9601041804451154, 1.6829162888501894, 1.5069407811902291, 1.417635714980974, 1.3896782932769711, 1.39371370049873, 1.4048997597728854, 1.406833204023422, 1.3913088176719413, 1.3565250530414497, 1.305123376909981, 1.2423816446104776, 1.174559128445377, 1.1074557612337341, 1.0454436947399348, 0.9913586920675931, 0.947490973111072, 0.9174045883101773, 0.9075842281741211, 0.9272960558550096, 0.9854707490893962, 1.085996839022995, 1.2252534833061677, 1.3935305956201878, 1.5781176970263462, 1.7657666129425313, 1.9441032674576324, 2.102394983242971, 2.232002198385823, 2.3266315162950977, 2.3824041160121103, 2.397755392108441, 2.3732714277065488, 2.31176738716189, 2.219286962848143, 2.1083378787508935, 2.0054009984420387, 1.963423672929011, 2.069026696640017, 2.4171057818748314], [12.237573899055308, 10.271491348005643, 8.561252888823487, 7.09154191534662, 5.8421265979155335, 4.789403032578766, 3.908602219565758, 3.176531454263801, 2.5745025299698674, 2.0908448425281665, 1.7218725915915987, 1.4689378084275968, 1.3289110046555663, 1.282606336688242, 1.2953224594924906, 1.3307032159090364, 1.3618565735853367, 1.37344205228245, 1.3595039330551717, 1.3208831481849543, 1.263127997994639, 1.1947292141419565, 1.1253651541013918, 1.0640122815161106, 1.0171655283378367, 0.9879009864655608, 0.976545810447938, 0.9828315053240504, 1.0082310385425601, 1.056861114841274, 1.134133513054467, 1.2438294997443868, 1.3855086481824557, 1.553811666831531, 1.7395540092484139, 1.9314926950235642, 2.1179187233632573, 2.287827936159046, 2.431718011288895, 2.5421003772053807, 2.613792892868858, 2.6440683908123708, 2.632811543590434, 2.5830119467294708, 2.5022376108561803, 2.406193341889385, 2.325669694759317, 2.3159812036415555, 2.458877171804436, 2.8392025575528215], [11.713281623654613, 9.791559585005231, 8.123776004326354, 6.693549241727865, 5.479641005358064, 4.4576366162027945, 3.6023522521768205, 2.890847697454866, 2.3057368158477427, 1.8382675782371747, 1.4898204352858817, 1.2677359976142717, 1.1699776258868697, 1.1686844094038555, 1.2180324362347519, 1.2769666297251003, 1.3194304616182653, 1.3327817166535159, 1.313968717287475, 1.266740825325361, 1.19982136009302, 1.1253922122679734, 1.057216981336681, 1.0078543998959468, 0.9852307719211967, 0.9904616790184078, 1.0191004053744852, 1.0652412897006398, 1.1254764396928334, 1.2005504672598464, 1.2944851514263447, 1.4120020037874441, 1.5555866098063076, 1.723594036236695, 1.9100419615790085, 2.1056998260022115, 2.29965357458167, 2.4807576983695467, 2.6387592772100357, 2.7650940654831966, 2.8534309369734356, 2.90007994494866, 2.9044524864544523, 2.869912014013269, 2.8056022063978947, 2.730111820197017, 2.6775974044522566, 2.7044132631079805, 2.887435143779703, 3.303308226434534], [11.168930143967684, 9.291827022996868, 7.667244577201898, 6.277882497812545, 5.101606493871593, 4.113229867843396, 3.2870910453686144, 2.6003344091163245, 2.036671873592748, 1.590268940542026, 1.268166285228549, 1.0841614371760186, 1.034199483509994, 1.076687581130935, 1.155360963085094, 1.2285274027145745, 1.2735415481214447, 1.281321261912072, 1.2518829582021564, 1.191982812285095, 1.1139005511650553, 1.0343802749309683, 0.9724296821731522, 0.9444653917262469, 0.9576682482610082, 1.0071761008512032, 1.0809044811444786, 1.1672090265535455, 1.2595439621913638, 1.357395097699114, 1.464917516274885, 1.5883087284478146, 1.7327240104533428, 1.8997547387636995, 2.0863395232009356, 2.28522316166316, 2.4863665618042448, 2.6785827649178082, 2.850963900979606, 2.993975807432661, 3.1002727773691627, 3.1653693857782685, 3.188383075537131, 3.1731838307734606, 3.130459822444638, 3.0812974061464553, 3.062315498097379, 3.1298581863495025, 3.356044335463409, 3.810704341990222], [10.60757640364885, 8.775538616581313, 7.19507195788359, 5.848101470305986, 4.711704439933318, 3.759956859217985, 2.966653437323392, 2.308860701174319, 1.771220214239347, 1.3509564641796599, 1.0616970136913266, 0.923640808153772, 0.9247949181611943, 1.0055290765672782, 1.10358815572124, 1.181174857146873, 1.2205304314827674, 1.2162187374530788, 1.1711692547518844, 1.0952357046939678, 1.0049663805906002, 0.9233110960563248, 0.876386572883957, 0.8835636648114451, 0.9458202689559231, 1.0470468756926956, 1.166908112423786, 1.2903670054961767, 1.410215978477387, 1.526331109264893, 1.6438396125575148, 1.7706088528444301, 1.914239075758665, 2.079222513840831, 2.265206922827538, 2.4668663784459213, 2.6750805905628177, 2.878686266217525, 3.0661878955308417, 3.2271615212511273, 3.3533526735635446, 3.439610639128441, 3.4848877508172906, 3.4936260884836416, 3.477947252217839, 3.4609896049405755, 3.480989239736294, 3.593463880403185, 3.8659642594062644, 4.362571771166891], [10.032398267704485, 8.246043086503981, 6.710751141048985, 5.407818438014, 4.313645534388785, 3.4016106628362546, 2.6449050767272477, 2.0203716037126873, 1.5134749360404902, 1.124868951094483, 0.8760859937117218, 0.791900284252755, 0.8430672227320977, 0.9520585852786055, 1.0582780450009266, 1.1310159925035008, 1.157554028709025, 1.13564505120176, 1.0708362352509377, 0.9763183299575919, 0.8743187534684, 0.797159057044121, 0.7804161957939612, 0.8409758177311538, 0.9635860616029288, 1.1184134788899092, 1.280645552233343, 1.43548947717222, 1.5769929438323278, 1.7062521484925033, 1.82966956903134, 1.9567892702556064, 2.097486594673375, 2.2589460915560853, 2.443394023359463, 2.64740253872615, 2.8627901013941597, 3.0784452358207246, 3.2823141188387948, 3.463126709490365, 3.6117882929415237, 3.7225700557452264, 3.7943340854039773, 3.8320921929340255, 3.8492143277586424, 3.8704048783055653, 3.9347477470133017, 4.096317317834237, 4.418329618296932, 4.959957181334081], [9.446670516322813, 7.706772266931905, 6.21783794872651, 4.960685846273909, 3.911163673706807, 3.042007429894602, 2.3257647256307745, 1.738946121891249, 1.2678492848118663, 0.9173098507432028, 0.7182678756889844, 0.6938608499553337, 0.7873378638219827, 0.9115306072705424, 1.015056475649551, 1.0750829096447254, 1.0831139277468234, 1.0393874778380086, 0.9517813169846137, 0.8374288990742743, 0.7271607633691332, 0.6687347596427148, 0.7066445973487555, 0.8385547289974389, 1.0244611361163285, 1.2272933310338128, 1.42405718507098, 1.6027114624261565, 1.7592315751332124, 1.8960543584625098, 2.0208429938582135, 2.144751958270328, 2.279832062200786, 2.435868589145449, 2.617623727600597, 2.8235680956536253, 3.0464640036584947, 3.2752400081425574, 3.4972654163587555, 3.700420324631646, 3.8747917857583523, 4.014110548414441, 4.117165696204827, 4.189469380978217, 4.24539093314194, 4.310696414077845, 4.424638419718676, 4.639400748300682, 5.014124909922834, 5.6037503417937975], [8.853741476205029, 7.161221797036316, 5.719936284451209, 4.510386975440647, 3.5080149445691586, 2.685001129114598, 2.0132505437274473, 1.4689098895785064, 1.0393448794861562, 0.7349262479183255, 0.5963630368237659, 0.6313247097069479, 0.7527319610908966, 0.8786507479674536, 0.9705004375238454, 1.0120879704430086, 0.9979462821993306, 0.930130406268554, 0.8187810364562522, 0.6865141811005987, 0.5792543582566956, 0.5691072664148615, 0.6905816273097, 0.8980023126587343, 1.1374116081395755, 1.3765945117463252, 1.5977505926980844, 1.7917818334980795, 1.9562548963795612, 2.0946800446381015, 2.215836006793963, 2.332421597105368, 2.4586443382965038, 2.6069128293387887, 2.784578918620651, 2.992057361378159, 3.2230500831799094, 3.4664679177453803, 3.709024552509443, 3.9376863584353616, 4.141687820796444, 4.314201063040715, 4.453899565633377, 4.566663595609177, 4.667563528242584, 4.7829275648414855, 4.95159822042747, 5.223564932556753, 5.654168924010719, 6.294669176058717], [8.257009845015833, 6.612932898140411, 5.220685604343041, 4.0606305361713755, 3.107984523174686, 2.3345167042619597, 1.7115701186421943, 1.2150496115641163, 0.8340473636269674, 0.586447957439296, 0.5175844870566325, 0.6005558425084162, 0.732381319947685, 0.8489075406167489, 0.9231514913277894, 0.9435591887545945, 0.9067167758853557, 0.8162988615480785, 0.6856325704519486, 0.5473825485145621, 0.47553714488333676, 0.5568118496703109, 0.7664254404660349, 1.0303866996925917, 1.304935260970227, 1.5665749226981465, 1.8014792758964875, 2.0022839727712936, 2.1674380109221216, 2.3011635823537886, 2.413201256571244, 2.517770179556992, 2.6313047556012674, 2.768978222399963, 2.940895552644865, 3.1495207270394188, 3.3894840328029083, 3.649563807887726, 3.9156624205988395, 4.173693502966909, 4.4119380379826145, 4.622930473970674, 4.805126954796394, 4.964589300301874, 5.116759541859865, 5.288055660805061, 5.516436761211379, 5.849513644455905, 6.339106056203438, 7.03325058128163], [7.659901213019972, 6.0654750116865275, 4.723751027187445, 3.6151509838924345, 2.714906846777964, 1.9946168816304866, 1.4252936143306307, 0.9830157147943068, 0.6599256003374459, 0.48240309296782635, 0.48272739444971563, 0.592544558522802, 0.7195870707271821, 0.8199611545990916, 0.8748275604683773, 0.8757230552744844, 0.8212011070862854, 0.7179421637541342, 0.5869506185945381, 0.4821017584106414, 0.5014808789866544, 0.6776703458113863, 0.9406326601831362, 1.2333044727057456, 1.524749291333076, 1.795967742844975, 2.0346058250413246, 2.2338002466888414, 2.3922765156494936, 2.5146812828726746, 2.611615764250507, 2.6988568023530872, 2.7952311300145154, 2.9189486110222598, 3.0831622785233934, 3.2925678143503805, 3.542704853904137, 3.8220291229586976, 4.115375674119803, 4.407373047379542, 4.685171274009123, 4.940524976668343, 5.171517140116639, 5.38416350413288, 5.593938251291756, 5.826923691645789, 6.1198277544499184, 6.517795870265609, 7.069402528841316, 7.819845667009168], [7.065843703797758, 5.522429108437491, 4.232816960713828, 3.1777179587782154, 2.3327096266968734, 1.6696339445101334, 1.1596890874362262, 0.7800338362205006, 0.5274702573070345, 0.4301031584961648, 0.48185493529181805, 0.596692167846189, 0.7099923139814311, 0.7931115396185541, 0.8324434237520991, 0.8223045333603646, 0.7648345020293259, 0.674066399702595, 0.5864193239709435, 0.571361254311335, 0.6875671503012158, 0.9135940679333352, 1.1965459022855631, 1.498037929459647, 1.7927836232848617, 2.0630121082528197, 2.296435090420368, 2.4860237827255602, 2.6304435795985888, 2.734605731951185, 2.809939932041067, 2.8738821573613573, 2.947916264821972, 3.0537105418085546, 3.2079260951074806, 3.417775781618325, 3.6796778799699417, 3.9814712547003985, 4.306534892757551, 4.637865063000556, 4.961218775078507, 5.267367975902661, 5.553823198048249, 5.826303278442141, 6.099986902282284, 6.400257887118891, 6.762306413805384, 7.228803391188459, 7.845346254570828, 8.65461845575444], [6.478242037909815, 4.987371530020369, 3.75158593064313, 2.7521614687202725, 1.9655035908632708, 1.3644336560830008, 0.9213683776083379, 0.615858193092314, 0.4473937353174898, 0.4236239883584543, 0.49887810712748415, 0.6049876134732317, 0.7033453818938271, 0.7749225434572026, 0.8100013915376986, 0.8065885088427889, 0.7728887520501981, 0.7324859026474055, 0.728045447605788, 0.8061621097873051, 0.9808315500903917, 1.228684383503298, 1.5166181492542543, 1.8162458745443109, 2.105173489465996, 2.366071528783107, 2.5864100033956015, 2.758830739529538, 2.8818395853316003, 2.960564232423622, 3.007287336381485, 3.0412583494374683, 3.0869818964305584, 3.1701821027163883, 3.311703363976457, 3.521702694861098, 3.7974267982048118, 4.125655151318191, 4.487744536055219, 4.864572792922593, 5.240153400359479, 5.604021355418042, 5.9528890342282885, 6.2919260292207735, 6.635720923013521, 7.0086696211035955, 7.444271072143212, 7.982772189219237, 8.667049460552054, 9.537547338084051], [5.9004491661383796, 4.46385831920223, 3.283785821905864, 2.342426183097009, 1.617765839586842, 1.0849586003876255, 0.719428284072774, 0.5025128132555073, 0.4209714790666228, 0.4434897778995846, 0.5202544256040081, 0.6145053624577516, 0.7049376205062579, 0.7784318523112163, 0.8284687120081994, 0.8567777432915853, 0.8758645767408021, 0.909863945624351, 0.9885785897353865, 1.1327278237036662, 1.3427548559053666, 1.602622834320445, 1.8898945992947809, 2.182058983705427, 2.4589782746972233, 2.7038953082770134, 2.904207757274356, 3.0523259340547826, 3.1466361411476282, 3.1925001983513135, 3.203104892938486, 3.1996955586975453, 3.2102505771417005, 3.2653535515725673, 3.3909956223524804, 3.6009059395643916, 3.8930766795338076, 4.252569901421405, 4.657916135432533, 5.087224921827532, 5.522331526020035, 5.951246883324925, 6.36965682600895, 6.78195177798325, 7.201887181523706, 7.652660373001636, 8.165987748838846, 8.779786587222253, 9.534453429112315, 10.468428741285866], [5.335734425125917, 3.9554101975052793, 2.833191748673898, 1.952683218111633, 1.2947274533058046, 0.8393552186923409, 0.566694876830585, 0.4479531867203381, 0.43188046848887773, 0.46988298625276126, 0.5392866265547398, 0.6286253172932713, 0.7263285009320231, 0.8218369924976364, 0.9095757088310334, 0.9916563377941816, 1.0785038366328488, 1.1864269302279211, 1.331588956571933, 1.522863115549938, 1.7582489613560357, 2.02639401900032, 2.3104957228997733, 2.5918351663496515, 2.8522210692898997, 3.0756766766430994, 3.2497764841225116, 3.3668709721277734, 3.4253146139416866, 3.430735525206582, 3.397262548510346, 3.348307702411333, 3.3158398337316277, 3.3363425361854033, 3.4423099536785875, 3.651965986240039, 3.9639112157965104, 4.360514051265792, 4.81635632161815, 5.3059449806575945, 5.808435976686961, 6.310026376468585, 6.805174036475417, 7.2973067107869865, 7.7991693414014005, 8.332628731661437, 8.927596725263534, 9.619785338655724, 10.447334866090316, 11.446882584976535], [4.787246959512813, 3.4654987952154466, 2.4036749877424564, 1.587563124043332, 1.0032300797371416, 0.6400733426408332, 0.4773434378185419, 0.44350227781673357, 0.45624026028717385, 0.491104929006748, 0.5568508531466142, 0.6574855198087232, 0.783711553857342, 0.922578047476529, 1.0657417119273698, 1.2120782585670438, 1.3669260477538987, 1.5392506714749035, 1.737535239903515, 1.9658472521948551, 2.2216805541262654, 2.4960935048783126, 2.7754149261077536, 3.0434725901818647, 3.283711244412672, 3.481023169620965, 3.6233404837898058, 3.70310027869976, 3.7186981476673995, 3.6760310365458855, 3.590150699122652, 3.486739488169817, 3.402285224078049, 3.380469076581762, 3.4621841680498253, 3.6715164641721088, 4.007449310503803, 4.448204815455905, 4.962871233255256, 5.521326457348789, 6.099517847588886, 6.68157913707772, 7.260599172794241, 7.838927285500608, 8.428194483640842, 9.04887863237251, 9.72912042056793, 10.502569085451368, 11.405313513849833, 12.47235917784082], [4.2579729984097066, 2.9975357420148745, 1.99930486000785, 1.2526609042670316, 0.7536481793449502, 0.5056157896563672, 0.45350163629166834, 0.4646108340270225, 0.47635789550089397, 0.5042485553782181, 0.581534884007708, 0.716539198659189, 0.8926797316459372, 1.0903728590615274, 1.2972699075949554, 1.5088871528893368, 1.726589829754673, 1.9548060837036234, 2.1979402013593967, 2.457610237089514, 2.7309141817461455, 3.0100621747571212, 3.2831872486885834, 3.535858105029551, 3.7528484247764244, 3.9198999685933074, 4.0253900303079515, 4.061927710711203, 4.027975370433539, 3.9296410976615563, 3.7827819157903253, 3.6153167519885736, 3.4687017439607635, 3.3953592428057506, 3.4472178349391456, 3.6562826162797575, 4.021549290668828, 4.514918079367601, 5.097888376442375, 5.734511158301789, 6.397034563308884, 7.067375112925517, 7.737205508659046, 8.407764239807383, 9.089540279487688, 9.801628185619917, 10.570472028919033, 11.42780874159495, 12.40786069976052, 13.544147268081305], [3.7506856458836713, 2.5548685173298655, 1.6245597314866052, 0.9556783118436948, 0.563570253160712, 0.4520165531242714, 0.47334885998761284, 0.4873321702483015, 0.4838091657986721, 0.5148825228187672, 0.6288888127831517, 0.8217786448654313, 1.062621834220661, 1.3262975633111178, 1.5984458705314146, 1.8727612755070902, 2.1481909087910322, 2.4263786947892294, 2.7092022550802284, 2.996622064404006, 3.285220680673285, 3.567681367006715, 3.833187021394902, 4.068505588139852, 4.259463955927022, 4.39257154929053, 4.4566637012383845, 4.444544809122103, 4.354713618285788, 4.193357492337918, 3.976891170527788, 3.7352201469934996, 3.51499632567986, 3.3790926853100047, 3.394111584669905, 3.6031322188450936, 4.004554030202655, 4.56066802256207, 5.2225957592653645, 5.9472669335250306, 6.702881004402547, 7.469142243526876, 8.236382072720412, 9.004785914655798, 9.783742114283553, 10.591018593002829, 11.451464503271106, 12.395054457248289, 13.454308564291878, 14.661383003390679], [3.267886573568172, 2.140792307813142, 1.2847727902326052, 0.708983503338063, 0.4587490556681648, 0.4675000148965506, 0.505948685997131, 0.49679372438509584, 0.47861773578614786, 0.5376117577472059, 0.7172698519933647, 0.9839983628754405, 1.2959133839975066, 1.6271231562565367, 1.9633175263521783, 2.2973671482780085, 2.626623198230495, 2.950767166779336, 3.2698201466737893, 3.5824006976451526, 3.884480946132263, 4.16884044629901, 4.425258770197651, 4.641330515440893, 4.803704032324815, 4.8995496587949505, 4.918126666618157, 4.852410956404158, 4.700859507999616, 4.469536880683887, 4.175025620004479, 3.8486781643150256, 3.5421472923596147, 3.330419769645971, 3.299719699031499, 3.5091468614859833, 3.955498411037178, 4.586436839641442, 5.339095610917936, 6.162059040751555, 7.019410110926192, 7.888866567834731, 8.759631322121392, 9.63098039450627, 10.511299672434497, 11.417122756668576, 12.371819562678237, 13.403744888390465, 14.543859752542943, 15.823059589059591], [2.8117414137076135, 1.7585999529995804, 0.9870879829394973, 0.5338568302751264, 0.44950389350606196, 0.5139372455233899, 0.5289115858057916, 0.48653763407826467, 0.47035767627840164, 0.594247078056261, 0.8607788708580634, 1.2071553364218168, 1.5910899422876548, 1.989111293969188, 2.3876306966691407, 2.7789741581220078, 3.159222781084598, 3.5264774468062545, 3.8792300030174767, 4.214916484763263, 4.528847343810187, 4.8136828150717355, 5.05951611925403, 5.254509020803324, 5.385945279698135, 5.441548559118388, 5.410946183683638, 5.287235484447721, 5.068725082230586, 4.761105884922342, 4.380611444300572, 3.959167937684818, 3.5525676407402984, 3.249092360030272, 3.1611263521919253, 3.3717291411247157, 3.8744136943519782, 4.59446519408499, 5.45056558421315, 6.382107300269944, 7.3494391678531965, 8.32878390495032, 9.308563071050235, 10.28735606327899, 11.27268259580407, 12.279953278112858, 13.33117646974053, 14.453216548313906, 15.675597382918523, 17.02803745807528], [2.3840172327836004, 1.411723745757455, 0.7423963486018218, 0.45660712880287907, 0.5006017122334869, 0.5583946791837796, 0.5300437881284078, 0.4578386254503126, 0.48092943084306355, 0.7054483016207524, 1.0655044361919632, 1.4909428181990216, 1.9458055257332567, 2.40942607848514, 2.8687447885209214, 3.31550297684979, 3.744629592538417, 4.152842388863525, 4.537290588626224, 4.894328243261239, 5.218584315781008, 5.502474917171515, 5.736226515177422, 5.908387212688185, 6.00673283739162, 6.019446163386579, 5.936464650710291, 5.750951913721275, 5.460958515706414, 5.071538423386265, 4.597982063721764, 4.0716002637030435, 3.5505631694356636, 3.1363837334585476, 2.9757676875618473, 3.1887777015499115, 3.7627841301607847, 4.588610082800039, 5.5614134321931825, 6.611419109680617, 7.696238140495911, 8.79136228915, 9.884884422134057, 10.974940278709695, 12.068334921445176, 13.179469615950175, 14.329100378454697, 15.542713056774604, 16.848495130970843, 18.27505478771865], [1.9860475514070024, 1.104102298353519, 0.5678870684260635, 0.4732184116780174, 0.5649364075148547, 0.5825829730249809, 0.5043404471218041, 0.4231088400701319, 0.5411859479877464, 0.8816145875187023, 1.3317453864037374, 1.8336991395616815, 2.3581045139580605, 2.886223099735167, 3.405112481104562, 3.9058158840130166, 4.382156430424587, 4.829587367046882, 5.244037935357592, 5.620854959021468, 5.953986271765199, 6.235533338032015, 6.455741164092949, 6.603420182516386, 6.666733267361913, 6.634249316335276, 6.496170337484716, 6.245684839485313, 5.880499452692794, 5.404801613113279, 4.832350683435006, 4.192448993016908, 3.5428739322810037, 2.9959248445710527, 2.741650368835182, 2.958999575766619, 3.6242416556664416, 4.574763681148608, 5.677401594514254, 6.854786942983826, 8.063497103547409, 9.279274838466081, 10.490385645213138, 11.694775974010925, 12.898678089561415, 14.115584232533632, 15.365090095304776, 16.671394133530665, 18.0614272858326, 19.562738213793434], [1.6187953821810495, 0.8410958020298777, 0.48268692679637376, 0.5360060184018726, 0.6147501782250782, 0.5778327288533585, 0.4536381276879171, 0.41376724230585077, 0.6737101221046345, 1.1233894966708162, 1.6577357405191337, 2.2338398045814225, 2.8266462598964854, 3.41837425461746, 3.995837480626938, 4.549280668023256, 5.07144664762986, 5.5566065190248395, 5.999559861731997, 6.39470820326574, 6.73533167120778, 7.013181051226552, 7.218449612256408, 7.340128671745546, 7.366697004757727, 7.287061765802324, 7.091665970684164, 6.7737103941888, 6.330520319942069, 5.765269470779986, 5.089712392152595, 4.329767973767747, 3.5392319464201303, 2.8350576997168804, 2.457792681766291, 2.682522228829283, 3.4656208733216074, 4.561296389979882, 5.805707045582651, 7.117739017325885, 8.4552710885619, 9.795363333101761, 11.126922152385074, 12.44791610098853, 13.764112389302513, 15.088167610966533, 16.43858513178874, 17.838344208705102, 19.31317865382598, 20.889613608488393], [1.2832109694656535, 0.631590620084501, 0.48282746507205526, 0.6018315573019006, 0.6376055771921819, 0.5416668708783894, 0.3922039105019781, 0.4760954039498783, 0.8818349605673913, 1.4277422382750393, 2.0416647964416486, 2.6902218533170768, 3.350576582439567, 4.005191133794124, 4.6403784349264905, 5.245515067606787, 5.812285167570847, 6.333841904933658, 6.803927735637224, 7.2160539348368, 7.562855266459685, 7.835719073408345, 8.024748208079723, 8.119066375811371, 8.107426900466935, 7.979053821438338, 7.7246355191685465, 7.337411612964015, 6.814356242198931, 6.157607496028207, 5.3766685723678735, 4.493030237023696, 3.5527626981885905, 2.666961005447635, 2.125239108182398, 2.3622187837431, 3.2985084946864522, 4.5594305375462705, 5.954872639276322, 7.4064343414198825, 8.875902548256304, 10.342593425782846, 11.796392916729797, 13.235415929465214, 14.665016779063885, 16.097052067958238, 17.54897195655093, 19.0425805443887, 20.602454199063796, 22.254116800799824], [0.981471302980851, 0.49123427685907617, 0.5310567383032259, 0.6499255880364928, 0.6295685160910098, 0.4787683927688833, 0.3626646629919067, 0.6336502448951785, 1.1592902922524289, 1.79171062215461, 2.4822253405936476, 3.2020980683441183, 3.9293496758530355, 4.646223750730481, 5.338364235845712, 5.994237396643089, 6.604491230136531, 7.161215394642454, 7.657157388529064, 8.084989509243147, 8.436730019364331, 8.703406652446464, 8.87501663677318, 8.94079377127681, 8.889750684896569, 8.711433113390992, 8.396809698483777, 7.93923033948167, 7.3354272643951735, 6.586635353470972, 5.700179330956648, 4.692738593799218, 3.59991392996315, 2.513625741588136, 1.7497713873016074, 2.00690114713408, 3.1412971174194744, 4.583367575928078, 6.134605603669768, 7.727499046395364, 9.329923933013932, 10.924003030714672, 12.50071586168582, 14.058323311073371, 15.601747080028506, 17.142034327173928, 18.695589382059623, 20.283060781894562, 21.927888325026004, 23.65460413079937], [0.7210063989600407, 0.4388875057333319, 0.5917484242717466, 0.6740391131714392, 0.5937919399342271, 0.40945195407996193, 0.43355956085650493, 0.8767329060167149, 1.5000202242166993, 2.2132978533948298, 2.9785827773731595, 3.7689830698820783, 4.562584895349917, 5.341127928444304, 6.089481036082592, 6.79517824412801, 7.447855896842414, 8.038588924125717, 8.559185763427777, 9.0015290404721, 9.357054458896997, 9.616446396293467, 9.769599312108362, 9.805856051174063, 9.714496037852927, 9.485416192982933, 9.10993084878221, 8.58161748557806, 7.897157260162325, 7.057178322749674, 6.067265605568839, 4.939806612565891, 3.699511093259744, 2.408692675079036, 1.3505415885580319, 1.639842853616874, 3.02120537297048, 4.649912690661791, 6.355395124290967, 8.087809581641634, 9.821945261021584, 11.542645964128402, 13.241800895024145, 14.917667098439136, 16.5746325969987, 18.22287685249351, 19.877733045020683, 21.558689847198558, 23.288053714761194, 25.089362740565075], [0.5269933875209503, 0.4731225239318607, 0.649703161932789, 0.677847651145479, 0.5444907660651784, 0.3896442984803875, 0.6242598616781451, 1.1911828670805469, 1.900331260275082, 2.691326364884734, 3.5302198965240206, 4.390533481576447, 5.249967177071056, 6.089581067419989, 6.893403324798, 7.6480276451268345, 8.342104927351231, 8.965740748788368, 9.509856519529196, 9.965593615683476, 10.323843271584913, 10.574972404137082, 10.708789816169029, 10.714763760136266, 10.582467511252425, 10.30220095413858, 9.86571791675823, 9.26698347918682, 8.502894055843408, 7.573920006848865, 6.4846964740246635, 5.244788822824131, 3.870727703610876, 2.3963715151471394, 0.9921127586715343, 1.322054310642688, 2.974392557257832, 4.7773555039668185, 6.627959156664591, 8.494238562725268, 10.356533588252288, 12.201533265532412, 14.021521366930367, 15.81444398108823, 17.583971269302545, 19.33930797244352, 21.094658962518555, 22.868326164812512, 24.68146966066768, 26.5566205162097], [0.4619599345142945, 0.5673741618816567, 0.7064941640185186, 0.6758466145365313, 0.5169603784057789, 0.49327634710289003, 0.90662300999202, 1.5690360278514803, 2.3582788425166923, 3.225139319117529, 4.136797353248597, 5.066461003167081, 5.991181644809249, 6.891229488037744, 7.749751919192157, 8.55240331064755, 9.28687656720917, 9.942351127913147, 10.50891099990664, 10.977004493637546, 11.33701993342049, 11.57904033350349, 11.692817365548724, 11.667975325559674, 11.494424914966878, 11.162940010421094, 10.665832286553588, 9.997650606146825, 9.155834905358999, 8.141268405386072, 6.958703166126735, 5.6171145839842795, 4.130359821360208, 2.5207145724445614, 0.8706832655702641, 1.1924966030666975, 3.0408969919687183, 4.983592219939879, 6.9625846717704105, 8.95338803883041, 10.938092493634107, 12.903574765224757, 14.841684788036106, 16.749604055279054, 18.63002349672844, 20.491020855651684, 22.34558616709531, 24.21078714689062, 26.106609828060677, 28.054555606636846]]}, {\"hoverinfo\": \"text\", \"legendgroup\": \"In-sample\", \"marker\": {\"color\": \"black\", \"opacity\": 0.5, \"symbol\": 1}, \"mode\": \"markers\", \"name\": \"In-sample\", \"text\": [\"Arm 0_0<br>branin: 42.0839 (SEM: 0)<br>x1: 1.05349<br>x2: 9.69501\", \"Arm 1_0<br>branin: 6.16198 (SEM: 0)<br>x1: 9.67388<br>x2: 5.03145\", \"Arm 2_0<br>branin: 4.77583 (SEM: 0)<br>x1: -2.69836<br>x2: 13.0926\", \"Arm 3_0<br>branin: 20.1772 (SEM: 0)<br>x1: 4.25573<br>x2: 5.3627\", \"Arm 4_0<br>branin: 3.53664 (SEM: 0)<br>x1: 9.89622<br>x2: 4.34752\", \"Arm 5_0<br>branin: 6.46653 (SEM: 0)<br>x1: -3.94754<br>x2: 12.5308\", \"Arm 6_0<br>branin: 5.7069 (SEM: 0)<br>x1: 10<br>x2: 1.06292\", \"Arm 7_0<br>branin: 16.379 (SEM: 0)<br>x1: 7.21844<br>x2: 0.418715\", \"Arm 8_0<br>branin: 151.694 (SEM: 0)<br>x1: -3.19908<br>x2: 0.113994\", \"Arm 9_0<br>branin: 17.5083 (SEM: 0)<br>x1: -5<br>x2: 15\", \"Arm 10_0<br>branin: 12.3704 (SEM: 0)<br>x1: 8.02277<br>x2: 3.54215\", \"Arm 11_0<br>branin: 208.881 (SEM: 0)<br>x1: 5.53314<br>x2: 15\", \"Arm 12_0<br>branin: 0.74213 (SEM: 0)<br>x1: 2.91104<br>x2: 2.16137\", \"Arm 13_0<br>branin: 5.16542 (SEM: 0)<br>x1: 3.5967<br>x2: 0\", \"Arm 14_0<br>branin: 1.54147 (SEM: 0)<br>x1: 3.63205<br>x2: 2.03165\", \"Arm 15_0<br>branin: 5.03334 (SEM: 0)<br>x1: -2.11716<br>x2: 9.79872\", \"Arm 16_0<br>branin: 2.03484 (SEM: 0)<br>x1: 10<br>x2: 3.30578\", \"Arm 17_0<br>branin: 2.25192 (SEM: 0)<br>x1: 2.52183<br>x2: 2.5468\", \"Arm 18_0<br>branin: 0.481058 (SEM: 0)<br>x1: 3.2582<br>x2: 2.05179\", \"Arm 19_0<br>branin: 0.761814 (SEM: 0)<br>x1: 3.41611<br>x2: 2.00439\", \"Arm 20_0<br>branin: 0.398119 (SEM: 0)<br>x1: 3.14347<br>x2: 2.28819\", \"Arm 21_0<br>branin: 0.475756 (SEM: 0)<br>x1: 3.15166<br>x2: 1.98899\", \"Arm 22_0<br>branin: 0.55421 (SEM: 0)<br>x1: 3.32022<br>x2: 2.19937\", \"Arm 23_0<br>branin: 0.66797 (SEM: 0)<br>x1: 3.35505<br>x2: 1.88604\", \"Arm 24_0<br>branin: 0.503379 (SEM: 0)<br>x1: 2.99545<br>x2: 2.4477\", \"Arm 25_0<br>branin: 4.03847 (SEM: 0)<br>x1: -3.575<br>x2: 15\", \"Arm 26_0<br>branin: 0.419002 (SEM: 0)<br>x1: 3.10412<br>x2: 2.18451\", \"Arm 27_0<br>branin: 0.743807 (SEM: 0)<br>x1: 3.40981<br>x2: 2.12609\", \"Arm 28_0<br>branin: 0.427756 (SEM: 0)<br>x1: 3.21861<br>x2: 2.25319\"], \"type\": \"scatter\", \"x\": [1.053490936756134, 9.673875807784498, -2.6983634615316987, 4.255731301382184, 9.896218599751592, -3.947538998984686, 10.0, 7.21844183648062, -3.1990796261421757, -5.0, 8.0227651133701, 5.533142090027264, 2.911041881584141, 3.5966954967872837, 3.6320456772082554, -2.1171632044281883, 10.0, 2.521829699771833, 3.2582006155846504, 3.4161086120295376, 3.143471996153947, 3.1516606150486464, 3.320215989374521, 3.3550495492967194, 2.9954482956770887, -3.575002873038719, 3.1041197799343703, 3.4098088553679933, 3.218610082260776], \"xaxis\": \"x\", \"y\": [9.695006310939789, 5.031454539857805, 13.092638882808387, 5.3627007734030485, 4.34751792345196, 12.530771731366281, 1.062916555044761, 0.41871484495313804, 0.11399374450743174, 15.0, 3.542145511842334, 15.0, 2.161366131603687, 0.0, 2.0316523415854526, 9.798724198318416, 3.305777701872517, 2.5468035759843533, 2.051792648782326, 2.004387098830192, 2.2881945397553003, 1.9889850619156846, 2.1993661124829935, 1.8860391984524798, 2.447697319486139, 15.0, 2.184512833398977, 2.126092134213714, 2.2531901460823534], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"legendgroup\": \"In-sample\", \"marker\": {\"color\": \"black\", \"opacity\": 0.5, \"symbol\": 1}, \"mode\": \"markers\", \"name\": \"In-sample\", \"showlegend\": false, \"text\": [\"Arm 0_0<br>branin: 42.0839 (SEM: 0)<br>x1: 1.05349<br>x2: 9.69501\", \"Arm 1_0<br>branin: 6.16198 (SEM: 0)<br>x1: 9.67388<br>x2: 5.03145\", \"Arm 2_0<br>branin: 4.77583 (SEM: 0)<br>x1: -2.69836<br>x2: 13.0926\", \"Arm 3_0<br>branin: 20.1772 (SEM: 0)<br>x1: 4.25573<br>x2: 5.3627\", \"Arm 4_0<br>branin: 3.53664 (SEM: 0)<br>x1: 9.89622<br>x2: 4.34752\", \"Arm 5_0<br>branin: 6.46653 (SEM: 0)<br>x1: -3.94754<br>x2: 12.5308\", \"Arm 6_0<br>branin: 5.7069 (SEM: 0)<br>x1: 10<br>x2: 1.06292\", \"Arm 7_0<br>branin: 16.379 (SEM: 0)<br>x1: 7.21844<br>x2: 0.418715\", \"Arm 8_0<br>branin: 151.694 (SEM: 0)<br>x1: -3.19908<br>x2: 0.113994\", \"Arm 9_0<br>branin: 17.5083 (SEM: 0)<br>x1: -5<br>x2: 15\", \"Arm 10_0<br>branin: 12.3704 (SEM: 0)<br>x1: 8.02277<br>x2: 3.54215\", \"Arm 11_0<br>branin: 208.881 (SEM: 0)<br>x1: 5.53314<br>x2: 15\", \"Arm 12_0<br>branin: 0.74213 (SEM: 0)<br>x1: 2.91104<br>x2: 2.16137\", \"Arm 13_0<br>branin: 5.16542 (SEM: 0)<br>x1: 3.5967<br>x2: 0\", \"Arm 14_0<br>branin: 1.54147 (SEM: 0)<br>x1: 3.63205<br>x2: 2.03165\", \"Arm 15_0<br>branin: 5.03334 (SEM: 0)<br>x1: -2.11716<br>x2: 9.79872\", \"Arm 16_0<br>branin: 2.03484 (SEM: 0)<br>x1: 10<br>x2: 3.30578\", \"Arm 17_0<br>branin: 2.25192 (SEM: 0)<br>x1: 2.52183<br>x2: 2.5468\", \"Arm 18_0<br>branin: 0.481058 (SEM: 0)<br>x1: 3.2582<br>x2: 2.05179\", \"Arm 19_0<br>branin: 0.761814 (SEM: 0)<br>x1: 3.41611<br>x2: 2.00439\", \"Arm 20_0<br>branin: 0.398119 (SEM: 0)<br>x1: 3.14347<br>x2: 2.28819\", \"Arm 21_0<br>branin: 0.475756 (SEM: 0)<br>x1: 3.15166<br>x2: 1.98899\", \"Arm 22_0<br>branin: 0.55421 (SEM: 0)<br>x1: 3.32022<br>x2: 2.19937\", \"Arm 23_0<br>branin: 0.66797 (SEM: 0)<br>x1: 3.35505<br>x2: 1.88604\", \"Arm 24_0<br>branin: 0.503379 (SEM: 0)<br>x1: 2.99545<br>x2: 2.4477\", \"Arm 25_0<br>branin: 4.03847 (SEM: 0)<br>x1: -3.575<br>x2: 15\", \"Arm 26_0<br>branin: 0.419002 (SEM: 0)<br>x1: 3.10412<br>x2: 2.18451\", \"Arm 27_0<br>branin: 0.743807 (SEM: 0)<br>x1: 3.40981<br>x2: 2.12609\", \"Arm 28_0<br>branin: 0.427756 (SEM: 0)<br>x1: 3.21861<br>x2: 2.25319\"], \"type\": \"scatter\", \"x\": [1.053490936756134, 9.673875807784498, -2.6983634615316987, 4.255731301382184, 9.896218599751592, -3.947538998984686, 10.0, 7.21844183648062, -3.1990796261421757, -5.0, 8.0227651133701, 5.533142090027264, 2.911041881584141, 3.5966954967872837, 3.6320456772082554, -2.1171632044281883, 10.0, 2.521829699771833, 3.2582006155846504, 3.4161086120295376, 3.143471996153947, 3.1516606150486464, 3.320215989374521, 3.3550495492967194, 2.9954482956770887, -3.575002873038719, 3.1041197799343703, 3.4098088553679933, 3.218610082260776], \"xaxis\": \"x2\", \"y\": [9.695006310939789, 5.031454539857805, 13.092638882808387, 5.3627007734030485, 4.34751792345196, 12.530771731366281, 1.062916555044761, 0.41871484495313804, 0.11399374450743174, 15.0, 3.542145511842334, 15.0, 2.161366131603687, 0.0, 2.0316523415854526, 9.798724198318416, 3.305777701872517, 2.5468035759843533, 2.051792648782326, 2.004387098830192, 2.2881945397553003, 1.9889850619156846, 2.1993661124829935, 1.8860391984524798, 2.447697319486139, 15.0, 2.184512833398977, 2.126092134213714, 2.2531901460823534], \"yaxis\": \"y2\"}],                        {\"annotations\": [{\"font\": {\"size\": 14}, \"showarrow\": false, \"text\": \"Mean\", \"x\": 0.25, \"xanchor\": \"center\", \"xref\": \"paper\", \"y\": 1, \"yanchor\": \"bottom\", \"yref\": \"paper\"}, {\"font\": {\"size\": 14}, \"showarrow\": false, \"text\": \"Standard Error\", \"x\": 0.8, \"xanchor\": \"center\", \"xref\": \"paper\", \"y\": 1, \"yanchor\": \"bottom\", \"yref\": \"paper\"}], \"autosize\": false, \"height\": 450, \"hovermode\": \"closest\", \"legend\": {\"orientation\": \"h\", \"x\": 0, \"y\": -0.25}, \"margin\": {\"b\": 100, \"l\": 35, \"pad\": 0, \"r\": 35, \"t\": 35}, \"template\": {\"data\": {\"bar\": [{\"error_x\": {\"color\": \"#2a3f5f\"}, \"error_y\": {\"color\": \"#2a3f5f\"}, \"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"bar\"}], \"barpolar\": [{\"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"barpolar\"}], \"carpet\": [{\"aaxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"baxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"type\": \"carpet\"}], \"choropleth\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"choropleth\"}], \"contour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"contour\"}], \"contourcarpet\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"contourcarpet\"}], \"heatmap\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmap\"}], \"heatmapgl\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmapgl\"}], \"histogram\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"histogram\"}], \"histogram2d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2d\"}], \"histogram2dcontour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2dcontour\"}], \"mesh3d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"mesh3d\"}], \"parcoords\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"parcoords\"}], \"pie\": [{\"automargin\": true, \"type\": \"pie\"}], \"scatter\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter\"}], \"scatter3d\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter3d\"}], \"scattercarpet\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattercarpet\"}], \"scattergeo\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergeo\"}], \"scattergl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergl\"}], \"scattermapbox\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattermapbox\"}], \"scatterpolar\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolar\"}], \"scatterpolargl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolargl\"}], \"scatterternary\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterternary\"}], \"surface\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"surface\"}], \"table\": [{\"cells\": {\"fill\": {\"color\": \"#EBF0F8\"}, \"line\": {\"color\": \"white\"}}, \"header\": {\"fill\": {\"color\": \"#C8D4E3\"}, \"line\": {\"color\": \"white\"}}, \"type\": \"table\"}]}, \"layout\": {\"annotationdefaults\": {\"arrowcolor\": \"#2a3f5f\", \"arrowhead\": 0, \"arrowwidth\": 1}, \"autotypenumbers\": \"strict\", \"coloraxis\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"colorscale\": {\"diverging\": [[0, \"#8e0152\"], [0.1, \"#c51b7d\"], [0.2, \"#de77ae\"], [0.3, \"#f1b6da\"], [0.4, \"#fde0ef\"], [0.5, \"#f7f7f7\"], [0.6, \"#e6f5d0\"], [0.7, \"#b8e186\"], [0.8, \"#7fbc41\"], [0.9, \"#4d9221\"], [1, \"#276419\"]], \"sequential\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"sequentialminus\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]]}, \"colorway\": [\"#636efa\", \"#EF553B\", \"#00cc96\", \"#ab63fa\", \"#FFA15A\", \"#19d3f3\", \"#FF6692\", \"#B6E880\", \"#FF97FF\", \"#FECB52\"], \"font\": {\"color\": \"#2a3f5f\"}, \"geo\": {\"bgcolor\": \"white\", \"lakecolor\": \"white\", \"landcolor\": \"#E5ECF6\", \"showlakes\": true, \"showland\": true, \"subunitcolor\": \"white\"}, \"hoverlabel\": {\"align\": \"left\"}, \"hovermode\": \"closest\", \"mapbox\": {\"style\": \"light\"}, \"paper_bgcolor\": \"white\", \"plot_bgcolor\": \"#E5ECF6\", \"polar\": {\"angularaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"radialaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"scene\": {\"xaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"yaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"zaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}}, \"shapedefaults\": {\"line\": {\"color\": \"#2a3f5f\"}}, \"ternary\": {\"aaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"baxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"caxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"title\": {\"x\": 0.05}, \"xaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}, \"yaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}}}, \"width\": 950, \"xaxis\": {\"anchor\": \"y\", \"autorange\": false, \"domain\": [0.05, 0.45], \"exponentformat\": \"e\", \"range\": [-5.0, 10.0], \"tickfont\": {\"size\": 11}, \"tickmode\": \"auto\", \"title\": {\"text\": \"x1\"}, \"type\": \"linear\"}, \"xaxis2\": {\"anchor\": \"y2\", \"autorange\": false, \"domain\": [0.6, 1], \"exponentformat\": \"e\", \"range\": [-5.0, 10.0], \"tickfont\": {\"size\": 11}, \"tickmode\": \"auto\", \"title\": {\"text\": \"x1\"}, \"type\": \"linear\"}, \"yaxis\": {\"anchor\": \"x\", \"autorange\": false, \"domain\": [0, 1], \"exponentformat\": \"e\", \"range\": [0.0, 15.0], \"tickfont\": {\"size\": 11}, \"tickmode\": \"auto\", \"title\": {\"text\": \"x2\"}, \"type\": \"linear\"}, \"yaxis2\": {\"anchor\": \"x2\", \"autorange\": false, \"domain\": [0, 1], \"exponentformat\": \"e\", \"range\": [0.0, 15.0], \"tickfont\": {\"size\": 11}, \"tickmode\": \"auto\", \"type\": \"linear\"}},                        {\"responsive\": true}                    ).then(function(){\n                            \nvar gd = document.getElementById('c8a2ed18-9784-499f-aa4d-3cffa82a8ac9');\nvar x = new MutationObserver(function (mutations, observer) {{\n        var display = window.getComputedStyle(gd).display;\n        if (!display || display === 'none') {{\n            console.log([gd, 'removed!']);\n            Plotly.purge(gd);\n            observer.disconnect();\n        }}\n}});\n\n// Listen for the removal of the full notebook cells\nvar notebookContainer = gd.closest('#notebook-container');\nif (notebookContainer) {{\n    x.observe(notebookContainer, {childList: true});\n}}\n\n// Listen for the clearing of the current output cell\nvar outputEl = gd.closest('.output');\nif (outputEl) {{\n    x.observe(outputEl, {childList: true});\n}}\n\n                        })                };                });            </script>        </div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "143fe15b-4d45-47ed-88cb-39595bdb5033",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "f3e3f04c-14ca-44df-adfa-0e30f46d2866",
+        "executionStopTime": 1646802638597,
+        "executionStartTime": 1646802638584
+      },
+      "source": [
+        "best_parameters, values = ax_client.get_best_parameters()\n",
+        "best_parameters, values[0]"
+      ],
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "({'x1': 3.143471996153947, 'x2': 2.2881945397553003},\n {'branin': 0.3981189727783203})"
+          },
+          "metadata": {
+            "bento_obj_id": "140418729165184"
+          },
+          "execution_count": 10
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "53e7063d-b1e2-42db-9629-98467c0f69d7",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "236623d1-ba20-47b5-83ba-670831a6706c",
+        "executionStopTime": 1646802638751,
+        "executionStartTime": 1646802638636
+      },
+      "source": [
+        "render(ax_client.get_optimization_trace(objective_optimum=0.397887))"
+      ],
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.plotly.v1+json": {
+              "config": {
+                "linkText": "Export to plot.ly",
+                "plotlyServerURL": "https://plot.ly",
+                "showLink": false
+              },
+              "data": [
+                {
+                  "hoverinfo": "none",
+                  "legendgroup": "",
+                  "line": {
+                    "width": 0
+                  },
+                  "mode": "lines",
+                  "showlegend": false,
+                  "type": "scatter",
+                  "x": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    20,
+                    21,
+                    22,
+                    23,
+                    24,
+                    25,
+                    26,
+                    27,
+                    28,
+                    29,
+                    30
+                  ],
+                  "y": [
+                    42.083900451660156,
+                    6.161984443664551,
+                    4.77583122253418,
+                    4.77583122253418,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.48105812072753906,
+                    0.48105812072753906,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203
+                  ]
+                },
+                {
+                  "fill": "tonexty",
+                  "fillcolor": "rgba(128,177,211,0.3)",
+                  "legendgroup": "objective value",
+                  "line": {
+                    "color": "rgba(128,177,211,1)"
+                  },
+                  "mode": "lines",
+                  "name": "objective value",
+                  "text": [
+                    "<br><em>Parameterization:</em><br>x1: 1.053490936756134<br>x2: 9.695006310939789",
+                    "<br><em>Parameterization:</em><br>x1: 9.673875807784498<br>x2: 5.031454539857805",
+                    "<br><em>Parameterization:</em><br>x1: -2.6983634615316987<br>x2: 13.092638882808387",
+                    "<br><em>Parameterization:</em><br>x1: 4.255731301382184<br>x2: 5.3627007734030485",
+                    "<br><em>Parameterization:</em><br>x1: 9.896218599751592<br>x2: 4.34751792345196",
+                    "<br><em>Parameterization:</em><br>x1: -3.947538998984686<br>x2: 12.530771731366281",
+                    "<br><em>Parameterization:</em><br>x1: 10.0<br>x2: 1.062916555044761",
+                    "<br><em>Parameterization:</em><br>x1: 7.21844183648062<br>x2: 0.41871484495313804",
+                    "<br><em>Parameterization:</em><br>x1: -3.1990796261421757<br>x2: 0.11399374450743174",
+                    "<br><em>Parameterization:</em><br>x1: -5.0<br>x2: 15.0",
+                    "<br><em>Parameterization:</em><br>x1: 8.0227651133701<br>x2: 3.542145511842334",
+                    "<br><em>Parameterization:</em><br>x1: 5.533142090027264<br>x2: 15.0",
+                    "<br><em>Parameterization:</em><br>x1: 2.911041881584141<br>x2: 2.161366131603687",
+                    "<br><em>Parameterization:</em><br>x1: 3.5966954967872837<br>x2: 0.0",
+                    "<br><em>Parameterization:</em><br>x1: 3.6320456772082554<br>x2: 2.0316523415854526",
+                    "<br><em>Parameterization:</em><br>x1: -2.1171632044281883<br>x2: 9.798724198318416",
+                    "<br><em>Parameterization:</em><br>x1: 10.0<br>x2: 3.305777701872517",
+                    "<br><em>Parameterization:</em><br>x1: 2.521829699771833<br>x2: 2.5468035759843533",
+                    "<br><em>Parameterization:</em><br>x1: 3.2582006155846504<br>x2: 2.051792648782326",
+                    "<br><em>Parameterization:</em><br>x1: 3.4161086120295376<br>x2: 2.004387098830192",
+                    "<br><em>Parameterization:</em><br>x1: 3.143471996153947<br>x2: 2.2881945397553003",
+                    "<br><em>Parameterization:</em><br>x1: 3.1516606150486464<br>x2: 1.9889850619156846",
+                    "<br><em>Parameterization:</em><br>x1: 3.320215989374521<br>x2: 2.1993661124829935",
+                    "<br><em>Parameterization:</em><br>x1: 3.3550495492967194<br>x2: 1.8860391984524798",
+                    "<br><em>Parameterization:</em><br>x1: 2.9954482956770887<br>x2: 2.447697319486139",
+                    "<br><em>Parameterization:</em><br>x1: -3.575002873038719<br>x2: 15.0",
+                    "<br><em>Parameterization:</em><br>x1: 3.1041197799343703<br>x2: 2.184512833398977",
+                    "<br><em>Parameterization:</em><br>x1: 3.4098088553679933<br>x2: 2.126092134213714",
+                    "<br><em>Parameterization:</em><br>x1: 3.218610082260776<br>x2: 2.2531901460823534",
+                    "<br><em>Parameterization:</em><br>x1: 3.1333359949622306<br>x2: 2.4422369680029155"
+                  ],
+                  "type": "scatter",
+                  "x": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    20,
+                    21,
+                    22,
+                    23,
+                    24,
+                    25,
+                    26,
+                    27,
+                    28,
+                    29,
+                    30
+                  ],
+                  "y": [
+                    42.083900451660156,
+                    6.161984443664551,
+                    4.77583122253418,
+                    4.77583122253418,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.48105812072753906,
+                    0.48105812072753906,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203
+                  ]
+                },
+                {
+                  "fill": "tonexty",
+                  "fillcolor": "rgba(128,177,211,0.3)",
+                  "hoverinfo": "none",
+                  "legendgroup": "",
+                  "line": {
+                    "width": 0
+                  },
+                  "mode": "lines",
+                  "showlegend": false,
+                  "type": "scatter",
+                  "x": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    20,
+                    21,
+                    22,
+                    23,
+                    24,
+                    25,
+                    26,
+                    27,
+                    28,
+                    29,
+                    30
+                  ],
+                  "y": [
+                    42.083900451660156,
+                    6.161984443664551,
+                    4.77583122253418,
+                    4.77583122253418,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    3.5366411209106445,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.7421302795410156,
+                    0.48105812072753906,
+                    0.48105812072753906,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203,
+                    0.3981189727783203
+                  ]
+                },
+                {
+                  "line": {
+                    "color": "rgba(253,180,98,1)",
+                    "dash": "dash"
+                  },
+                  "mode": "lines",
+                  "name": "Optimum",
+                  "type": "scatter",
+                  "x": [
+                    1,
+                    30
+                  ],
+                  "y": [
+                    0.397887,
+                    0.397887
+                  ]
+                },
+                {
+                  "line": {
+                    "color": "rgba(141,211,199,1)",
+                    "dash": "dash"
+                  },
+                  "mode": "lines",
+                  "name": "model change",
+                  "type": "scatter",
+                  "x": [
+                    5,
+                    5
+                  ],
+                  "y": [
+                    0.397887,
+                    42.083900451660156
+                  ]
+                }
+              ],
+              "layout": {
+                "showlegend": true,
+                "template": {
+                  "data": {
+                    "bar": [
+                      {
+                        "error_x": {
+                          "color": "#2a3f5f"
+                        },
+                        "error_y": {
+                          "color": "#2a3f5f"
+                        },
+                        "marker": {
+                          "line": {
+                            "color": "#E5ECF6",
+                            "width": 0.5
+                          }
+                        },
+                        "type": "bar"
+                      }
+                    ],
+                    "barpolar": [
+                      {
+                        "marker": {
+                          "line": {
+                            "color": "#E5ECF6",
+                            "width": 0.5
+                          }
+                        },
+                        "type": "barpolar"
+                      }
+                    ],
+                    "carpet": [
+                      {
+                        "aaxis": {
+                          "endlinecolor": "#2a3f5f",
+                          "gridcolor": "white",
+                          "linecolor": "white",
+                          "minorgridcolor": "white",
+                          "startlinecolor": "#2a3f5f"
+                        },
+                        "baxis": {
+                          "endlinecolor": "#2a3f5f",
+                          "gridcolor": "white",
+                          "linecolor": "white",
+                          "minorgridcolor": "white",
+                          "startlinecolor": "#2a3f5f"
+                        },
+                        "type": "carpet"
+                      }
+                    ],
+                    "choropleth": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "choropleth"
+                      }
+                    ],
+                    "contour": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "contour"
+                      }
+                    ],
+                    "contourcarpet": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "contourcarpet"
+                      }
+                    ],
+                    "heatmap": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "heatmap"
+                      }
+                    ],
+                    "heatmapgl": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "heatmapgl"
+                      }
+                    ],
+                    "histogram": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "histogram"
+                      }
+                    ],
+                    "histogram2d": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "histogram2d"
+                      }
+                    ],
+                    "histogram2dcontour": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "histogram2dcontour"
+                      }
+                    ],
+                    "mesh3d": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "mesh3d"
+                      }
+                    ],
+                    "parcoords": [
+                      {
+                        "line": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "parcoords"
+                      }
+                    ],
+                    "pie": [
+                      {
+                        "automargin": true,
+                        "type": "pie"
+                      }
+                    ],
+                    "scatter": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatter"
+                      }
+                    ],
+                    "scatter3d": [
+                      {
+                        "line": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatter3d"
+                      }
+                    ],
+                    "scattercarpet": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattercarpet"
+                      }
+                    ],
+                    "scattergeo": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattergeo"
+                      }
+                    ],
+                    "scattergl": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattergl"
+                      }
+                    ],
+                    "scattermapbox": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattermapbox"
+                      }
+                    ],
+                    "scatterpolar": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterpolar"
+                      }
+                    ],
+                    "scatterpolargl": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterpolargl"
+                      }
+                    ],
+                    "scatterternary": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterternary"
+                      }
+                    ],
+                    "surface": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "surface"
+                      }
+                    ],
+                    "table": [
+                      {
+                        "cells": {
+                          "fill": {
+                            "color": "#EBF0F8"
+                          },
+                          "line": {
+                            "color": "white"
+                          }
+                        },
+                        "header": {
+                          "fill": {
+                            "color": "#C8D4E3"
+                          },
+                          "line": {
+                            "color": "white"
+                          }
+                        },
+                        "type": "table"
+                      }
+                    ]
+                  },
+                  "layout": {
+                    "annotationdefaults": {
+                      "arrowcolor": "#2a3f5f",
+                      "arrowhead": 0,
+                      "arrowwidth": 1
+                    },
+                    "autotypenumbers": "strict",
+                    "coloraxis": {
+                      "colorbar": {
+                        "outlinewidth": 0,
+                        "ticks": ""
+                      }
+                    },
+                    "colorscale": {
+                      "diverging": [
+                        [
+                          0,
+                          "#8e0152"
+                        ],
+                        [
+                          0.1,
+                          "#c51b7d"
+                        ],
+                        [
+                          0.2,
+                          "#de77ae"
+                        ],
+                        [
+                          0.3,
+                          "#f1b6da"
+                        ],
+                        [
+                          0.4,
+                          "#fde0ef"
+                        ],
+                        [
+                          0.5,
+                          "#f7f7f7"
+                        ],
+                        [
+                          0.6,
+                          "#e6f5d0"
+                        ],
+                        [
+                          0.7,
+                          "#b8e186"
+                        ],
+                        [
+                          0.8,
+                          "#7fbc41"
+                        ],
+                        [
+                          0.9,
+                          "#4d9221"
+                        ],
+                        [
+                          1,
+                          "#276419"
+                        ]
+                      ],
+                      "sequential": [
+                        [
+                          0,
+                          "#0d0887"
+                        ],
+                        [
+                          0.1111111111111111,
+                          "#46039f"
+                        ],
+                        [
+                          0.2222222222222222,
+                          "#7201a8"
+                        ],
+                        [
+                          0.3333333333333333,
+                          "#9c179e"
+                        ],
+                        [
+                          0.4444444444444444,
+                          "#bd3786"
+                        ],
+                        [
+                          0.5555555555555556,
+                          "#d8576b"
+                        ],
+                        [
+                          0.6666666666666666,
+                          "#ed7953"
+                        ],
+                        [
+                          0.7777777777777778,
+                          "#fb9f3a"
+                        ],
+                        [
+                          0.8888888888888888,
+                          "#fdca26"
+                        ],
+                        [
+                          1,
+                          "#f0f921"
+                        ]
+                      ],
+                      "sequentialminus": [
+                        [
+                          0,
+                          "#0d0887"
+                        ],
+                        [
+                          0.1111111111111111,
+                          "#46039f"
+                        ],
+                        [
+                          0.2222222222222222,
+                          "#7201a8"
+                        ],
+                        [
+                          0.3333333333333333,
+                          "#9c179e"
+                        ],
+                        [
+                          0.4444444444444444,
+                          "#bd3786"
+                        ],
+                        [
+                          0.5555555555555556,
+                          "#d8576b"
+                        ],
+                        [
+                          0.6666666666666666,
+                          "#ed7953"
+                        ],
+                        [
+                          0.7777777777777778,
+                          "#fb9f3a"
+                        ],
+                        [
+                          0.8888888888888888,
+                          "#fdca26"
+                        ],
+                        [
+                          1,
+                          "#f0f921"
+                        ]
+                      ]
+                    },
+                    "colorway": [
+                      "#636efa",
+                      "#EF553B",
+                      "#00cc96",
+                      "#ab63fa",
+                      "#FFA15A",
+                      "#19d3f3",
+                      "#FF6692",
+                      "#B6E880",
+                      "#FF97FF",
+                      "#FECB52"
+                    ],
+                    "font": {
+                      "color": "#2a3f5f"
+                    },
+                    "geo": {
+                      "bgcolor": "white",
+                      "lakecolor": "white",
+                      "landcolor": "#E5ECF6",
+                      "showlakes": true,
+                      "showland": true,
+                      "subunitcolor": "white"
+                    },
+                    "hoverlabel": {
+                      "align": "left"
+                    },
+                    "hovermode": "closest",
+                    "mapbox": {
+                      "style": "light"
+                    },
+                    "paper_bgcolor": "white",
+                    "plot_bgcolor": "#E5ECF6",
+                    "polar": {
+                      "angularaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "bgcolor": "#E5ECF6",
+                      "radialaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      }
+                    },
+                    "scene": {
+                      "xaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      },
+                      "yaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      },
+                      "zaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      }
+                    },
+                    "shapedefaults": {
+                      "line": {
+                        "color": "#2a3f5f"
+                      }
+                    },
+                    "ternary": {
+                      "aaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "baxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "bgcolor": "#E5ECF6",
+                      "caxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      }
+                    },
+                    "title": {
+                      "x": 0.05
+                    },
+                    "xaxis": {
+                      "automargin": true,
+                      "gridcolor": "white",
+                      "linecolor": "white",
+                      "ticks": "",
+                      "title": {
+                        "standoff": 15
+                      },
+                      "zerolinecolor": "white",
+                      "zerolinewidth": 2
+                    },
+                    "yaxis": {
+                      "automargin": true,
+                      "gridcolor": "white",
+                      "linecolor": "white",
+                      "ticks": "",
+                      "title": {
+                        "standoff": 15
+                      },
+                      "zerolinecolor": "white",
+                      "zerolinewidth": 2
+                    }
+                  }
+                },
+                "title": {
+                  "text": "Model performance vs. # of iterations"
+                },
+                "xaxis": {
+                  "title": {
+                    "text": "Iteration"
+                  },
+                  "type": "linear",
+                  "range": [
+                    1,
+                    30
+                  ],
+                  "autorange": true
+                },
+                "yaxis": {
+                  "title": {
+                    "text": "Branin"
+                  },
+                  "type": "linear",
+                  "range": [
+                    -1.918002636203342,
+                    44.3997900878635
+                  ],
+                  "autorange": true
+                }
+              }
+            },
+            "text/html": "<div>                            <div id=\"e2f3d9d1-afa0-4b57-b2b3-ba1b069974a6\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"e2f3d9d1-afa0-4b57-b2b3-ba1b069974a6\")) {                    Plotly.newPlot(                        \"e2f3d9d1-afa0-4b57-b2b3-ba1b069974a6\",                        [{\"hoverinfo\": \"none\", \"legendgroup\": \"\", \"line\": {\"width\": 0}, \"mode\": \"lines\", \"showlegend\": false, \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30], \"y\": [42.083900451660156, 6.161984443664551, 4.77583122253418, 4.77583122253418, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.48105812072753906, 0.48105812072753906, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203]}, {\"fill\": \"tonexty\", \"fillcolor\": \"rgba(128,177,211,0.3)\", \"legendgroup\": \"objective value\", \"line\": {\"color\": \"rgba(128,177,211,1)\"}, \"mode\": \"lines\", \"name\": \"objective value\", \"text\": [\"<br><em>Parameterization:</em><br>x1: 1.053490936756134<br>x2: 9.695006310939789\", \"<br><em>Parameterization:</em><br>x1: 9.673875807784498<br>x2: 5.031454539857805\", \"<br><em>Parameterization:</em><br>x1: -2.6983634615316987<br>x2: 13.092638882808387\", \"<br><em>Parameterization:</em><br>x1: 4.255731301382184<br>x2: 5.3627007734030485\", \"<br><em>Parameterization:</em><br>x1: 9.896218599751592<br>x2: 4.34751792345196\", \"<br><em>Parameterization:</em><br>x1: -3.947538998984686<br>x2: 12.530771731366281\", \"<br><em>Parameterization:</em><br>x1: 10.0<br>x2: 1.062916555044761\", \"<br><em>Parameterization:</em><br>x1: 7.21844183648062<br>x2: 0.41871484495313804\", \"<br><em>Parameterization:</em><br>x1: -3.1990796261421757<br>x2: 0.11399374450743174\", \"<br><em>Parameterization:</em><br>x1: -5.0<br>x2: 15.0\", \"<br><em>Parameterization:</em><br>x1: 8.0227651133701<br>x2: 3.542145511842334\", \"<br><em>Parameterization:</em><br>x1: 5.533142090027264<br>x2: 15.0\", \"<br><em>Parameterization:</em><br>x1: 2.911041881584141<br>x2: 2.161366131603687\", \"<br><em>Parameterization:</em><br>x1: 3.5966954967872837<br>x2: 0.0\", \"<br><em>Parameterization:</em><br>x1: 3.6320456772082554<br>x2: 2.0316523415854526\", \"<br><em>Parameterization:</em><br>x1: -2.1171632044281883<br>x2: 9.798724198318416\", \"<br><em>Parameterization:</em><br>x1: 10.0<br>x2: 3.305777701872517\", \"<br><em>Parameterization:</em><br>x1: 2.521829699771833<br>x2: 2.5468035759843533\", \"<br><em>Parameterization:</em><br>x1: 3.2582006155846504<br>x2: 2.051792648782326\", \"<br><em>Parameterization:</em><br>x1: 3.4161086120295376<br>x2: 2.004387098830192\", \"<br><em>Parameterization:</em><br>x1: 3.143471996153947<br>x2: 2.2881945397553003\", \"<br><em>Parameterization:</em><br>x1: 3.1516606150486464<br>x2: 1.9889850619156846\", \"<br><em>Parameterization:</em><br>x1: 3.320215989374521<br>x2: 2.1993661124829935\", \"<br><em>Parameterization:</em><br>x1: 3.3550495492967194<br>x2: 1.8860391984524798\", \"<br><em>Parameterization:</em><br>x1: 2.9954482956770887<br>x2: 2.447697319486139\", \"<br><em>Parameterization:</em><br>x1: -3.575002873038719<br>x2: 15.0\", \"<br><em>Parameterization:</em><br>x1: 3.1041197799343703<br>x2: 2.184512833398977\", \"<br><em>Parameterization:</em><br>x1: 3.4098088553679933<br>x2: 2.126092134213714\", \"<br><em>Parameterization:</em><br>x1: 3.218610082260776<br>x2: 2.2531901460823534\", \"<br><em>Parameterization:</em><br>x1: 3.1333359949622306<br>x2: 2.4422369680029155\"], \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30], \"y\": [42.083900451660156, 6.161984443664551, 4.77583122253418, 4.77583122253418, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.48105812072753906, 0.48105812072753906, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203]}, {\"fill\": \"tonexty\", \"fillcolor\": \"rgba(128,177,211,0.3)\", \"hoverinfo\": \"none\", \"legendgroup\": \"\", \"line\": {\"width\": 0}, \"mode\": \"lines\", \"showlegend\": false, \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30], \"y\": [42.083900451660156, 6.161984443664551, 4.77583122253418, 4.77583122253418, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 3.5366411209106445, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.7421302795410156, 0.48105812072753906, 0.48105812072753906, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203, 0.3981189727783203]}, {\"line\": {\"color\": \"rgba(253,180,98,1)\", \"dash\": \"dash\"}, \"mode\": \"lines\", \"name\": \"Optimum\", \"type\": \"scatter\", \"x\": [1, 30], \"y\": [0.397887, 0.397887]}, {\"line\": {\"color\": \"rgba(141,211,199,1)\", \"dash\": \"dash\"}, \"mode\": \"lines\", \"name\": \"model change\", \"type\": \"scatter\", \"x\": [5, 5], \"y\": [0.397887, 42.083900451660156]}],                        {\"showlegend\": true, \"template\": {\"data\": {\"bar\": [{\"error_x\": {\"color\": \"#2a3f5f\"}, \"error_y\": {\"color\": \"#2a3f5f\"}, \"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"bar\"}], \"barpolar\": [{\"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"barpolar\"}], \"carpet\": [{\"aaxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"baxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"type\": \"carpet\"}], \"choropleth\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"choropleth\"}], \"contour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"contour\"}], \"contourcarpet\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"contourcarpet\"}], \"heatmap\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmap\"}], \"heatmapgl\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmapgl\"}], \"histogram\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"histogram\"}], \"histogram2d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2d\"}], \"histogram2dcontour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2dcontour\"}], \"mesh3d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"mesh3d\"}], \"parcoords\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"parcoords\"}], \"pie\": [{\"automargin\": true, \"type\": \"pie\"}], \"scatter\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter\"}], \"scatter3d\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter3d\"}], \"scattercarpet\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattercarpet\"}], \"scattergeo\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergeo\"}], \"scattergl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergl\"}], \"scattermapbox\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattermapbox\"}], \"scatterpolar\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolar\"}], \"scatterpolargl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolargl\"}], \"scatterternary\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterternary\"}], \"surface\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"surface\"}], \"table\": [{\"cells\": {\"fill\": {\"color\": \"#EBF0F8\"}, \"line\": {\"color\": \"white\"}}, \"header\": {\"fill\": {\"color\": \"#C8D4E3\"}, \"line\": {\"color\": \"white\"}}, \"type\": \"table\"}]}, \"layout\": {\"annotationdefaults\": {\"arrowcolor\": \"#2a3f5f\", \"arrowhead\": 0, \"arrowwidth\": 1}, \"autotypenumbers\": \"strict\", \"coloraxis\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"colorscale\": {\"diverging\": [[0, \"#8e0152\"], [0.1, \"#c51b7d\"], [0.2, \"#de77ae\"], [0.3, \"#f1b6da\"], [0.4, \"#fde0ef\"], [0.5, \"#f7f7f7\"], [0.6, \"#e6f5d0\"], [0.7, \"#b8e186\"], [0.8, \"#7fbc41\"], [0.9, \"#4d9221\"], [1, \"#276419\"]], \"sequential\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"sequentialminus\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]]}, \"colorway\": [\"#636efa\", \"#EF553B\", \"#00cc96\", \"#ab63fa\", \"#FFA15A\", \"#19d3f3\", \"#FF6692\", \"#B6E880\", \"#FF97FF\", \"#FECB52\"], \"font\": {\"color\": \"#2a3f5f\"}, \"geo\": {\"bgcolor\": \"white\", \"lakecolor\": \"white\", \"landcolor\": \"#E5ECF6\", \"showlakes\": true, \"showland\": true, \"subunitcolor\": \"white\"}, \"hoverlabel\": {\"align\": \"left\"}, \"hovermode\": \"closest\", \"mapbox\": {\"style\": \"light\"}, \"paper_bgcolor\": \"white\", \"plot_bgcolor\": \"#E5ECF6\", \"polar\": {\"angularaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"radialaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"scene\": {\"xaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"yaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"zaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}}, \"shapedefaults\": {\"line\": {\"color\": \"#2a3f5f\"}}, \"ternary\": {\"aaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"baxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"caxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"title\": {\"x\": 0.05}, \"xaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}, \"yaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}}}, \"title\": {\"text\": \"Model performance vs. # of iterations\"}, \"xaxis\": {\"title\": {\"text\": \"Iteration\"}}, \"yaxis\": {\"title\": {\"text\": \"Branin\"}}},                        {\"responsive\": true}                    ).then(function(){\n                            \nvar gd = document.getElementById('e2f3d9d1-afa0-4b57-b2b3-ba1b069974a6');\nvar x = new MutationObserver(function (mutations, observer) {{\n        var display = window.getComputedStyle(gd).display;\n        if (!display || display === 'none') {{\n            console.log([gd, 'removed!']);\n            Plotly.purge(gd);\n            observer.disconnect();\n        }}\n}});\n\n// Listen for the removal of the full notebook cells\nvar notebookContainer = gd.closest('#notebook-container');\nif (notebookContainer) {{\n    x.observe(notebookContainer, {childList: true});\n}}\n\n// Listen for the clearing of the current output cell\nvar outputEl = gd.closest('.output');\nif (outputEl) {{\n    x.observe(outputEl, {childList: true});\n}}\n\n                        })                };                });            </script>        </div>"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "59a5ea1e-1b70-433b-bd3d-e3708d270769",
+        "showInput": true,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "## Optimization with the Developer API\n",
+        "\n",
+        "A detailed tutorial on the Service API can be found [here](https://ax.dev/tutorials/gpei_hartmann_developer.html).\n",
+        "\n",
+        "### Set up the Experiment in Ax\n",
+        "\n",
+        "We need 3 inputs for an Ax `Experiment`:\n",
+        "- A search space to optimize over;\n",
+        "- An optimization config specifiying the objective / metrics to optimize, and optional outcome constraints;\n",
+        "- A runner that handles the deployment of trials. For a synthetic optimization problem, such as here, this only returns simple metadata about the trial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "16ddad39-c4ba-48d0-a67d-e42de25e7236",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "9063b301-cf83-423c-9d3c-809ec8107cc6",
+        "executionStartTime": 1646802638781,
+        "executionStopTime": 1646802638852
+      },
+      "source": [
+        "import pandas as pd\n",
+        "import torch\n",
+        "from ax import (\n",
+        "    Data,\n",
+        "    Experiment,\n",
+        "    Metric,\n",
+        "    Objective,\n",
+        "    OptimizationConfig,\n",
+        "    ParameterType,\n",
+        "    RangeParameter,\n",
+        "    Runner,\n",
+        "    SearchSpace,\n",
+        ")\n",
+        "from botorch.test_functions import Branin\n",
+        "\n",
+        "\n",
+        "branin_func = Branin()\n",
+        "\n",
+        "# For our purposes, the metric is a wrapper that structures the function output.\n",
+        "class BraninMetric(Metric):\n",
+        "    def fetch_trial_data(self, trial):\n",
+        "        records = []\n",
+        "        for arm_name, arm in trial.arms_by_name.items():\n",
+        "            params = arm.parameters\n",
+        "            tensor_params = torch.tensor([params[\"x1\"], params[\"x2\"]])\n",
+        "            records.append(\n",
+        "                {\n",
+        "                    \"arm_name\": arm_name,\n",
+        "                    \"metric_name\": self.name,\n",
+        "                    \"trial_index\": trial.index,\n",
+        "                    \"mean\": branin_func(tensor_params),\n",
+        "                    \"sem\": 0.0,  # SEM - standard error of the mean - corresponds to Yvar in BoTorch.\n",
+        "                }\n",
+        "            )\n",
+        "        return Data(df=pd.DataFrame.from_records(records))\n",
+        "\n",
+        "\n",
+        "# Search space defines the parameters, their types, and acceptable values.\n",
+        "search_space = SearchSpace(\n",
+        "    parameters=[\n",
+        "        RangeParameter(name=\"x1\", parameter_type=ParameterType.FLOAT, lower=-5, upper=10),\n",
+        "        RangeParameter(name=\"x2\", parameter_type=ParameterType.FLOAT, lower=0, upper=15),\n",
+        "    ]\n",
+        ")\n",
+        "\n",
+        "optimization_config = OptimizationConfig(\n",
+        "    objective=Objective(\n",
+        "        metric=BraninMetric(name=\"branin_metric\", lower_is_better=True),\n",
+        "        minimize=True,  # This is optional since we specified `lower_is_better=True`\n",
+        "    )\n",
+        ")\n",
+        "\n",
+        "\n",
+        "class MyRunner(Runner):\n",
+        "    def run(self, trial):\n",
+        "        trial_metadata = {\"name\": str(trial.index)}\n",
+        "        return trial_metadata\n",
+        "\n",
+        "\n",
+        "exp = Experiment(\n",
+        "    name=\"branin_experiment\",\n",
+        "    search_space=search_space,\n",
+        "    optimization_config=optimization_config,\n",
+        "    runner=MyRunner(),\n",
+        ")"
+      ],
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "a5cb8ffb-3af8-4fdd-85b4-a10917177dc7",
+        "showInput": false,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Run the BO loop\n",
+        "\n",
+        "First, we use the Sobol generator to create 5 (quasi-) random initial point in the search space. Ax controls objective evaluations via `Trial`s. \n",
+        "- We generate a `Trial` using a generator run, e.g., `Sobol` below. A `Trial` specifies relevant metadata as well as the parameters to be evaluated. At this point, the `Trial` is at the `CANDIDATE` stage.\n",
+        "- We run the `Trial` using `Trial.run()`. In our example, this serves to mark the `Trial` as `RUNNING`. In an advanced application, this can be used to dispatch the `Trial` for evaluation on a remote server.\n",
+        "- Once the `Trial` is done running, we mark it as `COMPLETED`. This tells the `Experiment` that it can fetch the `Trial` data. \n",
+        "\n",
+        "A `Trial` supports evaluation of a single parameterization. For parallel evaluations, see [`BatchTrial`](https://ax.dev/docs/core.html#trial-vs-batch-trial)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "13b3c924-8bf6-4af3-ab0e-1f8abe6580f0",
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "33b6b5d0-ffe2-429c-9891-df71eef48da9",
+        "executionStartTime": 1646802638888,
+        "executionStopTime": 1646802639051
+      },
+      "source": [
+        "from ax.modelbridge.registry import Models\n",
+        "\n",
+        "\n",
+        "sobol = Models.SOBOL(exp.search_space)\n",
+        "\n",
+        "for i in range(5):\n",
+        "    trial = exp.new_trial(generator_run=sobol.gen(1))\n",
+        "    trial.run()\n",
+        "    trial.mark_completed()"
+      ],
+      "execution_count": 13,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "33fef7a2-67db-43cd-bc84-4d5736c582e7",
+        "showInput": false,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "Once the initial (quasi-) random stage is completed, we can use our `SimpleCustomGP` with the default acquisition function chosen by `Ax` to run the BO loop."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "bbdd71d2-e2c9-40a1-8d86-c085a4789689",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "83733f3f-531b-4847-99da-468cc9bac3f8",
+        "executionStartTime": 1646802639078,
+        "executionStopTime": 1646802679659
+      },
+      "source": [
+        "with fast_smoke_test():\n",
+        "    for i in range(25):\n",
+        "        model_bridge = Models.BOTORCH_MODULAR(\n",
+        "            experiment=exp,\n",
+        "            data=exp.fetch_data(),\n",
+        "            surrogate=Surrogate(SimpleCustomGP),\n",
+        "        )\n",
+        "        trial = exp.new_trial(generator_run=model_bridge.gen(1))\n",
+        "        trial.run()\n",
+        "        trial.mark_completed()"
+      ],
+      "execution_count": 14,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "cb16843a-0e12-47fc-860f-eafb74f1bd3b",
+        "showInput": false,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "View the trials attached to the `Experiment`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "28a95fc8-848c-4cf0-a31d-20bde4fc95ff",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "cd1182e4-2326-48f2-bb18-6be5b16c7a10",
+        "executionStartTime": 1646802679684,
+        "executionStopTime": 1646802679777
+      },
+      "source": [
+        "exp.trials"
+      ],
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "{0: Trial(experiment_name='branin_experiment', index=0, status=TrialStatus.COMPLETED, arm=Arm(name='0_0', parameters={'x1': 3.9835897088050842, 'x2': 12.342978715896606})),\n 1: Trial(experiment_name='branin_experiment', index=1, status=TrialStatus.COMPLETED, arm=Arm(name='1_0', parameters={'x1': -3.593796114437282, 'x2': 0.6191267631947994})),\n 2: Trial(experiment_name='branin_experiment', index=2, status=TrialStatus.COMPLETED, arm=Arm(name='2_0', parameters={'x1': 1.2375280819833279, 'x2': 10.779688828624785})),\n 3: Trial(experiment_name='branin_experiment', index=3, status=TrialStatus.COMPLETED, arm=Arm(name='3_0', parameters={'x1': 8.4092768561095, 'x2': 6.551370648667216})),\n 4: Trial(experiment_name='branin_experiment', index=4, status=TrialStatus.COMPLETED, arm=Arm(name='4_0', parameters={'x1': 6.420887252315879, 'x2': 7.687858119606972})),\n 5: Trial(experiment_name='branin_experiment', index=5, status=TrialStatus.COMPLETED, arm=Arm(name='5_0', parameters={'x1': -5.0, 'x2': 5.964186525739804})),\n 6: Trial(experiment_name='branin_experiment', index=6, status=TrialStatus.COMPLETED, arm=Arm(name='6_0', parameters={'x1': 10.0, 'x2': 13.924586724703465})),\n 7: Trial(experiment_name='branin_experiment', index=7, status=TrialStatus.COMPLETED, arm=Arm(name='7_0', parameters={'x1': 10.0, 'x2': 4.4517560112749})),\n 8: Trial(experiment_name='branin_experiment', index=8, status=TrialStatus.COMPLETED, arm=Arm(name='8_0', parameters={'x1': 8.379592812792593, 'x2': 1.9013971302422787})),\n 9: Trial(experiment_name='branin_experiment', index=9, status=TrialStatus.COMPLETED, arm=Arm(name='9_0', parameters={'x1': 9.5818212436301, 'x2': 2.8214573590742535})),\n 10: Trial(experiment_name='branin_experiment', index=10, status=TrialStatus.COMPLETED, arm=Arm(name='10_0', parameters={'x1': -2.6006675036313465, 'x2': 15.0})),\n 11: Trial(experiment_name='branin_experiment', index=11, status=TrialStatus.COMPLETED, arm=Arm(name='11_0', parameters={'x1': 10.0, 'x2': 0.0})),\n 12: Trial(experiment_name='branin_experiment', index=12, status=TrialStatus.COMPLETED, arm=Arm(name='12_0', parameters={'x1': -5.0, 'x2': 15.0})),\n 13: Trial(experiment_name='branin_experiment', index=13, status=TrialStatus.COMPLETED, arm=Arm(name='13_0', parameters={'x1': 3.2014472029816456, 'x2': 0.0})),\n 14: Trial(experiment_name='branin_experiment', index=14, status=TrialStatus.COMPLETED, arm=Arm(name='14_0', parameters={'x1': 1.9343847442338067, 'x2': 1.871925657529758})),\n 15: Trial(experiment_name='branin_experiment', index=15, status=TrialStatus.COMPLETED, arm=Arm(name='15_0', parameters={'x1': 9.99981266967715, 'x2': 2.8700552768983005})),\n 16: Trial(experiment_name='branin_experiment', index=16, status=TrialStatus.COMPLETED, arm=Arm(name='16_0', parameters={'x1': 1.9405874816942408, 'x2': 0.0})),\n 17: Trial(experiment_name='branin_experiment', index=17, status=TrialStatus.COMPLETED, arm=Arm(name='17_0', parameters={'x1': 3.391264006193385, 'x2': 2.042703897555975})),\n 18: Trial(experiment_name='branin_experiment', index=18, status=TrialStatus.COMPLETED, arm=Arm(name='18_0', parameters={'x1': 3.47243300092296, 'x2': 1.5910939498249457})),\n 19: Trial(experiment_name='branin_experiment', index=19, status=TrialStatus.COMPLETED, arm=Arm(name='19_0', parameters={'x1': 3.1203781801727164, 'x2': 2.115274139345125})),\n 20: Trial(experiment_name='branin_experiment', index=20, status=TrialStatus.COMPLETED, arm=Arm(name='20_0', parameters={'x1': 2.996470054652713, 'x2': 2.575549008562363})),\n 21: Trial(experiment_name='branin_experiment', index=21, status=TrialStatus.COMPLETED, arm=Arm(name='21_0', parameters={'x1': 3.1921688171383664, 'x2': 1.8861011528150278})),\n 22: Trial(experiment_name='branin_experiment', index=22, status=TrialStatus.COMPLETED, arm=Arm(name='22_0', parameters={'x1': 9.466102809806777, 'x2': 2.8735390479699223})),\n 23: Trial(experiment_name='branin_experiment', index=23, status=TrialStatus.COMPLETED, arm=Arm(name='23_0', parameters={'x1': -3.2800335131481795, 'x2': 12.460074709333359})),\n 24: Trial(experiment_name='branin_experiment', index=24, status=TrialStatus.COMPLETED, arm=Arm(name='24_0', parameters={'x1': -3.583099210363769, 'x2': 13.091624739093264})),\n 25: Trial(experiment_name='branin_experiment', index=25, status=TrialStatus.COMPLETED, arm=Arm(name='25_0', parameters={'x1': -2.9101468533190387, 'x2': 12.51834290366669})),\n 26: Trial(experiment_name='branin_experiment', index=26, status=TrialStatus.COMPLETED, arm=Arm(name='26_0', parameters={'x1': -0.7592783019054927, 'x2': 7.44090211050809})),\n 27: Trial(experiment_name='branin_experiment', index=27, status=TrialStatus.COMPLETED, arm=Arm(name='27_0', parameters={'x1': -3.054410732837594, 'x2': 12.11074060874216})),\n 28: Trial(experiment_name='branin_experiment', index=28, status=TrialStatus.COMPLETED, arm=Arm(name='28_0', parameters={'x1': -3.187596886240865, 'x2': 12.663637858792194})),\n 29: Trial(experiment_name='branin_experiment', index=29, status=TrialStatus.COMPLETED, arm=Arm(name='29_0', parameters={'x1': 2.8278366854653134, 'x2': 3.1930332483755186}))}"
+          },
+          "metadata": {
+            "bento_obj_id": "140418871257408"
+          },
+          "execution_count": 15
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "f96540ca-1043-4803-ad8c-d143d98373a2",
+        "showInput": false,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "View the evaluation data about these trials."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "a0a7e159-ce6b-43d0-97e3-4d68f9779659",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "a00d8d83-c18a-46d2-8179-c180709a8c81",
+        "executionStartTime": 1646802679808,
+        "executionStopTime": 1646802680139
+      },
+      "source": [
+        "exp.fetch_data().df"
+      ],
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   arm_name    metric_name        mean  sem  trial_index\n0       0_0  branin_metric  116.666603  0.0            0\n1       1_0  branin_metric  164.411484  0.0            1\n2       2_0  branin_metric   56.062450  0.0            2\n3       3_0  branin_metric   27.975380  0.0            3\n4       4_0  branin_metric   62.821098  0.0            4\n5       5_0  branin_metric  138.683380  0.0            5\n6       6_0  branin_metric  121.225121  0.0            6\n7       7_0  branin_metric    4.042157  0.0            7\n8       8_0  branin_metric    5.210078  0.0            8\n9       9_0  branin_metric    0.560489  0.0            9\n10     10_0  branin_metric   17.666313  0.0           10\n11     11_0  branin_metric   10.960894  0.0           11\n12     12_0  branin_metric   17.508297  0.0           12\n13     13_0  branin_metric    5.382563  0.0           13\n14     14_0  branin_metric    8.934655  0.0           14\n15     15_0  branin_metric    1.959778  0.0           15\n16     16_0  branin_metric   18.075680  0.0           16\n17     17_0  branin_metric    0.697696  0.0           17\n18     18_0  branin_metric    1.112247  0.0           18\n19     19_0  branin_metric    0.431139  0.0           19\n20     20_0  branin_metric    0.532920  0.0           20\n21     21_0  branin_metric    0.532516  0.0           21\n22     22_0  branin_metric    0.538188  0.0           22\n23     23_0  branin_metric    0.512290  0.0           23\n24     24_0  branin_metric    1.391329  0.0           24\n25     25_0  branin_metric    1.282202  0.0           25\n26     26_0  branin_metric   16.989693  0.0           26\n27     27_0  branin_metric    0.436316  0.0           27\n28     28_0  branin_metric    0.485222  0.0           28\n29     29_0  branin_metric    1.303083  0.0           29",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>arm_name</th>\n      <th>metric_name</th>\n      <th>mean</th>\n      <th>sem</th>\n      <th>trial_index</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0_0</td>\n      <td>branin_metric</td>\n      <td>116.666603</td>\n      <td>0.0</td>\n      <td>0</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1_0</td>\n      <td>branin_metric</td>\n      <td>164.411484</td>\n      <td>0.0</td>\n      <td>1</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2_0</td>\n      <td>branin_metric</td>\n      <td>56.062450</td>\n      <td>0.0</td>\n      <td>2</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3_0</td>\n      <td>branin_metric</td>\n      <td>27.975380</td>\n      <td>0.0</td>\n      <td>3</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>4_0</td>\n      <td>branin_metric</td>\n      <td>62.821098</td>\n      <td>0.0</td>\n      <td>4</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>5_0</td>\n      <td>branin_metric</td>\n      <td>138.683380</td>\n      <td>0.0</td>\n      <td>5</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>6_0</td>\n      <td>branin_metric</td>\n      <td>121.225121</td>\n      <td>0.0</td>\n      <td>6</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>7_0</td>\n      <td>branin_metric</td>\n      <td>4.042157</td>\n      <td>0.0</td>\n      <td>7</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>8_0</td>\n      <td>branin_metric</td>\n      <td>5.210078</td>\n      <td>0.0</td>\n      <td>8</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>9_0</td>\n      <td>branin_metric</td>\n      <td>0.560489</td>\n      <td>0.0</td>\n      <td>9</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>10_0</td>\n      <td>branin_metric</td>\n      <td>17.666313</td>\n      <td>0.0</td>\n      <td>10</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>11_0</td>\n      <td>branin_metric</td>\n      <td>10.960894</td>\n      <td>0.0</td>\n      <td>11</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>12_0</td>\n      <td>branin_metric</td>\n      <td>17.508297</td>\n      <td>0.0</td>\n      <td>12</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>13_0</td>\n      <td>branin_metric</td>\n      <td>5.382563</td>\n      <td>0.0</td>\n      <td>13</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>14_0</td>\n      <td>branin_metric</td>\n      <td>8.934655</td>\n      <td>0.0</td>\n      <td>14</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>15_0</td>\n      <td>branin_metric</td>\n      <td>1.959778</td>\n      <td>0.0</td>\n      <td>15</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>16_0</td>\n      <td>branin_metric</td>\n      <td>18.075680</td>\n      <td>0.0</td>\n      <td>16</td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>17_0</td>\n      <td>branin_metric</td>\n      <td>0.697696</td>\n      <td>0.0</td>\n      <td>17</td>\n    </tr>\n    <tr>\n      <th>18</th>\n      <td>18_0</td>\n      <td>branin_metric</td>\n      <td>1.112247</td>\n      <td>0.0</td>\n      <td>18</td>\n    </tr>\n    <tr>\n      <th>19</th>\n      <td>19_0</td>\n      <td>branin_metric</td>\n      <td>0.431139</td>\n      <td>0.0</td>\n      <td>19</td>\n    </tr>\n    <tr>\n      <th>20</th>\n      <td>20_0</td>\n      <td>branin_metric</td>\n      <td>0.532920</td>\n      <td>0.0</td>\n      <td>20</td>\n    </tr>\n    <tr>\n      <th>21</th>\n      <td>21_0</td>\n      <td>branin_metric</td>\n      <td>0.532516</td>\n      <td>0.0</td>\n      <td>21</td>\n    </tr>\n    <tr>\n      <th>22</th>\n      <td>22_0</td>\n      <td>branin_metric</td>\n      <td>0.538188</td>\n      <td>0.0</td>\n      <td>22</td>\n    </tr>\n    <tr>\n      <th>23</th>\n      <td>23_0</td>\n      <td>branin_metric</td>\n      <td>0.512290</td>\n      <td>0.0</td>\n      <td>23</td>\n    </tr>\n    <tr>\n      <th>24</th>\n      <td>24_0</td>\n      <td>branin_metric</td>\n      <td>1.391329</td>\n      <td>0.0</td>\n      <td>24</td>\n    </tr>\n    <tr>\n      <th>25</th>\n      <td>25_0</td>\n      <td>branin_metric</td>\n      <td>1.282202</td>\n      <td>0.0</td>\n      <td>25</td>\n    </tr>\n    <tr>\n      <th>26</th>\n      <td>26_0</td>\n      <td>branin_metric</td>\n      <td>16.989693</td>\n      <td>0.0</td>\n      <td>26</td>\n    </tr>\n    <tr>\n      <th>27</th>\n      <td>27_0</td>\n      <td>branin_metric</td>\n      <td>0.436316</td>\n      <td>0.0</td>\n      <td>27</td>\n    </tr>\n    <tr>\n      <th>28</th>\n      <td>28_0</td>\n      <td>branin_metric</td>\n      <td>0.485222</td>\n      <td>0.0</td>\n      <td>28</td>\n    </tr>\n    <tr>\n      <th>29</th>\n      <td>29_0</td>\n      <td>branin_metric</td>\n      <td>1.303083</td>\n      <td>0.0</td>\n      <td>29</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+            "application/vnd.dataresource+json": {
+              "schema": {
+                "fields": [
+                  {
+                    "name": "index",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "arm_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "metric_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "mean",
+                    "type": "number"
+                  },
+                  {
+                    "name": "sem",
+                    "type": "number"
+                  },
+                  {
+                    "name": "trial_index",
+                    "type": "integer"
+                  }
+                ],
+                "primaryKey": [
+                  "index"
+                ],
+                "pandas_version": "0.20.0"
+              },
+              "data": [
+                {
+                  "index": 0,
+                  "arm_name": "0_0",
+                  "metric_name": "branin_metric",
+                  "mean": 116.6666030884,
+                  "sem": 0,
+                  "trial_index": 0
+                },
+                {
+                  "index": 1,
+                  "arm_name": "1_0",
+                  "metric_name": "branin_metric",
+                  "mean": 164.4114837646,
+                  "sem": 0,
+                  "trial_index": 1
+                },
+                {
+                  "index": 2,
+                  "arm_name": "2_0",
+                  "metric_name": "branin_metric",
+                  "mean": 56.0624504089,
+                  "sem": 0,
+                  "trial_index": 2
+                },
+                {
+                  "index": 3,
+                  "arm_name": "3_0",
+                  "metric_name": "branin_metric",
+                  "mean": 27.9753799438,
+                  "sem": 0,
+                  "trial_index": 3
+                },
+                {
+                  "index": 4,
+                  "arm_name": "4_0",
+                  "metric_name": "branin_metric",
+                  "mean": 62.8210983276,
+                  "sem": 0,
+                  "trial_index": 4
+                },
+                {
+                  "index": 5,
+                  "arm_name": "5_0",
+                  "metric_name": "branin_metric",
+                  "mean": 138.683380127,
+                  "sem": 0,
+                  "trial_index": 5
+                },
+                {
+                  "index": 6,
+                  "arm_name": "6_0",
+                  "metric_name": "branin_metric",
+                  "mean": 121.2251205444,
+                  "sem": 0,
+                  "trial_index": 6
+                },
+                {
+                  "index": 7,
+                  "arm_name": "7_0",
+                  "metric_name": "branin_metric",
+                  "mean": 4.0421571732,
+                  "sem": 0,
+                  "trial_index": 7
+                },
+                {
+                  "index": 8,
+                  "arm_name": "8_0",
+                  "metric_name": "branin_metric",
+                  "mean": 5.2100777626,
+                  "sem": 0,
+                  "trial_index": 8
+                },
+                {
+                  "index": 9,
+                  "arm_name": "9_0",
+                  "metric_name": "branin_metric",
+                  "mean": 0.5604887009,
+                  "sem": 0,
+                  "trial_index": 9
+                },
+                {
+                  "index": 10,
+                  "arm_name": "10_0",
+                  "metric_name": "branin_metric",
+                  "mean": 17.6663131714,
+                  "sem": 0,
+                  "trial_index": 10
+                },
+                {
+                  "index": 11,
+                  "arm_name": "11_0",
+                  "metric_name": "branin_metric",
+                  "mean": 10.960893631,
+                  "sem": 0,
+                  "trial_index": 11
+                },
+                {
+                  "index": 12,
+                  "arm_name": "12_0",
+                  "metric_name": "branin_metric",
+                  "mean": 17.5082969666,
+                  "sem": 0,
+                  "trial_index": 12
+                },
+                {
+                  "index": 13,
+                  "arm_name": "13_0",
+                  "metric_name": "branin_metric",
+                  "mean": 5.3825626373,
+                  "sem": 0,
+                  "trial_index": 13
+                },
+                {
+                  "index": 14,
+                  "arm_name": "14_0",
+                  "metric_name": "branin_metric",
+                  "mean": 8.9346551895,
+                  "sem": 0,
+                  "trial_index": 14
+                },
+                {
+                  "index": 15,
+                  "arm_name": "15_0",
+                  "metric_name": "branin_metric",
+                  "mean": 1.959777832,
+                  "sem": 0,
+                  "trial_index": 15
+                },
+                {
+                  "index": 16,
+                  "arm_name": "16_0",
+                  "metric_name": "branin_metric",
+                  "mean": 18.0756797791,
+                  "sem": 0,
+                  "trial_index": 16
+                },
+                {
+                  "index": 17,
+                  "arm_name": "17_0",
+                  "metric_name": "branin_metric",
+                  "mean": 0.6976957321,
+                  "sem": 0,
+                  "trial_index": 17
+                },
+                {
+                  "index": 18,
+                  "arm_name": "18_0",
+                  "metric_name": "branin_metric",
+                  "mean": 1.1122465134,
+                  "sem": 0,
+                  "trial_index": 18
+                },
+                {
+                  "index": 19,
+                  "arm_name": "19_0",
+                  "metric_name": "branin_metric",
+                  "mean": 0.4311389923,
+                  "sem": 0,
+                  "trial_index": 19
+                },
+                {
+                  "index": 20,
+                  "arm_name": "20_0",
+                  "metric_name": "branin_metric",
+                  "mean": 0.5329198837,
+                  "sem": 0,
+                  "trial_index": 20
+                },
+                {
+                  "index": 21,
+                  "arm_name": "21_0",
+                  "metric_name": "branin_metric",
+                  "mean": 0.5325164795,
+                  "sem": 0,
+                  "trial_index": 21
+                },
+                {
+                  "index": 22,
+                  "arm_name": "22_0",
+                  "metric_name": "branin_metric",
+                  "mean": 0.5381879807,
+                  "sem": 0,
+                  "trial_index": 22
+                },
+                {
+                  "index": 23,
+                  "arm_name": "23_0",
+                  "metric_name": "branin_metric",
+                  "mean": 0.5122900009,
+                  "sem": 0,
+                  "trial_index": 23
+                },
+                {
+                  "index": 24,
+                  "arm_name": "24_0",
+                  "metric_name": "branin_metric",
+                  "mean": 1.3913288116,
+                  "sem": 0,
+                  "trial_index": 24
+                },
+                {
+                  "index": 25,
+                  "arm_name": "25_0",
+                  "metric_name": "branin_metric",
+                  "mean": 1.282201767,
+                  "sem": 0,
+                  "trial_index": 25
+                },
+                {
+                  "index": 26,
+                  "arm_name": "26_0",
+                  "metric_name": "branin_metric",
+                  "mean": 16.989692688,
+                  "sem": 0,
+                  "trial_index": 26
+                },
+                {
+                  "index": 27,
+                  "arm_name": "27_0",
+                  "metric_name": "branin_metric",
+                  "mean": 0.4363164902,
+                  "sem": 0,
+                  "trial_index": 27
+                },
+                {
+                  "index": 28,
+                  "arm_name": "28_0",
+                  "metric_name": "branin_metric",
+                  "mean": 0.4852218628,
+                  "sem": 0,
+                  "trial_index": 28
+                },
+                {
+                  "index": 29,
+                  "arm_name": "29_0",
+                  "metric_name": "branin_metric",
+                  "mean": 1.3030834198,
+                  "sem": 0,
+                  "trial_index": 29
+                }
+              ]
+            }
+          },
+          "metadata": {
+            "bento_obj_id": "140418659567072"
+          },
+          "execution_count": 16
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "c3ed0ec0-5002-4e7c-9e57-915e2a671abc",
+        "showInput": false,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "### Plot results\n",
+        "\n",
+        "We can use convenient Ax utilities for plotting the results."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "261d0e3b-8f3c-4a46-93be-bd1664682527",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "75429ef3-ab3b-43bf-87ea-a5fa1a4a9d24",
+        "executionStartTime": 1646802680167,
+        "executionStopTime": 1646802680358
+      },
+      "source": [
+        "import numpy as np\n",
+        "from ax.plot.trace import optimization_trace_single_method\n",
+        "from ax.utils.notebook.plotting import render\n",
+        "\n",
+        "\n",
+        "# `plot_single_method` expects a 2-d array of means, because it expects to average means from multiple\n",
+        "# optimization runs, so we wrap out best objectives array in another array.\n",
+        "objective_means = np.array([[trial.objective_mean for trial in exp.trials.values()]])\n",
+        "best_objective_plot = optimization_trace_single_method(\n",
+        "    y=np.minimum.accumulate(objective_means, axis=1),\n",
+        "    optimum=0.397887,  # Known minimum objective for Branin function.\n",
+        ")\n",
+        "render(best_objective_plot)"
+      ],
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.plotly.v1+json": {
+              "config": {
+                "linkText": "Export to plot.ly",
+                "plotlyServerURL": "https://plot.ly",
+                "showLink": false
+              },
+              "data": [
+                {
+                  "hoverinfo": "none",
+                  "legendgroup": "",
+                  "line": {
+                    "width": 0
+                  },
+                  "mode": "lines",
+                  "showlegend": false,
+                  "type": "scatter",
+                  "x": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    20,
+                    21,
+                    22,
+                    23,
+                    24,
+                    25,
+                    26,
+                    27,
+                    28,
+                    29,
+                    30
+                  ],
+                  "y": [
+                    116.6666030883789,
+                    116.6666030883789,
+                    56.06245040893555,
+                    27.975379943847656,
+                    27.975379943847656,
+                    27.975379943847656,
+                    27.975379943847656,
+                    4.042157173156738,
+                    4.042157173156738,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703
+                  ]
+                },
+                {
+                  "fill": "tonexty",
+                  "fillcolor": "rgba(128,177,211,0.3)",
+                  "legendgroup": "objective value",
+                  "line": {
+                    "color": "rgba(128,177,211,1)"
+                  },
+                  "mode": "lines",
+                  "name": "objective value",
+                  "type": "scatter",
+                  "x": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    20,
+                    21,
+                    22,
+                    23,
+                    24,
+                    25,
+                    26,
+                    27,
+                    28,
+                    29,
+                    30
+                  ],
+                  "y": [
+                    116.6666030883789,
+                    116.6666030883789,
+                    56.06245040893555,
+                    27.975379943847656,
+                    27.975379943847656,
+                    27.975379943847656,
+                    27.975379943847656,
+                    4.042157173156738,
+                    4.042157173156738,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703
+                  ]
+                },
+                {
+                  "fill": "tonexty",
+                  "fillcolor": "rgba(128,177,211,0.3)",
+                  "hoverinfo": "none",
+                  "legendgroup": "",
+                  "line": {
+                    "width": 0
+                  },
+                  "mode": "lines",
+                  "showlegend": false,
+                  "type": "scatter",
+                  "x": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    20,
+                    21,
+                    22,
+                    23,
+                    24,
+                    25,
+                    26,
+                    27,
+                    28,
+                    29,
+                    30
+                  ],
+                  "y": [
+                    116.6666030883789,
+                    116.6666030883789,
+                    56.06245040893555,
+                    27.975379943847656,
+                    27.975379943847656,
+                    27.975379943847656,
+                    27.975379943847656,
+                    4.042157173156738,
+                    4.042157173156738,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.5604887008666992,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703,
+                    0.4311389923095703
+                  ]
+                },
+                {
+                  "line": {
+                    "color": "rgba(253,180,98,1)",
+                    "dash": "dash"
+                  },
+                  "mode": "lines",
+                  "name": "Optimum",
+                  "type": "scatter",
+                  "x": [
+                    1,
+                    30
+                  ],
+                  "y": [
+                    0.397887,
+                    0.397887
+                  ]
+                }
+              ],
+              "layout": {
+                "showlegend": true,
+                "template": {
+                  "data": {
+                    "bar": [
+                      {
+                        "error_x": {
+                          "color": "#2a3f5f"
+                        },
+                        "error_y": {
+                          "color": "#2a3f5f"
+                        },
+                        "marker": {
+                          "line": {
+                            "color": "#E5ECF6",
+                            "width": 0.5
+                          }
+                        },
+                        "type": "bar"
+                      }
+                    ],
+                    "barpolar": [
+                      {
+                        "marker": {
+                          "line": {
+                            "color": "#E5ECF6",
+                            "width": 0.5
+                          }
+                        },
+                        "type": "barpolar"
+                      }
+                    ],
+                    "carpet": [
+                      {
+                        "aaxis": {
+                          "endlinecolor": "#2a3f5f",
+                          "gridcolor": "white",
+                          "linecolor": "white",
+                          "minorgridcolor": "white",
+                          "startlinecolor": "#2a3f5f"
+                        },
+                        "baxis": {
+                          "endlinecolor": "#2a3f5f",
+                          "gridcolor": "white",
+                          "linecolor": "white",
+                          "minorgridcolor": "white",
+                          "startlinecolor": "#2a3f5f"
+                        },
+                        "type": "carpet"
+                      }
+                    ],
+                    "choropleth": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "choropleth"
+                      }
+                    ],
+                    "contour": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "contour"
+                      }
+                    ],
+                    "contourcarpet": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "contourcarpet"
+                      }
+                    ],
+                    "heatmap": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "heatmap"
+                      }
+                    ],
+                    "heatmapgl": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "heatmapgl"
+                      }
+                    ],
+                    "histogram": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "histogram"
+                      }
+                    ],
+                    "histogram2d": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "histogram2d"
+                      }
+                    ],
+                    "histogram2dcontour": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "histogram2dcontour"
+                      }
+                    ],
+                    "mesh3d": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "type": "mesh3d"
+                      }
+                    ],
+                    "parcoords": [
+                      {
+                        "line": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "parcoords"
+                      }
+                    ],
+                    "pie": [
+                      {
+                        "automargin": true,
+                        "type": "pie"
+                      }
+                    ],
+                    "scatter": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatter"
+                      }
+                    ],
+                    "scatter3d": [
+                      {
+                        "line": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatter3d"
+                      }
+                    ],
+                    "scattercarpet": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattercarpet"
+                      }
+                    ],
+                    "scattergeo": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattergeo"
+                      }
+                    ],
+                    "scattergl": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattergl"
+                      }
+                    ],
+                    "scattermapbox": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scattermapbox"
+                      }
+                    ],
+                    "scatterpolar": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterpolar"
+                      }
+                    ],
+                    "scatterpolargl": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterpolargl"
+                      }
+                    ],
+                    "scatterternary": [
+                      {
+                        "marker": {
+                          "colorbar": {
+                            "outlinewidth": 0,
+                            "ticks": ""
+                          }
+                        },
+                        "type": "scatterternary"
+                      }
+                    ],
+                    "surface": [
+                      {
+                        "colorbar": {
+                          "outlinewidth": 0,
+                          "ticks": ""
+                        },
+                        "colorscale": [
+                          [
+                            0,
+                            "#0d0887"
+                          ],
+                          [
+                            0.1111111111111111,
+                            "#46039f"
+                          ],
+                          [
+                            0.2222222222222222,
+                            "#7201a8"
+                          ],
+                          [
+                            0.3333333333333333,
+                            "#9c179e"
+                          ],
+                          [
+                            0.4444444444444444,
+                            "#bd3786"
+                          ],
+                          [
+                            0.5555555555555556,
+                            "#d8576b"
+                          ],
+                          [
+                            0.6666666666666666,
+                            "#ed7953"
+                          ],
+                          [
+                            0.7777777777777778,
+                            "#fb9f3a"
+                          ],
+                          [
+                            0.8888888888888888,
+                            "#fdca26"
+                          ],
+                          [
+                            1,
+                            "#f0f921"
+                          ]
+                        ],
+                        "type": "surface"
+                      }
+                    ],
+                    "table": [
+                      {
+                        "cells": {
+                          "fill": {
+                            "color": "#EBF0F8"
+                          },
+                          "line": {
+                            "color": "white"
+                          }
+                        },
+                        "header": {
+                          "fill": {
+                            "color": "#C8D4E3"
+                          },
+                          "line": {
+                            "color": "white"
+                          }
+                        },
+                        "type": "table"
+                      }
+                    ]
+                  },
+                  "layout": {
+                    "annotationdefaults": {
+                      "arrowcolor": "#2a3f5f",
+                      "arrowhead": 0,
+                      "arrowwidth": 1
+                    },
+                    "autotypenumbers": "strict",
+                    "coloraxis": {
+                      "colorbar": {
+                        "outlinewidth": 0,
+                        "ticks": ""
+                      }
+                    },
+                    "colorscale": {
+                      "diverging": [
+                        [
+                          0,
+                          "#8e0152"
+                        ],
+                        [
+                          0.1,
+                          "#c51b7d"
+                        ],
+                        [
+                          0.2,
+                          "#de77ae"
+                        ],
+                        [
+                          0.3,
+                          "#f1b6da"
+                        ],
+                        [
+                          0.4,
+                          "#fde0ef"
+                        ],
+                        [
+                          0.5,
+                          "#f7f7f7"
+                        ],
+                        [
+                          0.6,
+                          "#e6f5d0"
+                        ],
+                        [
+                          0.7,
+                          "#b8e186"
+                        ],
+                        [
+                          0.8,
+                          "#7fbc41"
+                        ],
+                        [
+                          0.9,
+                          "#4d9221"
+                        ],
+                        [
+                          1,
+                          "#276419"
+                        ]
+                      ],
+                      "sequential": [
+                        [
+                          0,
+                          "#0d0887"
+                        ],
+                        [
+                          0.1111111111111111,
+                          "#46039f"
+                        ],
+                        [
+                          0.2222222222222222,
+                          "#7201a8"
+                        ],
+                        [
+                          0.3333333333333333,
+                          "#9c179e"
+                        ],
+                        [
+                          0.4444444444444444,
+                          "#bd3786"
+                        ],
+                        [
+                          0.5555555555555556,
+                          "#d8576b"
+                        ],
+                        [
+                          0.6666666666666666,
+                          "#ed7953"
+                        ],
+                        [
+                          0.7777777777777778,
+                          "#fb9f3a"
+                        ],
+                        [
+                          0.8888888888888888,
+                          "#fdca26"
+                        ],
+                        [
+                          1,
+                          "#f0f921"
+                        ]
+                      ],
+                      "sequentialminus": [
+                        [
+                          0,
+                          "#0d0887"
+                        ],
+                        [
+                          0.1111111111111111,
+                          "#46039f"
+                        ],
+                        [
+                          0.2222222222222222,
+                          "#7201a8"
+                        ],
+                        [
+                          0.3333333333333333,
+                          "#9c179e"
+                        ],
+                        [
+                          0.4444444444444444,
+                          "#bd3786"
+                        ],
+                        [
+                          0.5555555555555556,
+                          "#d8576b"
+                        ],
+                        [
+                          0.6666666666666666,
+                          "#ed7953"
+                        ],
+                        [
+                          0.7777777777777778,
+                          "#fb9f3a"
+                        ],
+                        [
+                          0.8888888888888888,
+                          "#fdca26"
+                        ],
+                        [
+                          1,
+                          "#f0f921"
+                        ]
+                      ]
+                    },
+                    "colorway": [
+                      "#636efa",
+                      "#EF553B",
+                      "#00cc96",
+                      "#ab63fa",
+                      "#FFA15A",
+                      "#19d3f3",
+                      "#FF6692",
+                      "#B6E880",
+                      "#FF97FF",
+                      "#FECB52"
+                    ],
+                    "font": {
+                      "color": "#2a3f5f"
+                    },
+                    "geo": {
+                      "bgcolor": "white",
+                      "lakecolor": "white",
+                      "landcolor": "#E5ECF6",
+                      "showlakes": true,
+                      "showland": true,
+                      "subunitcolor": "white"
+                    },
+                    "hoverlabel": {
+                      "align": "left"
+                    },
+                    "hovermode": "closest",
+                    "mapbox": {
+                      "style": "light"
+                    },
+                    "paper_bgcolor": "white",
+                    "plot_bgcolor": "#E5ECF6",
+                    "polar": {
+                      "angularaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "bgcolor": "#E5ECF6",
+                      "radialaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      }
+                    },
+                    "scene": {
+                      "xaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      },
+                      "yaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      },
+                      "zaxis": {
+                        "backgroundcolor": "#E5ECF6",
+                        "gridcolor": "white",
+                        "gridwidth": 2,
+                        "linecolor": "white",
+                        "showbackground": true,
+                        "ticks": "",
+                        "zerolinecolor": "white"
+                      }
+                    },
+                    "shapedefaults": {
+                      "line": {
+                        "color": "#2a3f5f"
+                      }
+                    },
+                    "ternary": {
+                      "aaxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "baxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      },
+                      "bgcolor": "#E5ECF6",
+                      "caxis": {
+                        "gridcolor": "white",
+                        "linecolor": "white",
+                        "ticks": ""
+                      }
+                    },
+                    "title": {
+                      "x": 0.05
+                    },
+                    "xaxis": {
+                      "automargin": true,
+                      "gridcolor": "white",
+                      "linecolor": "white",
+                      "ticks": "",
+                      "title": {
+                        "standoff": 15
+                      },
+                      "zerolinecolor": "white",
+                      "zerolinewidth": 2
+                    },
+                    "yaxis": {
+                      "automargin": true,
+                      "gridcolor": "white",
+                      "linecolor": "white",
+                      "ticks": "",
+                      "title": {
+                        "standoff": 15
+                      },
+                      "zerolinecolor": "white",
+                      "zerolinewidth": 2
+                    }
+                  }
+                },
+                "title": {
+                  "text": ""
+                },
+                "xaxis": {
+                  "title": {
+                    "text": "Iteration"
+                  },
+                  "type": "linear",
+                  "range": [
+                    1,
+                    30
+                  ],
+                  "autorange": true
+                },
+                "yaxis": {
+                  "title": {
+                    "text": ""
+                  },
+                  "type": "linear",
+                  "range": [
+                    -6.06148611602105,
+                    123.12597620439996
+                  ],
+                  "autorange": true
+                }
+              }
+            },
+            "text/html": "<div>                            <div id=\"f66bb125-5cdc-45ca-ad52-9594565b3420\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"f66bb125-5cdc-45ca-ad52-9594565b3420\")) {                    Plotly.newPlot(                        \"f66bb125-5cdc-45ca-ad52-9594565b3420\",                        [{\"hoverinfo\": \"none\", \"legendgroup\": \"\", \"line\": {\"width\": 0}, \"mode\": \"lines\", \"showlegend\": false, \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30], \"y\": [116.6666030883789, 116.6666030883789, 56.06245040893555, 27.975379943847656, 27.975379943847656, 27.975379943847656, 27.975379943847656, 4.042157173156738, 4.042157173156738, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703]}, {\"fill\": \"tonexty\", \"fillcolor\": \"rgba(128,177,211,0.3)\", \"legendgroup\": \"objective value\", \"line\": {\"color\": \"rgba(128,177,211,1)\"}, \"mode\": \"lines\", \"name\": \"objective value\", \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30], \"y\": [116.6666030883789, 116.6666030883789, 56.06245040893555, 27.975379943847656, 27.975379943847656, 27.975379943847656, 27.975379943847656, 4.042157173156738, 4.042157173156738, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703]}, {\"fill\": \"tonexty\", \"fillcolor\": \"rgba(128,177,211,0.3)\", \"hoverinfo\": \"none\", \"legendgroup\": \"\", \"line\": {\"width\": 0}, \"mode\": \"lines\", \"showlegend\": false, \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30], \"y\": [116.6666030883789, 116.6666030883789, 56.06245040893555, 27.975379943847656, 27.975379943847656, 27.975379943847656, 27.975379943847656, 4.042157173156738, 4.042157173156738, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.5604887008666992, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703, 0.4311389923095703]}, {\"line\": {\"color\": \"rgba(253,180,98,1)\", \"dash\": \"dash\"}, \"mode\": \"lines\", \"name\": \"Optimum\", \"type\": \"scatter\", \"x\": [1, 30], \"y\": [0.397887, 0.397887]}],                        {\"showlegend\": true, \"template\": {\"data\": {\"bar\": [{\"error_x\": {\"color\": \"#2a3f5f\"}, \"error_y\": {\"color\": \"#2a3f5f\"}, \"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"bar\"}], \"barpolar\": [{\"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"barpolar\"}], \"carpet\": [{\"aaxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"baxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"type\": \"carpet\"}], \"choropleth\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"choropleth\"}], \"contour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"contour\"}], \"contourcarpet\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"contourcarpet\"}], \"heatmap\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmap\"}], \"heatmapgl\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmapgl\"}], \"histogram\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"histogram\"}], \"histogram2d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2d\"}], \"histogram2dcontour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2dcontour\"}], \"mesh3d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"mesh3d\"}], \"parcoords\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"parcoords\"}], \"pie\": [{\"automargin\": true, \"type\": \"pie\"}], \"scatter\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter\"}], \"scatter3d\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter3d\"}], \"scattercarpet\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattercarpet\"}], \"scattergeo\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergeo\"}], \"scattergl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergl\"}], \"scattermapbox\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattermapbox\"}], \"scatterpolar\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolar\"}], \"scatterpolargl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolargl\"}], \"scatterternary\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterternary\"}], \"surface\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"surface\"}], \"table\": [{\"cells\": {\"fill\": {\"color\": \"#EBF0F8\"}, \"line\": {\"color\": \"white\"}}, \"header\": {\"fill\": {\"color\": \"#C8D4E3\"}, \"line\": {\"color\": \"white\"}}, \"type\": \"table\"}]}, \"layout\": {\"annotationdefaults\": {\"arrowcolor\": \"#2a3f5f\", \"arrowhead\": 0, \"arrowwidth\": 1}, \"autotypenumbers\": \"strict\", \"coloraxis\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"colorscale\": {\"diverging\": [[0, \"#8e0152\"], [0.1, \"#c51b7d\"], [0.2, \"#de77ae\"], [0.3, \"#f1b6da\"], [0.4, \"#fde0ef\"], [0.5, \"#f7f7f7\"], [0.6, \"#e6f5d0\"], [0.7, \"#b8e186\"], [0.8, \"#7fbc41\"], [0.9, \"#4d9221\"], [1, \"#276419\"]], \"sequential\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"sequentialminus\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]]}, \"colorway\": [\"#636efa\", \"#EF553B\", \"#00cc96\", \"#ab63fa\", \"#FFA15A\", \"#19d3f3\", \"#FF6692\", \"#B6E880\", \"#FF97FF\", \"#FECB52\"], \"font\": {\"color\": \"#2a3f5f\"}, \"geo\": {\"bgcolor\": \"white\", \"lakecolor\": \"white\", \"landcolor\": \"#E5ECF6\", \"showlakes\": true, \"showland\": true, \"subunitcolor\": \"white\"}, \"hoverlabel\": {\"align\": \"left\"}, \"hovermode\": \"closest\", \"mapbox\": {\"style\": \"light\"}, \"paper_bgcolor\": \"white\", \"plot_bgcolor\": \"#E5ECF6\", \"polar\": {\"angularaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"radialaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"scene\": {\"xaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"yaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"zaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}}, \"shapedefaults\": {\"line\": {\"color\": \"#2a3f5f\"}}, \"ternary\": {\"aaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"baxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"caxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"title\": {\"x\": 0.05}, \"xaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}, \"yaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}}}, \"title\": {\"text\": \"\"}, \"xaxis\": {\"title\": {\"text\": \"Iteration\"}}, \"yaxis\": {\"title\": {\"text\": \"\"}}},                        {\"responsive\": true}                    ).then(function(){\n                            \nvar gd = document.getElementById('f66bb125-5cdc-45ca-ad52-9594565b3420');\nvar x = new MutationObserver(function (mutations, observer) {{\n        var display = window.getComputedStyle(gd).display;\n        if (!display || display === 'none') {{\n            console.log([gd, 'removed!']);\n            Plotly.purge(gd);\n            observer.disconnect();\n        }}\n}});\n\n// Listen for the removal of the full notebook cells\nvar notebookContainer = gd.closest('#notebook-container');\nif (notebookContainer) {{\n    x.observe(notebookContainer, {childList: true});\n}}\n\n// Listen for the clearing of the current output cell\nvar outputEl = gd.closest('.output');\nif (outputEl) {{\n    x.observe(outputEl, {childList: true});\n}}\n\n                        })                };                });            </script>        </div>"
+          },
+          "metadata": {}
+        }
+      ]
     }
-   ],
-   "source": [
-    "from ax.modelbridge.factory import get_botorch\n",
-    "\n",
-    "for i in range(5):\n",
-    "    print(f\"Running optimization batch {i+1}/5...\")\n",
-    "    model = get_botorch(\n",
-    "        experiment=exp,\n",
-    "        data=exp.eval(),\n",
-    "        search_space=exp.search_space,\n",
-    "        model_constructor=_get_and_fit_simple_custom_gp,\n",
-    "    )\n",
-    "    batch = exp.new_trial(generator_run=model.gen(1))\n",
-    "    \n",
-    "print(\"Done!\")"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.6"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  ]
 }

--- a/website/tutorials.json
+++ b/website/tutorials.json
@@ -3,6 +3,10 @@
     {
       "id": "custom_botorch_model_in_ax",
       "title": "Using a custom BoTorch model"
+    },
+    {
+      "id": "custom_acquisition",
+      "title": "Writing a custom acquisition function"
     }
   ],
   "Full Optimization Loops": [
@@ -57,10 +61,6 @@
     {
       "id": "batch_mode_cross_validation",
       "title": "Using batch evaluation for fast cross-validation"
-    },
-    {
-      "id": "custom_acquisition",
-      "title": "Writing a custom acquisition function"
     },
     {
       "id": "one_shot_kg",


### PR DESCRIPTION
Summary:
Update the Ax-related tutorials in BoTorch to use the BOTORCH_MODULAR interface.

For starters, this updates custom BoTorch model tutorial. I will update others based on feedback on the style.

Differential Revision: D34646421

