### PR TITLE
Proximal bugfixes

### DIFF
--- a/botorch/acquisition/proximal.py
+++ b/botorch/acquisition/proximal.py
@@ -66,65 +66,7 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
             self.X_pending = acq_function.X_pending
 
         self.register_buffer("proximal_weights", proximal_weights)
-
-        # check model for train_inputs and single batch
-        if not hasattr(model, "train_inputs"):
-            raise UnsupportedError(
-                "Acquisition function model must have " "`train_inputs`."
-            )
-
-        # change behavior depending on type of model
-        if isinstance(model, ModelListGP):
-            # ModelListGP
-            # make sure that all of the training inputs match and are single batch
-            training_data = model.train_inputs[0][0]
-            for i in range(len(model.train_inputs)):
-
-                if (
-                    self.acq_func.model.batch_shape != torch.Size([])
-                    and model.train_inputs[i][0].shape[1] != 1
-                ):
-                    raise UnsupportedError(
-                        "Proximal acquisition function requires a single batch model"
-                    )
-
-                if not torch.equal(training_data, model.train_inputs[i][0]):
-                    raise UnsupportedError(
-                        "Proximal acquisition function does not support unequal "
-                        "training inputs"
-                    )
-
-            # check to make sure that weights match the training data shape
-            if (
-                len(self.proximal_weights.shape) != 1
-                or self.proximal_weights.shape[0] != training_data.shape[-1]
-            ):
-                raise ValueError(
-                    "`proximal_weights` must be a one dimensional tensor with "
-                    "same feature dimension as model."
-                )
-
-        else:
-            # SingleTask GP
-            # check to make sure that the model is single batch
-            if (
-                self.acq_func.model.batch_shape != torch.Size([])
-                and self.acq_func.model.train_inputs[0].shape[1] != 1
-            ):
-                raise UnsupportedError(
-                    "Proximal acquisition function requires a single batch model"
-                )
-
-            # check to make sure that weights match the training data shape
-            if (
-                len(self.proximal_weights.shape) != 1
-                or self.proximal_weights.shape[0]
-                != self.acq_func.model.train_inputs[0][-1].shape[-1]
-            ):
-                raise ValueError(
-                    "`proximal_weights` must be a one dimensional tensor with "
-                    "same feature dimension as model."
-                )
+        _validate_model(model, proximal_weights)
 
     @t_batch_mode_transform(expected_q=1, assert_output_shape=False)
     def forward(self, X: Tensor) -> Tensor:
