### PR TITLE
Add `ipython_genutils` in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[dev]
         pip install beautifulsoup4 ipython "nbconvert<6.0"
+        # This is needed as a stop-gap until we remove nbconvert<6.0 restriction.
+        pip install ipython_genutils
     - name: Validate Sphinx
       run: |
         python scripts/validate_sphinx.py -p "$(pwd)"


### PR DESCRIPTION
Summary: Docs workflow has been failing since yesterday due to the new `nbformat 5.2.0` release dropping `ipython_genutils` dependency. `ipython_genutils` is required by `nbconvert<6.0` but is not marked as a dependency. Adding it here to unblock the workflow.

Reviewed By: Balandat

Differential Revision: D34831066

