### PR TITLE
Fix FixedSingleSampleModel dtype/device conversion

### DIFF
--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -215,10 +215,7 @@ class FixedSingleSampleModel(DeterministicModel):
         self.model = model
         self._num_outputs = model.num_outputs
         self.w = torch.randn(model.num_outputs)
-        # Check since Model doesn't guarantee a train_inputs attribute
-        if hasattr(model, "train_inputs"):
-            self.w = self.w.to(model.train_inputs[0])
 
     def forward(self, X: Tensor) -> Tensor:
         post = self.model.posterior(X)
-        return post.mean + post.variance.sqrt() * self.w
+        return post.mean + post.variance.sqrt() * self.w.to(X)

--- a/test/models/test_deterministic.py
+++ b/test/models/test_deterministic.py
@@ -168,4 +168,7 @@ class TestDeterministicModels(BotorchTestCase):
         train_Y_double = torch.rand(2, 2, dtype=torch.double)
         model_double = SingleTaskGP(train_X=train_X_double, train_Y=train_Y_double)
         fss_model_double = FixedSingleSampleModel(model=model_double)
-        self.assertTrue(fss_model_double.w.dtype == train_X_double.dtype)
+        test_X_float = torch.rand(2, 3, dtype=torch.float)
+
+        # the following line should execute fine
+        fss_model_double.posterior(test_X_float)


### PR DESCRIPTION
Summary: Sometimes `model.train_inputs[0]` is a tuple instead of a tensor. Instead of assuming the structure of the model's class members, will just cast X on the fly in `forward`. It shouldn't cause any additional runtime if device and dtype align.

Reviewed By: Balandat

Differential Revision: D36976244

