### PR TITLE
add construct inputs for SaasFullyBayesianMultiTaskGP

### DIFF
--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 import logging
 import warnings
 from copy import deepcopy
-from typing import Any, Callable
+from typing import Any, Callable, Union
 
 from botorch.exceptions.errors import UnsupportedError
 from botorch.exceptions.warnings import BotorchWarning, OptimizationWarning
 from botorch.models.converter import batched_to_model_list, model_list_to_batched
 from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
+from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
+
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
 from botorch.optim.fit import fit_gpytorch_scipy
 from botorch.optim.utils import sample_all_priors
@@ -157,7 +159,7 @@ def fit_gpytorch_model(
 
 
 def fit_fully_bayesian_model_nuts(
-    model: SaasFullyBayesianSingleTaskGP,
+    model: Union[SaasFullyBayesianSingleTaskGP, SaasFullyBayesianMultiTaskGP],
     max_tree_depth: int = 6,
     warmup_steps: int = 512,
     num_samples: int = 256,

--- a/botorch/models/__init__.py
+++ b/botorch/models/__init__.py
@@ -15,6 +15,8 @@ from botorch.models.deterministic import (
     PosteriorMeanModel,
 )
 from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
+from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
+
 from botorch.models.gp_regression import (
     FixedNoiseGP,
     HeteroskedasticSingleTaskGP,
@@ -39,6 +41,7 @@ __all__ = [
     "FixedNoiseGP",
     "FixedNoiseMultiTaskGP",
     "SaasFullyBayesianSingleTaskGP",
+    "SaasFullyBayesianMultiTaskGP",
     "GenericDeterministicModel",
     "HeteroskedasticSingleTaskGP",
     "HigherOrderGP",

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -25,6 +25,7 @@ from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
 from botorch.posteriors.fully_bayesian import FullyBayesianPosterior, MCMC_DIM
 from botorch.sampling.samplers import MCSampler
+from botorch.utils.datasets import SupervisedDataset
 from gpytorch.distributions.multivariate_normal import MultivariateNormal
 from gpytorch.kernels import MaternKernel
 from gpytorch.kernels.kernel import Kernel
@@ -372,3 +373,26 @@ class SaasFullyBayesianMultiTaskGP(FixedNoiseMultiTaskGP):
         covar_i = self.task_covar_module(latent_features)
         covar = covar_x.mul(covar_i)
         return MultivariateNormal(mean_x, covar)
+
+    @classmethod
+    def construct_inputs(
+        cls,
+        training_data: Dict[str, SupervisedDataset],
+        task_feature: int,
+        rank: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        r"""Construct `Model` keyword arguments from dictionary of `SupervisedDataset`.
+
+        Args:
+            training_data: Dictionary of `SupervisedDataset`.
+            task_feature: Column index of embedded task indicator features. For details,
+                see `parse_training_data`.
+            rank: The rank of the cross-task covariance matrix.
+        """
+
+        inputs = super().construct_inputs(
+            training_data=training_data, task_feature=task_feature, rank=rank, **kwargs
+        )
+        inputs.pop("task_covar_prior")
+        return inputs

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -1,0 +1,374 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+r"""Multi-task Gaussian Process Regression models with fully Bayesian inference.
+"""
+
+
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import pyro
+import torch
+from botorch.acquisition.objective import PosteriorTransform
+from botorch.models.fully_bayesian import (
+    matern52_kernel,
+    MIN_INFERRED_NOISE_LEVEL,
+    PyroModel,
+    reshape_and_detach,
+    SaasPyroModel,
+)
+from botorch.models.multitask import FixedNoiseMultiTaskGP
+from botorch.models.transforms.input import InputTransform
+from botorch.models.transforms.outcome import OutcomeTransform
+from botorch.posteriors.fully_bayesian import FullyBayesianPosterior, MCMC_DIM
+from botorch.sampling.samplers import MCSampler
+from gpytorch.distributions.multivariate_normal import MultivariateNormal
+from gpytorch.kernels import MaternKernel
+from gpytorch.kernels.kernel import Kernel
+from gpytorch.likelihoods.likelihood import Likelihood
+from gpytorch.means.mean import Mean
+from torch import Tensor
+from torch.nn.parameter import Parameter
+
+
+class MultitaskSaasPyroModel(SaasPyroModel):
+    r"""
+    Implementation of the multi-task sparse axis-aligned subspace priors (SAAS) model.
+
+    The multi-task model uses an ICM kernel. The data kernel is same as the single task
+    SAAS model in order to handle high-dimensional parameter spaces. The task kernel
+    is a Matern-5/2 kernel using learned task embeddings as the input.
+    """
+
+    def set_inputs(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        train_Yvar: Tensor,
+        task_feature: int,
+        task_rank: Optional[int] = None,
+    ):
+        """Set the training data.
+
+        Args:
+            train_X: Training inputs (n x (d + 1))
+            train_Y: Training targets (n x 1)
+            train_Yvar: Observed noise variance (n x 1).
+            task_feature: The index of the task feature (`-d <= task_feature <= d`).
+            task_rank: The num of learned task embeddings to be used in the task kernel.
+                If omitted, set it to be 1.
+        """
+        if (train_Yvar is None) or (torch.isnan(train_Yvar).all()):
+            # TODO: revisit inferred noise for batched MTGP
+            raise NotImplementedError(
+                "Currently do not support inferred noise for multitask GP with MCMC!"
+            )
+        super().set_inputs(train_X, train_Y, train_Yvar)
+        # obtain a list of task indicies
+        all_tasks = train_X[:, task_feature].unique().to(dtype=torch.long).tolist()
+        self.task_feature = task_feature
+        self.num_tasks = len(all_tasks)
+        self.task_rank = task_rank or 1
+        # assume there is one column for task feature
+        self.ard_num_dims = self.train_X.shape[-1] - 1
+
+    def sample(self) -> None:
+        r"""Sample from the SAAS model.
+
+        This samples the mean, noise variance, outputscale, and lengthscales according
+        to the SAAS prior.
+        """
+        tkwargs = {"dtype": self.train_X.dtype, "device": self.train_X.device}
+        base_idxr = torch.arange(self.ard_num_dims, **{"device": tkwargs["device"]})
+        base_idxr[self.task_feature :] += 1  # exclude task feature
+        task_indices = self.train_X[..., self.task_feature].to(
+            device=tkwargs["device"], dtype=torch.long
+        )
+
+        outputscale = self.sample_outputscale(concentration=2.0, rate=0.15, **tkwargs)
+        mean = self.sample_mean(**tkwargs)
+        noise = self.sample_noise(**tkwargs)
+
+        lengthscale = self.sample_lengthscale(dim=self.ard_num_dims, **tkwargs)
+        k = matern52_kernel(X=self.train_X[..., base_idxr], lengthscale=lengthscale)
+
+        # compute task covar matrix
+        task_latent_features = self.sample_latent_features(**tkwargs)[task_indices]
+        task_lengthscale = self.sample_task_lengthscale(**tkwargs)
+        task_covar = matern52_kernel(
+            X=task_latent_features, lengthscale=task_lengthscale
+        )
+        k = k.mul(task_covar)
+        k = outputscale * k + noise * torch.eye(self.train_X.shape[0], **tkwargs)
+        pyro.sample(
+            "Y",
+            pyro.distributions.MultivariateNormal(
+                loc=mean.view(-1).expand(self.train_X.shape[0]),
+                covariance_matrix=k,
+            ),
+            obs=self.train_Y.squeeze(-1),
+        )
+
+    def sample_latent_features(self, **tkwargs: Any):
+        return pyro.sample(
+            "latent_features",
+            pyro.distributions.Normal(
+                torch.tensor(0.0, **tkwargs),
+                torch.tensor(1.0, **tkwargs),
+            ).expand(torch.Size([self.num_tasks, self.task_rank])),
+        )
+
+    def sample_task_lengthscale(
+        self, concentration: float = 6.0, rate: float = 3.0, **tkwargs: Any
+    ):
+        return pyro.sample(
+            "task_lengthscale",
+            pyro.distributions.Gamma(
+                torch.tensor(concentration, **tkwargs),
+                torch.tensor(rate, **tkwargs),
+            ).expand(torch.Size([self.task_rank])),
+        )
+
+    def load_mcmc_samples(
+        self, mcmc_samples: Dict[str, Tensor]
+    ) -> Tuple[Mean, Kernel, Likelihood, Kernel, Parameter]:
+        r"""Load the MCMC samples into the mean_module, covar_module, and likelihood."""
+        tkwargs = {"device": self.train_X.device, "dtype": self.train_X.dtype}
+        num_mcmc_samples = len(mcmc_samples["mean"])
+        batch_shape = torch.Size([num_mcmc_samples])
+
+        mean_module, covar_module, likelihood = super().load_mcmc_samples(
+            mcmc_samples=mcmc_samples
+        )
+
+        task_covar_module = MaternKernel(
+            nu=2.5,
+            ard_num_dims=self.task_rank,
+            batch_shape=batch_shape,
+        ).to(**tkwargs)
+        task_covar_module.lengthscale = reshape_and_detach(
+            target=task_covar_module.lengthscale,
+            new_value=mcmc_samples["task_lengthscale"],
+        )
+        latent_features = Parameter(
+            torch.rand(
+                batch_shape + torch.Size([self.num_tasks, self.task_rank]),
+                requires_grad=True,
+                **tkwargs,
+            )
+        )
+        latent_features = reshape_and_detach(
+            target=latent_features,
+            new_value=mcmc_samples["latent_features"],
+        )
+        return mean_module, covar_module, likelihood, task_covar_module, latent_features
+
+
+class SaasFullyBayesianMultiTaskGP(FixedNoiseMultiTaskGP):
+    r"""A fully Bayesian multi-task GP model with the SAAS prior.
+
+    This model assumes that the inputs have been normalized to [0, 1]^d and that the
+    output has been stratified standardized to have zero mean and unit variance for
+    each task.The SAAS model [Eriksson2021saasbo]_ with a Matern-5/2 is used as data
+    kernel by default.
+
+    You are expected to use `fit_fully_bayesian_model_nuts` to fit this model as it
+    isn't compatible with `fit_gpytorch_model`.
+
+    Example:
+        >>> X1, X2 = torch.rand(10, 2), torch.rand(20, 2)
+        >>> i1, i2 = torch.zeros(10, 1), torch.ones(20, 1)
+        >>> train_X = torch.cat([
+        >>>     torch.cat([X1, i1], -1), torch.cat([X2, i2], -1),
+        >>> ])
+        >>> train_Y = torch.cat(f1(X1), f2(X2)).unsqueeze(-1)
+        >>> train_Yvar = 0.01 * torch.ones_like(train_Y)
+        >>> mtsaas_gp = SaasFullyBayesianFixedNoiseMultiTaskGP(
+        >>>     train_X, train_Y, train_Yvar, task_feature=-1,
+        >>> )
+        >>> fit_fully_bayesian_model_nuts(mtsaas_gp)
+        >>> posterior = mtsaas_gp.posterior(test_X)
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        train_Yvar: Tensor,
+        task_feature: int,
+        output_tasks: Optional[List[int]] = None,
+        rank: Optional[int] = None,
+        outcome_transform: Optional[OutcomeTransform] = None,
+        input_transform: Optional[InputTransform] = None,
+        pyro_model: Optional[PyroModel] = None,
+    ) -> None:
+        r"""Initialize the fully Bayesian multi-task GP model.
+
+        Args:
+            train_X: Training inputs (n x (d + 1))
+            train_Y: Training targets (n x 1)
+            train_Yvar: Observed noise variance (n x 1).
+            task_feature: The index of the task feature (`-d <= task_feature <= d`).
+            rank: The num of learned task embeddings to be used in the task kernel.
+                If omitted, set it to be 1.
+        """
+        if not (
+            train_X.ndim == train_Y.ndim == 2
+            and len(train_X) == len(train_Y)
+            and train_Y.shape[-1] == 1
+        ):
+            raise ValueError(
+                "Expected train_X to have shape n x d and train_Y to have shape n x 1"
+            )
+        if train_Yvar is None:
+            raise NotImplementedError(
+                "Inferred Noise is not supported in multitask SAAS GP."
+            )
+        else:
+            if train_Y.shape != train_Yvar.shape:
+                raise ValueError(
+                    "Expected train_Yvar to be None or have the same shape as train_Y"
+                )
+        with torch.no_grad():
+            transformed_X = self.transform_inputs(
+                X=train_X, input_transform=input_transform
+            )
+        if outcome_transform is not None:
+            train_Y, train_Yvar = outcome_transform(train_Y, train_Yvar)
+
+        train_Yvar = train_Yvar.clamp(MIN_INFERRED_NOISE_LEVEL)
+
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            task_feature=task_feature,
+            output_tasks=output_tasks,
+        )
+        self.to(train_X)
+
+        self.mean_module = None
+        self.covar_module = None
+        self.likelihood = None
+        self.task_covar_module = None
+        if pyro_model is None:
+            pyro_model = MultitaskSaasPyroModel()
+        pyro_model.set_inputs(
+            train_X=transformed_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            task_feature=task_feature,
+            task_rank=rank,
+        )
+        self.pyro_model = pyro_model
+        if outcome_transform is not None:
+            self.outcome_transform = outcome_transform
+        if input_transform is not None:
+            self.input_transform = input_transform
+
+    def train(self, mode: bool = True) -> None:
+        r"""Puts the model in `train` mode."""
+        super().train(mode=mode)
+        if mode:
+            self.mean_module = None
+            self.covar_module = None
+            self.likelihood = None
+            self.task_covar_module = None
+
+    @property
+    def median_lengthscale(self) -> Tensor:
+        r"""Median lengthscales across the MCMC samples."""
+        self._check_if_fitted()
+        lengthscale = self.covar_module.base_kernel.lengthscale.clone()
+        return lengthscale.median(0).values.squeeze(0)
+
+    @property
+    def num_mcmc_samples(self) -> int:
+        r"""Number of MCMC samples in the model."""
+        self._check_if_fitted()
+        return len(self.covar_module.outputscale)
+
+    def fantasize(
+        self,
+        X: Tensor,
+        sampler: MCSampler,
+        observation_noise: Union[bool, Tensor] = True,
+        **kwargs: Any,
+    ) -> FixedNoiseMultiTaskGP:
+        raise NotImplementedError("Fantasize is not implemented!")
+
+    def _check_if_fitted(self):
+        r"""Raise an exception if the model hasn't been fitted."""
+        if self.covar_module is None:
+            raise RuntimeError(
+                "Model has not been fitted. You need to call "
+                "`fit_fully_bayesian_model_nuts` to fit the model."
+            )
+
+    def load_mcmc_samples(self, mcmc_samples: Dict[str, Tensor]) -> None:
+        r"""Load the MCMC hyperparameter samples into the model.
+
+        This method will be called by `fit_fully_bayesian_model_nuts` when the model
+        has been fitted in order to create a batched SingleTaskGP model.
+        """
+        (
+            self.mean_module,
+            self.covar_module,
+            self.likelihood,
+            self.task_covar_module,
+            self.latent_features,
+        ) = self.pyro_model.load_mcmc_samples(mcmc_samples=mcmc_samples)
+
+    def posterior(
+        self,
+        X: Tensor,
+        output_indices: Optional[List[int]] = None,
+        observation_noise: bool = False,
+        posterior_transform: Optional[PosteriorTransform] = None,
+        **kwargs: Any,
+    ) -> FullyBayesianPosterior:
+        r"""Computes the posterior over model outputs at the provided points.
+
+        Returns:
+            A `FullyBayesianPosterior` object. Includes observation noise if specified.
+        """
+        self._check_if_fitted()
+        posterior = super().posterior(
+            X=X,
+            output_indices=output_indices,
+            observation_noise=observation_noise,
+            posterior_transform=posterior_transform,
+            **kwargs,
+        )
+        posterior = FullyBayesianPosterior(mvn=posterior.mvn)
+        return posterior
+
+    def forward(self, X: Tensor) -> MultivariateNormal:
+        self._check_if_fitted()
+        X = X.unsqueeze(MCMC_DIM)
+
+        x_basic, task_idcs = self._split_inputs(X)
+
+        mean_x = self.mean_module(x_basic)
+        covar_x = self.covar_module(x_basic)
+
+        tsub_idcs = task_idcs.squeeze(-3).squeeze(-1)
+        latent_features = self.latent_features[:, tsub_idcs, :]
+
+        if X.ndim > 3:
+            # batch eval mode
+            # for X (batch_shape x num_samples x q x d), task_idcs[:,i,:,] are the same
+            # reshape X to (batch_shape x num_samples x q x d)
+            latent_features = latent_features.permute(
+                [-i for i in range(X.ndim - 1, 2, -1)]
+                + [0]
+                + [-i for i in range(2, 0, -1)]
+            )
+
+        # Combine the two in an ICM fashion
+        covar_i = self.task_covar_module(latent_features)
+        covar = covar_x.mul(covar_i)
+        return MultivariateNormal(mean_x, covar)

--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -685,7 +685,9 @@ class MultiTaskGPyTorchModel(GPyTorchModel, ABC):
         else:
             # Otherwise, make a MultitaskMultivariateNormal out of this
             mtmvn = MultitaskMultivariateNormal(
-                mean=mvn.mean.view(*X.shape[:-2], num_outputs, -1).transpose(-1, -2),
+                mean=mvn.mean.view(*mvn.mean.shape[:-1], num_outputs, -1).transpose(
+                    -1, -2
+                ),
                 covariance_matrix=mvn.lazy_covariance_matrix,
                 interleaved=False,
             )

--- a/botorch/utils/transforms.py
+++ b/botorch/utils/transforms.py
@@ -185,13 +185,25 @@ def is_fully_bayesian(model: Model) -> bool:
     """
     from botorch.models import ModelList, ModelListGP
     from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
+    from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
 
-    if isinstance(model, SaasFullyBayesianSingleTaskGP):
+    full_bayesian_model_cls = [
+        SaasFullyBayesianSingleTaskGP,
+        SaasFullyBayesianMultiTaskGP,
+    ]
+
+    if any(isinstance(model, m_cls) for m_cls in full_bayesian_model_cls):
         return True
-    elif isinstance(model, (ModelList, ModelListGP)) and any(
-        isinstance(m, SaasFullyBayesianSingleTaskGP) for m in model.models
-    ):
-        return True
+    elif isinstance(model, ModelList):
+        for m in model.models:
+            if any(isinstance(m, m_cls) for m_cls in full_bayesian_model_cls):
+                return True
+            elif isinstance(m, ModelListGP) and any(
+                isinstance(m_sub, m_cls)
+                for m_sub in m.models
+                for m_cls in full_bayesian_model_cls
+            ):
+                return True
     return False
 
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -113,6 +113,9 @@ instead.
 * [`KroneckerMultiTaskGP`](../api/models.html#botorch.models.multitask.KroneckerMultiTaskGP): A multi-task,
   multi-output GP using an ICM kernel, with Kronecker structure. Useful for
   multi-fidelity optimization.
+* [`SaasFullyBayesianMultiTaskGP`](../api/models.html#saasfullybayesianmultitaskgp):
+  a fully Bayesian multi-task GP using an ICM kernel. The data kernel uses the SAAS
+  prior to model high-dimensional parameter spaces.
 
 All of the above models use Matérn 5/2 kernels with Automatic Relevance
 Discovery (ARD), and have reasonable priors on hyperparameters that make them

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -89,6 +89,11 @@ Fully Bayesian GP Models
 .. automodule:: botorch.models.fully_bayesian
     :members:
 
+Fully Bayesian Multitask GP Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.fully_bayesian_multitask
+    :members:
+
 
 Model Components
 -------------------------------------------

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import itertools
+from typing import Optional
+
+import torch
+from botorch import fit_fully_bayesian_model_nuts
+from botorch.acquisition.analytic import (
+    ExpectedImprovement,
+    PosteriorMean,
+    ProbabilityOfImprovement,
+    UpperConfidenceBound,
+)
+from botorch.acquisition.monte_carlo import (
+    qExpectedImprovement,
+    qNoisyExpectedImprovement,
+    qProbabilityOfImprovement,
+    qSimpleRegret,
+    qUpperConfidenceBound,
+)
+from botorch.acquisition.multi_objective import (
+    qExpectedHypervolumeImprovement,
+    qNoisyExpectedHypervolumeImprovement,
+)
+from botorch.models import ModelList, ModelListGP
+from botorch.models.deterministic import GenericDeterministicModel
+from botorch.models.fully_bayesian import MCMC_DIM, MIN_INFERRED_NOISE_LEVEL
+from botorch.models.fully_bayesian_multitask import (
+    MultitaskSaasPyroModel,
+    SaasFullyBayesianMultiTaskGP,
+)
+from botorch.models.transforms.input import Normalize
+from botorch.models.transforms.outcome import Standardize
+from botorch.posteriors import FullyBayesianPosterior
+from botorch.sampling.samplers import IIDNormalSampler
+from botorch.utils.multi_objective.box_decompositions.non_dominated import (
+    NondominatedPartitioning,
+)
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.kernels import MaternKernel, ScaleKernel
+from gpytorch.likelihoods import FixedNoiseGaussianLikelihood
+from gpytorch.means import ConstantMean
+
+
+class TestFullyBayesianMultiTaskGP(BotorchTestCase):
+    def _get_data_and_model(self, task_rank: Optional[int] = 1, **tkwargs):
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 4, **tkwargs)
+            task_indices = torch.cat(
+                [torch.zeros(5, 1, **tkwargs), torch.ones(5, 1, **tkwargs)], dim=0
+            )
+            self.num_tasks = 2
+            train_X = torch.cat([train_X, task_indices], dim=1)
+            train_Y = torch.sin(train_X[:, :1])
+            train_Yvar = 0.5 * torch.arange(10, **tkwargs).unsqueeze(-1)
+            model = SaasFullyBayesianMultiTaskGP(
+                train_X=train_X,
+                train_Y=train_Y,
+                train_Yvar=train_Yvar,
+                task_feature=4,
+                rank=task_rank,
+            )
+        return train_X, train_Y, train_Yvar, model
+
+    def _get_unnormalized_data(self, **tkwargs):
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 4, **tkwargs)
+            train_Y = torch.sin(train_X[:, :1])
+            task_indices = torch.cat(
+                [torch.zeros(5, 1, **tkwargs), torch.ones(5, 1, **tkwargs)], dim=0
+            )
+            train_X = torch.cat([5 + 5 * train_X, task_indices], dim=1)
+            test_X = 5 + 5 * torch.rand(5, 4, **tkwargs)
+            train_Yvar = 0.1 * torch.arange(10, **tkwargs).unsqueeze(-1)
+        return train_X, train_Y, train_Yvar, test_X
+
+    def _get_mcmc_samples(self, num_samples: int, dim: int, task_rank: int, **tkwargs):
+        mcmc_samples = {
+            "lengthscale": torch.rand(num_samples, 1, dim, **tkwargs),
+            "outputscale": torch.rand(num_samples, **tkwargs),
+            "mean": torch.randn(num_samples, **tkwargs),
+            "noise": torch.rand(num_samples, 1, **tkwargs),
+            "task_lengthscale": torch.rand(num_samples, 1, task_rank, **tkwargs),
+            "latent_features": torch.rand(
+                num_samples, self.num_tasks, task_rank, **tkwargs
+            ),
+        }
+        return mcmc_samples
+
+    def test_raises(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expected train_X to have shape n x d and train_Y to have shape n x 1",
+        ):
+            SaasFullyBayesianMultiTaskGP(
+                train_X=torch.rand(10, 4, **tkwargs),
+                train_Y=torch.randn(10, **tkwargs),
+                train_Yvar=torch.rand(10, 1, **tkwargs),
+                task_feature=4,
+            )
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expected train_X to have shape n x d and train_Y to have shape n x 1",
+        ):
+            SaasFullyBayesianMultiTaskGP(
+                train_X=torch.rand(10, 4, **tkwargs),
+                train_Y=torch.randn(12, 1, **tkwargs),
+                train_Yvar=torch.rand(12, 1, **tkwargs),
+                task_feature=4,
+            )
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expected train_X to have shape n x d and train_Y to have shape n x 1",
+        ):
+            SaasFullyBayesianMultiTaskGP(
+                train_X=torch.rand(10, **tkwargs),
+                train_Y=torch.randn(10, 1, **tkwargs),
+                train_Yvar=torch.rand(10, 1, **tkwargs),
+                task_feature=4,
+            )
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expected train_Yvar to be None or have the same shape as train_Y",
+        ):
+            SaasFullyBayesianMultiTaskGP(
+                train_X=torch.rand(10, 4, **tkwargs),
+                train_Y=torch.randn(10, 1, **tkwargs),
+                train_Yvar=torch.rand(10, **tkwargs),
+                task_feature=4,
+            )
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "Inferred Noise is not supported in multitask SAAS GP.",
+        ):
+            SaasFullyBayesianMultiTaskGP(
+                train_X=torch.rand(10, 4, **tkwargs),
+                train_Y=torch.randn(10, 1, **tkwargs),
+                train_Yvar=None,
+                task_feature=4,
+            )
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "Currently do not support inferred noise for multitask GP with MCMC!",
+        ):
+            MultitaskSaasPyroModel().set_inputs(
+                train_X=torch.rand(10, 4, **tkwargs),
+                train_Y=torch.randn(10, 1, **tkwargs),
+                train_Yvar=torch.tensor(torch.nan, **tkwargs).expand(10, 1),
+                task_feature=4,
+            )
+        train_X, train_Y, train_Yvar, model = self._get_data_and_model(**tkwargs)
+        sampler = IIDNormalSampler(num_samples=2)
+        with self.assertRaisesRegex(
+            NotImplementedError, "Fantasize is not implemented!"
+        ):
+            model.fantasize(
+                X=torch.cat(
+                    [torch.rand(5, 4, **tkwargs), torch.ones(5, 1, **tkwargs)], dim=1
+                ),
+                sampler=sampler,
+            )
+        # Make sure an exception is raised if the model has not been fitted
+        not_fitted_error_msg = (
+            "Model has not been fitted. You need to call "
+            "`fit_fully_bayesian_model_nuts` to fit the model."
+        )
+        with self.assertRaisesRegex(RuntimeError, not_fitted_error_msg):
+            model.num_mcmc_samples
+        with self.assertRaisesRegex(RuntimeError, not_fitted_error_msg):
+            model.median_lengthscale
+        with self.assertRaisesRegex(RuntimeError, not_fitted_error_msg):
+            model.forward(torch.rand(1, 4, **tkwargs))
+        with self.assertRaisesRegex(RuntimeError, not_fitted_error_msg):
+            model.posterior(torch.rand(1, 4, **tkwargs))
+
+    def test_fit_model(self):
+        for dtype in [torch.float, torch.double]:
+            tkwargs = {"device": self.device, "dtype": dtype}
+            train_X, train_Y, train_Yvar, model = self._get_data_and_model(**tkwargs)
+            n = train_X.shape[0]
+            d = train_X.shape[1] - 1
+            task_rank = 1
+
+            # Test init
+            self.assertIsNone(model.mean_module)
+            self.assertIsNone(model.covar_module)
+            self.assertIsNone(model.likelihood)
+            self.assertIsInstance(model.pyro_model, MultitaskSaasPyroModel)
+            self.assertTrue(torch.allclose(train_X, model.pyro_model.train_X))
+            self.assertTrue(torch.allclose(train_Y, model.pyro_model.train_Y))
+            self.assertTrue(
+                torch.allclose(
+                    train_Yvar.clamp(MIN_INFERRED_NOISE_LEVEL),
+                    model.pyro_model.train_Yvar,
+                )
+            )
+
+            # Fit a model and check that the hyperparameters have the correct shape
+            fit_fully_bayesian_model_nuts(
+                model, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
+            )
+            self.assertIsInstance(model.mean_module, ConstantMean)
+            self.assertEqual(model.mean_module.raw_constant.shape, torch.Size([3]))
+            self.assertIsInstance(model.covar_module, ScaleKernel)
+            self.assertEqual(model.covar_module.outputscale.shape, torch.Size([3]))
+            self.assertIsInstance(model.covar_module.base_kernel, MaternKernel)
+            self.assertEqual(
+                model.covar_module.base_kernel.lengthscale.shape, torch.Size([3, 1, d])
+            )
+            self.assertIsInstance(model.likelihood, FixedNoiseGaussianLikelihood)
+            self.assertIsInstance(model.task_covar_module, MaternKernel)
+            self.assertEqual(
+                model.task_covar_module.lengthscale.shape, torch.Size([3, 1, task_rank])
+            )
+            self.assertEqual(
+                model.latent_features.shape, torch.Size([3, self.num_tasks, task_rank])
+            )
+
+            # Predict on some test points
+            for batch_shape in [[5], [5, 2], [5, 2, 6]]:
+                test_X = torch.rand(*batch_shape, d, **tkwargs)
+                posterior = model.posterior(test_X)
+                self.assertIsInstance(posterior, FullyBayesianPosterior)
+                self.assertIsInstance(posterior, FullyBayesianPosterior)
+
+                test_X = torch.rand(*batch_shape, d, **tkwargs)
+                posterior = model.posterior(test_X)
+                self.assertIsInstance(posterior, FullyBayesianPosterior)
+                # Mean/variance
+                expected_shape = (
+                    batch_shape[: MCMC_DIM + 2]
+                    + [3]
+                    + batch_shape[MCMC_DIM + 2 :]
+                    + [self.num_tasks]
+                )
+                mean, var = posterior.mean, posterior.variance
+                self.assertEqual(mean.shape, torch.Size(expected_shape))
+                self.assertEqual(var.shape, torch.Size(expected_shape))
+
+                # Mixture mean/variance/median/quantiles
+                mixture_mean = posterior.mixture_mean
+                mixture_median = posterior.mixture_median
+                mixture_variance = posterior.mixture_variance
+                mixture_quantile1 = posterior.mixture_quantile(q=0.01)
+                mixture_quantile2 = posterior.mixture_quantile(q=0.99)
+
+                # Marginalized mean/variance
+                self.assertEqual(
+                    mixture_mean.shape, torch.Size(batch_shape + [self.num_tasks])
+                )
+                self.assertEqual(
+                    mixture_median.shape, torch.Size(batch_shape + [self.num_tasks])
+                )
+                self.assertTrue(
+                    torch.allclose(mixture_median, posterior.mixture_quantile(q=0.5))
+                )
+                self.assertEqual(
+                    mixture_variance.shape, torch.Size(batch_shape + [self.num_tasks])
+                )
+                self.assertTrue(mixture_variance.min() > 0.0)
+                self.assertEqual(
+                    mixture_quantile1.shape, torch.Size(batch_shape + [self.num_tasks])
+                )
+                self.assertEqual(
+                    mixture_quantile2.shape, torch.Size(batch_shape + [self.num_tasks])
+                )
+                self.assertTrue((mixture_quantile2 > mixture_quantile1).all())
+
+                dist = torch.distributions.Normal(
+                    loc=posterior.mean, scale=posterior.variance.sqrt()
+                )
+                torch.allclose(
+                    dist.cdf(mixture_median.unsqueeze(MCMC_DIM)).mean(dim=MCMC_DIM),
+                    0.5 * torch.ones(batch_shape + [1], **tkwargs),
+                )
+                torch.allclose(
+                    dist.cdf(mixture_quantile1.unsqueeze(MCMC_DIM)).mean(dim=MCMC_DIM),
+                    0.05 * torch.ones(batch_shape + [1], **tkwargs),
+                )
+                torch.allclose(
+                    dist.cdf(mixture_quantile2.unsqueeze(MCMC_DIM)).mean(dim=MCMC_DIM),
+                    0.95 * torch.ones(batch_shape + [1], **tkwargs),
+                )
+                # Invalid quantile should raise
+                with self.assertRaisesRegex(ValueError, "q is expected to be a float."):
+                    posterior.mixture_quantile(q="cat")
+                for q in [-1.0, 0.0, 1.0, 1.3333]:
+                    with self.assertRaisesRegex(
+                        ValueError, "q is expected to be in the range"
+                    ):
+                        posterior.mixture_quantile(q=q)
+
+                # Test model lists with fully Bayesian models and mixed modeling
+                deterministic = GenericDeterministicModel(f=lambda x: x[..., :1])
+                test_X = torch.cat(
+                    [test_X, torch.ones(*batch_shape, 1, **tkwargs)], dim=-1
+                )
+                for ModelListClass, models in zip(
+                    [ModelList, ModelListGP],
+                    [[deterministic, ModelListGP(model)], [model, model]],
+                ):
+                    expected_shape = (
+                        batch_shape[: MCMC_DIM + 2]
+                        + [3]
+                        + batch_shape[MCMC_DIM + 2 :]
+                        + [2]
+                    )
+                    model_list = ModelListClass(*models)
+                    posterior = model_list.posterior(test_X)
+                    mean, var = posterior.mean, posterior.variance
+                    self.assertEqual(mean.shape, torch.Size(expected_shape))
+                    self.assertEqual(var.shape, torch.Size(expected_shape))
+
+            # Check properties
+            median_lengthscale = model.median_lengthscale
+            self.assertEqual(median_lengthscale.shape, torch.Size([d]))
+            self.assertEqual(model.num_mcmc_samples, 3)
+
+            # Make sure the model shapes are set correctly
+            self.assertEqual(model.pyro_model.train_X.shape, torch.Size([n, d + 1]))
+            self.assertTrue(torch.allclose(model.pyro_model.train_X, train_X))
+            model.train()  # Put the model in train mode
+            self.assertTrue(torch.allclose(train_X, model.pyro_model.train_X))
+            self.assertIsNone(model.mean_module)
+            self.assertIsNone(model.covar_module)
+            self.assertIsNone(model.likelihood)
+            self.assertIsNone(model.task_covar_module)
+
+    def test_transforms(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        train_X, train_Y, train_Yvar, test_X = self._get_unnormalized_data(**tkwargs)
+        n, d = train_X.shape
+        normalize_indices = torch.tensor(
+            list(range(train_X.shape[-1] - 1)), **{"device": self.device}
+        )
+
+        lb, ub = (
+            train_X[:, normalize_indices].min(dim=0).values,
+            train_X[:, normalize_indices].max(dim=0).values,
+        )
+        train_X_new = train_X.clone()
+        train_X_new[..., normalize_indices] = (train_X[..., normalize_indices] - lb) / (
+            ub - lb
+        )
+        # TODO: add testing of stratified standardization
+        mu, sigma = train_Y.mean(), train_Y.std()
+
+        # Fit without transforms
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            gp1 = SaasFullyBayesianMultiTaskGP(
+                train_X=train_X_new,
+                train_Y=(train_Y - mu) / sigma,
+                train_Yvar=train_Yvar / sigma**2,
+                task_feature=d - 1,
+            )
+            fit_fully_bayesian_model_nuts(
+                gp1, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
+            )
+        posterior1 = gp1.posterior((test_X - lb) / (ub - lb), output_indices=[0])
+        pred_mean1 = mu + sigma * posterior1.mean
+        pred_var1 = (sigma**2) * posterior1.variance
+
+        # Fit with transforms
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            gp2 = SaasFullyBayesianMultiTaskGP(
+                train_X=train_X,
+                train_Y=train_Y,
+                train_Yvar=train_Yvar,
+                task_feature=d - 1,
+                input_transform=Normalize(
+                    d=train_X.shape[-1], indices=normalize_indices
+                ),
+                outcome_transform=Standardize(m=1),
+            )
+            fit_fully_bayesian_model_nuts(
+                gp2, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
+            )
+            posterior2 = gp2.posterior(X=test_X, output_indices=[0])
+            pred_mean2, pred_var2 = posterior2.mean, posterior2.variance
+
+        self.assertTrue(torch.allclose(pred_mean1, pred_mean2))
+        self.assertTrue(torch.allclose(pred_var1, pred_var2))
+
+    def test_acquisition_functions(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        train_X, train_Y, train_Yvar, model = self._get_data_and_model(
+            task_rank=1, **tkwargs
+        )
+        fit_fully_bayesian_model_nuts(
+            model, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
+        )
+
+        deterministic = GenericDeterministicModel(f=lambda x: x[..., :1])
+        sampler = IIDNormalSampler(num_samples=2)
+        # wrap mtgp with ModelList
+        acquisition_functions = [
+            ExpectedImprovement(model=ModelListGP(model), best_f=train_Y.max()),
+            ProbabilityOfImprovement(model=ModelListGP(model), best_f=train_Y.max()),
+            PosteriorMean(model=ModelListGP(model)),
+            UpperConfidenceBound(model=ModelListGP(model), beta=4),
+            qExpectedImprovement(
+                model=ModelListGP(model), best_f=train_Y.max(), sampler=sampler
+            ),
+            qNoisyExpectedImprovement(
+                model=ModelListGP(model), X_baseline=train_X, sampler=sampler
+            ),
+            qProbabilityOfImprovement(
+                model=ModelListGP(model), best_f=train_Y.max(), sampler=sampler
+            ),
+            qSimpleRegret(model=ModelListGP(model), sampler=sampler),
+            qUpperConfidenceBound(model=ModelListGP(model), beta=4, sampler=sampler),
+            qNoisyExpectedHypervolumeImprovement(
+                model=ModelListGP(model, model),
+                X_baseline=train_X,
+                ref_point=torch.zeros(2, **tkwargs),
+                sampler=sampler,
+            ),
+            qExpectedHypervolumeImprovement(
+                model=ModelListGP(model, model),
+                ref_point=torch.zeros(2, **tkwargs),
+                sampler=sampler,
+                partitioning=NondominatedPartitioning(
+                    ref_point=torch.zeros(2, **tkwargs), Y=train_Y.repeat([1, 2])
+                ),
+            ),
+            # qEHVI/qNEHVI with mixed models
+            qNoisyExpectedHypervolumeImprovement(
+                model=ModelList(deterministic, ModelListGP(model)),
+                X_baseline=train_X,
+                ref_point=torch.zeros(2, **tkwargs),
+                sampler=sampler,
+            ),
+            qExpectedHypervolumeImprovement(
+                model=ModelList(deterministic, ModelListGP(model)),
+                ref_point=torch.zeros(2, **tkwargs),
+                sampler=sampler,
+                partitioning=NondominatedPartitioning(
+                    ref_point=torch.zeros(2, **tkwargs), Y=train_Y.repeat([1, 2])
+                ),
+            ),
+        ]
+
+        for acqf in acquisition_functions:
+            for batch_shape in [[2], [6, 2], [5, 6, 2]]:
+                test_X = torch.cat(
+                    [
+                        torch.rand(*batch_shape, 1, 4, **tkwargs),
+                        torch.zeros(*batch_shape, 1, 1, **tkwargs),
+                    ],
+                    dim=-1,
+                )
+                self.assertEqual(acqf(test_X).shape, torch.Size(batch_shape))
+
+    def test_load_samples(self):
+        for task_rank, dtype in itertools.product([1, 2], [torch.float, torch.double]):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            train_X, train_Y, train_Yvar, model = self._get_data_and_model(
+                task_rank=task_rank, **tkwargs
+            )
+            d = train_X.shape[1] - 1
+            mcmc_samples = self._get_mcmc_samples(
+                num_samples=3, dim=d, task_rank=task_rank, **tkwargs
+            )
+            model.load_mcmc_samples(mcmc_samples)
+
+            self.assertTrue(
+                torch.allclose(
+                    model.covar_module.base_kernel.lengthscale,
+                    mcmc_samples["lengthscale"],
+                )
+            )
+            self.assertTrue(
+                torch.allclose(
+                    model.covar_module.outputscale,
+                    mcmc_samples["outputscale"],
+                )
+            )
+            self.assertTrue(
+                torch.allclose(
+                    model.mean_module.raw_constant.data,
+                    mcmc_samples["mean"],
+                )
+            )
+            self.assertTrue(
+                torch.allclose(
+                    model.pyro_model.train_Yvar,
+                    train_Yvar.clamp(MIN_INFERRED_NOISE_LEVEL),
+                )
+            )
+            self.assertTrue(
+                torch.allclose(
+                    model.task_covar_module.lengthscale,
+                    mcmc_samples["task_lengthscale"],
+                )
+            )
+            self.assertTrue(
+                torch.allclose(
+                    model.latent_features,
+                    mcmc_samples["latent_features"],
+                )
+            )


### PR DESCRIPTION
Summary:
as title.

D35573439 is too big. I make a separate diff to add construct_inputs for using `SaasFullyBayesianMultiTaskGP`. This overwritten is necessary in order to use the model in BotAx

Differential Revision: D36136031

