### PR TITLE
Fix missing posterior transform in qNEI and get_acquisition_function

### DIFF
--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -266,7 +266,9 @@ class qNoisyExpectedImprovement(
             self.q = -1
             # set baseline samples
             with torch.no_grad():
-                posterior = self.model.posterior(X_baseline)
+                posterior = self.model.posterior(
+                    X_baseline, posterior_transform=self.posterior_transform
+                )
                 baseline_samples = self.base_sampler(posterior)
             baseline_obj = self.objective(baseline_samples, X=X_baseline)
             self.register_buffer("baseline_samples", baseline_samples)

--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -94,7 +94,9 @@ def get_acquisition_function(
         )
     # instantiate and return the requested acquisition function
     if acquisition_function_name in ("qEI", "qPI"):
-        obj = objective(model.posterior(X_observed).mean)
+        obj = objective(
+            model.posterior(X_observed, posterior_transform=posterior_transform).mean
+        )
         best_f = obj.max(dim=-1).values
     if acquisition_function_name == "qEI":
         return monte_carlo.qExpectedImprovement(


### PR DESCRIPTION
Summary:
This was leading to the wrong posterior getting cached when using a `posterior_transform` (and the opt performance issues that follow).

Found and fixed the same issue in `get_acquisition_function`.

Took a pass through all acquisition functions to make sure we don't have the same issue elsewhere.

Differential Revision: D34731428

