### PR TITLE
Fix cached cholesky sampling in qNEHVI when using Standardize

### DIFF
--- a/test/posteriors/test_gpytorch.py
+++ b/test/posteriors/test_gpytorch.py
@@ -261,6 +261,9 @@ class TestGPyTorchPosterior(BotorchTestCase):
             tkwargs = {"device": self.device, "dtype": dtype}
             offset = torch.rand(1).item()
             weights = torch.randn(m, **tkwargs)
+            # Make sure the weights are not too small.
+            while torch.any(weights.abs() < 0.1):
+                weights = torch.randn(m, **tkwargs)
             # test q=1
             posterior = _get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
             mean, covar = posterior.mvn.mean, posterior.mvn.covariance_matrix


### PR DESCRIPTION
Summary:
In `cached_cholesky / low_rank`, we require the lazy covariance matrix of a  `MultitaskMultivariateNormal` to be `BlockDiagLazyTensor`. With the existing implementation, when using `Standardize`, this ends up being a `MatmulLazyTensor` leading to errors.

This updates `Standardize.untransform_posterior` to special case `BlockDiagLazyTensor`. The new implementation transforms blocks of `BlockDiagLazyTensor` in a batch and returns an untransformed `BlockDiagLazyTensor`.

Fixes #1030.

Differential Revision: D36321587

