### PR TITLE
Implement SAASBO

### DIFF
--- a/botorch/__init__.py
+++ b/botorch/__init__.py
@@ -14,7 +14,7 @@ from botorch import (
     test_functions,
 )
 from botorch.cross_validation import batch_cross_validation
-from botorch.fit import fit_gpytorch_model
+from botorch.fit import fit_gpytorch_model, fit_fully_bayesian_model_nuts
 from botorch.generation.gen import (
     gen_candidates_scipy,
     gen_candidates_torch,
@@ -33,6 +33,7 @@ __all__ = [
     "acquisition",
     "batch_cross_validation",
     "exceptions",
+    "fit_fully_bayesian_model_nuts",
     "fit_gpytorch_model",
     "gen_candidates_scipy",
     "gen_candidates_torch",

--- a/botorch/models/__init__.py
+++ b/botorch/models/__init__.py
@@ -13,6 +13,7 @@ from botorch.models.deterministic import (
     AffineDeterministicModel,
     GenericDeterministicModel,
 )
+from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 from botorch.models.gp_regression import (
     FixedNoiseGP,
     HeteroskedasticSingleTaskGP,
@@ -36,6 +37,7 @@ __all__ = [
     "ApproximateGPyTorchModel",
     "FixedNoiseGP",
     "FixedNoiseMultiTaskGP",
+    "SaasFullyBayesianSingleTaskGP",
     "GenericDeterministicModel",
     "HeteroskedasticSingleTaskGP",
     "HigherOrderGP",

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -1,0 +1,421 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+r"""Gaussian Process Regression models with fully Bayesian inference.
+
+We use a lightweight PyTorch implementation of a Matern-5/2 kernel as there are some
+performance issues with running NUTS on top of standard GPyTorch models. The resulting
+hyperparameter samples are loaded into a batched GPyTorch model after fitting.
+
+References:
+
+.. [Eriksson2021saasbo]
+    D. Eriksson, M. Jankowiak. High-Dimensional Bayesian Optimization
+    with Sparse Axis-Aligned Subspaces. Proceedings of the Thirty-
+    Seventh Conference on Uncertainty in Artificial Intelligence, 2021.
+"""
+
+
+import math
+from abc import abstractmethod
+from typing import Any, Dict, List, Optional, Union
+
+import pyro
+import torch
+from botorch.acquisition.objective import PosteriorTransform
+from botorch.models.gp_regression import SingleTaskGP, FixedNoiseGP
+from botorch.models.transforms.input import InputTransform
+from botorch.models.transforms.outcome import OutcomeTransform
+from botorch.models.utils import validate_input_scaling
+from botorch.posteriors.fully_bayesian import FullyBayesianPosterior
+from botorch.sampling.samplers import MCSampler
+from gpytorch.constraints import GreaterThan
+from gpytorch.distributions.multivariate_normal import MultivariateNormal
+from gpytorch.kernels import MaternKernel, ScaleKernel
+from gpytorch.kernels.kernel import Distance
+from gpytorch.likelihoods.gaussian_likelihood import (
+    FixedNoiseGaussianLikelihood,
+    GaussianLikelihood,
+)
+from gpytorch.means.constant_mean import ConstantMean
+from torch import Tensor
+
+MIN_INFERRED_NOISE_LEVEL = 1e-6
+
+
+def matern52_kernel(X: Tensor, lengthscale: Tensor) -> Tensor:
+    """Matern-5/2 kernel."""
+    nu = 5 / 2
+    dist = compute_dists(X=X, lengthscale=lengthscale)
+    exp_component = torch.exp(-math.sqrt(nu * 2) * dist)
+    constant_component = (math.sqrt(5) * dist).add(1).add(5.0 / 3.0 * (dist ** 2))
+    return constant_component * exp_component
+
+
+def compute_dists(X: Tensor, lengthscale: Tensor) -> Tensor:
+    """Compute kernel distances."""
+    return Distance()._dist(
+        X / lengthscale, X / lengthscale, postprocess=False, x1_eq_x2=True
+    )
+
+
+class PyroModel:
+    r"""Abstract base class for a Pyro model."""
+
+    @abstractmethod
+    def sample(self) -> None:
+        r"""Sample from the model."""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def postprocess_mcmc_samples(
+        self, mcmc_samples: Dict[str, Tensor], **kwargs: Any
+    ) -> Dict[str, Tensor]:
+        """Post-process the final MCMC samples."""
+        pass  # pragma: no cover
+
+
+class SaasPyroModel(PyroModel):
+    r"""Implementation of the sparse axis-aligned subspace priors (SAAS) model.
+
+    The SAAS model uses sparsity-inducing priors to identift the most important
+    parameters. This model is suitable for high-dimensional BO with potentially
+    hundreds of tunable parameters. See [Eriksson2021saasbo]_ for more details.
+    """
+
+    def __init__(
+        self, train_X: Tensor, train_Y: Tensor, train_Yvar: Optional[Tensor] = None
+    ):
+        r"""Initialize the SAAS model.
+
+        Args:
+            train_X: Training inputs (n x d)
+            train_Y: Training targets (n x 1)
+            train_Yvar: Observed noise variance (n x 1). Inferred if None.
+        """
+        self.train_X = train_X
+        self.train_Y = train_Y
+        self.train_Yvar = train_Yvar
+
+    def sample(self) -> None:
+        r"""Sample from the SAAS model.
+
+        This samples the mean, noise variance, outputscale, and lengthscales according
+        to the SAAS prior.
+        """
+        tkwargs = {"dtype": self.train_X.dtype, "device": self.train_X.device}
+        outputscale = self.sample_outputscale(concentration=2.0, rate=0.15, **tkwargs)
+        mean = self.sample_mean(**tkwargs)
+        noise = self.sample_noise(**tkwargs)
+        lengthscale = self.sample_lengthscale(dim=self.train_X.shape[-1], **tkwargs)
+        k = matern52_kernel(X=self.train_X, lengthscale=lengthscale)
+        k = outputscale * k + noise * torch.eye(self.train_X.shape[0], **tkwargs)
+        pyro.sample(
+            "Y",
+            pyro.distributions.MultivariateNormal(
+                loc=mean.view(-1).expand(self.train_X.shape[0]),
+                covariance_matrix=k,
+            ),
+            obs=self.train_Y.squeeze(-1),
+        )
+
+    def sample_outputscale(
+        self, concentration: float = 2.0, rate: float = 0.15, **tkwargs: Any
+    ) -> Tensor:
+        r"""Sample the outputscale."""
+        return pyro.sample(
+            "outputscale",
+            pyro.distributions.Gamma(
+                torch.tensor(concentration, **tkwargs),
+                torch.tensor(rate, **tkwargs),
+            ),
+        )
+
+    def sample_mean(self, **tkwargs: Any) -> Tensor:
+        r"""Sample the mean constant."""
+        return pyro.sample(
+            "mean",
+            pyro.distributions.Normal(
+                torch.tensor(0.0, **tkwargs),
+                torch.tensor(1.0, **tkwargs),
+            ),
+        )
+
+    def sample_noise(self, **tkwargs: Any) -> Tensor:
+        r"""Sample the noise variance."""
+        if self.train_Yvar is None:
+            return pyro.sample(
+                "noise",
+                pyro.distributions.Gamma(
+                    torch.tensor(0.9, **tkwargs),
+                    torch.tensor(10.0, **tkwargs),
+                ),
+            )
+        else:
+            return self.train_Yvar
+
+    def sample_lengthscale(
+        self, dim: int, alpha: float = 0.1, **tkwargs: Any
+    ) -> Tensor:
+        r"""Sample the lengthscale."""
+        tausq = pyro.sample(
+            "kernel_tausq",
+            pyro.distributions.HalfCauchy(torch.tensor(alpha, **tkwargs)),
+        )
+        inv_length_sq = pyro.sample(
+            "_kernel_inv_length_sq",
+            pyro.distributions.HalfCauchy(torch.ones(dim, **tkwargs)),
+        )
+        inv_length_sq = pyro.deterministic(
+            "kernel_inv_length_sq", tausq * inv_length_sq
+        )
+        lengthscale = pyro.deterministic(
+            "lengthscale",
+            (1.0 / inv_length_sq).sqrt(),
+        )
+        return lengthscale
+
+    def postprocess_mcmc_samples(
+        self, mcmc_samples: Dict[str, Tensor]
+    ) -> Dict[str, Tensor]:
+        r"""Post-process the MCMC samples.
+
+        This computes the true lengthscales and removes the inverse lengthscales and
+        tausq (global shrinkage).
+        """
+        inv_length_sq = (
+            mcmc_samples["kernel_tausq"].unsqueeze(-1)
+            * mcmc_samples["_kernel_inv_length_sq"]
+        )
+        mcmc_samples["lengthscale"] = (1.0 / inv_length_sq).sqrt()
+        # Delete `kernel_tausq` and `_kernel_inv_length_sq` since they aren't loaded
+        # into the final model.
+        del mcmc_samples["kernel_tausq"], mcmc_samples["_kernel_inv_length_sq"]
+        return mcmc_samples
+
+
+class SaasFullyBayesianSingleTaskGP(SingleTaskGP):
+    r"""A fully Bayesian single-task GP model with the SAAS prior.
+
+    This model assumes that the inputs have been normalized to [0, 1]^d and that
+    the output has been standardizes to have zero mean and unit variance. The SAAS
+    model [Eriksson2021saasbo]_ with a Matern-5/2 is used by default.
+
+    You are expected to use `fit_fully_bayesian_model_nuts` to fit this model as it
+    isn't compatible with `fit_gpytorch_model`.
+
+    Example:
+    >>> saas_gp = SaasFullyBayesianSingleTaskGP(train_X, train_Y)
+    >>> fit_fully_bayesian_model_nuts(saas_gp)
+    >>> posterior = saas_gp.posterior(test_X, marginalize_over_mcmc_samples=True)
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        train_Yvar: Optional[Tensor] = None,
+        outcome_transform: Optional[OutcomeTransform] = None,
+        input_transform: Optional[InputTransform] = None,
+    ) -> None:
+        r"""Initialize the fully Bayesian single-task GP model.
+
+        Args:
+            train_X: Training inputs (n x d)
+            train_Y: Training targets (n x 1)
+            train_Yvar: Observed noise variance (n x 1). Inferred if None.
+        """
+        if not (
+            train_X.ndim == train_Y.ndim == 2
+            and len(train_X) == len(train_Y)
+            and train_Y.shape[-1] == 1
+        ):
+            raise ValueError(
+                "Expected train_X to have shape n x d and train_Y to have shape n x 1"
+            )
+        if train_Yvar is not None:
+            if train_Y.shape != train_Yvar.shape:
+                raise ValueError(
+                    "Expected train_Yvar to be None or have the same shape as train_Y"
+                )
+        with torch.no_grad():
+            transformed_X = self.transform_inputs(
+                X=train_X, input_transform=input_transform
+            )
+        if outcome_transform is not None:
+            train_Y, train_Yvar = outcome_transform(train_Y, train_Yvar)
+        self._validate_tensor_args(X=transformed_X, Y=train_Y)
+        validate_input_scaling(
+            train_X=transformed_X, train_Y=train_Y, train_Yvar=train_Yvar
+        )
+        self._set_dimensions(train_X=train_X, train_Y=train_Y)
+        if train_Yvar is not None:  # Clamp after transforming
+            train_Yvar = train_Yvar.clamp(MIN_INFERRED_NOISE_LEVEL)
+
+        super().__init__(train_X, train_Y)
+        self.train_X = train_X
+        self.train_Y = train_Y
+        self.train_Yvar = train_Yvar
+        self.mean_module = None
+        self.covar_module = None
+        self.likelihood = None
+        self.pyro_model = SaasPyroModel(
+            train_X=transformed_X, train_Y=train_Y, train_Yvar=train_Yvar
+        )
+        if outcome_transform is not None:
+            self.outcome_transform = outcome_transform
+        if input_transform is not None:
+            self.input_transform = input_transform
+
+    def _check_if_fitted(self):
+        r"""Raise an exception if the model hasn't been fitted."""
+        if self.covar_module is None:
+            raise RuntimeError(
+                "Model has not been fitted. You need to call "
+                "`fit_fully_bayesian_model_nuts` to fit the model."
+            )
+
+    @property
+    def median_lengthscale(self) -> Tensor:
+        r"""Median lengthscales across the MCMC samples."""
+        self._check_if_fitted()
+        lengthscale = self.covar_module.base_kernel.lengthscale.clone()
+        return lengthscale.median(0).values.squeeze(0)
+
+    @property
+    def num_mcmc_samples(self) -> int:
+        r"""Number of MCMC samples in the model."""
+        self._check_if_fitted()
+        return len(self.covar_module.outputscale)
+
+    def fantasize(
+        self,
+        X: Tensor,
+        sampler: MCSampler,
+        observation_noise: Union[bool, Tensor] = True,
+        **kwargs: Any,
+    ) -> FixedNoiseGP:
+        raise NotImplementedError("Fantasize is not implemented!")
+
+    def train(self, mode: bool = True) -> None:
+        r"""Puts the model in `train` mode."""
+        super().train(mode=mode)
+        if mode and self.train_X.ndim == 3:
+            self.train_X = self.train_X[0, ...].squeeze(0)
+            self.mean_module = None
+            self.covar_module = None
+            self.likelihood = None
+
+    def load_mcmc_samples(self, mcmc_samples: Dict[str, Tensor]) -> None:
+        r"""Load the MCMC hyperparameter samples into the model.
+
+        This method will be called by `fit_fully_bayesian_model_nuts` when the model
+        has been fitted in order to create a batched SingleTaskGP model.
+        """
+        tkwargs = {"device": self.train_X.device, "dtype": self.train_X.dtype}
+        num_mcmc_samples = len(mcmc_samples["mean"])
+        batch_shape = torch.Size([num_mcmc_samples])
+
+        self.train_X = self.train_X.unsqueeze(0).expand(
+            num_mcmc_samples, self.train_X.shape[0], -1
+        )
+        self.mean_module = ConstantMean(batch_shape=batch_shape).to(**tkwargs)
+        self.covar_module = ScaleKernel(
+            base_kernel=MaternKernel(
+                ard_num_dims=self.train_X.shape[-1],
+                batch_shape=batch_shape,
+            ),
+            batch_shape=batch_shape,
+        ).to(**tkwargs)
+        if self.train_Yvar is not None:
+            self.likelihood = FixedNoiseGaussianLikelihood(
+                noise=self.train_Yvar, batch_shape=batch_shape
+            ).to(**tkwargs)
+        else:
+            self.likelihood = GaussianLikelihood(
+                batch_shape=batch_shape,
+                noise_constraint=GreaterThan(MIN_INFERRED_NOISE_LEVEL),
+            ).to(**tkwargs)
+            self.likelihood.noise_covar.noise = (
+                mcmc_samples["noise"]
+                .detach()
+                .clone()
+                .view(self.likelihood.noise_covar.noise.shape)
+                .clamp_min(MIN_INFERRED_NOISE_LEVEL)
+                .to(**tkwargs)
+            )
+
+        self.covar_module.base_kernel.lengthscale = (
+            mcmc_samples["lengthscale"]
+            .detach()
+            .clone()
+            .view(self.covar_module.base_kernel.lengthscale.shape)
+            .to(**tkwargs)
+        )
+        self.covar_module.outputscale = (
+            mcmc_samples["outputscale"]
+            .detach()
+            .clone()
+            .view(self.covar_module.outputscale.shape)
+            .to(**tkwargs)
+        )
+        self.mean_module.constant.data = (
+            mcmc_samples["mean"]
+            .detach()
+            .clone()
+            .view(self.mean_module.constant.shape)
+            .to(**tkwargs)
+        )
+
+    def forward(self, X: Tensor) -> MultivariateNormal:
+        self._check_if_fitted()
+        return super().forward(X.unsqueeze(-3))
+
+    def posterior(
+        self,
+        X: Tensor,
+        output_indices: Optional[List[int]] = None,
+        observation_noise: bool = False,
+        posterior_transform: Optional[PosteriorTransform] = None,
+        marginalize_over_mcmc_samples: bool = False,
+        **kwargs: Any,
+    ) -> FullyBayesianPosterior:
+        r"""Computes the posterior over model outputs at the provided points.
+
+        Args:
+            X: A `(batch_shape) x q x d`-dim Tensor, where `d` is the dimension
+                of the feature space and `q` is the number of points considered
+                jointly.
+            output_indices: A list of indices, corresponding to the outputs over
+                which to compute the posterior (if the model is multi-output).
+                Can be used to speed up computation if only a subset of the
+                model's outputs are required for optimization. If omitted,
+                computes the posterior over all model outputs.
+            observation_noise: If True, add the observation noise from the
+                likelihood to the posterior. If a Tensor, use it directly as the
+                observation noise (must be of shape `(batch_shape) x q x m`).
+            posterior_transform: An optional PosteriorTransform.
+            marginalize_over_mcmc_samples: If True, we will use the law of total
+                variance to marginalize over the MCMC samples. This is useful when
+                making test predictions, but shouldn't be used when computing
+                acquisition functions values.
+
+        Returns:
+            A `FullyBayesianPosterior` object. Includes observation noise if specified.
+        """
+        self._check_if_fitted()
+        posterior = super().posterior(
+            X=X,
+            output_indices=output_indices,
+            observation_noise=observation_noise,
+            posterior_transform=posterior_transform,
+            **kwargs,
+        )
+        posterior = FullyBayesianPosterior(
+            mvn=posterior.mvn,
+            marginalize_over_mcmc_samples=marginalize_over_mcmc_samples,
+        )
+        return posterior

--- a/botorch/posteriors/__init__.py
+++ b/botorch/posteriors/__init__.py
@@ -5,15 +5,16 @@
 # LICENSE file in the root directory of this source tree.
 
 from botorch.posteriors.deterministic import DeterministicPosterior
+from botorch.posteriors.fully_bayesian import FullyBayesianPosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.higher_order import HigherOrderGPPosterior
 from botorch.posteriors.multitask import MultitaskGPPosterior
 from botorch.posteriors.posterior import Posterior, PosteriorList
 from botorch.posteriors.transformed import TransformedPosterior
 
-
 __all__ = [
     "DeterministicPosterior",
+    "FullyBayesianPosterior",
     "GPyTorchPosterior",
     "HigherOrderGPPosterior",
     "MultitaskGPPosterior",

--- a/botorch/posteriors/fully_bayesian.py
+++ b/botorch/posteriors/fully_bayesian.py
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from botorch.posteriors.gpytorch import GPyTorchPosterior
+from gpytorch.distributions.multivariate_normal import MultivariateNormal
+from torch import Tensor
+
+
+class FullyBayesianPosterior(GPyTorchPosterior):
+    r"""A posterior for a fully Bayesian model."""
+
+    def __init__(
+        self, mvn: MultivariateNormal, marginalize_over_mcmc_samples: bool = False
+    ) -> None:
+        r"""A posterior for a fully Bayesian model.
+
+        The MCMC batch dimension is -3.
+
+        Args:
+            mvn: A GPyTorch MultivariateNormal (single-output case)
+            marginalize_over_mcmc_samples: If true, use the law of total variance to
+                marginalize over the hyperparameter samples. This should always be
+                false when computing acquisition functions.
+        """
+        super().__init__(mvn=mvn)
+        self._mean = mvn.mean.unsqueeze(-1)
+        self._variance = mvn.covariance_matrix.diagonal(dim1=-2, dim2=-1).unsqueeze(-1)
+        if marginalize_over_mcmc_samples:
+            num_mcmc_samples = self._variance.shape[-3]
+            t1 = self._variance.sum(dim=-3) / num_mcmc_samples
+            t2 = self._mean.pow(2).sum(dim=-3) / num_mcmc_samples
+            t3 = -(self._mean.sum(dim=-3) / num_mcmc_samples).pow(2)
+            self._variance = t1 + t2 + t3
+            self._mean = self._mean.mean(dim=-3)
+            self.mvn = None
+
+    @property
+    def mean(self) -> Tensor:
+        r"""The posterior mean."""
+        return self._mean
+
+    @property
+    def variance(self) -> Tensor:
+        r"""The posterior variance."""
+        return self._variance

--- a/docs/models.md
+++ b/docs/models.md
@@ -69,6 +69,9 @@ uses fixed observation noise levels (requires noise observations).
 * [`HeteroskedasticSingleTaskGP`](../api/models.html#heteropskedasticsingletaskgp):
   a single-task exact GP that models heteroskedastic noise using an additional
   internal GP model (requires noise observations).
+* [`SaasFullyBayesianSingleTaskGP`](../api/models.html#saasfullybayesiansingletaskgp):
+  a fully Bayesian single-task GP with the SAAS prior. This model is suitable for
+  sample-efficient high-dimensional Bayesian optimization.
 
 ### Model List of Single-Task GPs
 * [`ModelListGP`](../api/models.html#modellistgp): A multi-output model in

--- a/docs/papers.md
+++ b/docs/papers.md
@@ -29,7 +29,7 @@ Here is an incomplete selection of peer-reviewed Bayesian optimization papers th
 - [PareCO: Pareto-aware Channel Optimization for Slimmable Neural Networks
 ](https://arxiv.org/abs/2007.11752). Ting-Wu Chin, Ari S. Morcos, Diana Marculescu. ICML 2020 Workshop on Real World Experiment Design and Active Learning.
 - [High-Dimensional Bayesian Optimization with Sparse Axis-Aligned Subspaces
-](https://arxiv.org/abs/2103.00349). David Eriksson, Martin Jankowiak. UAI 2021.
+](https://proceedings.mlr.press/v161/eriksson21a.html). David Eriksson, Martin Jankowiak. UAI 2021.
 - [Bayesian Optimization over Permutation Spaces](https://arxiv.org/abs/2112.01049). Aryan Deshwal, Syrine Belakaria, Janardhan Rao Doppa, Dae Hyun Kim. AAAI 2021.
 - [GIBBON: General-purpose Information-Based Bayesian Optimisation](https://jmlr.org/papers/v22/21-0120.html). Henry B. Moss, David S. Leslie, Javier Gonzalez, Paul Rayson. JMLR, 2021.
 - [Bayesian Optimization with High-Dimensional Outputs](https://papers.nips.cc/paper/2021/hash/a0d3973ad100ad83a64c304bb58677dd-Abstract.html). Wesley J. Maddox, Maximilian Balandat, Andrew G. Wilson, Eytan Bakshy. NeurIPS 2021.

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         "gpytorch>=1.6",
         "scipy",
         "multipledispatch",
+        "pyro-ppl==1.8.0",
     ],
     extras_require={
         "dev": DEV_REQUIRES,

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -84,6 +84,11 @@ Variational GP Models
 .. automodule:: botorch.models.approximate_gp
     :members:
 
+Fully Bayesian GP Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.fully_bayesian
+    :members:
+
 
 Model Components
 -------------------------------------------

--- a/sphinx/source/posteriors.rst
+++ b/sphinx/source/posteriors.rst
@@ -44,6 +44,12 @@ Transformed Posterior
 .. automodule:: botorch.posteriors.transformed
     :members:
 
+Fully Bayesian Posterior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.posteriors.fully_bayesian
+    :members:
+
+
 Utilities
 ---------------------------------------------
 

--- a/test/acquisition/test_analytic.py
+++ b/test/acquisition/test_analytic.py
@@ -200,16 +200,16 @@ class TestExpectedImprovement(BotorchTestCase):
 class TestPosteriorMean(BotorchTestCase):
     def test_posterior_mean(self):
         for dtype in (torch.float, torch.double):
-            mean = torch.tensor([[0.25]], device=self.device, dtype=dtype)
+            mean = torch.rand(3, 1, device=self.device, dtype=dtype)
             mm = MockModel(MockPosterior(mean=mean))
 
             module = PosteriorMean(model=mm)
-            X = torch.empty(1, 1, device=self.device, dtype=dtype)
+            X = torch.rand(3, 1, 2, device=self.device, dtype=dtype)
             pm = module(X)
             self.assertTrue(torch.equal(pm, mean.view(-1)))
 
             module = PosteriorMean(model=mm, maximize=False)
-            X = torch.empty(1, 1, device=self.device, dtype=dtype)
+            X = torch.rand(3, 1, 2, device=self.device, dtype=dtype)
             pm = module(X)
             self.assertTrue(torch.equal(pm, -mean.view(-1)))
 

--- a/test/acquisition/test_penalized.py
+++ b/test/acquisition/test_penalized.py
@@ -110,8 +110,8 @@ class TestPenalizedAcquisitionFunction(BotorchTestCase):
             tkwargs = {"device": self.device, "dtype": dtype}
             mock_model = MockModel(
                 MockPosterior(
-                    mean=torch.tensor([1.0], **tkwargs),
-                    variance=torch.tensor([1.0], **tkwargs),
+                    mean=torch.tensor([[1.0]], **tkwargs),
+                    variance=torch.tensor([[1.0]], **tkwargs),
                 )
             )
             init_point = torch.tensor([0.5, 0.5, 0.5], **tkwargs)

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import itertools
+
+import torch
+from botorch import fit_fully_bayesian_model_nuts
+from botorch.acquisition.analytic import (
+    ExpectedImprovement,
+    PosteriorMean,
+    ProbabilityOfImprovement,
+    UpperConfidenceBound,
+)
+from botorch.acquisition.monte_carlo import (
+    qExpectedImprovement,
+    qNoisyExpectedImprovement,
+    qProbabilityOfImprovement,
+    qSimpleRegret,
+    qUpperConfidenceBound,
+)
+from botorch.acquisition.multi_objective import (
+    qNoisyExpectedHypervolumeImprovement,
+    qExpectedHypervolumeImprovement,
+)
+from botorch.models import ModelListGP
+from botorch.models.fully_bayesian import (
+    SaasFullyBayesianSingleTaskGP,
+    SaasPyroModel,
+    MIN_INFERRED_NOISE_LEVEL,
+)
+from botorch.models.transforms import Normalize, Standardize
+from botorch.posteriors import FullyBayesianPosterior
+from botorch.sampling.samplers import IIDNormalSampler
+from botorch.utils.multi_objective.box_decompositions.non_dominated import (
+    NondominatedPartitioning,
+)
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.kernels import MaternKernel, ScaleKernel
+from gpytorch.likelihoods import GaussianLikelihood, FixedNoiseGaussianLikelihood
+from gpytorch.means import ConstantMean
+
+
+class TestSingleTaskGP(BotorchTestCase):
+    def _get_data_and_model(self, infer_noise: bool, **tkwargs):
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 4, **tkwargs)
+            train_Y = torch.sin(train_X[:, :1])
+            train_Yvar = (
+                None if infer_noise else 0.1 * torch.arange(10, **tkwargs).unsqueeze(-1)
+            )
+            model = SaasFullyBayesianSingleTaskGP(
+                train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar
+            )
+        return train_X, train_Y, train_Yvar, model
+
+    def _get_unnormalized_data(self, infer_noise: bool, **tkwargs):
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = 5 + 5 * torch.rand(10, 4, **tkwargs)
+            train_Y = 10 + torch.sin(train_X[:, :1])
+            test_X = 5 + 5 * torch.rand(5, 4, **tkwargs)
+            train_Yvar = (
+                None if infer_noise else 0.1 * torch.arange(10, **tkwargs).unsqueeze(-1)
+            )
+        return train_X, train_Y, train_Yvar, test_X
+
+    def _get_mcmc_samples(
+        self, num_samples: int, dim: int, infer_noise: bool, **tkwargs
+    ):
+        mcmc_samples = {
+            "lengthscale": torch.rand(num_samples, 1, dim, **tkwargs),
+            "outputscale": torch.rand(num_samples, **tkwargs),
+            "mean": torch.randn(num_samples, 1, **tkwargs),
+        }
+        if infer_noise:
+            mcmc_samples["noise"] = torch.rand(num_samples, 1, **tkwargs)
+        return mcmc_samples
+
+    def test_raises(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expected train_X to have shape n x d and train_Y to have shape n x 1",
+        ):
+            SaasFullyBayesianSingleTaskGP(
+                train_X=torch.rand(10, 4, **tkwargs), train_Y=torch.randn(10, **tkwargs)
+            )
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expected train_X to have shape n x d and train_Y to have shape n x 1",
+        ):
+            SaasFullyBayesianSingleTaskGP(
+                train_X=torch.rand(10, 4, **tkwargs),
+                train_Y=torch.randn(12, 1, **tkwargs),
+            )
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expected train_X to have shape n x d and train_Y to have shape n x 1",
+        ):
+            SaasFullyBayesianSingleTaskGP(
+                train_X=torch.rand(10, **tkwargs),
+                train_Y=torch.randn(10, 1, **tkwargs),
+            )
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expected train_Yvar to be None or have the same shape as train_Y",
+        ):
+            SaasFullyBayesianSingleTaskGP(
+                train_X=torch.rand(10, 4, **tkwargs),
+                train_Y=torch.randn(10, 1, **tkwargs),
+                train_Yvar=torch.rand(10, **tkwargs),
+            )
+        train_X, train_Y, train_Yvar, model = self._get_data_and_model(
+            infer_noise=True, **tkwargs
+        )
+        sampler = IIDNormalSampler(num_samples=2)
+        with self.assertRaisesRegex(
+            NotImplementedError, "Fantasize is not implemented!"
+        ):
+            model.fantasize(X=torch.rand(5, 4, **tkwargs), sampler=sampler)
+        # Make sure an exception is raised if the model has not been fitted
+        not_fitted_error_msg = (
+            "Model has not been fitted. You need to call "
+            "`fit_fully_bayesian_model_nuts` to fit the model."
+        )
+        with self.assertRaisesRegex(RuntimeError, not_fitted_error_msg):
+            model.num_mcmc_samples
+        with self.assertRaisesRegex(RuntimeError, not_fitted_error_msg):
+            model.median_lengthscale
+        with self.assertRaisesRegex(RuntimeError, not_fitted_error_msg):
+            model.forward(torch.rand(1, 4, **tkwargs))
+        with self.assertRaisesRegex(RuntimeError, not_fitted_error_msg):
+            model.posterior(torch.rand(1, 4, **tkwargs))
+
+    def test_fit_model(self):
+        for infer_noise, dtype in itertools.product(
+            [True, False], [torch.float, torch.double]
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            train_X, train_Y, train_Yvar, model = self._get_data_and_model(
+                infer_noise=infer_noise, **tkwargs
+            )
+            n, d = train_X.shape
+
+            # Test init
+            self.assertIsNone(model.mean_module)
+            self.assertIsNone(model.covar_module)
+            self.assertIsNone(model.likelihood)
+            self.assertIsInstance(model.pyro_model, SaasPyroModel)
+            self.assertTrue(torch.allclose(train_X, model.train_X))
+            self.assertTrue(torch.allclose(train_Y, model.train_Y))
+            if infer_noise:
+                self.assertIsNone(model.train_Yvar)
+            else:
+                self.assertTrue(
+                    torch.allclose(
+                        train_Yvar.clamp(MIN_INFERRED_NOISE_LEVEL), model.train_Yvar
+                    )
+                )
+
+            # Fit a model and check that the hyperparameters have the correct shape
+            fit_fully_bayesian_model_nuts(
+                model, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
+            )
+            self.assertIsInstance(model.mean_module, ConstantMean)
+            self.assertEqual(model.mean_module.constant.shape, torch.Size([3, 1]))
+            self.assertIsInstance(model.covar_module, ScaleKernel)
+            self.assertEqual(model.covar_module.outputscale.shape, torch.Size([3]))
+            self.assertIsInstance(model.covar_module.base_kernel, MaternKernel)
+            self.assertEqual(
+                model.covar_module.base_kernel.lengthscale.shape, torch.Size([3, 1, d])
+            )
+            self.assertIsInstance(
+                model.likelihood,
+                GaussianLikelihood if infer_noise else FixedNoiseGaussianLikelihood,
+            )
+            if infer_noise:
+                self.assertEqual(model.likelihood.noise.shape, torch.Size([3, 1]))
+            else:
+                self.assertEqual(model.likelihood.noise.shape, torch.Size([n, 1]))
+                self.assertTrue(
+                    torch.allclose(
+                        train_Yvar.clamp(MIN_INFERRED_NOISE_LEVEL),
+                        model.likelihood.noise,
+                    )
+                )
+
+            # Predict on some test points
+            for batch_shape, marginalize in itertools.product(
+                [[5], [6, 5, 2]], [True, False]
+            ):
+                test_X = torch.rand(*batch_shape, d, **tkwargs)
+                posterior = model.posterior(
+                    test_X, marginalize_over_mcmc_samples=marginalize
+                )
+                self.assertIsInstance(posterior, FullyBayesianPosterior)
+                expected_shape = (
+                    batch_shape + [1]
+                    if marginalize
+                    else batch_shape[:-1] + [3] + batch_shape[-1:] + [1]
+                )
+                mean, var = posterior.mean, posterior.variance
+                self.assertEqual(mean.shape, torch.Size(expected_shape))
+                self.assertEqual(var.shape, torch.Size(expected_shape))
+
+            # Check properties
+            median_lengthscale = model.median_lengthscale
+            self.assertEqual(median_lengthscale.shape, torch.Size([4]))
+            self.assertEqual(model.num_mcmc_samples, 3)
+
+            # Make sure the model shapes are set correctly
+            self.assertEqual(model.train_X.shape, torch.Size([3, n, d]))
+            self.assertTrue(
+                all(torch.allclose(model.train_X[i], model.train_X) for i in range(3))
+            )
+            model.train()  # Put the model in train mode
+            self.assertTrue(torch.allclose(train_X, model.train_X))
+            self.assertIsNone(model.mean_module)
+            self.assertIsNone(model.covar_module)
+            self.assertIsNone(model.likelihood)
+
+    def test_input_transforms(self):
+        for infer_noise in [True, False]:
+            tkwargs = {"device": self.device, "dtype": torch.double}
+            train_X, train_Y, train_Yvar, test_X = self._get_unnormalized_data(
+                infer_noise=infer_noise, **tkwargs
+            )
+            n, d = train_X.shape
+
+            lb, ub = train_X.min(dim=0).values, train_X.max(dim=0).values
+            mu, sigma = train_Y.mean(), train_Y.std()
+
+            # Fit without transforms
+            with torch.random.fork_rng():
+                torch.manual_seed(0)
+                gp1 = SaasFullyBayesianSingleTaskGP(
+                    train_X=(train_X - lb) / (ub - lb),
+                    train_Y=(train_Y - mu) / sigma,
+                    train_Yvar=train_Yvar / sigma ** 2
+                    if train_Yvar is not None
+                    else train_Yvar,
+                )
+                fit_fully_bayesian_model_nuts(
+                    gp1, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
+                )
+                posterior1 = gp1.posterior(
+                    (test_X - lb) / (ub - lb), marginalize_over_mcmc_samples=True
+                )
+                pred_mean1 = mu + sigma * posterior1.mean
+                pred_var1 = (sigma ** 2) * posterior1.variance
+
+            # Fit with transforms
+            with torch.random.fork_rng():
+                torch.manual_seed(0)
+                gp2 = SaasFullyBayesianSingleTaskGP(
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    train_Yvar=train_Yvar,
+                    input_transform=Normalize(d=train_X.shape[-1]),
+                    outcome_transform=Standardize(m=1),
+                )
+                fit_fully_bayesian_model_nuts(
+                    gp2, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
+                )
+                posterior2 = gp2.posterior(test_X, marginalize_over_mcmc_samples=True)
+                pred_mean2, pred_var2 = posterior2.mean, posterior2.variance
+
+            self.assertTrue(torch.allclose(pred_mean1, pred_mean2))
+            self.assertTrue(torch.allclose(pred_var1, pred_var2))
+
+    def test_acquisition_functions(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        train_X, train_Y, train_Yvar, model = self._get_data_and_model(
+            infer_noise=True, **tkwargs
+        )
+        fit_fully_bayesian_model_nuts(
+            model, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
+        )
+        sampler = IIDNormalSampler(num_samples=2)
+        acquisition_functions = [
+            ExpectedImprovement(model=model, best_f=train_Y.max()),
+            ProbabilityOfImprovement(model=model, best_f=train_Y.max()),
+            PosteriorMean(model=model),
+            UpperConfidenceBound(model=model, beta=4),
+            qExpectedImprovement(model=model, best_f=train_Y.max(), sampler=sampler),
+            qNoisyExpectedImprovement(model=model, X_baseline=train_X, sampler=sampler),
+            qProbabilityOfImprovement(
+                model=model, best_f=train_Y.max(), sampler=sampler
+            ),
+            qSimpleRegret(model=model, sampler=sampler),
+            qUpperConfidenceBound(model=model, beta=4, sampler=sampler),
+            qNoisyExpectedHypervolumeImprovement(
+                model=ModelListGP(model, model),
+                X_baseline=train_X,
+                ref_point=torch.zeros(2, **tkwargs),
+                sampler=sampler,
+            ),
+            qExpectedHypervolumeImprovement(
+                model=ModelListGP(model, model),
+                ref_point=torch.zeros(2, **tkwargs),
+                sampler=sampler,
+                partitioning=NondominatedPartitioning(
+                    ref_point=torch.zeros(2, **tkwargs), Y=train_Y.repeat([1, 2])
+                ),
+            ),
+        ]
+
+        for acqf in acquisition_functions:
+            for batch_shape in [[5], [6, 5, 2]]:
+                test_X = torch.rand(*batch_shape, 1, 4, **tkwargs)
+                self.assertEqual(acqf(test_X).shape, torch.Size(batch_shape))
+
+    def test_load_samples(self):
+        for infer_noise, dtype in itertools.product(
+            [True, False], [torch.float, torch.double]
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            train_X, train_Y, train_Yvar, model = self._get_data_and_model(
+                infer_noise=infer_noise, **tkwargs
+            )
+            n, d = train_X.shape
+            mcmc_samples = self._get_mcmc_samples(
+                num_samples=3, dim=train_X.shape[-1], infer_noise=infer_noise, **tkwargs
+            )
+            model.load_mcmc_samples(mcmc_samples)
+
+            self.assertTrue(
+                torch.allclose(
+                    model.covar_module.base_kernel.lengthscale,
+                    mcmc_samples["lengthscale"],
+                )
+            )
+            self.assertTrue(
+                torch.allclose(
+                    model.covar_module.outputscale,
+                    mcmc_samples["outputscale"],
+                )
+            )
+            self.assertTrue(
+                torch.allclose(
+                    model.mean_module.constant.data,
+                    mcmc_samples["mean"],
+                )
+            )
+            if infer_noise:
+                self.assertTrue(
+                    torch.allclose(
+                        model.likelihood.noise_covar.noise, mcmc_samples["noise"]
+                    )
+                )
+            else:
+                self.assertTrue(
+                    torch.allclose(
+                        model.likelihood.noise_covar.noise,
+                        train_Yvar.clamp(MIN_INFERRED_NOISE_LEVEL),
+                    )
+                )


### PR DESCRIPTION
Summary:
This implements a `SaasFullyBayesianSingleTaskGP` model that uses the SAAS prior and a Matern-5/2 kernel as well as `fit_fully_bayesian_model_nuts` for fitting the model. The model fitting uses Pyro and the final hyperparameters are loaded into a batched GPyTorch model.

The interface looks like this:
```
saas_gp = SaasFullyBayesianSingleTaskGP(train_X=train_X, train_Y=train_Y)
fit_fully_bayesian_model_nuts(saas_gp)
posterior = saas_gp.posterior(test_X, marginalize_over_mcmc_samples=True)
```

Differential Revision: D34037765

