### PR TITLE
Remove deprecated usage of setuptools_scm in setup.py

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -14,7 +14,7 @@ build:
 requirements:
   host:
     - python>=3.7
-    - setuptools<48  # setup_requires was deprecated in v48.0.0
+    - setuptools
     - setuptools-scm
   run:
     - pytorch >=1.9

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
         pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[test]
-        pip install --upgrade setuptools wheel
+        pip install --upgrade setuptools setuptools_scm wheel
     - name: Build packages (wheel and source distribution)
       run: |
         # set a pseudo version that strips the commit hash to enable upload to pypi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,14 +55,14 @@ jobs:
         pip install .[test]
         pip install --upgrade setuptools wheel
     - name: Build packages (wheel and source distribution)
-      env:
-        SCM_NO_LOCAL_VERSION: true
       run: |
+        # set a pseudo version that strips the commit hash to enable upload to pypi
+        no_local_version=$(python -m setuptools_scm | cut -d "+" -f 1)
+        echo "SETUPTOOLS_SCM_PRETEND_VERSION=${no_local_version}" >> $GITHUB_ENV
         python setup.py sdist bdist_wheel
     - name: Verify packages
-      env:
-        SCM_NO_LOCAL_VERSION: true
       run: |
+        # env var SETUPTOOLS_SCM_PRETEND_VERSION persists from previous step
         ./scripts/build_and_verify_py_packages.sh
     - name: Deploy to Test PyPI
       uses: pypa/gh-action-pypi-publish@master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
-[tool.setuptools_scm]
-
 [build-system]
-requires = ["setuptools<48", "wheel", "setuptools-scm"]
+requires = ["setuptools", "setuptools-scm", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+local_scheme = "node-and-date"
+write_to = "./botorch/version.py"
 
 [tool.usort]
 first_party_detection = false

--- a/setup.py
+++ b/setup.py
@@ -80,16 +80,6 @@ setup(
     long_description_content_type="text/markdown",
     python_requires=">=3.7",
     setup_requires=["setuptools-scm"],
-    use_scm_version={
-        "root": ".",
-        "relative_to": __file__,
-        "write_to": os.path.join(root_dir, "botorch", "version.py"),
-        "local_scheme": (
-            "no-local-version"
-            if os.environ.get("SCM_NO_LOCAL_VERSION", False)
-            else "node-and-date"
-        ),
-    },
     packages=find_packages(exclude=["test", "test.*"]),
     install_requires=[
         "torch>=1.9",

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">=3.7",
-    setup_requires=["setuptools-scm"],
     packages=find_packages(exclude=["test", "test.*"]),
     install_requires=[
         "torch>=1.9",


### PR DESCRIPTION
This removes the deprecated use of `use_setuptools_scm` in `setup.py` so that we can use newer setuptools versions. 

Previously we parsed the `USE_SCM_LOCAL_VERSION` env var as part of `setup.py` in order to programmatically set the `local_scheme` setting, but this kind of dynamism is not possible in the pyproject.toml configuration. Instead, we now simply use the `SETUPTOOLS_SCM_PRETEND_VERSION` env var in order to provide a specific version name without the github hash (which we strip from the full name in a bash script).

What this means is that for untagged commits, `setuptools_scm` will always create a version string that includes the github hash and date (and overriding this will require to manually specifying the `SETUPTOOLS_SCM_PRETEND_VERSION` env var). 