### PR TITLE
Add Bilog outcome transform

### DIFF
--- a/botorch/models/transforms/__init__.py
+++ b/botorch/models/transforms/__init__.py
@@ -11,15 +11,17 @@ from botorch.models.transforms.input import (
     Warp,
 )
 from botorch.models.transforms.outcome import (
+    Bilog,
     ChainedOutcomeTransform,
     Log,
     Power,
     Standardize,
-    Tanh,
+
 )
 
 
 __all__ = [
+    "Bilog",
     "ChainedInputTransform",
     "ChainedOutcomeTransform",
     "Log",
@@ -28,5 +30,4 @@ __all__ = [
     "Round",
     "Standardize",
     "Warp",
-    "Tanh",
 ]

--- a/botorch/models/transforms/__init__.py
+++ b/botorch/models/transforms/__init__.py
@@ -16,7 +16,6 @@ from botorch.models.transforms.outcome import (
     Log,
     Power,
     Standardize,
-
 )
 
 

--- a/botorch/models/transforms/__init__.py
+++ b/botorch/models/transforms/__init__.py
@@ -15,7 +15,7 @@ from botorch.models.transforms.outcome import (
     Log,
     Power,
     Standardize,
-    Tanh
+    Tanh,
 )
 
 
@@ -28,5 +28,5 @@ __all__ = [
     "Round",
     "Standardize",
     "Warp",
-    "Tanh"
+    "Tanh",
 ]

--- a/botorch/models/transforms/__init__.py
+++ b/botorch/models/transforms/__init__.py
@@ -15,6 +15,7 @@ from botorch.models.transforms.outcome import (
     Log,
     Power,
     Standardize,
+    Tanh
 )
 
 
@@ -27,4 +28,5 @@ __all__ = [
     "Round",
     "Standardize",
     "Warp",
+    "Tanh"
 ]

--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -644,7 +644,7 @@ class Power(OutcomeTransform):
 class Bilog(OutcomeTransform):
     r"""Bilog-transform outcomes.
 
-    The Bilog transform [eriksson2021scalable] is useful for modeling constraining
+    The Bilog transform [eriksson2021scalable]_ is useful for modeling constraining
     functions. It magnifies values near zero and flattens extreme values outside the
     domain [-1,1].
     """

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -14,7 +14,7 @@ from botorch.models.transforms.outcome import (
     OutcomeTransform,
     Power,
     Standardize,
-    Tanh
+    Tanh,
 )
 from botorch.models.transforms.utils import (
     norm_to_lognorm_mean,

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -608,7 +608,7 @@ class TestOutcomeTransforms(BotorchTestCase):
             tf.eval()
             self.assertFalse(tf.training)
             Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
-            self.assertTrue(torch.allclose(Y_utf, Y))
+            self.assertTrue(torch.allclose(Y_utf, Y, atol=1e-7))
             self.assertIsNone(Yvar_utf)
 
             # subset_output

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -14,6 +14,7 @@ from botorch.models.transforms.outcome import (
     OutcomeTransform,
     Power,
     Standardize,
+    Tanh
 )
 from botorch.models.transforms.utils import (
     norm_to_lognorm_mean,
@@ -577,6 +578,119 @@ class TestOutcomeTransforms(BotorchTestCase):
 
             # test subset_output with positive on subset of outcomes (pos. index)
             tf = Power(power=power, outputs=[0])
+            Y_tf, Yvar_tf = tf(Y, None)
+            tf_subset = tf.subset_output(idcs=[0])
+            Y_tf_subset, Yvar_tf_subset = tf_subset(Y[..., [0]], None)
+            self.assertTrue(torch.equal(Y_tf_subset, Y_tf[..., [0]]))
+            self.assertIsNone(Yvar_tf_subset)
+
+    def test_tanh(self, seed=0):
+        torch.random.manual_seed(seed)
+
+        ms = (1, 2)
+        batch_shapes = (torch.Size(), torch.Size([2]))
+        dtypes = (torch.float, torch.double)
+
+        # test transform and untransform
+        for m, batch_shape, dtype in itertools.product(ms, batch_shapes, dtypes):
+
+            # test init
+            tf = Tanh()
+            self.assertTrue(tf.training)
+            self.assertIsNone(tf._outputs)
+
+            # no observation noise
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Y_tf, Yvar_tf = tf(Y, None)
+            self.assertTrue(tf.training)
+            self.assertTrue(torch.allclose(Y_tf, Y.tanh()))
+            self.assertIsNone(Yvar_tf)
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            self.assertTrue(torch.allclose(Y_utf, Y))
+            self.assertIsNone(Yvar_utf)
+
+            # subset_output
+            tf_subset = tf.subset_output(idcs=[0])
+            Y_tf_subset, Yvar_tf_subset = tf_subset(Y[..., [0]])
+            self.assertTrue(torch.equal(Y_tf[..., [0]], Y_tf_subset))
+            self.assertIsNone(Yvar_tf_subset)
+
+            # test error if observation noise present
+            tf = Tanh()
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Yvar = 1e-8 + torch.rand(
+                *batch_shape, 3, m, device=self.device, dtype=dtype
+            )
+            with self.assertRaises(NotImplementedError):
+                tf(Y, Yvar)
+            tf.eval()
+            with self.assertRaises(NotImplementedError):
+                tf.untransform(Y, Yvar)
+
+            # untransform_posterior
+            tf = Tanh()
+            Y_tf, Yvar_tf = tf(Y, None)
+            tf.eval()
+            shape = batch_shape + torch.Size([3, m])
+            posterior = _get_test_posterior(shape, device=self.device, dtype=dtype)
+            p_utf = tf.untransform_posterior(posterior)
+            self.assertIsInstance(p_utf, TransformedPosterior)
+            self.assertEqual(p_utf.device.type, self.device.type)
+            self.assertTrue(p_utf.dtype == dtype)
+
+            samples = p_utf.rsample()
+            self.assertEqual(samples.shape, torch.Size([1]) + shape)
+            samples = p_utf.rsample(sample_shape=torch.Size([4]))
+            self.assertEqual(samples.shape, torch.Size([4]) + shape)
+            samples2 = p_utf.rsample(sample_shape=torch.Size([4, 2]))
+            self.assertEqual(samples2.shape, torch.Size([4, 2]) + shape)
+
+        # test transforming a subset of outcomes
+        for batch_shape, dtype in itertools.product(batch_shapes, dtypes):
+
+            m = 2
+            outputs = [-1]
+
+            # test init
+            tf = Tanh(outputs=outputs)
+            self.assertTrue(tf.training)
+            # cannot normalize indices b/c we don't know dimension yet
+            self.assertEqual(tf._outputs, [-1])
+
+            # no observation noise
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Y_tf, Yvar_tf = tf(Y, None)
+            self.assertTrue(tf.training)
+            self.assertTrue(torch.allclose(Y_tf[..., 1], Y[..., 1].tanh()))
+            self.assertTrue(torch.allclose(Y_tf[..., 0], Y[..., 0]))
+            self.assertIsNone(Yvar_tf)
+            tf.eval()
+            self.assertFalse(tf.training)
+            Y_utf, Yvar_utf = tf.untransform(Y_tf, Yvar_tf)
+            self.assertTrue(torch.allclose(Y_utf, Y))
+            self.assertIsNone(Yvar_utf)
+
+            # subset_output
+            with self.assertRaises(NotImplementedError):
+                tf_subset = tf.subset_output(idcs=[0])
+
+            # with observation noise
+            tf = Tanh(outputs=outputs)
+            Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
+            Yvar = 1e-8 + torch.rand(
+                *batch_shape, 3, m, device=self.device, dtype=dtype
+            )
+            with self.assertRaises(NotImplementedError):
+                tf(Y, Yvar)
+
+            # error on untransform_posterior
+            with self.assertRaises(NotImplementedError):
+                tf.untransform_posterior(None)
+
+            # test subset_output with positive on subset of outcomes (pos. index)
+            tf = Tanh(outputs=[0])
             Y_tf, Yvar_tf = tf(Y, None)
             tf_subset = tf.subset_output(idcs=[0])
             Y_tf_subset, Yvar_tf_subset = tf_subset(Y[..., [0]], None)

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -603,11 +603,7 @@ class TestOutcomeTransforms(BotorchTestCase):
             Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
             Y_tf, Yvar_tf = tf(Y, None)
             self.assertTrue(tf.training)
-            self.assertTrue(
-                torch.allclose(
-                    Y_tf, torch.sign(Y) * torch.log(torch.tensor(1.0) + torch.abs(Y))
-                )
-            )
+            self.assertTrue(torch.allclose(Y_tf, Y.sign() * (Y.abs() + 1).log()))
             self.assertIsNone(Yvar_tf)
             tf.eval()
             self.assertFalse(tf.training)
@@ -667,7 +663,11 @@ class TestOutcomeTransforms(BotorchTestCase):
             Y = torch.rand(*batch_shape, 3, m, device=self.device, dtype=dtype)
             Y_tf, Yvar_tf = tf(Y, None)
             self.assertTrue(tf.training)
-            self.assertTrue(torch.allclose(Y_tf[..., 1], Y[..., 1].tanh()))
+            self.assertTrue(
+                torch.allclose(
+                    Y_tf[..., 1], Y[..., 1].sign() * (Y[..., 1].abs() + 1).log()
+                )
+            )
             self.assertTrue(torch.allclose(Y_tf[..., 0], Y[..., 0]))
             self.assertIsNone(Yvar_tf)
             tf.eval()


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This paper https://arxiv.org/abs/2002.08526 suggests that using a bilog transformation can help improve constrained BO optimization by magnifying the region around zero. However, the bilog transformation is not (to my knowledge) analytically invertible. I have replicated most of the bilog behavior using a tanh function, which is invertible. This comes with a caveat though, as the derivatives of the transformed function go to zero if the raw values are far outside the range [-1,1]. For now I think this is an acceptable trade-off.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tests have been included.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
