### PR TITLE
Implements Multi-Fidelity GIBBON (Lower Bound MES) acquisition.

### DIFF
--- a/botorch/acquisition/__init__.py
+++ b/botorch/acquisition/__init__.py
@@ -34,6 +34,7 @@ from botorch.acquisition.knowledge_gradient import (
 from botorch.acquisition.max_value_entropy_search import (
     MaxValueBase,
     qLowerBoundMaxValueEntropy,
+    qMultiFidelityLowerBoundMaxValueEntropy,
     qMaxValueEntropy,
     qMultiFidelityMaxValueEntropy,
 )
@@ -81,6 +82,7 @@ __all__ = [
     "MaxValueBase",
     "qMultiFidelityKnowledgeGradient",
     "qMaxValueEntropy",
+    "qMultiFidelityLowerBoundMaxValueEntropy",
     "qLowerBoundMaxValueEntropy",
     "qMultiFidelityMaxValueEntropy",
     "qMultiStepLookahead",

--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -795,9 +795,7 @@ class qMultiFidelityMaxValueEntropy(qMaxValueEntropy):
         return ig.mean(dim=0)  # average over the fantasies
 
 
-class qMultiFidelityLowerBoundMaxValueEntropy(
-    qMultiFidelityMaxValueEntropy, qLowerBoundMaxValueEntropy
-):
+class qMultiFidelityLowerBoundMaxValueEntropy(qMultiFidelityMaxValueEntropy):
     r"""Multi-fidelity acquisition function for General-purpose Information-Based
     Bayesian optimization (GIBBON).
 

--- a/test/acquisition/test_max_value_entropy_search.py
+++ b/test/acquisition/test_max_value_entropy_search.py
@@ -242,14 +242,16 @@ class TestMaxValueEntropySearch(BotorchTestCase):
             with self.assertRaisesRegex(UnsupportedError, "X_pending is not None"):
                 qGIBBON(X)
 
-    def test_q_multi_fidelity_max_value_entropy(self):
+    def test_q_multi_fidelity_max_value_entropy(
+        self, acqf_class=qMultiFidelityMaxValueEntropy
+    ):
         for dtype in (torch.float, torch.double):
             torch.manual_seed(7)
             mm = MESMockModel()
             train_inputs = torch.rand(10, 2, device=self.device, dtype=dtype)
             mm.train_inputs = (train_inputs,)
             candidate_set = torch.rand(10, 2, device=self.device, dtype=dtype)
-            qMF_MVE = qMultiFidelityMaxValueEntropy(
+            qMF_MVE = acqf_class(
                 model=mm, candidate_set=candidate_set, num_mv_samples=10
             )
 
@@ -278,7 +280,7 @@ class TestMaxValueEntropySearch(BotorchTestCase):
             pt = ScalarizedPosteriorTransform(
                 weights=torch.ones(2, device=self.device, dtype=dtype)
             )
-            qMF_MVE = qMultiFidelityMaxValueEntropy(
+            qMF_MVE = acqf_class(
                 model=mm,
                 candidate_set=candidate_set,
                 num_mv_samples=10,
@@ -288,49 +290,11 @@ class TestMaxValueEntropySearch(BotorchTestCase):
             self.assertEqual(qMF_MVE(X).shape, torch.Size([1]))
 
     def test_q_multi_fidelity_lower_bound_max_value_entropy(self):
-        for dtype in (torch.float, torch.double):
-            torch.manual_seed(7)
-            mm = MESMockModel()
-            train_inputs = torch.rand(10, 2, device=self.device, dtype=dtype)
-            mm.train_inputs = (train_inputs,)
-            candidate_set = torch.rand(10, 2, device=self.device, dtype=dtype)
-            qMF_LBMVE = qMultiFidelityLowerBoundMaxValueEntropy(
-                model=mm, candidate_set=candidate_set, num_mv_samples=10
-            )
-
-            # test initialization
-            self.assertEqual(qMF_LBMVE.num_fantasies, 16)
-            self.assertEqual(qMF_LBMVE.num_mv_samples, 10)
-            self.assertIsInstance(qMF_LBMVE.sampler, SobolQMCNormalSampler)
-            self.assertIsInstance(qMF_LBMVE.cost_sampler, SobolQMCNormalSampler)
-            self.assertEqual(qMF_LBMVE.sampler.sample_shape, torch.Size([128]))
-            self.assertIsInstance(qMF_LBMVE.fantasies_sampler, SobolQMCNormalSampler)
-            self.assertEqual(qMF_LBMVE.fantasies_sampler.sample_shape, torch.Size([16]))
-            self.assertIsInstance(qMF_LBMVE.expand, Callable)
-            self.assertIsInstance(qMF_LBMVE.project, Callable)
-            self.assertIsNone(qMF_LBMVE.X_pending)
-            self.assertEqual(qMF_LBMVE.posterior_max_values.shape, torch.Size([10, 1]))
-            self.assertIsInstance(
-                qMF_LBMVE.cost_aware_utility, InverseCostWeightedUtility
-            )
-
-            # test evaluation
-            X = torch.rand(1, 2, device=self.device, dtype=dtype)
-            self.assertEqual(qMF_LBMVE(X).shape, torch.Size([1]))
-
-            # Test with multi-output model w/ transform.
-            mm = MESMockModel(num_outputs=2)
-            pt = ScalarizedPosteriorTransform(
-                weights=torch.ones(2, device=self.device, dtype=dtype)
-            )
-            qMF_LBMVE = qMultiFidelityLowerBoundMaxValueEntropy(
-                model=mm,
-                candidate_set=candidate_set,
-                num_mv_samples=10,
-                posterior_transform=pt,
-            )
-            X = torch.rand(1, 2, device=self.device, dtype=dtype)
-            self.assertEqual(qMF_LBMVE(X).shape, torch.Size([1]))
+        # Same test as for MF-MES since GIBBON only changes in the way it computes the
+        # information gain.
+        self.test_q_multi_fidelity_max_value_entropy(
+            acqf_class=qMultiFidelityLowerBoundMaxValueEntropy
+        )
 
     def test_sample_max_value_Gumbel(self):
         for dtype in (torch.float, torch.double):


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

Since `qLowerBoundMaxValueEntropy` provides a cheap approximation to `qMaxValueEntropy`, this PR implements the multi-fidelity version of `qMultiFidelityMaxValueEntropy` to be able to use the approximation in a multi-fidelity setting as well.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Copied the unit test for `qMultiFidelityMaxValueEntropy` without changes (besides the class name). The `qMultiFidelityLowerBoundMaxValueEntropy` class is the same as `qMultiFidelityMaxValueEntropy` with a different compute_information_gain function, so doesn't require a different set of tests.
