### PR TITLE
Fix automated release process by installing setuptools_scm

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .[test]
-        pip install --upgrade setuptools wheel
+        pip install --upgrade setuptools setuptools_scm wheel
     - name: Build packages (wheel and source distribution)
       run: |
         python setup.py sdist bdist_wheel
@@ -82,10 +82,10 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
+        conda install -y setuptools_scm conda-build conda-verify anaconda-client
         conda install -y -c pytorch pytorch cpuonly
         conda install -y scipy sphinx pytest flake8
         conda install -y -c gpytorch gpytorch
-        conda install -y conda-build anaconda-client
         conda install -y -c conda-forge pyro-ppl>=1.8.0
         conda config --set anaconda_upload no
     - name: Build and verify conda package


### PR DESCRIPTION
#1292 made changes to `setup.py`, which require `setuptools_scm` to be installed for the version generation to work properly. While this change was made to the nightly workflow, it was not made to the deployment ones. This PR fixes that. 