### PR TITLE
Add `FeasibilityWeightedMCMultiOutputObjective`

### DIFF
--- a/test/acquisition/multi_objective/test_objective.py
+++ b/test/acquisition/multi_objective/test_objective.py
@@ -7,6 +7,12 @@
 import itertools
 
 import torch
+from botorch.acquisition.multi_objective.multi_output_risk_measures import (
+    MultiOutputExpectation,
+)
+from botorch.acquisition.multi_objective.objective import (
+    FeasibilityWeightedMCMultiOutputObjective,
+)
 from botorch.acquisition.multi_objective.objective import (
     IdentityMCMultiOutputObjective,
     MCMultiOutputObjective,
@@ -14,9 +20,11 @@ from botorch.acquisition.multi_objective.objective import (
     UnstandardizeMCMultiOutputObjective,
     WeightedMCMultiOutputObjective,
 )
+from botorch.acquisition.objective import IdentityMCObjective
 from botorch.exceptions.errors import BotorchError, BotorchTensorDimensionError
 from botorch.models.transforms.outcome import Standardize
 from botorch.utils.testing import BotorchTestCase, MockPosterior
+from botorch.utils.testing import MockModel
 
 
 class TestMCMultiOutputObjective(BotorchTestCase):
@@ -55,6 +63,77 @@ class TestWeightedMCMultiOutputObjective(BotorchTestCase):
             objective = WeightedMCMultiOutputObjective(weights=weights)
             samples = torch.rand(*batch_shape, 2, m, device=self.device, dtype=dtype)
             self.assertTrue(torch.equal(objective(samples), samples * weights))
+
+
+class TestFeasibilityWeightedMCMultiOutputObjective(BotorchTestCase):
+    def test_feasibility_weighted_mc_multi_output_objective(self):
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"dtype": dtype, "device": self.device}
+            X = torch.zeros(5, 1, **tkwargs)
+            # The infeasible cost will be 0.0.
+            means = torch.tensor(
+                [
+                    [1.0, 0.5],
+                    [2.0, -1.0],
+                    [3.0, -0.5],
+                    [4.0, 1.0],
+                    [5.0, 1.0],
+                ],
+                **tkwargs
+            )
+            variances = torch.zeros(5, 2, **tkwargs)
+            mm = MockModel(MockPosterior(mean=means, variance=variances))
+            feas_obj = FeasibilityWeightedMCMultiOutputObjective(
+                model=mm,
+                X_baseline=X,
+                constraint_idcs=[-1],
+                objective=None,
+            )
+            feas_samples = feas_obj(means)
+            expected = torch.tensor([[1.0], [0.0], [0.0], [4.0], [5.0]], **tkwargs)
+            self.assertTrue(torch.allclose(feas_samples, expected))
+            self.assertTrue(feas_obj._verify_output_shape)
+
+            # With an objective.
+            dummy_obj = MultiOutputExpectation(n_w=1, weights=[2.0])
+            dummy_obj._verify_output_shape = False  # for testing
+            feas_obj = FeasibilityWeightedMCMultiOutputObjective(
+                model=mm,
+                X_baseline=X,
+                constraint_idcs=[1],
+                objective=dummy_obj,
+            )
+            feas_samples = feas_obj(means)
+            self.assertTrue(torch.allclose(feas_samples, expected * 2.0))
+            self.assertFalse(feas_obj._verify_output_shape)
+
+            # No constraints.
+            feas_obj = FeasibilityWeightedMCMultiOutputObjective(
+                model=mm,
+                X_baseline=X,
+                constraint_idcs=[],
+                objective=None,
+            )
+            feas_samples = feas_obj(means)
+            self.assertIs(feas_samples, means)
+
+            # With a single-output objective.
+            feas_obj = FeasibilityWeightedMCMultiOutputObjective(
+                model=mm,
+                X_baseline=X,
+                constraint_idcs=[1],
+                objective=IdentityMCObjective(),
+            )
+            feas_samples = feas_obj(means)
+            self.assertTrue(torch.allclose(feas_samples, expected.squeeze(-1)))
+
+            # Error with duplicate idcs.
+            with self.assertRaisesRegex(ValueError, "duplicate"):
+                FeasibilityWeightedMCMultiOutputObjective(
+                    model=mm,
+                    X_baseline=X,
+                    constraint_idcs=[1, -1],
+                )
 
 
 class TestUnstandardizeMultiOutputObjective(BotorchTestCase):


### PR DESCRIPTION
Summary:
Implements a `FeasbilityWeightedMCMultiOutputObjective` that applies feasibility-weighting to samples before evaluating the objective. This is useful for constrained optimization when a secondary objective is needed, e.g., when optimizing risk measures.

NOTE: Although it is implemented as a multi-output objective, this can be used as a single-output objective as well, as long as it is paired with an `MCAcquisitionObjective`.

Differential Revision: D36072208

