### PR TITLE
Update conda install instructions & listed dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Optimization simply use Ax.
 - PyTorch >= 1.9
 - gpytorch >= 1.6
 - scipy
+- multiple-dispatch
+- pyro-ppl == 1.8.0
 
 
 ##### Installing the latest release
@@ -66,7 +68,7 @@ Optimization simply use Ax.
 The latest release of BoTorch is easily installed either via
 [Anaconda](https://www.anaconda.com/distribution/#download-section) (recommended):
 ```bash
-conda install botorch -c pytorch -c gpytorch
+conda install botorch -c pytorch -c gpytorch -c conda-forge
 ```
 or via `pip`:
 ```bash

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,6 +17,8 @@ Before jumping the gun, we recommend you start with the high-level
 - PyTorch >= 1.9
 - gpytorch >= 1.6
 - scipy
+- multiple-dispatch
+- pyro-ppl == 1.8.0
 
 BoTorch is easily installed via
 [Anaconda](https://www.anaconda.com/distribution/#download-section) (recommended)
@@ -25,7 +27,7 @@ or `pip`:
 <!--DOCUSAURUS_CODE_TABS-->
 <!--conda-->
 ```bash
-conda install botorch -c pytorch -c gpytorch
+conda install botorch -c pytorch -c gpytorch -c conda-forge
 ```
 <!--pip-->
 ```bash

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -165,7 +165,7 @@ candidate  # tensor([0.4887, 0.5063])
             <li>
               <h4>Install BoTorch:</h4>
               <a>via conda (recommended):</a>
-              <MarkdownBlock>{bash`conda install botorch -c pytorch -c gpytorch`}</MarkdownBlock>
+              <MarkdownBlock>{bash`conda install botorch -c pytorch -c gpytorch -c conda-forge`}</MarkdownBlock>
               <a>via pip:</a>
               <MarkdownBlock>{bash`pip install botorch`}</MarkdownBlock>
             </li>


### PR DESCRIPTION
## Motivation

As noted in #1206, current conda installation instructions do not work for latest versions since the listed channels cannot resolve the `pyro-ppl` dependency. This updates the instructions to include the `conda-forge` channel as a fix.

Note: Technically `conda-forge` has `botorch` and `gpytorch` as well, so we could get away without including `-c pytorch` and `-c gpytorch`. However, `conda-forge` versions of these packages may not always be up-to-date, so keeping these channels makes sure we can always install the latest versions.

## Test Plan

`./scripts/build_docs.sh`

