### PR TITLE
Fix issue introdued in nightly flow in #1292

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,15 +54,17 @@ jobs:
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[test]
         pip install --upgrade setuptools setuptools_scm wheel
-    - name: Build packages (wheel and source distribution)
+    - name: Extract reduced version and save to env var
+      # strip the commit hash from the version to enable upload to pypi
+      # env var will persist for subsequent steps
       run: |
-        # set a pseudo version that strips the commit hash to enable upload to pypi
         no_local_version=$(python -m setuptools_scm | cut -d "+" -f 1)
         echo "SETUPTOOLS_SCM_PRETEND_VERSION=${no_local_version}" >> $GITHUB_ENV
+    - name: Build packages (wheel and source distribution)
+      run: |
         python setup.py sdist bdist_wheel
     - name: Verify packages
       run: |
-        # env var SETUPTOOLS_SCM_PRETEND_VERSION persists from previous step
         ./scripts/build_and_verify_py_packages.sh
     - name: Deploy to Test PyPI
       uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
It appears that the env var was set but not sourced in the same step, which resulted in the build using a wrong version name.