### PR TITLE
Add in transformed weighting flag to Proximal Acquisition function

### DIFF
--- a/botorch/acquisition/proximal.py
+++ b/botorch/acquisition/proximal.py
@@ -47,6 +47,7 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
         self,
         acq_function: AcquisitionFunction,
         proximal_weights: Tensor,
+        transformed_weighting: bool = False,
     ) -> None:
         r"""Derived Acquisition Function weighted by proximity to recently
         observed point.
@@ -56,6 +57,10 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
                 of feature dimension `d`.
             proximal_weights: A `d` dim tensor used to bias locality
                 along each axis.
+            transformed_weighting: If True, the proximal weights are applied in
+                the transformed input space given by
+                `acq_function.model.input_transform` (if available), otherwise
+                proximal weights are applied in real input space.
         """
         Module.__init__(self)
 
@@ -70,6 +75,9 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
             self.X_pending = acq_function.X_pending
 
         self.register_buffer("proximal_weights", proximal_weights)
+        self.register_buffer(
+            "transformed_weighting", torch.tensor(transformed_weighting)
+        )
         _validate_model(model, proximal_weights)
 
     @t_batch_mode_transform(expected_q=1, assert_output_shape=False)
@@ -95,13 +103,23 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
 
         last_X = train_inputs[-1].reshape(1, 1, -1)
 
-        # un-transform last_X
+        # if transformed_weighting, transform X to calculate diff
+        # (proximal weighting in transformed space)
+        # otherwise,un-transform the last observed point to real space
+        # (proximal weighting in real space)
         if input_transform is not None:
-            last_X = input_transform.untransform(last_X)
+            if self.transformed_weighting:
+                # transformed space weighting
+                diff = input_transform.transform(X) - last_X
+            else:
+                # real space weighting
+                diff = X - input_transform.untransform(last_X)
 
-        diff = X - last_X
+        else:
+            # no transformation
+            diff = X - last_X
+
         M = torch.linalg.norm(diff / self.proximal_weights, dim=-1) ** 2
-
         proximal_acq_weight = torch.exp(-0.5 * M)
         return self.acq_func(X) * proximal_acq_weight.flatten()
 

--- a/botorch/acquisition/proximal.py
+++ b/botorch/acquisition/proximal.py
@@ -47,7 +47,7 @@ class ProximalAcquisitionFunction(AcquisitionFunction):
         self,
         acq_function: AcquisitionFunction,
         proximal_weights: Tensor,
