### PR TITLE
Fix handling of raw BotorchDatasets in acquisition/input_constructors.py

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -100,7 +100,7 @@ MaybeDict = Union[T, Dict[Hashable, T]]
 
 
 def _field_is_shared(
-    datasets: Union[Dict[Hashable, BotorchDataset], Iterable[BotorchDataset]],
+    datasets: Union[Iterable[BotorchDataset], Dict[Hashable, BotorchDataset]],
     fieldname: Hashable,
 ) -> bool:
     r"""Determines whether or not a given field is shared by all datasets."""
@@ -1006,7 +1006,9 @@ def get_best_f_analytic(
     posterior_transform: Optional[PosteriorTransform] = None,
     **kwargs,
 ) -> Tensor:
-    if not _field_is_shared(training_data, fieldname="X"):
+    if isinstance(training_data, dict) and not _field_is_shared(
+        training_data, fieldname="X"
+    ):
         raise NotImplementedError("Currently only block designs are supported.")
 
     Y = _get_dataset_field(
@@ -1034,7 +1036,9 @@ def get_best_f_mc(
     objective: Optional[MCAcquisitionObjective] = None,
     posterior_transform: Optional[PosteriorTransform] = None,
 ) -> Tensor:
-    if not _field_is_shared(training_data, fieldname="X"):
+    if isinstance(training_data, dict) and not _field_is_shared(
+        training_data, fieldname="X"
+    ):
         raise NotImplementedError("Currently only block designs are supported.")
 
     Y = _get_dataset_field(

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -105,7 +105,10 @@ class TestInputConstructorUtils(InputConstructorBaseTestCase, BotorchTestCase):
     def test_get_best_f_analytic(self):
         with self.assertRaises(NotImplementedError):
             get_best_f_analytic(training_data=self.multiX_multiY)
+
         best_f = get_best_f_analytic(training_data=self.blockX_blockY)
+        self.assertEqual(best_f, get_best_f_analytic(self.blockX_blockY[0]))
+
         best_f_expected = self.blockX_blockY[0].Y().squeeze().max()
         self.assertEqual(best_f, best_f_expected)
         with self.assertRaises(NotImplementedError):
@@ -128,7 +131,10 @@ class TestInputConstructorUtils(InputConstructorBaseTestCase, BotorchTestCase):
     def test_get_best_f_mc(self):
         with self.assertRaises(NotImplementedError):
             get_best_f_mc(training_data=self.multiX_multiY)
+
         best_f = get_best_f_mc(training_data=self.blockX_blockY)
+        self.assertEqual(best_f, get_best_f_mc(self.blockX_blockY[0]))
+
         best_f_expected = self.blockX_blockY[0].Y().squeeze().max()
         self.assertEqual(best_f, best_f_expected)
         with self.assertRaisesRegex(UnsupportedError, "require an objective"):


### PR DESCRIPTION
Summary: Fix handling of raw BotorchDatasets in `input_constructors`

Differential Revision: D36351761

