### PR TITLE
Add expectation risk measures

### DIFF
--- a/botorch/acquisition/multi_objective/multi_output_risk_measures.py
+++ b/botorch/acquisition/multi_objective/multi_output_risk_measures.py
@@ -94,6 +94,26 @@ class MultiOutputRiskMeasureMCObjective(
         pass  # pragma: no cover
 
 
+class MultiOutputExpectation(MultiOutputRiskMeasureMCObjective):
+    r"""A multi-output MC expectation risk measure."""
+
+    def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
+        r"""Calculate the expectation of the given samples. Expectation is
+        calculated over each `n_w` samples in the q-batch dimension.
+
+        Args:
+            samples: A `sample_shape x batch_shape x (q * n_w) x m`-dim tensor of
+                posterior samples. The q-batches should be ordered so that each
+                `n_w` block of samples correspond to the same input.
+            X: A `batch_shape x q x d`-dim tensor of inputs. Ignored.
+
+        Returns:
+            A `sample_shape x batch_shape x q x m`-dim tensor of expectation samples.
+        """
+        prepared_samples = self._prepare_samples(samples)
+        return prepared_samples.mean(dim=-2)
+
+
 class IndependentCVaR(CVaR, MultiOutputRiskMeasureMCObjective):
     r"""The multi-output Conditional Value-at-Risk risk measure that operates on
     each output dimension independently. Since this does not consider the joint

--- a/botorch/acquisition/risk_measures.py
+++ b/botorch/acquisition/risk_measures.py
@@ -225,3 +225,25 @@ class WorstCase(RiskMeasureMCObjective):
         """
         prepared_samples = self._prepare_samples(samples)
         return prepared_samples.min(dim=-1).values
+
+
+class Expectation(RiskMeasureMCObjective):
+    r"""The expectation risk measure."""
+
+    def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
+        r"""Calculate the expectation corresponding to the given samples.
+        This calculates the expectation / mean / average of each `n_w` samples
+        across the q-batch dimension. If `self.weights` is given, the samples
+        are scalarized across the output dimension before taking the expectation.
+
+        Args:
+            samples: A `sample_shape x batch_shape x (q * n_w) x m`-dim tensor of
+                posterior samples. The q-batches should be ordered so that each
+                `n_w` block of samples correspond to the same input.
+            X: A `batch_shape x q x d`-dim tensor of inputs. Ignored.
+
+        Returns:
+            A `sample_shape x batch_shape x q`-dim tensor of expectation samples.
+        """
+        prepared_samples = self._prepare_samples(samples)
+        return prepared_samples.mean(dim=-1)

--- a/test/acquisition/test_risk_measures.py
+++ b/test/acquisition/test_risk_measures.py
@@ -10,6 +10,7 @@ from typing import Optional
 import torch
 from botorch.acquisition.risk_measures import (
     CVaR,
+    Expectation,
     RiskMeasureMCObjective,
     VaR,
     WorstCase,
@@ -171,5 +172,47 @@ class TestWorstCase(BotorchTestCase):
                 torch.equal(
                     rm_samples,
                     torch.tensor([[-2.0, -5.0]], device=self.device, dtype=dtype),
+                )
+            )
+
+
+class TestExpectation(BotorchTestCase):
+    def test_expectation(self):
+        for dtype in (torch.float, torch.double):
+            obj = Expectation(n_w=3)
+            samples = torch.tensor(
+                [[[1.0], [0.5], [1.5], [3.0], [1.0], [5.0]]],
+                device=self.device,
+                dtype=dtype,
+            )
+            rm_samples = obj(samples)
+            self.assertTrue(
+                torch.equal(
+                    rm_samples,
+                    torch.tensor([[1.0, 3.0]], device=self.device, dtype=dtype),
+                )
+            )
+            # w/ weights
+            samples = torch.tensor(
+                [
+                    [
+                        [1.0, 3.0],
+                        [0.5, 1.0],
+                        [1.5, 2.0],
+                        [3.0, 1.0],
+                        [1.0, 2.0],
+                        [5.0, 3.0],
+                    ]
+                ],
+                device=self.device,
+                dtype=dtype,
+            )
+            weights = torch.tensor([-1.0, 2.0], device=self.device, dtype=dtype)
+            obj = Expectation(n_w=3, weights=weights)
+            rm_samples = obj(samples)
+            self.assertTrue(
+                torch.equal(
+                    rm_samples,
+                    torch.tensor([[3.0, 1.0]], device=self.device, dtype=dtype),
                 )
             )


### PR DESCRIPTION
Summary:
Adds MC expectation risk measures, both single-output and multi-output.
We initially skipped these thinking that one should use the analytic expectation. The work on robust MOBO made us realize that you can't use analytic expectation if you have constraints. So, adding these now to provide a full selection of risk measures out of the box in Ax.

Differential Revision: D35631768