-        transformed_weighting: bool = False,
+        transformed_weighting: bool = True,
     ) -> None:
         r"""Derived Acquisition Function weighted by proximity to recently
         observed point.

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -54,6 +54,8 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                 3, bounds=torch.tensor(((0.0, 0.0, 0.0), (2.0, 2.0, 2.0)))
             )
             for input_transform in [None, normalize]:
+
+                # test with and without transformed weights
                 for transformed_weighting in [True, False]:
                     model = (
                         SingleTaskGP(train_X, train_Y, input_transform=input_transform)
@@ -110,7 +112,7 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                     )
                     self.assertTrue(ei_prox.shape == torch.Size([4]))
 
-                    # test MC acquisition function
+                    # test q-based MC acquisition function
                     qEI = qExpectedImprovement(model, best_f=0.0)
                     test_X = torch.rand(4, 1, 3, device=self.device, dtype=dtype)
                     proximal_test_X = test_X.clone()

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -7,7 +7,7 @@
 from typing import Any, Dict, List
 
 import torch
-from botorch.acquisition import LinearMCObjective, ScalarizedObjective
+from botorch.acquisition import LinearMCObjective, ScalarizedPosteriorTransform
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.analytic import ExpectedImprovement
 from botorch.acquisition.monte_carlo import qExpectedImprovement
@@ -54,31 +54,41 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                 3, bounds=torch.tensor(((0.0, 0.0, 0.0), (2.0, 2.0, 2.0)))
             )
             for input_transform in [None, normalize]:
-                model = (
-                    SingleTaskGP(train_X, train_Y, input_transform=input_transform)
-                    .to(device=self.device, dtype=dtype)
-                    .eval()
-                )
+                for transformed_weighting in [True, False]:
+                    model = (
+                        SingleTaskGP(train_X, train_Y, input_transform=input_transform)
+                        .to(device=self.device, dtype=dtype)
+                        .eval()
+                    )
 
-                EI = ExpectedImprovement(model, best_f=0.0)
+                    EI = ExpectedImprovement(model, best_f=0.0)
 
-                proximal_weights = torch.ones(3, device=self.device, dtype=dtype)
-                test_X = torch.rand(1, 3, device=self.device, dtype=dtype)
-                EI_prox = ProximalAcquisitionFunction(
-                    EI, proximal_weights=proximal_weights
-                )
+                    proximal_weights = torch.ones(3, device=self.device, dtype=dtype)
+                    last_X = train_X[-1]
+                    test_X = torch.rand(1, 3, device=self.device, dtype=dtype)
+                    EI_prox = ProximalAcquisitionFunction(
+                        EI,
+                        proximal_weights=proximal_weights,
+                        transformed_weighting=transformed_weighting,
+                    )
 
-                ei = EI(test_X)
-                mv_normal = MultivariateNormal(
-                    train_X[-1], torch.diag(proximal_weights)
-                )
-                test_prox_weight = torch.exp(mv_normal.log_prob(test_X)) / torch.exp(
-                    mv_normal.log_prob(train_X[-1])
-                )
+                    ei = EI(test_X)
 
-                ei_prox = EI_prox(test_X)
-                self.assertTrue(torch.allclose(ei_prox, ei * test_prox_weight))
-                self.assertTrue(ei_prox.shape == torch.Size([1]))
+                    # modify last_X/test_X depending on transformed_weighting
+                    proximal_test_X = test_X.clone()
+                    if transformed_weighting:
+                        if input_transform is not None:
+                            last_X = input_transform(train_X[-1])
+                            proximal_test_X = input_transform(test_X)
+
+                    mv_normal = MultivariateNormal(last_X, torch.diag(proximal_weights))
+                    test_prox_weight = torch.exp(
+                        mv_normal.log_prob(proximal_test_X)
+                    ) / torch.exp(mv_normal.log_prob(last_X))
+
+                    ei_prox = EI_prox(test_X)
+                    self.assertTrue(torch.allclose(ei_prox, ei * test_prox_weight))
+                    self.assertTrue(ei_prox.shape == torch.Size([1]))
 
             # test t-batch with broadcasting
             test_X = torch.rand(4, 1, 3, device=self.device, dtype=dtype)
@@ -132,6 +142,7 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                     ExpectedImprovement(model, 0.0), proximal_weights[:1]
                 )
 
+            # test proximal weights that are not 1D
             with self.assertRaises(ValueError):
                 ProximalAcquisitionFunction(
                     ExpectedImprovement(model, 0.0),
@@ -166,14 +177,16 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
             gp = SingleTaskGP(train_X, train_Y).to(device=self.device)
             model = ModelListGP(gp, gp)
 
-            scalarized_objective = ScalarizedObjective(
+            scalarized_posterior_transform = ScalarizedPosteriorTransform(
                 torch.ones(2, device=self.device, dtype=dtype)
             )
             mc_linear_objective = LinearMCObjective(
                 torch.ones(2, device=self.device, dtype=dtype)
             )
 
-            EI = ExpectedImprovement(model, best_f=0.0, objective=scalarized_objective)
+            EI = ExpectedImprovement(
+                model, best_f=0.0, posterior_transform=scalarized_posterior_transform
+            )
 
             test_X = torch.rand(1, 3, device=self.device, dtype=dtype)
             EI_prox = ProximalAcquisitionFunction(EI, proximal_weights=proximal_weights)
@@ -221,13 +234,17 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
             )
             with self.assertRaisesRegex(ValueError, expected_err_msg):
                 ProximalAcquisitionFunction(
-                    ExpectedImprovement(model, 0.0, objective=scalarized_objective),
+                    ExpectedImprovement(
+                        model, 0.0, posterior_transform=scalarized_posterior_transform
+                    ),
                     proximal_weights[:1],
                 )
 
             with self.assertRaisesRegex(ValueError, expected_err_msg):
                 ProximalAcquisitionFunction(
-                    ExpectedImprovement(model, 0.0, objective=scalarized_objective),
+                    ExpectedImprovement(
+                        model, 0.0, posterior_transform=scalarized_posterior_transform
+                    ),
                     torch.rand(3, 3, device=self.device, dtype=dtype),
                 )
 
@@ -246,7 +263,11 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
             )
             with self.assertRaises(UnsupportedError):
                 ProximalAcquisitionFunction(
-                    ExpectedImprovement(bad_model, 0.0, objective=scalarized_objective),
+                    ExpectedImprovement(
+                        bad_model,
+                        0.0,
+                        posterior_transform=scalarized_posterior_transform,
+                    ),
                     proximal_weights,
                 )
 
@@ -259,7 +280,11 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
             )
             with self.assertRaises(UnsupportedError):
                 ProximalAcquisitionFunction(
-                    ExpectedImprovement(bad_model, 0.0, objective=scalarized_objective),
+                    ExpectedImprovement(
+                        bad_model,
+                        0.0,
+                        posterior_transform=scalarized_posterior_transform,
+                    ),
                     proximal_weights,
                 )
 
@@ -274,6 +299,10 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
             )
             with self.assertRaises(UnsupportedError):
                 ProximalAcquisitionFunction(
-                    ExpectedImprovement(bad_model, 0.0, objective=scalarized_objective),
+                    ExpectedImprovement(
+                        bad_model,
+                        0.0,
+                        posterior_transform=scalarized_posterior_transform,
+                    ),
                     proximal_weights,
                 )


### PR DESCRIPTION
## Motivation
In the majority of cases it makes sense to specify proximal biasing weights in normalized input space. This PR adds a flag to the proximal acquisition function that allows this behavior. If True the distance between evaluation points and the last measured point is calculated in transformed space, given by `acq_function.model.input_transform` if available. Otherwise, the distance is calculated in real space.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Tests have been added.

## Related PRs
N/A