### PR TITLE
Use re-usable workflows for Tutorials workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,6 @@ on:
 
 
 jobs:
-
   tests-and-coverage-nightly:
     name: Tests and coverage (pip, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -135,25 +134,9 @@ jobs:
         ./scripts/publish_site.sh -d
 
   run_tutorials:
-    name: Run tutorials without smoke test
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Fetch all history for all tags and branches
-      # we need to do this so setuptools_scm knows how to set the botorch version
-      run: git fetch --prune --unshallow
-    - name: Install dependencies
-      env:
-        # this is so Ax's setup doesn't install a pinned BoTorch version
-        ALLOW_BOTORCH_LATEST: true
-      run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/facebook/Ax.git
-        pip install .[tutorials]
-    - name: Run tutorials
-      run: |
-        python scripts/run_tutorials.py -p "$(pwd)"
+    name: Run tutorials without smoke test on latest PyTorch / GPyTorch / Ax
+    uses: ./.github/workflows/reusable_tutorials.yml
+    with:
+      smoke_test: false
+      use_stable_pytorch_gpytorch: false
+      use_stable_ax: false

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -1,0 +1,64 @@
+name: Reusable Tutorials Workflow
+
+on:
+  workflow_call:
+    inputs:
+      smoke_test:
+        required: false
+        type: boolean
+        default: true
+      use_stable_pytorch_gpytorch:
+        required: false
+        type: boolean
+        default: false
+      use_stable_ax:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  tutorials:
+    name: Run tutorials
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Fetch all history for all tags and branches
+      # We need to do this so setuptools_scm knows how to set the BoTorch version.
+      run: git fetch --prune --unshallow
+    - if: ${{ !inputs.use_stable_pytorch_botorch }}
+      name: Install latest PyTorch & GPyTorch
+      run: |
+        pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        pip install git+https://github.com/cornellius-gp/gpytorch.git
+    - if: ${{ inputs.use_stable_pytorch_botorch }}
+      name: Install min required PyTorch & GPyTorch
+      run: |
+        python setup.py egg_info
+        req_txt="botorch.egg-info/requires.txt"
+        min_torch_version=$(grep '\btorch>=' ${req_txt} | sed 's/[^0-9.]//g')
+        min_gpytorch_version=$(grep '\bgpytorch>=' ${req_txt} | sed 's/[^0-9.]//g')
+        pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}"
+    - if: ${{ !inputs.use_stable_ax }}
+      name: Install latest Ax
+      env:
+        # This is so Ax's setup doesn't install a pinned BoTorch version.
+        ALLOW_BOTORCH_LATEST: true
+      run: |
+        pip install git+https://github.com/facebook/Ax.git
+    - name: Install BoTorch with tutorials dependencies
+      env:
+        ALLOW_BOTORCH_LATEST: true
+      run: |
+        pip install .[tutorials]
+    - if: ${{ inputs.smoke_test }}
+      name: Run tutorials with smoke test
+      run: |
+        python scripts/run_tutorials.py -p "$(pwd)" -s
+    - if: ${{ !inputs.smoke_test }}
+      name: Run tutorials without smoke test
+      run: |
+        python scripts/run_tutorials.py -p "$(pwd)"

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -82,56 +82,17 @@ jobs:
         pytest -ra --cov=. --cov-report term-missing
 
   run_tutorials_stable_w_latest_ax:
-    name: Run tutorials without smoke test on min req. versions of torch & gpytorch and latest Ax
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Fetch all history for all tags and branches
-      # we need to do this so setuptools_scm knows how to set the botorch version
-      run: git fetch --prune --unshallow
-    - name: Install dependencies
-      env:
-        # this is so Ax's setup doesn't install a pinned BoTorch version
-        ALLOW_BOTORCH_LATEST: true
-      run: |
-        python setup.py egg_info
-        req_txt="botorch.egg-info/requires.txt"
-        min_torch_version=$(grep '\btorch>=' ${req_txt} | sed 's/[^0-9.]//g')
-        min_gpytorch_version=$(grep '\bgpytorch>=' ${req_txt} | sed 's/[^0-9.]//g')
-        pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}"
-        pip install git+https://github.com/facebook/Ax.git
-        pip install .[tutorials]
-    - name: Run tutorials
-      run: |
-        python scripts/run_tutorials.py -p "$(pwd)"
+    name: Run tutorials without smoke test on min req. versions of PyTorch & GPyTorch and latest Ax
+    uses: ./.github/workflows/reusable_tutorials.yml
+    with:
+      smoke_test: false
+      use_stable_pytorch_gpytorch: true
+      use_stable_ax: false
 
   run_tutorials_stable_w_stable_ax:
-    name: Run tutorials without smoke test on min req. versions of torch & gpytorch and stable Ax
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Fetch all history for all tags and branches
-      # we need to do this so setuptools_scm knows how to set the botorch version
-      run: git fetch --prune --unshallow
-    - name: Install dependencies
-      env:
-        # this is so Ax's setup doesn't install a pinned BoTorch version
-        ALLOW_BOTORCH_LATEST: true
-      run: |
-        python setup.py egg_info
-        req_txt="botorch.egg-info/requires.txt"
-        min_torch_version=$(grep '\btorch>=' ${req_txt} | sed 's/[^0-9.]//g')
-        min_gpytorch_version=$(grep '\bgpytorch>=' ${req_txt} | sed 's/[^0-9.]//g')
-        pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}"
-        pip install .[tutorials]
-    - name: Run tutorials
-      run: |
-        python scripts/run_tutorials.py -p "$(pwd)"
+    name: Run tutorials without smoke test on min req. versions of PyTorch & GPyTorch and stable Ax
+    uses: ./.github/workflows/reusable_tutorials.yml
+    with:
+      smoke_test: false
+      use_stable_pytorch_gpytorch: true
+      use_stable_ax: true

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -9,27 +9,10 @@ on:
 
 
 jobs:
-
-  tutorials:
-    name: Run tutorials
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Fetch all history for all tags and branches
-      # we need to do this so setuptools_scm knows how to set the botorch version
-      run: git fetch --prune --unshallow
-    - name: Install dependencies
-      env:
-        # this is so Ax's setup doesn't install a pinned BoTorch version
-        ALLOW_BOTORCH_LATEST: true
-      run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/facebook/Ax.git
-        pip install .[tutorials]
-    - name: Run tutorials
-      run: |
-        python scripts/run_tutorials.py -p "$(pwd)" -s
+  run_tutorials_with_smoke_test:
+    name: Run tutorials with smoke test on latest PyTorch / GPyTorch / Ax
+    uses: ./.github/workflows/reusable_tutorials.yml
+    with:
+      smoke_test: true
+      use_stable_pytorch_gpytorch: false
+      use_stable_ax: false


### PR DESCRIPTION
This is the first attempt at cleaning up GHA workflows. We currently have lots of duplicate code. By using re-usable workflows, we can significantly lower the maintenance burden. 

Test Plan:
* Nightly: https://github.com/pytorch/botorch/runs/5765190193?check_suite_focus=true
* Stable w/ stable Ax: https://github.com/pytorch/botorch/runs/5765197499?check_suite_focus=true
* Stable w/ latest Ax: https://github.com/pytorch/botorch/runs/5765197454?check_suite_focus=true
* Smoke test: https://github.com/pytorch/botorch/runs/5765209107?check_suite_focus=true