### PR TITLE
Skip bound validation in optimize_acqf if inequality constraints are specified

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -125,10 +125,14 @@ def optimize_acqf(
         >>>     qEI, bounds, 3, 15, 256, sequential=True
         >>> )
     """
-    if not (bounds.ndim == 2 and bounds.shape[0] == 2):
-        raise ValueError(
-            f"bounds should be a `2 x d` tensor, current shape: {list(bounds.shape)}."
-        )
+    if inequality_constraints is None:
+        if not (bounds.ndim == 2 and bounds.shape[0] == 2):
+            raise ValueError(
+                "bounds should be a `2 x d` tensor, current shape: "
+                f"{list(bounds.shape)}."
+            )
+        # TODO: Validate constraints if provided:
+        # https://github.com/pytorch/botorch/pull/1231
 
     if sequential and q > 1:
         if not return_best_only:


### PR DESCRIPTION
In some cases we may allow not using box constraints (e.g. when optimizing Alebo). This removes a check that currently breaks Alebo optimization. A proper solution should actually validate the constraint set, this was started in https://github.com/pytorch/botorch/pull/1231 but there are some nontrivial issues with this, so this provides a quick fix in the meantime.