### PR TITLE
Support inf values in `bounds` arg of `optimize_acqf`

### DIFF
--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -98,6 +98,11 @@ def gen_batch_initial_conditions(
         >>>     qEI, bounds, q=3, num_restarts=25, raw_samples=500
         >>> )
     """
+    if bounds.isinf().any():
+        raise NotImplementedError(
+            "Currently only finite values in `bounds` are supported "
+            "for generating initial conditions for optimization."
+        )
     options = options or {}
     seed: Optional[int] = options.get("seed")
     batch_limit: Optional[int] = options.get(

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -68,7 +68,9 @@ def optimize_acqf(
 
     Args:
         acq_function: An AcquisitionFunction.
-        bounds: A `2 x d` tensor of lower and upper bounds for each column of `X`.
+        bounds: A `2 x d` tensor of lower and upper bounds for each column of `X`
+            (if inequality_constraints is provided, these bounds can be -inf and
+            +inf, respectively).
         q: The number of candidates.
         num_restarts: The number of starting points for multistart acquisition
             function optimization.
@@ -229,8 +231,8 @@ def optimize_acqf(
         batch_candidates_curr, batch_acq_values_curr = gen_candidates_scipy(
             initial_conditions=batched_ics_,
             acquisition_function=acq_function,
-            lower_bounds=bounds[0],
-            upper_bounds=bounds[1],
+            lower_bounds=None if bounds[0].isinf().all() else bounds[0],
+            upper_bounds=None if bounds[1].isinf().all() else bounds[1],
             options={k: v for k, v in options.items() if k not in INIT_OPTION_KEYS},
             inequality_constraints=inequality_constraints,
             equality_constraints=equality_constraints,
@@ -276,7 +278,9 @@ def optimize_acqf_cyclic(
 
     Args:
         acq_function: An AcquisitionFunction
-        bounds: A `2 x d` tensor of lower and upper bounds for each column of `X`.
+        bounds: A `2 x d` tensor of lower and upper bounds for each column of `X`
+            (if inequality_constraints is provided, these bounds can be -inf and
+            +inf, respectively).
         q: The number of candidates.
         num_restarts:  Number of starting points for multistart acquisition
             function optimization.
@@ -389,7 +393,9 @@ def optimize_acqf_list(
 
     Args:
         acq_function_list: A list of acquisition functions.
-        bounds: A `2 x d` tensor of lower and upper bounds for each column of `X`.
+        bounds: A `2 x d` tensor of lower and upper bounds for each column of `X`
+            (if inequality_constraints is provided, these bounds can be -inf and
+            +inf, respectively).
         num_restarts:  Number of starting points for multistart acquisition
             function optimization.
         raw_samples: Number of samples for initialization. This is required
@@ -469,7 +475,9 @@ def optimize_acqf_mixed(
 
     Args:
         acq_function: An AcquisitionFunction
-        bounds: A `2 x d` tensor of lower and upper bounds for each column of `X`.
+        bounds: A `2 x d` tensor of lower and upper bounds for each column of `X`
+            (if inequality_constraints is provided, these bounds can be -inf and
+            +inf, respectively).
         q: The number of candidates.
         num_restarts:  Number of starting points for multistart acquisition
             function optimization.

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -129,7 +129,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
         with self.assertRaisesRegex(
             NotImplementedError,
             r"Currently only finite values in `bounds` are supported for "
-            r"generating initial conditions for optimization."
+            r"generating initial conditions for optimization.",
         ):
             gen_batch_initial_conditions(
                 acq_function=mock.Mock(),

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -123,6 +123,22 @@ class TestInitializeQBatch(BotorchTestCase):
 
 
 class TestGenBatchInitialCandidates(BotorchTestCase):
+    def test_gen_batch_initial_inf_bounds(self):
+        bounds = torch.rand(2, 2)
+        bounds[0, 1] = float("inf")
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            r"Currently only finite values in `bounds` are supported for "
+            r"generating initial conditions for optimization."
+        ):
+            gen_batch_initial_conditions(
+                acq_function=mock.Mock(),
+                bounds=bounds,
+                q=1,
+                num_restarts=2,
+                raw_samples=2,
+            )
+
     def test_gen_batch_initial_conditions(self):
         bounds = torch.stack([torch.zeros(2), torch.ones(2)])
         mock_acqf = MockAcquisitionFunction()


### PR DESCRIPTION
Previously, the code assumed that finite bounds were provided. This allows specifying `inf` values which are then internally identified and passed as `None` to optimizers.

Note that in that case `batch_initial_conditions` will need to be provided since the default initializers will raise a `NotImplementedError` if `bounds` contain `inf` values. This is not a common scenario and this change is mainly to fix a current bug with Alebo on the Ax side. Down the road we may want to consider initialization strategies for spaces without finite (explicit) bounds if needed. 