### PR TITLE
Fix missing `ipython_genutils` in nightly website workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,6 +122,8 @@ jobs:
         pip install .[dev]
         pip install git+https://github.com/facebook/Ax.git
         pip install beautifulsoup4 ipython "nbconvert<6.0"
+        # This is needed as a stop-gap until we remove nbconvert<6.0 restriction.
+        pip install ipython_genutils
     - name: Unit tests
       run: |
         pytest -ra


### PR DESCRIPTION
## Motivation

 Currently, tutorials are broken in the latest version of the website: https://botorch.org/v/latest/tutorials/custom_botorch_model_in_ax. This is due to missing `ipython_genutils` in the nightly website workflow: https://github.com/pytorch/botorch/runs/5535779946?check_suite_focus=true. 

Note: This is not an issue for the website part of the `deploy_on_release` workflow since one of the packages in `pip install .[tutorials]` installs `ipython_genutils` as a dependency.

## Test Plan

N/A

## Related PRs

#1118, which fixes the same issue for the docs workflow.
