### PR TITLE
Fix missing warnings on failed optimization in `fit_gpytorch_scipy`

### DIFF
--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -120,6 +120,8 @@ def fit_gpytorch_model(
     retry = 0
     while retry < max_retries:
         with warnings.catch_warnings(record=True) as ws:
+            # Make sure we catch all OptimizationWarnings.
+            warnings.simplefilter("always", category=OptimizationWarning)
             if retry > 0:  # use normal initial conditions on first try
                 mll.model.load_state_dict(original_state_dict)
                 sample_all_priors(mll.model)

--- a/test/models/test_pairwise_gp.py
+++ b/test/models/test_pairwise_gp.py
@@ -287,3 +287,15 @@ class TestPairwiseGP(BotorchTestCase):
             self.assertIsInstance(fm, model.__class__)
             fm = model.fantasize(X=X_f, sampler=sampler, observation_noise=False)
             self.assertIsInstance(fm, model.__class__)
+
+    def test_load_state_dict(self):
+        model, _ = self._get_model_and_data(batch_shape=[])
+        sd = model.state_dict()
+        with warnings.catch_warnings(record=True) as ws:
+            missing, unexpected = model.load_state_dict(sd, strict=True)
+        # Check that the warning was raised.
+        self.assertTrue(any("strict=True" in str(w.message) for w in ws))
+        # Check that buffers are missing.
+        self.assertIn("datapoints", missing)
+        self.assertIn("D", missing)
+        self.assertIn("covar", missing)


### PR DESCRIPTION
Summary:
`OptimizationWarnings` are sometimes filtered out due to quirks of `warnings.catch_warnings`, leading to us treating the failed model fits as successful, despite explicitly warning about these in `fit_gpytorch_scipy`. This adds a `warnings.simplefilter("always", category=OptimizationWarning)` to make sure we always catch these.

Fixes #1169.

Differential Revision: D35594755

