### PR TITLE
PE and PLBO support in Ax

### DIFF
--- a/botorch/acquisition/preference.py
+++ b/botorch/acquisition/preference.py
@@ -6,9 +6,9 @@
 
 r"""
 Preference acquisition functions. This includes:
-Analytical EUBO acquisition function as introduced in [Lin2020preference]_.
+Analytical EUBO acquisition function as introduced in [Lin2022preference]_.
 
-.. [Lin2020preference]
+.. [Lin2022preference]
     Lin, Z.J., Astudillo, R., Frazier, P.I. and Bakshy, E. Preference Exploration
     for Efficient Bayesian Optimization with Multiple Outcomes. International
     Conference on Artificial Intelligence and Statistics (AISTATS), 2022.
@@ -38,7 +38,7 @@ class AnalyticExpectedUtilityOfBestOption(AnalyticAcquisitionFunction):
     ) -> None:
         r"""Analytic implementation of Expected Utility of the Best Option under the
         Laplace model (assumes a PairwiseGP is used as the preference model) as
-        proposed in [Lin2020preference]_.
+        proposed in [Lin2022preference]_.
 
         Args:
             pref_model: The preference model that maps the outcomes (i.e., Y) to
@@ -47,7 +47,7 @@ class AnalyticExpectedUtilityOfBestOption(AnalyticAcquisitionFunction):
                 (i.e., Y). The outcome model f defines the search space of Y = f(X).
                 If model is None, we are directly calculating EUBO on the parameter
                 space. When used with `OneSamplePosteriorDrawModel`, we are obtaining
-                EUBO-zeta as described in [Lin2020preference].
+                EUBO-zeta as described in [Lin2022preference].
             previous_winner: Tensor representing the previous winner in the Y space.
                 Defaults to None.
         """


### PR DESCRIPTION
Summary:
Support PE/PLBO in Ax by revamping Shaun's previous implementation.

Given that now the preference data is stored as an Ax experiment, we no longer need to pass in the preference data around, but the `pref_model` instead. `pref_model` will either be passed directly into the EUBO acqf (as in the PE exmample) or will serve as the objective (as in the PLBO example), extracting it from a `PairwiseModelBridge` and passing it through `acquisition_options` seems to be a nice solution. Comments and feedbacks are welcomed.

This should be the last missing piece of supporting PL/PE/PLBO in Ax. Though we should still need to work out a usable NB UI (probably something based on top of the BoTorch backend PL NB game), but with this diff, we should be able to perform close-loop PL/PE/PLBO in Ax programmatically.

Reviewed By: lena-kashtelyan

Differential Revision: D36060116

