### PR TITLE
Unpin nbconvert in workflows

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -118,7 +118,9 @@ jobs:
         pip install .[dev]
         pip install git+https://github.com/facebook/Ax.git
         pip install .[tutorials]
-        pip install beautifulsoup4 ipython "nbconvert<6.0"
+        # NOTE: nbconvert 6.4.4 is incompatible with jinja2 3.1.0.
+        # We can unpin this with a future release of nbconvert.
+        pip install beautifulsoup4 ipython nbconvert "jinja2==3.0.3"
     - name: Publish latest website
       env:
         DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,9 @@ jobs:
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[dev]
-        pip install beautifulsoup4 ipython "nbconvert<6.0"
-        # This is needed as a stop-gap until we remove nbconvert<6.0 restriction.
-        pip install ipython_genutils
+        # NOTE: nbconvert 6.4.4 is incompatible with jinja2 3.1.0.
+        # We can unpin this with a future release of nbconvert.
+        pip install beautifulsoup4 ipython nbconvert "jinja2==3.0.3"
     - name: Validate Sphinx
       run: |
         python scripts/validate_sphinx.py -p "$(pwd)"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,9 +122,9 @@ jobs:
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[dev]
         pip install git+https://github.com/facebook/Ax.git
-        pip install beautifulsoup4 ipython "nbconvert<6.0"
-        # This is needed as a stop-gap until we remove nbconvert<6.0 restriction.
-        pip install ipython_genutils
+        # NOTE: nbconvert 6.4.4 is incompatible with jinja2 3.1.0.
+        # We can unpin this with a future release of nbconvert.
+        pip install beautifulsoup4 ipython nbconvert "jinja2==3.0.3"
     - name: Unit tests
       run: |
         pytest -ra

--- a/scripts/parse_tutorials.py
+++ b/scripts/parse_tutorials.py
@@ -102,10 +102,11 @@ def gen_tutorials(repo_dir: str) -> None:
         exporter = HTMLExporter()
         html, meta = exporter.from_notebook_node(nb)
 
-        # pull out html div for notebook
+        # pull out html body for notebook
         soup = BeautifulSoup(html, "html.parser")
-        nb_meat = soup.find("div", {"id": "notebook-container"})
-        del nb_meat.attrs["id"]
+        nb_meat = soup.find("body", {"class": "jp-Notebook"})
+        del nb_meat.attrs["data-jp-theme-light"]
+        del nb_meat.attrs["data-jp-theme-name"]
         nb_meat.attrs["class"] = ["notebook"]
         html_out = JS_SCRIPTS + str(nb_meat)
 


### PR DESCRIPTION
Summary: This updates `parse_tutorials` to work with `nbconvert > 6.0`, and unpins the `nbconvert` version in the workflows.

Differential Revision: D35134055

