### PR TITLE
Bump black version to 22.3.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         # pin dependencies to match Meta-internal versions
-        pip install black==21.4b2
+        pip install black==22.3.0
         pip install usort==0.6.4
         pip install libcst==0.3.19
         pip install ufmt

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ TEST_REQUIRES = ["pytest", "pytest-cov"]
 DEV_REQUIRES = TEST_REQUIRES + [
     "flake8",
     "sphinx",
-    "black==21.4b2",
+    "black==22.3.0",
     "libcst==0.3.19",
     "usort==0.6.4",
     "ufmt",


### PR DESCRIPTION
1825f4dbe5009b420d0eb164cae34a21ec5b89a6 introduced black 22.3.0 formatting and with that lint failures, this bumps black to that version.