### PR TITLE
No need to reshape train_X in SAASBO

### DIFF
--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -304,8 +304,7 @@ class SaasFullyBayesianSingleTaskGP(SingleTaskGP):
     def train(self, mode: bool = True) -> None:
         r"""Puts the model in `train` mode."""
         super().train(mode=mode)
-        if mode and self.train_X.ndim == 3:
-            self.train_X = self.train_X[0, ...].squeeze(0)
+        if mode:
             self.mean_module = None
             self.covar_module = None
             self.likelihood = None
@@ -319,10 +318,6 @@ class SaasFullyBayesianSingleTaskGP(SingleTaskGP):
         tkwargs = {"device": self.train_X.device, "dtype": self.train_X.dtype}
         num_mcmc_samples = len(mcmc_samples["mean"])
         batch_shape = torch.Size([num_mcmc_samples])
-
-        self.train_X = self.train_X.unsqueeze(0).expand(
-            num_mcmc_samples, self.train_X.shape[0], -1
-        )
         self.mean_module = ConstantMean(batch_shape=batch_shape).to(**tkwargs)
         self.covar_module = ScaleKernel(
             base_kernel=MaternKernel(

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -45,7 +45,7 @@ from gpytorch.likelihoods import GaussianLikelihood, FixedNoiseGaussianLikelihoo
 from gpytorch.means import ConstantMean
 
 
-class TestSingleTaskGP(BotorchTestCase):
+class TestFullyBayesianSingleTaskGP(BotorchTestCase):
     def _get_data_and_model(self, infer_noise: bool, **tkwargs):
         with torch.random.fork_rng():
             torch.manual_seed(0)
@@ -215,10 +215,8 @@ class TestSingleTaskGP(BotorchTestCase):
             self.assertEqual(model.num_mcmc_samples, 3)
 
             # Make sure the model shapes are set correctly
-            self.assertEqual(model.train_X.shape, torch.Size([3, n, d]))
-            self.assertTrue(
-                all(torch.allclose(model.train_X[i], model.train_X) for i in range(3))
-            )
+            self.assertEqual(model.train_X.shape, torch.Size([n, d]))
+            self.assertTrue(torch.allclose(model.train_X, train_X))
             model.train()  # Put the model in train mode
             self.assertTrue(torch.allclose(train_X, model.train_X))
             self.assertIsNone(model.mean_module)


### PR DESCRIPTION
Summary: We're only keeping `train_X` around for convenience, it isn't actually used anywhere.

Reviewed By: saitcakmak

Differential Revision: D35206814

