### PR TITLE
Make `get_infeasible_cost` return a cost value for each outcome.

### DIFF
--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import inspect
 import warnings
 from abc import ABC, abstractmethod
-from typing import Callable, List, Optional
+from typing import Union, Callable, List, Optional
 
 import torch
 from botorch.exceptions.errors import UnsupportedError
@@ -441,7 +441,7 @@ class ConstrainedMCObjective(GenericMCObjective):
         self,
         objective: Callable[[Tensor, Optional[Tensor]], Tensor],
         constraints: List[Callable[[Tensor], Tensor]],
-        infeasible_cost: float = 0.0,
+        infeasible_cost: Union[Tensor, float] = 0.0,
         eta: float = 1e-3,
     ) -> None:
         r"""Feasibility-weighted objective.

--- a/test/acquisition/test_objective.py
+++ b/test/acquisition/test_objective.py
@@ -320,7 +320,7 @@ class TestConstrainedMCObjective(BotorchTestCase):
                 obj=constrained_obj,
                 constraints=[feasible_con, infeasible_con],
                 samples=samples,
-                infeasible_cost=0.0,
+                infeasible_cost=torch.tensor([0.0], device=self.device, dtype=dtype),
             )
             self.assertTrue(torch.equal(obj(samples), constrained_obj))
             # one feasible, one infeasible, infeasible_cost
@@ -342,7 +342,7 @@ class TestConstrainedMCObjective(BotorchTestCase):
             obj = ConstrainedMCObjective(
                 objective=generic_obj,
                 constraints=[feasible_con, infeasible_con],
-                infeasible_cost=5.0,
+                infeasible_cost=torch.tensor([5.0], device=self.device, dtype=dtype),
             )
             samples = torch.randn(4, 3, 2, device=self.device, dtype=dtype)
             constrained_obj = generic_obj(samples)

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -585,12 +585,11 @@ class TestGetAcquisitionFunction(BotorchTestCase):
 class TestGetInfeasibleCost(BotorchTestCase):
     def test_get_infeasible_cost(self):
         for dtype in (torch.float, torch.double):
-            X = torch.zeros(5, 1, device=self.device, dtype=dtype)
-            means = torch.tensor(
-                [1.0, 2.0, 3.0, 4.0, 5.0], device=self.device, dtype=dtype
-            )
-            variances = torch.tensor(
-                [0.09, 0.25, 0.36, 0.25, 0.09], device=self.device, dtype=dtype
+            tkwargs = {"dtype": dtype, "device": self.device}
+            X = torch.zeros(5, 1, **tkwargs)
+            means = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], **tkwargs).view(-1, 1)
+            variances = torch.tensor([0.09, 0.25, 0.36, 0.25, 0.09], **tkwargs).view(
+                -1, 1
             )
             mm = MockModel(MockPosterior(mean=means, variance=variances))
             # means - 6 * std = [-0.8, -1, -0.6, 1, 3.2]. After applying the
@@ -598,10 +597,22 @@ class TestGetInfeasibleCost(BotorchTestCase):
             M = get_infeasible_cost(
                 X=X, model=mm, objective=lambda Y: Y.squeeze(-1) - 5.0
             )
-            self.assertEqual(M, 6.0)
-            # test default objective (squeeze last dim)
+            self.assertTrue(torch.allclose(M, torch.tensor([6.0], **tkwargs)))
+            # Test default objective (squeeze last dim).
             M2 = get_infeasible_cost(X=X, model=mm)
-            self.assertEqual(M2, 1.0)
+            self.assertTrue(torch.allclose(M2, torch.tensor([1.0], **tkwargs)))
+            # Test multi-output.
+            m_ = means.repeat(1, 2)
+            m_[:, 1] -= 10
+            mm = MockModel(MockPosterior(mean=m_, variance=variances.expand(-1, 2)))
+            M3 = get_infeasible_cost(X=X, model=mm)
+            self.assertTrue(torch.allclose(M3, torch.tensor([1.0, 11.0], **tkwargs)))
+            # With a batched model.
+            means = means.expand(2, 4, -1, -1)
+            variances = variances.expand(2, 4, -1, -1)
+            mm = MockModel(MockPosterior(mean=means, variance=variances))
+            M4 = get_infeasible_cost(X=X, model=mm)
+            self.assertTrue(torch.allclose(M4, torch.tensor([1.0], **tkwargs)))
 
 
 class TestPruneInferiorPoints(BotorchTestCase):


### PR DESCRIPTION
Summary: Current implementation returns a single `M` value. This modifies it to return an `m`-dim tensor of infeasible cost values, each corresponding to one of the `m` outcomes.

Differential Revision: D35847505