@@ -138,13 +80,56 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
             weighting.
         """
         model = self.acq_func.model
+        train_inputs = model.train_inputs[0]
         if isinstance(model, ModelListGP):
-            last_X = model.train_inputs[0][0][-1].reshape(1, 1, -1)
-        else:
-            last_X = model.train_inputs[0][-1].reshape(1, 1, -1)
+            train_inputs = train_inputs[0]
+        last_X = train_inputs[-1].reshape(1, 1, -1)
         diff = X - last_X
 
         M = torch.linalg.norm(diff / self.proximal_weights, dim=-1) ** 2
 
         proximal_acq_weight = torch.exp(-0.5 * M)
         return self.acq_func(X) * proximal_acq_weight.flatten()
+
+
+def _validate_model(model, proximal_weights):
+    """
+    Perform vaidation checks on model used in base acquisition function to make sure
+    it is compatable with proximal weighting.
+    """
+
+    # check model for train_inputs and single batch
+    if not hasattr(model, "train_inputs"):
+        raise UnsupportedError("Acquisition function model must have `train_inputs`.")
+
+    # get train inputs for each type of possible model
+    if isinstance(model, ModelListGP):
+        # ModelListGP models
+        # check to make sure that the training inputs for each model match
+        train_inputs = model.train_inputs[0][0]
+        for i in range(len(model.train_inputs)):
+            if not torch.equal(train_inputs, model.train_inputs[i][0]):
+                raise UnsupportedError(
+                    "Proximal acquisition function does not support unequal "
+                    "training inputs"
+                )
+
+    else:
+        # any non-ModelListGP model
+        train_inputs = model.train_inputs[0]
+
+    # check to make sure that the model is single t-batch (q-batches are allowed)
+    if model.batch_shape != torch.Size([]) and train_inputs.shape[1] != 1:
+        raise UnsupportedError(
+            "Proximal acquisition function requires a single batch model"
+        )
+
+    # check to make sure that weights match the training data shape
+    if (
+        len(proximal_weights.shape) != 1
+        or proximal_weights.shape[0] != train_inputs.shape[-1]
+    ):
+        raise ValueError(
+            "`proximal_weights` must be a one dimensional tensor with "
+            "same feature dimension as model."
+        )

--- a/botorch/acquisition/proximal.py
+++ b/botorch/acquisition/proximal.py
@@ -16,7 +16,6 @@ from botorch.acquisition import AcquisitionFunction
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models import ModelListGP
 from botorch.models.model import Model
-from botorch.models.transforms.input import ReversibleInputTransform
 from botorch.utils import t_batch_mode_transform
 from torch import Tensor
 from torch.nn import Module

--- a/botorch/acquisition/proximal.py
+++ b/botorch/acquisition/proximal.py
@@ -15,6 +15,7 @@ import torch
 from botorch.acquisition import AcquisitionFunction
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models import ModelListGP
+from botorch.models.model import Model
 from botorch.utils import t_batch_mode_transform
 from torch import Tensor
 from torch.nn import Module
@@ -92,10 +93,19 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
         return self.acq_func(X) * proximal_acq_weight.flatten()
 
 
-def _validate_model(model, proximal_weights):
-    """
+def _validate_model(model: Model, proximal_weights: Tensor):
+    r"""Validate model
+
     Perform vaidation checks on model used in base acquisition function to make sure
     it is compatable with proximal weighting.
+
+    Args:
+        model: Model associated with base acquisition function to be validated.
+        proximal_weights: A `d` dim tensor used to bias locality
+                along each axis.
+
+        Returns:
+            None
     """
 
     # check model for train_inputs and single batch

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -16,7 +16,7 @@ from botorch.exceptions.errors import UnsupportedError
 from botorch.models import SingleTaskGP, ModelListGP
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model import Model
-from botorch.models.transforms.input import InputTransform, Normalize
+from botorch.models.transforms.input import Normalize
 from botorch.utils.containers import TrainingData
 from botorch.utils.testing import BotorchTestCase
 from torch.distributions.multivariate_normal import MultivariateNormal

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -13,7 +13,7 @@ from botorch.acquisition.analytic import ExpectedImprovement
 from botorch.acquisition.monte_carlo import qExpectedImprovement
 from botorch.acquisition.proximal import ProximalAcquisitionFunction
 from botorch.exceptions.errors import UnsupportedError
-from botorch.models import SingleTaskGP, ModelListGP, KroneckerMultiTaskGP
+from botorch.models import SingleTaskGP, ModelListGP
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model import Model
 from botorch.utils.containers import TrainingData
@@ -209,7 +209,7 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
             with self.assertRaises(ValueError):
                 ProximalAcquisitionFunction(
                     ExpectedImprovement(model, 0.0, objective=scalarized_objective),
-                    proximal_weights[:1]
+                    proximal_weights[:1],
                 )
 
             with self.assertRaises(ValueError):
@@ -234,5 +234,5 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
             with self.assertRaises(UnsupportedError):
                 ProximalAcquisitionFunction(
                     ExpectedImprovement(bad_model, 0.0, objective=scalarized_objective),
-                    proximal_weights
+                    proximal_weights,
                 )

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -236,3 +236,16 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                     ExpectedImprovement(bad_model, 0.0, objective=scalarized_objective),
                     proximal_weights,
                 )
+
+            # try using unequal training sets
+            train_X = torch.rand(5, 3, device=self.device, dtype=dtype)
+            train_Y = train_X.norm(dim=-1, keepdim=True)
+            bad_model = ModelListGP(
+                SingleTaskGP(train_X[:-1], train_Y[:-1]).to(device=self.device),
+                SingleTaskGP(train_X, train_Y).to(device=self.device),
+            )
+            with self.assertRaises(UnsupportedError):
+                ProximalAcquisitionFunction(
+                    ExpectedImprovement(bad_model, 0.0, objective=scalarized_objective),
+                    proximal_weights,
+                )


### PR DESCRIPTION
## Motivation

This PR adds support for ModelListGP models in the Proximal biasing acquisition function. Previously, model indexing errors prevented proper selection of the most recently observed point. ModelListGP models are required for flexible optimization of multi-objective and constrained problems.

Note that we check to make sure that the training inputs for all models are identical

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Unit tests added

## Related PRs
# 919 https://github.com/pytorch/botorch/pull/919#issue-977505704
