### PR TITLE
Ignore data related buffers in PairwiseGP.load_state_dict

### DIFF
--- a/test/models/test_pairwise_gp.py
+++ b/test/models/test_pairwise_gp.py
@@ -287,3 +287,15 @@ class TestPairwiseGP(BotorchTestCase):
             self.assertIsInstance(fm, model.__class__)
             fm = model.fantasize(X=X_f, sampler=sampler, observation_noise=False)
             self.assertIsInstance(fm, model.__class__)
+
+    def test_load_state_dict(self):
+        model, _ = self._get_model_and_data(batch_shape=[])
+        sd = model.state_dict()
+        with warnings.catch_warnings(record=True) as ws:
+            missing, unexpected = model.load_state_dict(sd, strict=True)
+        # Check that the warning was raised.
+        self.assertTrue(any("strict=True" in str(w.message) for w in ws))
+        # Check that buffers are missing.
+        self.assertIn("datapoints", missing)
+        self.assertIn("D", missing)
+        self.assertIn("covar", missing)


### PR DESCRIPTION
Summary: Implements a `load_state_dict` method in `PairwiseGP` that skips over the data related buffers. This should help avoid errors such as https://github.com/pytorch/botorch/runs/5997923346?check_suite_focus=true (When `utility=None` it is excluded from `model.state_dict`. Since it exists in the `original_state_dict`, `load_state_dict` throws an error.)

Differential Revision: D35599169

