### PR TITLE
Update tutorial workflows to run on latest Ax

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -149,6 +149,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install git+https://github.com/facebook/Ax.git
         pip install .[tutorials]
     - name: Run tutorials
       run: |

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -80,8 +80,36 @@ jobs:
       run: |
         pytest -ra --cov=. --cov-report term-missing
 
-  run_tutorials_stable:
-    name: Run tutorials without smoke test on min req. versions of torch & gpytorch
+  run_tutorials_stable_w_latest_ax:
+    name: Run tutorials without smoke test on min req. versions of torch & gpytorch and latest Ax
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Fetch all history for all tags and branches
+      # we need to do this so setuptools_scm knows how to set the botorch version
+      run: git fetch --prune --unshallow
+    - name: Install dependencies
+      env:
+        # this is so Ax's setup doesn't install a pinned BoTorch version
+        ALLOW_BOTORCH_LATEST: true
+      run: |
+        python setup.py egg_info
+        req_txt="botorch.egg-info/requires.txt"
+        min_torch_version=$(grep '\btorch>=' ${req_txt} | sed 's/[^0-9.]//g')
+        min_gpytorch_version=$(grep '\bgpytorch>=' ${req_txt} | sed 's/[^0-9.]//g')
+        pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}"
+        pip install git+https://github.com/facebook/Ax.git
+        pip install .[tutorials]
+    - name: Run tutorials
+      run: |
+        python scripts/run_tutorials.py -p "$(pwd)"
+
+  run_tutorials_stable_w_stable_ax:
+    name: Run tutorials without smoke test on min req. versions of torch & gpytorch and stable Ax
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -28,6 +28,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install git+https://github.com/facebook/Ax.git
         pip install .[tutorials]
     - name: Run tutorials
       run: |


### PR DESCRIPTION
Summary: Since the Ax related tutorials may rely on latest features in Ax, we're changing the workflows to run on Ax/main rather than the stable release.

Differential Revision: D34766536

