### PR TITLE
Fix `ModelListGP.condition_on_observations/fantasize` bug

### DIFF
--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -215,6 +215,13 @@ class TestGPyTorchModel(BotorchTestCase):
                     BotorchTensorDimensionWarning
                 ):
                     GPyTorchModel._validate_tensor_args(X, Y[0], strict=False)
+            # with Yvar
+            if len(output_dim_shape) > 0:
+                Yvar = torch.empty(torch.Size([n]) + output_dim_shape, **tkwargs)
+                GPyTorchModel._validate_tensor_args(X, Y, Yvar)
+                Yvar = torch.empty(n, 5, **tkwargs)
+                with self.assertRaises(BotorchTensorDimensionError):
+                    GPyTorchModel._validate_tensor_args(X, Y, Yvar)
 
     def test_fantasize_flag(self):
         train_X = torch.rand(5, 1)


### PR DESCRIPTION
Summary:
`ModelListGP.fantasize` would fail due to `X` being transformed into a list of `X` in `fantasize`, then again being made into a list of `X`s in `condition_on_observations`. This removes the duplication of `X` in condition on observations, using the correctly transformed `X`s for fantasizing.

Fixes #1247

Differential Revision: D36949105

