### PR TITLE
Check that `choices` is non-empty in `optimize_acqf_discrete`

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -18,7 +18,7 @@ from botorch.acquisition.acquisition import (
     OneShotAcquisitionFunction,
 )
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
-from botorch.exceptions import UnsupportedError
+from botorch.exceptions import InputDataError, UnsupportedError
 from botorch.generation.gen import gen_candidates_scipy
 from botorch.logging import logger
 from botorch.optim.initializers import (
@@ -600,6 +600,8 @@ def optimize_acqf_discrete(
             "Discrete optimization is not supported for"
             "one-shot acquisition functions."
         )
+    if choices.numel() == 0:
+        raise InputDataError("`choices` must be non-emtpy.")
     choices_batched = choices.unsqueeze(-2)
     if q > 1:
         candidate_list, acq_value_list = [], []

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -13,7 +13,7 @@ from botorch.acquisition.acquisition import (
     AcquisitionFunction,
     OneShotAcquisitionFunction,
 )
-from botorch.exceptions import UnsupportedError
+from botorch.exceptions import InputDataError, UnsupportedError
 from botorch.optim.optimize import (
     _filter_infeasible,
     _filter_invalid,
@@ -879,6 +879,14 @@ class TestOptimizeAcqfDiscrete(BotorchTestCase):
 
             mock_acq_function = SquaredAcquisitionFunction()
             mock_acq_function.set_X_pending(None)
+
+            # ensure proper raising of errors if no choices
+            with self.assertRaisesRegex(InputDataError, "`choices` must be non-emtpy."):
+                optimize_acqf_discrete(
+                    acq_function=mock_acq_function,
+                    q=q,
+                    choices=torch.empty(0, 2),
+                )
 
             choices = torch.rand(5, 2, **tkwargs)
             exp_acq_vals = mock_acq_function(choices)


### PR DESCRIPTION
Otherwise this produces confusing tensor dimension errors if no chocies are given.
Also applies ufmt style throughout.
