### PR TITLE
Add check for __init__ docstring from flake8-docstrings to GH Actions; fix docstrings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: |
-        pip install flake8
+        pip install flake8 flake8-docstrings
     - name: Flake8
       run: |
         flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,11 @@ from the repository root. No additional configuration should be needed (see the
 [black documentation](https://black.readthedocs.io/en/stable/installation_and_usage.html#usage)
 for advanced usage).
 
-Docstring formatting: We recommend [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings. 
+Docstring formatting: We recommend [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings.
 To make sure documentation is rendered correctly, we require that every `__init__`
-function contains an "Args" block. 
+function contains an "Args" block.
 We use `flake8-docstrings` to check this, as well as `flake8` to check code style. To use these tools, run
-`pip install flake8` and `pip install flake8-docstrings`, and then run 
+`pip install flake8` and `pip install flake8-docstrings`, and then run
 ```bash
 flake8 .
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Docstring formatting: Although we are not extremely
 picky about docstrings,
 we do recommend [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings. 
 To make sure documentation is rendered correctly, we require that every `__init__`
-function contain an "Args" block. 
+function contains an "Args" block. 
 We use `flake8-docstrings` to check this, as well as `flake8` to check code style. To use these tools, run
 `pip install flake8` and `pip install flake8-docstrings`, and then run 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,7 @@ from the repository root. No additional configuration should be needed (see the
 [black documentation](https://black.readthedocs.io/en/stable/installation_and_usage.html#usage)
 for advanced usage).
 
-Docstring formatting: Although we are not extremely
-picky about docstrings,
-we do recommend [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings. 
+Docstring formatting: We recommend [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings. 
 To make sure documentation is rendered correctly, we require that every `__init__`
 function contains an "Args" block. 
 We use `flake8-docstrings` to check this, as well as `flake8` to check code style. To use these tools, run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,17 @@ from the repository root. No additional configuration should be needed (see the
 [black documentation](https://black.readthedocs.io/en/stable/installation_and_usage.html#usage)
 for advanced usage).
 
+Docstring formatting: Although we are not extremely
+picky about docstrings,
+we do recommend [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings. 
+To make sure documentation is rendered correctly, we require that every `__init__`
+function contain an "Args" block. 
+We use `flake8-docstrings` to check this, as well as `flake8` to check code style. To use these tools, run
+`pip install flake8` and `pip install flake8-docstrings`, and then run 
+```bash
+flake8 .
+```
+
 
 #### Import Sorting
 

--- a/botorch/acquisition/knowledge_gradient.py
+++ b/botorch/acquisition/knowledge_gradient.py
@@ -505,8 +505,11 @@ class ProjectedAcquisitionFunction(AcquisitionFunction):
     ) -> None:
         """
         Args:
-            base_value_function
-            project
+            base_value_function: The wrapped `AcquisitionFunction`
+            project: A callable mapping a `batch_shape x q x d` tensor of design
+                points to a tensor with shape `batch_shape x q_term x d` projected
+                to the desired target set (e.g. the target fidelities in case of
+                multi-fidelity optimization). For the basic case, `q_term = q`
         """
         super().__init__(base_value_function.model)
         self.base_value_function = base_value_function

--- a/botorch/acquisition/knowledge_gradient.py
+++ b/botorch/acquisition/knowledge_gradient.py
@@ -505,11 +505,11 @@ class ProjectedAcquisitionFunction(AcquisitionFunction):
     ) -> None:
         """
         Args:
-            base_value_function: The wrapped `AcquisitionFunction`
+            base_value_function: The wrapped `AcquisitionFunction`.
             project: A callable mapping a `batch_shape x q x d` tensor of design
                 points to a tensor with shape `batch_shape x q_term x d` projected
                 to the desired target set (e.g. the target fidelities in case of
-                multi-fidelity optimization). For the basic case, `q_term = q`
+                multi-fidelity optimization). For the basic case, `q_term = q`.
         """
         super().__init__(base_value_function.model)
         self.base_value_function = base_value_function

--- a/botorch/acquisition/knowledge_gradient.py
+++ b/botorch/acquisition/knowledge_gradient.py
@@ -503,6 +503,11 @@ class ProjectedAcquisitionFunction(AcquisitionFunction):
         base_value_function: AcquisitionFunction,
         project: Callable[[Tensor], Tensor],
     ) -> None:
+        """
+        Args:
+            base_value_function
+            project
+        """
         super().__init__(base_value_function.model)
         self.base_value_function = base_value_function
         self.project = project

--- a/botorch/acquisition/knowledge_gradient.py
+++ b/botorch/acquisition/knowledge_gradient.py
@@ -503,7 +503,7 @@ class ProjectedAcquisitionFunction(AcquisitionFunction):
         base_value_function: AcquisitionFunction,
         project: Callable[[Tensor], Tensor],
     ) -> None:
-        """
+        r"""
         Args:
             base_value_function: The wrapped `AcquisitionFunction`.
             project: A callable mapping a `batch_shape x q x d` tensor of design

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -132,7 +132,7 @@ class ScalarizedObjective(ScalarizedPosteriorTransform, AcquisitionObjective):
     """DEPRECATED - Use ScalarizedPosteriorTransform instead."""
 
     def __init__(self, weights: Tensor, offset: float = 0.0) -> None:
-        """
+        r"""
         Args:
             weights: A one-dimensional tensor with `m` elements representing the
                 linear weights on the outputs.

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -134,8 +134,9 @@ class ScalarizedObjective(ScalarizedPosteriorTransform, AcquisitionObjective):
     def __init__(self, weights: Tensor, offset: float = 0.0) -> None:
         """
         Args:
-            weights
-            offset: Defaults to 0.0.
+            weights: A one-dimensional tensor with `m` elements representing the
+                linear weights on the outputs.
+            offset: An offset to be added to posterior mean.
         """
         warnings.warn(
             "ScalarizedObjective is deprecated and will be removed in the next "

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -90,8 +90,7 @@ class ScalarizedPosteriorTransform(PosteriorTransform):
     scalarize: bool = True
 
     def __init__(self, weights: Tensor, offset: float = 0.0) -> None:
-        r"""Affine posterior transform.
-
+        r"""
         Args:
             weights: A one-dimensional tensor with `m` elements representing the
                 linear weights on the outputs.
@@ -133,6 +132,11 @@ class ScalarizedObjective(ScalarizedPosteriorTransform, AcquisitionObjective):
     """DEPRECATED - Use ScalarizedPosteriorTransform instead."""
 
     def __init__(self, weights: Tensor, offset: float = 0.0) -> None:
+        """
+        Args:
+            weights
+            offset: Defaults to 0.0.
+        """
         warnings.warn(
             "ScalarizedObjective is deprecated and will be removed in the next "
             "version. Use ScalarizedPosteriorTransform instead."
@@ -329,8 +333,7 @@ class LinearMCObjective(MCAcquisitionObjective):
     """
 
     def __init__(self, weights: Tensor) -> None:
-        r"""Linear Objective.
-
+        r"""
         Args:
             weights: A one-dimensional tensor with `m` elements representing the
                 linear weights on the outputs.
@@ -373,8 +376,7 @@ class GenericMCObjective(MCAcquisitionObjective):
     """
 
     def __init__(self, objective: Callable[[Tensor, Optional[Tensor]], Tensor]) -> None:
-        r"""Objective generated from a generic callable.
-
+        r"""
         Args:
             objective: A callable `f(samples, X)` mapping a
                 `sample_shape x batch-shape x q x m`-dim Tensor `samples` and
@@ -444,8 +446,7 @@ class ConstrainedMCObjective(GenericMCObjective):
         infeasible_cost: Union[Tensor, float] = 0.0,
         eta: float = 1e-3,
     ) -> None:
-        r"""Feasibility-weighted objective.
-
+        r"""
         Args:
             objective: A callable `f(samples, X)` mapping a
                 `sample_shape x batch-shape x q x m`-dim Tensor `samples` and
@@ -508,8 +509,7 @@ class LearnedObjective(MCAcquisitionObjective):
         pref_model: Model,
         sampler: Optional[MCSampler] = None,
     ):
-        r"""Learned preference objective constructed from a preference model.
-
+        r"""
         Args:
             pref_model: A BoTorch model, which models the latent preference/utility
                 function. Given an input tensor of size

--- a/botorch/acquisition/preference.py
+++ b/botorch/acquisition/preference.py
@@ -49,7 +49,6 @@ class AnalyticExpectedUtilityOfBestOption(AnalyticAcquisitionFunction):
                 space. When used with `OneSamplePosteriorDrawModel`, we are obtaining
                 EUBO-zeta as described in [Lin2022preference].
             previous_winner: Tensor representing the previous winner in the Y space.
-                Defaults to None.
         """
         pref_model.eval()
         super().__init__(model=pref_model)

--- a/botorch/models/contextual.py
+++ b/botorch/models/contextual.py
@@ -13,16 +13,7 @@ from torch import Tensor
 
 
 class SACGP(FixedNoiseGP):
-    """The GP uses Structural Additive Contextual(SAC) kernel.
-
-    Args:
-        train_X: (n x d) X training data.
-        train_Y: (n x 1) Y training data.
-        train_Yvar: (n x 1) Noise variances of each training Y.
-        decomposition: Keys are context names. Values are the indexes of
-            parameters belong to the context. The parameter indexes are in
-            the same order across contexts.
-    """
+    """The GP uses Structural Additive Contextual(SAC) kernel."""
 
     def __init__(
         self,
@@ -31,6 +22,15 @@ class SACGP(FixedNoiseGP):
         train_Yvar: Tensor,
         decomposition: Dict[str, List[int]],
     ) -> None:
+        """
+        Args:
+            train_X: (n x d) X training data.
+            train_Y: (n x 1) Y training data.
+            train_Yvar: (n x 1) Noise variances of each training Y.
+            decomposition: Keys are context names. Values are the indexes of
+                parameters belong to the context. The parameter indexes are in
+                the same order across contexts.
+        """
         super().__init__(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
         self.covar_module = SACKernel(
             decomposition=decomposition,
@@ -43,27 +43,10 @@ class SACGP(FixedNoiseGP):
 
 class LCEAGP(FixedNoiseGP):
     r"""The GP with Latent Context Embedding Additive (LCE-A) Kernel.
+
     Note that the model does not support batch training. Input training
     data sets should have dim = 2.
-
-    Args:
-        train_X: (n x d) X training data.
-        train_Y: (n x 1) Y training data.
-        train_Yvar: (n x 1) Noise variance of Y.
-        decomposition: Keys are context names. Values are the indexes of
-            parameters belong to the context. The parameter indexes are in the
-            same order across contexts.
-        cat_feature_dict: Keys are context names and values are list of categorical
-            features i.e. {"context_name" : [cat_0, ..., cat_k]}. k equals to number
-            of categorical variables. If None, we use context names in the
-            decomposition as the only categorical feature i.e. k = 1
-        embs_feature_dict: Pre-trained continuous embedding features of each context.
-        embs_dim_list: Embedding dimension for each categorical variable. The length
-            equals to num of categorical features k. If None, emb dim is set to 1
-            for each categorical variable.
-        context_weight_dict: Known population Weights of each context.
     """
-
     def __init__(
         self,
         train_X: Tensor,
@@ -76,6 +59,25 @@ class LCEAGP(FixedNoiseGP):
         embs_dim_list: Optional[List[int]] = None,
         context_weight_dict: Optional[Dict] = None,
     ) -> None:
+        """
+        Args:
+            train_X: (n x d) X training data.
+            train_Y: (n x 1) Y training data.
+            train_Yvar: (n x 1) Noise variance of Y.
+            decomposition: Keys are context names. Values are the indexes of
+                parameters belong to the context. The parameter indexes are in the
+                same order across contexts.
+            cat_feature_dict: Keys are context names and values are list of categorical
+                features i.e. {"context_name" : [cat_0, ..., cat_k]}. k equals to number
+                of categorical variables. If None, we use context names in the
+                decomposition as the only categorical feature i.e. k = 1
+            embs_feature_dict: Pre-trained continuous embedding features of each
+                context.
+            embs_dim_list: Embedding dimension for each categorical variable. The length
+                equals to num of categorical features k. If None, emb dim is set to 1
+                for each categorical variable.
+            context_weight_dict: Known population Weights of each context.
+        """
         super().__init__(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
         self.covar_module = LCEAKernel(
             decomposition=decomposition,

--- a/botorch/models/contextual.py
+++ b/botorch/models/contextual.py
@@ -47,6 +47,7 @@ class LCEAGP(FixedNoiseGP):
     Note that the model does not support batch training. Input training
     data sets should have dim = 2.
     """
+
     def __init__(
         self,
         train_X: Tensor,

--- a/botorch/models/contextual.py
+++ b/botorch/models/contextual.py
@@ -13,7 +13,7 @@ from torch import Tensor
 
 
 class SACGP(FixedNoiseGP):
-    """A GP using a Structural Additive Contextual(SAC) kernel."""
+    r"""A GP using a Structural Additive Contextual(SAC) kernel."""
 
     def __init__(
         self,
@@ -42,7 +42,7 @@ class SACGP(FixedNoiseGP):
 
 
 class LCEAGP(FixedNoiseGP):
-    r"""A GP using a Latent Context Embedding Additive (LCE-A) kernel.
+    r"""A GP using a Latent Context Embedding Additive (LCE-A) Kernel.
 
     Note that the model does not support batch training. Input training
     data sets should have dim = 2.

--- a/botorch/models/contextual.py
+++ b/botorch/models/contextual.py
@@ -13,7 +13,7 @@ from torch import Tensor
 
 
 class SACGP(FixedNoiseGP):
-    """The GP uses Structural Additive Contextual(SAC) kernel."""
+    """A GP using a Structural Additive Contextual(SAC) kernel."""
 
     def __init__(
         self,
@@ -22,7 +22,7 @@ class SACGP(FixedNoiseGP):
         train_Yvar: Tensor,
         decomposition: Dict[str, List[int]],
     ) -> None:
-        """
+        r"""
         Args:
             train_X: (n x d) X training data.
             train_Y: (n x 1) Y training data.
@@ -42,7 +42,7 @@ class SACGP(FixedNoiseGP):
 
 
 class LCEAGP(FixedNoiseGP):
-    r"""The GP with Latent Context Embedding Additive (LCE-A) Kernel.
+    r"""A GP using a Latent Context Embedding Additive (LCE-A) kernel.
 
     Note that the model does not support batch training. Input training
     data sets should have dim = 2.
@@ -60,7 +60,7 @@ class LCEAGP(FixedNoiseGP):
         embs_dim_list: Optional[List[int]] = None,
         context_weight_dict: Optional[Dict] = None,
     ) -> None:
-        """
+        r"""
         Args:
             train_X: (n x d) X training data.
             train_Y: (n x 1) Y training data.
@@ -69,15 +69,15 @@ class LCEAGP(FixedNoiseGP):
                 parameters belong to the context. The parameter indexes are in the
                 same order across contexts.
             cat_feature_dict: Keys are context names and values are list of categorical
-                features i.e. {"context_name" : [cat_0, ..., cat_k]}. k equals to number
-                of categorical variables. If None, we use context names in the
-                decomposition as the only categorical feature i.e. k = 1
+                features i.e. {"context_name" : [cat_0, ..., cat_k]}, where k is the
+                number of categorical variables. If None, we use context names in the
+                decomposition as the only categorical feature, i.e., k = 1.
             embs_feature_dict: Pre-trained continuous embedding features of each
                 context.
             embs_dim_list: Embedding dimension for each categorical variable. The length
-                equals to num of categorical features k. If None, emb dim is set to 1
-                for each categorical variable.
-            context_weight_dict: Known population Weights of each context.
+                equals the number of categorical features k. If None, the embedding
+                dimension is set to 1 for each categorical variable.
+            context_weight_dict: Known population weights of each context.
         """
         super().__init__(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
         self.covar_module = LCEAKernel(

--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -36,7 +36,7 @@ class LCEMGP(MultiTaskGP):
         input_transform: Optional[InputTransform] = None,
         outcome_transform: Optional[OutcomeTransform] = None,
     ) -> None:
-        """
+        r"""
         Args:
             train_X: (n x d) X training data.
             train_Y: (n x 1) Y training data.
@@ -122,7 +122,7 @@ class LCEMGP(MultiTaskGP):
         return embeddings
 
     def task_covar_matrix(self, task_idcs: Tensor) -> Tensor:
-        """compute covariance matrix of a list of given context
+        r"""compute covariance matrix of a list of given context
 
         Args:
             task_idcs: (n x 1) or (b x n x 1) task indices tensor

--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -40,16 +40,16 @@ class LCEMGP(MultiTaskGP):
         Args:
             train_X: (n x d) X training data.
             train_Y: (n x 1) Y training data.
-            task_feature: column index of train_X to get context indices.
+            task_feature: Column index of train_X to get context indices.
             context_cat_feature: (n_contexts x k) one-hot encoded context
-                features. Rows are ordered by context indices. k equals to
+                features. Rows are ordered by context indices, where k is the
                 number of categorical variables. If None, task indices will
-                be used and k = 1
+                be used and k = 1.
             context_emb_feature: (n_contexts x m) pre-given continuous
                 embedding features. Rows are ordered by context indices.
             embs_dim_list: Embedding dimension for each categorical variable.
-                The length equals to k. If None, emb dim is set to 1 for each
-                categorical variable.
+                The length equals k. If None, the embedding dimension is set to 1
+                for each categorical variable.
             output_tasks: A list of task indices for which to compute model
                 outputs for. If omitted, return outputs for all task indices.
         """
@@ -163,21 +163,21 @@ class FixedNoiseLCEMGP(LCEMGP):
         embs_dim_list: Optional[List[int]] = None,
         output_tasks: Optional[List[int]] = None,
     ) -> None:
-        """
+        r"""
         Args:
             train_X: (n x d) X training data.
             train_Y: (n x 1) Y training data.
             train_Yvar: (n x 1) Noise variances of each training Y.
-            task_feature: column index of train_X to get context indices.
+            task_feature: Column index of train_X to get context indices.
             context_cat_feature: (n_contexts x k) one-hot encoded context
-                features. Rows are ordered by context indices. k equals to
+                features. Rows are ordered by context indices, where k is the
                 number of categorical variables. If None, task indices will
                 be used and k = 1.
             context_emb_feature: (n_contexts x m) pre-given continuous
                 embedding features. Rows are ordered by context indices.
             embs_dim_list: Embedding dimension for each categorical variable.
-                The length equals to k. If None, emb dim is set to 1 for each
-                categorical variable.
+                The length equals to k. If None, the embedding dimension is set to
+                1 for each categorical variable.
             output_tasks: A list of task indices for which to compute model
                 outputs for. If omitted, return outputs for all task indices.
         """

--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -22,22 +22,6 @@ from torch.nn import ModuleList
 class LCEMGP(MultiTaskGP):
     r"""The Multi-Task GP with the latent context embedding multioutput
     (LCE-M) kernel.
-
-    Args:
-        train_X: (n x d) X training data.
-        train_Y: (n x 1) Y training data.
-        task_feature: column index of train_X to get context indices.
-        context_cat_feature: (n_contexts x k) one-hot encoded context
-            features. Rows are ordered by context indices. k equals to
-            number of categorical variables. If None, task indices will
-            be used and k = 1
-        context_emb_feature: (n_contexts x m) pre-given continuous
-            embedding features. Rows are ordered by context indices.
-        embs_dim_list: Embedding dimension for each categorical variable.
-            The length equals to k. If None, emb dim is set to 1 for each
-            categorical variable.
-        output_tasks: A list of task indices for which to compute model
-            outputs for. If omitted, return outputs for all task indices.
     """
 
     def __init__(
@@ -52,6 +36,23 @@ class LCEMGP(MultiTaskGP):
         input_transform: Optional[InputTransform] = None,
         outcome_transform: Optional[OutcomeTransform] = None,
     ) -> None:
+        """
+        Args:
+            train_X: (n x d) X training data.
+            train_Y: (n x 1) Y training data.
+            task_feature: column index of train_X to get context indices.
+            context_cat_feature: (n_contexts x k) one-hot encoded context
+                features. Rows are ordered by context indices. k equals to
+                number of categorical variables. If None, task indices will
+                be used and k = 1
+            context_emb_feature: (n_contexts x m) pre-given continuous
+                embedding features. Rows are ordered by context indices.
+            embs_dim_list: Embedding dimension for each categorical variable.
+                The length equals to k. If None, emb dim is set to 1 for each
+                categorical variable.
+            output_tasks: A list of task indices for which to compute model
+                outputs for. If omitted, return outputs for all task indices.
+        """
         super().__init__(
             train_X=train_X,
             train_Y=train_Y,
@@ -149,25 +150,7 @@ class LCEMGP(MultiTaskGP):
 class FixedNoiseLCEMGP(LCEMGP):
     r"""The Multi-Task GP the latent context embedding multioutput
     (LCE-M) kernel, with known observation noise.
-
-    Args:
-        train_X: (n x d) X training data.
-        train_Y: (n x 1) Y training data.
-        train_Yvar: (n x 1) Noise variances of each training Y.
-        task_feature: column index of train_X to get context indices.
-        context_cat_feature: (n_contexts x k) one-hot encoded context
-            features. Rows are ordered by context indices. k equals to
-            number of categorical variables. If None, task indices will
-            be used and k = 1.
-        context_emb_feature: (n_contexts x m) pre-given continuous
-            embedding features. Rows are ordered by context indices.
-        embs_dim_list: Embedding dimension for each categorical variable.
-            The length equals to k. If None, emb dim is set to 1 for each
-            categorical variable.
-        output_tasks: A list of task indices for which to compute model
-            outputs for. If omitted, return outputs for all task indices.
     """
-
     def __init__(
         self,
         train_X: Tensor,
@@ -179,6 +162,24 @@ class FixedNoiseLCEMGP(LCEMGP):
         embs_dim_list: Optional[List[int]] = None,
         output_tasks: Optional[List[int]] = None,
     ) -> None:
+        """
+        Args:
+            train_X: (n x d) X training data.
+            train_Y: (n x 1) Y training data.
+            train_Yvar: (n x 1) Noise variances of each training Y.
+            task_feature: column index of train_X to get context indices.
+            context_cat_feature: (n_contexts x k) one-hot encoded context
+                features. Rows are ordered by context indices. k equals to
+                number of categorical variables. If None, task indices will
+                be used and k = 1.
+            context_emb_feature: (n_contexts x m) pre-given continuous
+                embedding features. Rows are ordered by context indices.
+            embs_dim_list: Embedding dimension for each categorical variable.
+                The length equals to k. If None, emb dim is set to 1 for each
+                categorical variable.
+            output_tasks: A list of task indices for which to compute model
+                outputs for. If omitted, return outputs for all task indices.
+        """
         self._validate_tensor_args(X=train_X, Y=train_Y, Yvar=train_Yvar)
         super().__init__(
             train_X=train_X,

--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -151,6 +151,7 @@ class FixedNoiseLCEMGP(LCEMGP):
     r"""The Multi-Task GP the latent context embedding multioutput
     (LCE-M) kernel, with known observation noise.
     """
+
     def __init__(
         self,
         train_X: Tensor,

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -44,28 +44,6 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
 
     This kernel is described in [Wu2019mf]_.
 
-    Args:
-        train_X: A `batch_shape x n x (d + s)` tensor of training features,
-            where `s` is the dimension of the fidelity parameters (either one
-            or two).
-        train_Y: A `batch_shape x n x m` tensor of training observations.
-        iteration_fidelity: The column index for the training iteration fidelity
-            parameter (optional).
-        data_fidelity: The column index for the downsampling fidelity parameter
-            (optional).
-        linear_truncated: If True, use a `LinearTruncatedFidelityKernel` instead
-            of the default kernel.
-        nu: The smoothness parameter for the Matern kernel: either 1/2, 3/2, or
-            5/2. Only used when `linear_truncated=True`.
-        likelihood: A likelihood. If omitted, use a standard GaussianLikelihood
-            with inferred noise level.
-        outcome_transform: An outcome transform that is applied to the
-                training data during instantiation and to the posterior during
-                inference (that is, the `Posterior` obtained by calling
-                `.posterior` on the model will be on the original scale).
-        input_transform: An input transform that is applied in the model's
-                forward pass.
-
     Example:
         >>> train_X = torch.rand(20, 4)
         >>> train_Y = train_X.pow(2).sum(dim=-1, keepdim=True)
@@ -84,6 +62,29 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         outcome_transform: Optional[OutcomeTransform] = None,
         input_transform: Optional[InputTransform] = None,
     ) -> None:
+        """
+        Args:
+            train_X: A `batch_shape x n x (d + s)` tensor of training features,
+                where `s` is the dimension of the fidelity parameters (either one
+                or two).
+            train_Y: A `batch_shape x n x m` tensor of training observations.
+            iteration_fidelity: The column index for the training iteration fidelity
+                parameter (optional).
+            data_fidelity: The column index for the downsampling fidelity parameter
+                (optional).
+            linear_truncated: If True, use a `LinearTruncatedFidelityKernel` instead
+                of the default kernel.
+            nu: The smoothness parameter for the Matern kernel: either 1/2, 3/2, or
+                5/2. Only used when `linear_truncated=True`.
+            likelihood: A likelihood. If omitted, use a standard GaussianLikelihood
+                with inferred noise level.
+            outcome_transform: An outcome transform that is applied to the
+                    training data during instantiation and to the posterior during
+                    inference (that is, the `Posterior` obtained by calling
+                    `.posterior` on the model will be on the original scale).
+            input_transform: An input transform that is applied in the model's
+                    forward pass.
+        """
         self._init_args = {
             "iteration_fidelity": iteration_fidelity,
             "data_fidelity": data_fidelity,
@@ -155,28 +156,6 @@ class FixedNoiseMultiFidelityGP(FixedNoiseGP):
 
     This kernel is described in [Wu2019mf]_.
 
-    Args:
-        train_X: A `batch_shape x n x (d + s)` tensor of training features,
-            where `s` is the dimension of the fidelity parameters (either one
-            or two).
-        train_Y: A `batch_shape x n x m` tensor of training observations.
-        train_Yvar: A `batch_shape x n x m` tensor of observed measurement noise.
-        iteration_fidelity: The column index for the training iteration fidelity
-            parameter (optional).
-        data_fidelity: The column index for the downsampling fidelity parameter
-            (optional).
-        linear_truncated: If True, use a `LinearTruncatedFidelityKernel` instead
-            of the default kernel.
-        nu: The smoothness parameter for the Matern kernel: either 1/2, 3/2, or
-            5/2. Only used when `linear_truncated=True`.
-        outcome_transform: An outcome transform that is applied to the
-            training data during instantiation and to the posterior during
-            inference (that is, the `Posterior` obtained by calling
-            `.posterior` on the model will be on the original scale).
-        input_transform: An input transform that is applied in the model's
-                forward pass.
-
-
     Example:
         >>> train_X = torch.rand(20, 4)
         >>> train_Y = train_X.pow(2).sum(dim=-1, keepdim=True)
@@ -201,6 +180,28 @@ class FixedNoiseMultiFidelityGP(FixedNoiseGP):
         outcome_transform: Optional[OutcomeTransform] = None,
         input_transform: Optional[InputTransform] = None,
     ) -> None:
+        """
+        Args:
+            train_X: A `batch_shape x n x (d + s)` tensor of training features,
+                where `s` is the dimension of the fidelity parameters (either one
+                or two).
+            train_Y: A `batch_shape x n x m` tensor of training observations.
+            train_Yvar: A `batch_shape x n x m` tensor of observed measurement noise.
+            iteration_fidelity: The column index for the training iteration fidelity
+                parameter (optional).
+            data_fidelity: The column index for the downsampling fidelity parameter
+                (optional).
+            linear_truncated: If True, use a `LinearTruncatedFidelityKernel` instead
+                of the default kernel.
+            nu: The smoothness parameter for the Matern kernel: either 1/2, 3/2, or
+                5/2. Only used when `linear_truncated=True`.
+            outcome_transform: An outcome transform that is applied to the
+                training data during instantiation and to the posterior during
+                inference (that is, the `Posterior` obtained by calling
+                `.posterior` on the model will be on the original scale).
+            input_transform: An input transform that is applied in the model's
+                    forward pass.
+        """
         if iteration_fidelity is None and data_fidelity is None:
             raise UnsupportedError(
                 "FixedNoiseMultiFidelityGP requires at least one fidelity parameter."

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -62,7 +62,7 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         outcome_transform: Optional[OutcomeTransform] = None,
         input_transform: Optional[InputTransform] = None,
     ) -> None:
-        """
+        r"""
         Args:
             train_X: A `batch_shape x n x (d + s)` tensor of training features,
                 where `s` is the dimension of the fidelity parameters (either one
@@ -180,7 +180,7 @@ class FixedNoiseMultiFidelityGP(FixedNoiseGP):
         outcome_transform: Optional[OutcomeTransform] = None,
         input_transform: Optional[InputTransform] = None,
     ) -> None:
-        """
+        r"""
         Args:
             train_X: A `batch_shape x n x (d + s)` tensor of training features,
                 where `s` is the dimension of the fidelity parameters (either one
@@ -200,7 +200,7 @@ class FixedNoiseMultiFidelityGP(FixedNoiseGP):
                 inference (that is, the `Posterior` obtained by calling
                 `.posterior` on the model will be on the original scale).
             input_transform: An input transform that is applied in the model's
-                    forward pass.
+                forward pass.
         """
         if iteration_fidelity is None and data_fidelity is None:
             raise UnsupportedError(

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -63,11 +63,12 @@ class FlattenedStandardize(Standardize):
         batch_shape: torch.Size = None,
         min_stdv: float = 1e-8,
     ):
-        """
+        r"""
         Args:
             output_shape: A `n x output_shape`-dim tensor of training targets.
-            batch_shape: Defaults to None.
-            min_stdv: Defaults to 1e-8.
+            batch_shape: The batch_shape of the training targets.
+            min_stddv: The minimum standard deviation for which to perform
+                standardization (if lower, only de-mean the data).
         """
         if batch_shape is None:
             batch_shape = torch.Size()

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -65,7 +65,7 @@ class FlattenedStandardize(Standardize):
     ):
         """
         Args:
-            output_shape
+            output_shape: A `n x output_shape`-dim tensor of training targets.
             batch_shape: Defaults to None.
             min_stdv: Defaults to 1e-8.
         """

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -63,6 +63,12 @@ class FlattenedStandardize(Standardize):
         batch_shape: torch.Size = None,
         min_stdv: float = 1e-8,
     ):
+        """
+        Args:
+            output_shape
+            batch_shape: Defaults to None.
+            min_stdv: Defaults to 1e-8.
+        """
         if batch_shape is None:
             batch_shape = torch.Size()
 

--- a/botorch/models/kernels/contextual_lcea.py
+++ b/botorch/models/kernels/contextual_lcea.py
@@ -37,7 +37,7 @@ class LCEAKernel(Kernel):
         context_weight_dict: Optional[Dict] = None,
         device: Optional[torch.device] = None,
     ) -> None:
-        """
+        r"""
         Args:
             decomposition: Keys index context names. Values are the indexes of
                 parameters belong to the context. The parameter indexes are in the same
@@ -45,17 +45,17 @@ class LCEAKernel(Kernel):
             batch_shape: Batch shape as usual for gpytorch kernels. Model does not
                 support batch training. When batch_shape is non-empty, it is used for
                 loading hyper-parameter values generated from MCMC sampling.
-            train_embedding: A boolean indictor of whether to learn context embeddings
+            train_embedding: A boolean indictor of whether to learn context embeddings.
             cat_feature_dict: Keys are context names and values are list of categorical
-                features i.e. {"context_name" : [cat_0, ..., cat_k]}. k equals to number
-                of categorical variables. If None, we use context names in the
-                decomposition as the only categorical feature i.e. k = 1
+                features i.e. {"context_name" : [cat_0, ..., cat_k]}. k equals the number
+                of categorical variables. If None, uses context names in the decomposition
+               as the only categorical feature, i.e., k = 1.
             embs_feature_dict: Pre-trained continuous embedding features of each
                 context.
             embs_dim_list: Embedding dimension for each categorical variable. The length
-                equals to num of categorical features k. If None, emb dim is set to 1
-                for each categorical variable.
-            context_weight_dict: Known population Weights of each context.
+                equals to num of categorical features k. If None, the embedding dimension
+                is set to 1 for each categorical variable.
+            context_weight_dict: Known population weights of each context.
         """
         super().__init__(batch_shape=batch_shape)
         self.decomposition = decomposition

--- a/botorch/models/kernels/contextual_lcea.py
+++ b/botorch/models/kernels/contextual_lcea.py
@@ -24,24 +24,6 @@ class LCEAKernel(Kernel):
     across contexts. Rather than assuming independence, LCEAKernel models the
     correlation in the latent functions for each context through learning context
     embeddings.
-
-    Args:
-        decomposition: Keys index context names. Values are the indexes of parameters
-            belong to the context. The parameter indexes are in the same order across
-            contexts.
-        batch_shape: Batch shape as usual for gpytorch kernels. Model does not support
-            batch training. When batch_shape is non-empty, it is used for loading
-            hyper-parameter values generated from MCMC sampling.
-        train_embedding: A boolean indictor of whether to learn context embeddings
-        cat_feature_dict: Keys are context names and values are list of categorical
-            features i.e. {"context_name" : [cat_0, ..., cat_k]}. k equals to number
-            of categorical variables. If None, we use context names in the
-            decomposition as the only categorical feature i.e. k = 1
-        embs_feature_dict: Pre-trained continuous embedding features of each context.
-        embs_dim_list: Embedding dimension for each categorical variable. The length
-            equals to num of categorical features k. If None, emb dim is set to 1
-            for each categorical variable.
-        context_weight_dict: Known population Weights of each context.
     """
 
     def __init__(
@@ -55,7 +37,26 @@ class LCEAKernel(Kernel):
         context_weight_dict: Optional[Dict] = None,
         device: Optional[torch.device] = None,
     ) -> None:
-
+        """
+        Args:
+            decomposition: Keys index context names. Values are the indexes of
+                parameters belong to the context. The parameter indexes are in the same
+                order across contexts.
+            batch_shape: Batch shape as usual for gpytorch kernels. Model does not
+                support batch training. When batch_shape is non-empty, it is used for
+                loading hyper-parameter values generated from MCMC sampling.
+            train_embedding: A boolean indictor of whether to learn context embeddings
+            cat_feature_dict: Keys are context names and values are list of categorical
+                features i.e. {"context_name" : [cat_0, ..., cat_k]}. k equals to number
+                of categorical variables. If None, we use context names in the
+                decomposition as the only categorical feature i.e. k = 1
+            embs_feature_dict: Pre-trained continuous embedding features of each
+                context.
+            embs_dim_list: Embedding dimension for each categorical variable. The length
+                equals to num of categorical features k. If None, emb dim is set to 1
+                for each categorical variable.
+            context_weight_dict: Known population Weights of each context.
+        """
         super().__init__(batch_shape=batch_shape)
         self.decomposition = decomposition
         self.batch_shape = batch_shape

--- a/botorch/models/kernels/contextual_lcea.py
+++ b/botorch/models/kernels/contextual_lcea.py
@@ -47,14 +47,14 @@ class LCEAKernel(Kernel):
                 loading hyper-parameter values generated from MCMC sampling.
             train_embedding: A boolean indictor of whether to learn context embeddings.
             cat_feature_dict: Keys are context names and values are list of categorical
-                features i.e. {"context_name" : [cat_0, ..., cat_k]}. k equals the number
-                of categorical variables. If None, uses context names in the decomposition
-               as the only categorical feature, i.e., k = 1.
+                features i.e. {"context_name" : [cat_0, ..., cat_k]}. k equals the
+                number of categorical variables. If None, uses context names in the
+                decomposition as the only categorical feature, i.e., k = 1.
             embs_feature_dict: Pre-trained continuous embedding features of each
                 context.
             embs_dim_list: Embedding dimension for each categorical variable. The length
-                equals to num of categorical features k. If None, the embedding dimension
-                is set to 1 for each categorical variable.
+                equals to num of categorical features k. If None, the embedding
+                dimension is set to 1 for each categorical variable.
             context_weight_dict: Known population weights of each context.
         """
         super().__init__(batch_shape=batch_shape)

--- a/botorch/models/kernels/contextual_sac.py
+++ b/botorch/models/kernels/contextual_sac.py
@@ -38,12 +38,6 @@ class SACKernel(Kernel):
     same number of parameters d. Each kernel `k_i` acts only on d parameters of ith
     partition i.e. `\mathbf{x}_(i)`. Each kernel `k_i` is a scaled Matern kernel
     with same lengthscales but different outputscales.
-
-    Args:
-        decomposition: Keys are context names. Values are the indexes of parameters
-            belong to the context. The parameter indexes are in the same order across
-            contexts.
-        batch_shape: Batch shape as usual for gpytorch kernels.
     """
 
     def __init__(
@@ -52,6 +46,15 @@ class SACKernel(Kernel):
         batch_shape: torch.Size,
         device: Optional[torch.device] = None,
     ) -> None:
+        """
+        Args:
+            decomposition: Keys are context names. Values are the indexes of parameters
+                belong to the context. The parameter indexes are in the same order
+                across contexts.
+            batch_shape: Batch shape as usual for gpytorch kernels.
+            device: Defaults to None.
+        """
+
         super().__init__(batch_shape=batch_shape)
         self.decomposition = decomposition
         self.device = device

--- a/botorch/models/kernels/contextual_sac.py
+++ b/botorch/models/kernels/contextual_sac.py
@@ -46,13 +46,13 @@ class SACKernel(Kernel):
         batch_shape: torch.Size,
         device: Optional[torch.device] = None,
     ) -> None:
-        """
+        r"""
         Args:
             decomposition: Keys are context names. Values are the indexes of parameters
                 belong to the context. The parameter indexes are in the same order
                 across contexts.
             batch_shape: Batch shape as usual for gpytorch kernels.
-            device: The torch device. Defaults to None.
+            device: The torch device.
         """
 
         super().__init__(batch_shape=batch_shape)

--- a/botorch/models/kernels/contextual_sac.py
+++ b/botorch/models/kernels/contextual_sac.py
@@ -52,7 +52,7 @@ class SACKernel(Kernel):
                 belong to the context. The parameter indexes are in the same order
                 across contexts.
             batch_shape: Batch shape as usual for gpytorch kernels.
-            device: Defaults to None.
+            device: The torch device. Defaults to None.
         """
 
         super().__init__(batch_shape=batch_shape)

--- a/botorch/models/kernels/downsampling.py
+++ b/botorch/models/kernels/downsampling.py
@@ -35,7 +35,7 @@ class DownsamplingKernel(Kernel):
         offset_constraint: Optional[Interval] = None,
         **kwargs,
     ):
-        """
+        r"""
         Args:
             power_constraint: Constraint to place on power parameter. Default is
                 `Positive`.

--- a/botorch/models/kernels/downsampling.py
+++ b/botorch/models/kernels/downsampling.py
@@ -25,15 +25,6 @@ class DownsamplingKernel(Kernel):
             (1 - x_2)^(1 + delta).
 
     where `c` is an offset parameter, and `delta` is a power parameter.
-
-    Args:
-        power_constraint: Constraint to place on power parameter. Default is
-            `Positive`.
-        power_prior: Prior over the power parameter.
-        offset_constraint: Constraint to place on offset parameter. Default is
-            `Positive`.
-        active_dims: List of data dimensions to operate on. `len(active_dims)`
-            should equal `num_dimensions`.
     """
 
     def __init__(
@@ -44,6 +35,16 @@ class DownsamplingKernel(Kernel):
         offset_constraint: Optional[Interval] = None,
         **kwargs,
     ):
+        """
+        Args:
+            power_constraint: Constraint to place on power parameter. Default is
+                `Positive`.
+            power_prior: Prior over the power parameter.
+            offset_constraint: Constraint to place on offset parameter. Default is
+                `Positive`.
+            active_dims: List of data dimensions to operate on. `len(active_dims)`
+                should equal `num_dimensions`.
+        """
         super().__init__(**kwargs)
 
         if power_constraint is None:

--- a/botorch/models/kernels/exponential_decay.py
+++ b/botorch/models/kernels/exponential_decay.py
@@ -37,7 +37,7 @@ class ExponentialDecayKernel(Kernel):
         offset_constraint: Optional[Interval] = None,
         **kwargs,
     ):
-        """
+        r"""
         Args:
             lengthscale_constraint: Constraint to place on lengthscale parameter.
                 Default is `Positive`.

--- a/botorch/models/kernels/exponential_decay.py
+++ b/botorch/models/kernels/exponential_decay.py
@@ -25,18 +25,6 @@ class ExponentialDecayKernel(Kernel):
 
     where `w` is an offset parameter, `beta` is a lenthscale parameter, and
     `alpha` is a power parameter.
-
-    Args:
-        lengthscale_constraint: Constraint to place on lengthscale parameter.
-            Default is `Positive`.
-        lengthscale_prior: Prior over the lengthscale parameter.
-        power_constraint: Constraint to place on power parameter. Default is
-            `Positive`.
-        power_prior: Prior over the power parameter.
-        offset_constraint: Constraint to place on offset parameter. Default is
-            `Positive`.
-        active_dims: List of data dimensions to operate on. `len(active_dims)`
-            should equal `num_dimensions`.
     """
 
     has_lengthscale = True
@@ -49,6 +37,19 @@ class ExponentialDecayKernel(Kernel):
         offset_constraint: Optional[Interval] = None,
         **kwargs,
     ):
+        """
+        Args:
+            lengthscale_constraint: Constraint to place on lengthscale parameter.
+                Default is `Positive`.
+            lengthscale_prior: Prior over the lengthscale parameter.
+            power_constraint: Constraint to place on power parameter. Default is
+                `Positive`.
+            power_prior: Prior over the power parameter.
+            offset_constraint: Constraint to place on offset parameter. Default is
+                `Positive`.
+            active_dims: List of data dimensions to operate on. `len(active_dims)`
+                should equal `num_dimensions`.
+        """
         super().__init__(**kwargs)
 
         if power_constraint is None:

--- a/botorch/posteriors/deterministic.py
+++ b/botorch/posteriors/deterministic.py
@@ -22,9 +22,9 @@ class DeterministicPosterior(Posterior):
     r"""Deterministic posterior."""
 
     def __init__(self, values: Tensor) -> None:
-        """
+        r"""
         Args:
-            values: Values to deterministically sample from.
+            values: Values of the samples produced by this posterior.
         """
         self.values = values
 

--- a/botorch/posteriors/deterministic.py
+++ b/botorch/posteriors/deterministic.py
@@ -24,7 +24,7 @@ class DeterministicPosterior(Posterior):
     def __init__(self, values: Tensor) -> None:
         """
         Args:
-            values
+            values: Values to deterministically sample from.
         """
         self.values = values
 

--- a/botorch/posteriors/deterministic.py
+++ b/botorch/posteriors/deterministic.py
@@ -22,6 +22,10 @@ class DeterministicPosterior(Posterior):
     r"""Deterministic posterior."""
 
     def __init__(self, values: Tensor) -> None:
+        """
+        Args:
+            values
+        """
         self.values = values
 
     @property

--- a/botorch/sampling/pairwise_samplers.py
+++ b/botorch/sampling/pairwise_samplers.py
@@ -87,11 +87,17 @@ class PairwiseIIDNormalSampler(PairwiseMCSampler, IIDNormalSampler):
     ) -> None:
         """
         Args:
-            num_samples
-            resample: Defaults to False.
-            seed: Defaults to None.
-            collapse_batch_dims: Defaults to True.
-            max_num_comparisons: Defaults to None.
+            num_samples: The number of samples to use.
+            resample: If `True`, re-draw samples in each `forward` evaluation -
+                this results in stochastic acquisition functions (and thus should
+                not be used with deterministic optimization algorithms). Defaults to
+                False.
+            seed: The seed for the RNG. If omitted, use a random seed. Defaults to None.
+            collapse_batch_dims: If True, collapse the t-batch dimensions to
+                size 1. This is useful for preventing sampling variance across
+                t-batches. Defaults to True.
+            max_num_comparisons:  Max number of comparisons drawn within samples.
+                If None, use all possible pairwise comparisons. Defaults to None.
         """
         PairwiseMCSampler.__init__(
             self, max_num_comparisons=max_num_comparisons, seed=seed
@@ -116,11 +122,17 @@ class PairwiseSobolQMCNormalSampler(PairwiseMCSampler, SobolQMCNormalSampler):
     ) -> None:
         """
         Args:
-            num_samples
-            resample: Defaults to False.
-            seed: Defaults to None.
-            collapse_batch_dims: Defaults to True.
-            max_num_comparisons: Defaults to None.
+            num_samples: The number of samples to use.
+            resample: If `True`, re-draw samples in each `forward` evaluation -
+                this results in stochastic acquisition functions (and thus should
+                not be used with deterministic optimization algorithms). Defaults to
+                False.
+            seed: The seed for the RNG. If omitted, use a random seed. Defaults to None.
+            collapse_batch_dims: If True, collapse the t-batch dimensions to
+                size 1. This is useful for preventing sampling variance across
+                t-batches. Defaults to True.
+            max_num_comparisons:  Max number of comparisons drawn within samples.
+                If None, use all possible pairwise comparisons. Defaults to None.
         """
         PairwiseMCSampler.__init__(
             self, max_num_comparisons=max_num_comparisons, seed=seed

--- a/botorch/sampling/pairwise_samplers.py
+++ b/botorch/sampling/pairwise_samplers.py
@@ -24,6 +24,7 @@ class PairwiseMCSampler(MCSampler):
     with PairwiseGP and BoTorch acquisition functions (e.g., qKnowledgeGradient)
 
     """
+
     def __init__(self, max_num_comparisons: int = None, seed: int = None) -> None:
         r"""
         Args:

--- a/botorch/sampling/pairwise_samplers.py
+++ b/botorch/sampling/pairwise_samplers.py
@@ -17,12 +17,15 @@ from torch import Tensor
 
 
 class PairwiseMCSampler(MCSampler):
+    """
+    Abstract class for Pairwise MC Sampler.
+
+    This sampler will sample pairwise comparisons. It is to be used together
+    with PairwiseGP and BoTorch acquisition functions (e.g., qKnowledgeGradient)
+
+    """
     def __init__(self, max_num_comparisons: int = None, seed: int = None) -> None:
-        r"""Abstract class for Pairwise MC Sampler.
-
-        This sampler will sample pairwise comparisons. It is to be used together
-        with PairwiseGP and BoTorch acquisition functions (e.g., qKnowledgeGradient)
-
+        r"""
         Args:
             max_num_comparisons: Max number of comparisons drawn within samples.
                 If None, use all possible pairwise comparisons
@@ -81,6 +84,14 @@ class PairwiseIIDNormalSampler(PairwiseMCSampler, IIDNormalSampler):
         collapse_batch_dims: bool = True,
         max_num_comparisons: int = None,
     ) -> None:
+        """
+        Args:
+            num_samples
+            resample: Defaults to False.
+            seed: Defaults to None.
+            collapse_batch_dims: Defaults to True.
+            max_num_comparisons: Defaults to None.
+        """
         PairwiseMCSampler.__init__(
             self, max_num_comparisons=max_num_comparisons, seed=seed
         )
@@ -102,6 +113,14 @@ class PairwiseSobolQMCNormalSampler(PairwiseMCSampler, SobolQMCNormalSampler):
         collapse_batch_dims: bool = True,
         max_num_comparisons: int = None,
     ) -> None:
+        """
+        Args:
+            num_samples
+            resample: Defaults to False.
+            seed: Defaults to None.
+            collapse_batch_dims: Defaults to True.
+            max_num_comparisons: Defaults to None.
+        """
         PairwiseMCSampler.__init__(
             self, max_num_comparisons=max_num_comparisons, seed=seed
         )

--- a/botorch/sampling/pairwise_samplers.py
+++ b/botorch/sampling/pairwise_samplers.py
@@ -17,7 +17,7 @@ from torch import Tensor
 
 
 class PairwiseMCSampler(MCSampler):
-    """
+    r"""
     Abstract class for Pairwise MC Sampler.
 
     This sampler will sample pairwise comparisons. It is to be used together
@@ -85,19 +85,17 @@ class PairwiseIIDNormalSampler(PairwiseMCSampler, IIDNormalSampler):
         collapse_batch_dims: bool = True,
         max_num_comparisons: int = None,
     ) -> None:
-        """
+        r"""
         Args:
             num_samples: The number of samples to use.
             resample: If `True`, re-draw samples in each `forward` evaluation -
                 this results in stochastic acquisition functions (and thus should
-                not be used with deterministic optimization algorithms). Defaults to
-                False.
-            seed: The seed for the RNG. If omitted, use a random seed. Defaults to None.
+                not be used with deterministic optimization algorithms).
+            seed: The seed for the RNG. If omitted, use a random seed.
             collapse_batch_dims: If True, collapse the t-batch dimensions to
-                size 1. This is useful for preventing sampling variance across
-                t-batches. Defaults to True.
+                size 1. This is useful for preventing sampling variance across t-batches.
             max_num_comparisons:  Max number of comparisons drawn within samples.
-                If None, use all possible pairwise comparisons. Defaults to None.
+                If None, use all possible pairwise comparisons.
         """
         PairwiseMCSampler.__init__(
             self, max_num_comparisons=max_num_comparisons, seed=seed
@@ -120,19 +118,17 @@ class PairwiseSobolQMCNormalSampler(PairwiseMCSampler, SobolQMCNormalSampler):
         collapse_batch_dims: bool = True,
         max_num_comparisons: int = None,
     ) -> None:
-        """
+        r"""
         Args:
             num_samples: The number of samples to use.
             resample: If `True`, re-draw samples in each `forward` evaluation -
                 this results in stochastic acquisition functions (and thus should
-                not be used with deterministic optimization algorithms). Defaults to
-                False.
-            seed: The seed for the RNG. If omitted, use a random seed. Defaults to None.
+                not be used with deterministic optimization algorithms).
+            seed: The seed for the RNG. If omitted, use a random seed.
             collapse_batch_dims: If True, collapse the t-batch dimensions to
-                size 1. This is useful for preventing sampling variance across
-                t-batches. Defaults to True.
+                size 1. This is useful for preventing sampling variance across t-batches.
             max_num_comparisons:  Max number of comparisons drawn within samples.
-                If None, use all possible pairwise comparisons. Defaults to None.
+                If None, use all possible pairwise comparisons.
         """
         PairwiseMCSampler.__init__(
             self, max_num_comparisons=max_num_comparisons, seed=seed

--- a/botorch/sampling/pairwise_samplers.py
+++ b/botorch/sampling/pairwise_samplers.py
@@ -93,7 +93,8 @@ class PairwiseIIDNormalSampler(PairwiseMCSampler, IIDNormalSampler):
                 not be used with deterministic optimization algorithms).
             seed: The seed for the RNG. If omitted, use a random seed.
             collapse_batch_dims: If True, collapse the t-batch dimensions to
-                size 1. This is useful for preventing sampling variance across t-batches.
+                size 1. This is useful for preventing sampling variance across
+                t-batches.
             max_num_comparisons:  Max number of comparisons drawn within samples.
                 If None, use all possible pairwise comparisons.
         """
@@ -126,7 +127,8 @@ class PairwiseSobolQMCNormalSampler(PairwiseMCSampler, SobolQMCNormalSampler):
                 not be used with deterministic optimization algorithms).
             seed: The seed for the RNG. If omitted, use a random seed.
             collapse_batch_dims: If True, collapse the t-batch dimensions to
-                size 1. This is useful for preventing sampling variance across t-batches.
+                size 1. This is useful for preventing sampling variance across
+                t-batches.
             max_num_comparisons:  Max number of comparisons drawn within samples.
                 If None, use all possible pairwise comparisons.
         """

--- a/botorch/settings.py
+++ b/botorch/settings.py
@@ -114,7 +114,7 @@ class log_level:
     def __init__(self, level: int = LOG_LEVEL_DEFAULT) -> None:
         """
         Args:
-            level: Defaults to LOG_LEVEL_DEFAULT.
+            level: How much to log. Defaults to LOG_LEVEL_DEFAULT.
         """
         self.prev = self.__class__.level
         self.level = level

--- a/botorch/settings.py
+++ b/botorch/settings.py
@@ -112,9 +112,9 @@ class log_level:
         logger.setLevel(level)
 
     def __init__(self, level: int = LOG_LEVEL_DEFAULT) -> None:
-        """
+        r"""
         Args:
-            level: How much to log. Defaults to LOG_LEVEL_DEFAULT.
+            level: The log level. Defaults to LOG_LEVEL_DEFAULT.
         """
         self.prev = self.__class__.level
         self.level = level

--- a/botorch/settings.py
+++ b/botorch/settings.py
@@ -112,6 +112,10 @@ class log_level:
         logger.setLevel(level)
 
     def __init__(self, level: int = LOG_LEVEL_DEFAULT) -> None:
+        """
+        Args:
+            level: Defaults to LOG_LEVEL_DEFAULT.
+        """
         self.prev = self.__class__.level
         self.level = level
 

--- a/botorch/test_functions/multi_fidelity.py
+++ b/botorch/test_functions/multi_fidelity.py
@@ -131,7 +131,7 @@ class AugmentedRosenbrock(SyntheticTestFunction):
     ) -> None:
         r"""
         Args:
-            dim: Dimension of the function. Must be at least 3.
+            dim: The (input) dimension. Must be at least 3.
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
         """

--- a/botorch/test_functions/multi_fidelity.py
+++ b/botorch/test_functions/multi_fidelity.py
@@ -76,6 +76,11 @@ class AugmentedHartmann(SyntheticTestFunction):
     _check_grad_at_opt = False
 
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
+        """
+        Args:
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         super().__init__(noise_std=noise_std, negate=negate)
         self.register_buffer("ALPHA", torch.tensor([1.0, 1.2, 3.0, 3.2]))
         A = [
@@ -124,6 +129,12 @@ class AugmentedRosenbrock(SyntheticTestFunction):
     def __init__(
         self, dim=3, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            dim: Defaults to 3.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         if dim < 3:
             raise ValueError(
                 "AugmentedRosenbrock must be defined it at least 3 dimensions"

--- a/botorch/test_functions/multi_fidelity.py
+++ b/botorch/test_functions/multi_fidelity.py
@@ -78,8 +78,8 @@ class AugmentedHartmann(SyntheticTestFunction):
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
         """
         Args:
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         super().__init__(noise_std=noise_std, negate=negate)
         self.register_buffer("ALPHA", torch.tensor([1.0, 1.2, 3.0, 3.2]))
@@ -131,9 +131,9 @@ class AugmentedRosenbrock(SyntheticTestFunction):
     ) -> None:
         """
         Args:
-            dim: Defaults to 3.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension of the function. Must be at least 3 and defaults to 3.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         if dim < 3:
             raise ValueError(

--- a/botorch/test_functions/multi_fidelity.py
+++ b/botorch/test_functions/multi_fidelity.py
@@ -76,10 +76,10 @@ class AugmentedHartmann(SyntheticTestFunction):
     _check_grad_at_opt = False
 
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
-        """
+        r"""
         Args:
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         super().__init__(noise_std=noise_std, negate=negate)
         self.register_buffer("ALPHA", torch.tensor([1.0, 1.2, 3.0, 3.2]))
@@ -129,11 +129,11 @@ class AugmentedRosenbrock(SyntheticTestFunction):
     def __init__(
         self, dim=3, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension of the function. Must be at least 3 and defaults to 3.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: Dimension of the function. Must be at least 3.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         if dim < 3:
             raise ValueError(

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -176,9 +176,9 @@ class DH(MultiObjectiveTestProblem, ABC):
         noise_std: Optional[float] = None,
         negate: bool = False,
     ) -> None:
-        """
+        r"""
         Args:
-            dim: The (input) dimension. 
+            dim: The (input) dimension.
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
         """
@@ -928,7 +928,7 @@ class ZDT(MultiObjectiveTestProblem):
         noise_std: Optional[float] = None,
         negate: bool = False,
     ) -> None:
-        """
+        r"""
         Args:
             dim: The (input) dimension of the function.
             num_objectives: Number of objectives. Must not be larger than dim.

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -116,8 +116,7 @@ class BraninCurrin(MultiObjectiveTestProblem):
     _max_hv = 59.36011874867746  # this is approximated using NSGA-II
 
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
-        r"""Constructor for Branin-Currin.
-
+        r"""
         Args:
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the objectives.
@@ -177,6 +176,15 @@ class DH(MultiObjectiveTestProblem, ABC):
         noise_std: Optional[float] = None,
         negate: bool = False,
     ) -> None:
+        """
+        Args:
+            dim (int)
+            noise_std (Optional[float], optional): Defaults to None.
+            negate (bool, optional): Defaults to False.
+
+        Raises:
+            ValueError
+        """
         if dim < self._min_dim:
             raise ValueError(f"dim must be >= {self._min_dim}, but got dim={dim}!")
         self.dim = dim
@@ -331,6 +339,16 @@ class DTLZ(MultiObjectiveTestProblem):
         noise_std: Optional[float] = None,
         negate: bool = False,
     ) -> None:
+        """
+        Args:
+            dim (int)
+            num_objectives (int, optional): Defaults to 2.
+            noise_std (Optional[float], optional): Defaults to None.
+            negate (bool, optional): Defaults to False.
+
+        Raises:
+            ValueError
+        """
         if dim <= num_objectives:
             raise ValueError(
                 f"dim must be > num_objectives, but got {dim} and {num_objectives}."
@@ -591,8 +609,7 @@ class GMM(MultiObjectiveTestProblem):
         negate: bool = False,
         num_objectives: int = 2,
     ) -> None:
-        r"""Constructor.
-
+        r"""
         Args:
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the objectives.
@@ -917,6 +934,13 @@ class ZDT(MultiObjectiveTestProblem):
         noise_std: Optional[float] = None,
         negate: bool = False,
     ) -> None:
+        """
+        Args:
+            dim
+            num_objectives: Defaults to 2.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         if num_objectives != 2:
             raise NotImplementedError(
                 f"{type(self).__name__} currently only supports 2 objectives."
@@ -1216,6 +1240,11 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
     _max_hv = 608.4004237022673  # from NSGA-II with 90k evaluations
 
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
+        """
+        Args:
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         super().__init__(noise_std=noise_std, negate=negate)
         con_bounds = torch.tensor(self._con_bounds, dtype=torch.float).transpose(-1, -2)
         self.register_buffer("con_bounds", con_bounds)
@@ -1316,6 +1345,12 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
         noise_std: Optional[float] = None,
         negate: bool = False,
     ) -> None:
+        """
+        Args:
+            dim
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         if dim < 2:
             raise ValueError("dim must be greater than or equal to 2.")
         self.dim = dim

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -178,12 +178,9 @@ class DH(MultiObjectiveTestProblem, ABC):
     ) -> None:
         """
         Args:
-            dim (int)
-            noise_std (Optional[float], optional): Defaults to None.
-            negate (bool, optional): Defaults to False.
-
-        Raises:
-            ValueError
+            dim: Dimension.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         if dim < self._min_dim:
             raise ValueError(f"dim must be >= {self._min_dim}, but got dim={dim}!")
@@ -341,13 +338,11 @@ class DTLZ(MultiObjectiveTestProblem):
     ) -> None:
         """
         Args:
-            dim (int)
-            num_objectives (int, optional): Defaults to 2.
-            noise_std (Optional[float], optional): Defaults to None.
-            negate (bool, optional): Defaults to False.
-
-        Raises:
-            ValueError
+            dim: Dimension of the function.
+            num_objectives: Must be smaller than dim. Defaults to 2.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+                Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         if dim <= num_objectives:
             raise ValueError(
@@ -936,10 +931,11 @@ class ZDT(MultiObjectiveTestProblem):
     ) -> None:
         """
         Args:
-            dim
-            num_objectives: Defaults to 2.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension of the function.
+            num_objectives: Number of objectives. Must not be larger than dim. Defaults
+                to 2.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         if num_objectives != 2:
             raise NotImplementedError(
@@ -1242,8 +1238,8 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
         """
         Args:
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         super().__init__(noise_std=noise_std, negate=negate)
         con_bounds = torch.tensor(self._con_bounds, dtype=torch.float).transpose(-1, -2)
@@ -1347,9 +1343,9 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     ) -> None:
         """
         Args:
-            dim
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension of the function. Must be at least 2.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False
         """
         if dim < 2:
             raise ValueError("dim must be greater than or equal to 2.")

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -178,9 +178,9 @@ class DH(MultiObjectiveTestProblem, ABC):
     ) -> None:
         """
         Args:
-            dim: Dimension.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension. 
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         if dim < self._min_dim:
             raise ValueError(f"dim must be >= {self._min_dim}, but got dim={dim}!")
@@ -336,13 +336,12 @@ class DTLZ(MultiObjectiveTestProblem):
         noise_std: Optional[float] = None,
         negate: bool = False,
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension of the function.
-            num_objectives: Must be smaller than dim. Defaults to 2.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-                Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension of the function.
+            num_objectives: Must be less than dim.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         if dim <= num_objectives:
             raise ValueError(
@@ -931,11 +930,10 @@ class ZDT(MultiObjectiveTestProblem):
     ) -> None:
         """
         Args:
-            dim: Dimension of the function.
-            num_objectives: Number of objectives. Must not be larger than dim. Defaults
-                to 2.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension of the function.
+            num_objectives: Number of objectives. Must not be larger than dim.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         if num_objectives != 2:
             raise NotImplementedError(
@@ -1236,10 +1234,10 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
     _max_hv = 608.4004237022673  # from NSGA-II with 90k evaluations
 
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
-        """
+        r"""
         Args:
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         super().__init__(noise_std=noise_std, negate=negate)
         con_bounds = torch.tensor(self._con_bounds, dtype=torch.float).transpose(-1, -2)
@@ -1341,11 +1339,11 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
         noise_std: Optional[float] = None,
         negate: bool = False,
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension of the function. Must be at least 2.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False
+            dim: The (input) dimension of the function. Must be at least 2.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         if dim < 2:
             raise ValueError("dim must be greater than or equal to 2.")

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -183,11 +183,11 @@ class DixonPrice(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension. Defaults to 2.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         self.dim = dim
         self._bounds = [(-10.0, 10.0) for _ in range(self.dim)]
@@ -237,11 +237,11 @@ class Griewank(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension. Defaults to 2.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         self.dim = dim
         self._bounds = [(-600.0, 600.0) for _ in range(self.dim)]
@@ -273,11 +273,11 @@ class Hartmann(SyntheticTestFunction):
     def __init__(
         self, dim=6, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension. Defaults to 6.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         if dim not in (3, 4, 6):
             raise ValueError(f"Hartmann with dim {dim} not defined")
@@ -403,11 +403,11 @@ class Levy(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension. Defaults to 2.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         self.dim = dim
         self._bounds = [(-10.0, 10.0) for _ in range(self.dim)]
@@ -439,11 +439,11 @@ class Michalewicz(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension. Defaults to 2.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         self.dim = dim
         self._bounds = [(0.0, math.pi) for _ in range(self.dim)]
@@ -479,11 +479,11 @@ class Powell(SyntheticTestFunction):
     def __init__(
         self, dim=4, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension. Defaults to 4.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         self.dim = dim
         self._bounds = [(-4.0, 5.0) for _ in range(self.dim)]
@@ -509,11 +509,11 @@ class Rastrigin(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension. Defaults to 2.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         self.dim = dim
         self._bounds = [(-5.12, 5.12) for _ in range(self.dim)]
@@ -542,11 +542,11 @@ class Rosenbrock(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension. Defaults to 2.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         self.dim = dim
         self._bounds = [(-5.0, 10.0) for _ in range(self.dim)]
@@ -578,11 +578,11 @@ class Shekel(SyntheticTestFunction):
     def __init__(
         self, m: int = 10, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
             m: Defaults to 10.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         self.m = m
         optvals = {5: -10.1532, 7: -10.4029, 10: -10.536443}
@@ -642,11 +642,11 @@ class StyblinskiTang(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension. Defaults to 2.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         self.dim = dim
         self._bounds = [(-5.0, 5.0) for _ in range(self.dim)]

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -27,8 +27,7 @@ class SyntheticTestFunction(BaseTestProblem):
     num_objectives: int = 1
 
     def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
-        r"""Base constructor for synthetic test functions.
-
+        r"""
         Args:
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
@@ -63,6 +62,12 @@ class Ackley(SyntheticTestFunction):
     def __init__(
         self, dim: int = 2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            dim: Defaults to 2.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         self.dim = dim
         self._bounds = [(-32.768, 32.768) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
@@ -178,6 +183,12 @@ class DixonPrice(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            dim: Defaults to 2.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         self.dim = dim
         self._bounds = [(-10.0, 10.0) for _ in range(self.dim)]
         self._optimizers = [
@@ -226,6 +237,12 @@ class Griewank(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            dim: Defaults to 2.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         self.dim = dim
         self._bounds = [(-600.0, 600.0) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
@@ -256,6 +273,12 @@ class Hartmann(SyntheticTestFunction):
     def __init__(
         self, dim=6, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            dim: Defaults to 6.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         if dim not in (3, 4, 6):
             raise ValueError(f"Hartmann with dim {dim} not defined")
         self.dim = dim
@@ -380,6 +403,12 @@ class Levy(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            dim: Defaults to 2.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         self.dim = dim
         self._bounds = [(-10.0, 10.0) for _ in range(self.dim)]
         self._optimizers = [tuple(1.0 for _ in range(self.dim))]
@@ -410,6 +439,12 @@ class Michalewicz(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            dim: Defaults to 2.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         self.dim = dim
         self._bounds = [(0.0, math.pi) for _ in range(self.dim)]
         optvals = {2: -1.80130341, 5: -4.687658, 10: -9.66015}
@@ -444,6 +479,12 @@ class Powell(SyntheticTestFunction):
     def __init__(
         self, dim=4, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            dim: Defaults to 4.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         self.dim = dim
         self._bounds = [(-4.0, 5.0) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
@@ -468,6 +509,12 @@ class Rastrigin(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            dim: Defaults to 2.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         self.dim = dim
         self._bounds = [(-5.12, 5.12) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
@@ -495,6 +542,12 @@ class Rosenbrock(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            dim: Defaults to 2.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         self.dim = dim
         self._bounds = [(-5.0, 10.0) for _ in range(self.dim)]
         self._optimizers = [tuple(1.0 for _ in range(self.dim))]
@@ -525,6 +578,12 @@ class Shekel(SyntheticTestFunction):
     def __init__(
         self, m: int = 10, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            m: Defaults to 10.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         self.m = m
         optvals = {5: -10.1532, 7: -10.4029, 10: -10.536443}
         self._optimal_value = optvals[self.m]
@@ -583,6 +642,12 @@ class StyblinskiTang(SyntheticTestFunction):
     def __init__(
         self, dim=2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
+        """
+        Args:
+            dim: Defaults to 2.
+            noise_std: Defaults to None.
+            negate: Defaults to False.
+        """
         self.dim = dim
         self._bounds = [(-5.0, 5.0) for _ in range(self.dim)]
         self._optimal_value = -39.166166 * self.dim

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -64,9 +64,9 @@ class Ackley(SyntheticTestFunction):
     ) -> None:
         """
         Args:
-            dim: Defaults to 2.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension. Defaults to 2.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         self.dim = dim
         self._bounds = [(-32.768, 32.768) for _ in range(self.dim)]
@@ -185,9 +185,9 @@ class DixonPrice(SyntheticTestFunction):
     ) -> None:
         """
         Args:
-            dim: Defaults to 2.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension. Defaults to 2.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         self.dim = dim
         self._bounds = [(-10.0, 10.0) for _ in range(self.dim)]
@@ -239,9 +239,9 @@ class Griewank(SyntheticTestFunction):
     ) -> None:
         """
         Args:
-            dim: Defaults to 2.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension. Defaults to 2.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         self.dim = dim
         self._bounds = [(-600.0, 600.0) for _ in range(self.dim)]
@@ -275,9 +275,9 @@ class Hartmann(SyntheticTestFunction):
     ) -> None:
         """
         Args:
-            dim: Defaults to 6.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension. Defaults to 6.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         if dim not in (3, 4, 6):
             raise ValueError(f"Hartmann with dim {dim} not defined")
@@ -405,9 +405,9 @@ class Levy(SyntheticTestFunction):
     ) -> None:
         """
         Args:
-            dim: Defaults to 2.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension. Defaults to 2.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         self.dim = dim
         self._bounds = [(-10.0, 10.0) for _ in range(self.dim)]
@@ -441,9 +441,9 @@ class Michalewicz(SyntheticTestFunction):
     ) -> None:
         """
         Args:
-            dim: Defaults to 2.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension. Defaults to 2.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         self.dim = dim
         self._bounds = [(0.0, math.pi) for _ in range(self.dim)]
@@ -481,9 +481,9 @@ class Powell(SyntheticTestFunction):
     ) -> None:
         """
         Args:
-            dim: Defaults to 4.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension. Defaults to 4.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         self.dim = dim
         self._bounds = [(-4.0, 5.0) for _ in range(self.dim)]
@@ -511,9 +511,9 @@ class Rastrigin(SyntheticTestFunction):
     ) -> None:
         """
         Args:
-            dim: Defaults to 2.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension. Defaults to 2.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         self.dim = dim
         self._bounds = [(-5.12, 5.12) for _ in range(self.dim)]
@@ -544,9 +544,9 @@ class Rosenbrock(SyntheticTestFunction):
     ) -> None:
         """
         Args:
-            dim: Defaults to 2.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension. Defaults to 2.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         self.dim = dim
         self._bounds = [(-5.0, 10.0) for _ in range(self.dim)]
@@ -581,8 +581,8 @@ class Shekel(SyntheticTestFunction):
         """
         Args:
             m: Defaults to 10.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         self.m = m
         optvals = {5: -10.1532, 7: -10.4029, 10: -10.536443}
@@ -644,9 +644,9 @@ class StyblinskiTang(SyntheticTestFunction):
     ) -> None:
         """
         Args:
-            dim: Defaults to 2.
-            noise_std: Defaults to None.
-            negate: Defaults to False.
+            dim: Dimension. Defaults to 2.
+            noise_std: Standard deviation of the observation noise. Defaults to None.
+            negate: If True, negate the function. Defaults to False.
         """
         self.dim = dim
         self._bounds = [(-5.0, 5.0) for _ in range(self.dim)]

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -62,11 +62,11 @@ class Ackley(SyntheticTestFunction):
     def __init__(
         self, dim: int = 2, noise_std: Optional[float] = None, negate: bool = False
     ) -> None:
-        """
+        r"""
         Args:
-            dim: Dimension. Defaults to 2.
-            noise_std: Standard deviation of the observation noise. Defaults to None.
-            negate: If True, negate the function. Defaults to False.
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            negate: If True, negate the function.
         """
         self.dim = dim
         self._bounds = [(-32.768, 32.768) for _ in range(self.dim)]

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -100,10 +100,10 @@ class MockPosterior(Posterior):
     def __init__(self, mean=None, variance=None, samples=None):
         """
         Args:
-            mean: The mean of the posterior. Defaults to None.
-            variance: The variance of the posterior. Defaults to None.
+            mean: The mean of the posterior.
+            variance: The variance of the posterior.
             samples: Samples to return from `rsample`, unless `base_samples` is
-                provided. Defaults to None.
+                provided.
         """
         self._mean = mean
         self._variance = variance

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -98,8 +98,8 @@ class MockPosterior(Posterior):
     r"""Mock object that implements dummy methods and feeds through specified outputs"""
 
     def __init__(self, mean=None, variance=None, samples=None):
-        """
-        Args:
+        r"""
+        Args
             mean: The mean of the posterior.
             variance: The variance of the posterior.
             samples: Samples to return from `rsample`, unless `base_samples` is

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -99,7 +99,7 @@ class MockPosterior(Posterior):
 
     def __init__(self, mean=None, variance=None, samples=None):
         r"""
-        Args
+        Args:
             mean: The mean of the posterior.
             variance: The variance of the posterior.
             samples: Samples to return from `rsample`, unless `base_samples` is

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -100,9 +100,10 @@ class MockPosterior(Posterior):
     def __init__(self, mean=None, variance=None, samples=None):
         """
         Args:
-            mean: Defaults to None.
-            variance: Defaults to None.
-            samples: Defaults to None.
+            mean: The mean of the posterior. Defaults to None.
+            variance: The variance of the posterior. Defaults to None.
+            samples: Samples to return from `rsample`, unless `base_samples` is
+                provided. Defaults to None.
         """
         self._mean = mean
         self._variance = variance
@@ -159,11 +160,7 @@ class MockPosterior(Posterior):
 class MockModel(Model):
     r"""Mock object that implements dummy methods and feeds through specified outputs"""
 
-    def __init__(self, posterior: MockPosterior) -> None:
-        """
-        Args:
-            posterior
-        """
+    def __init__(self, posterior: MockPosterior) -> None:  # noqa: D107
         super(Model, self).__init__()
         self._posterior = posterior
 

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -98,6 +98,12 @@ class MockPosterior(Posterior):
     r"""Mock object that implements dummy methods and feeds through specified outputs"""
 
     def __init__(self, mean=None, variance=None, samples=None):
+        """
+        Args:
+            mean: Defaults to None.
+            variance: Defaults to None.
+            samples: Defaults to None.
+        """
         self._mean = mean
         self._variance = variance
         self._samples = samples
@@ -154,6 +160,10 @@ class MockModel(Model):
     r"""Mock object that implements dummy methods and feeds through specified outputs"""
 
     def __init__(self, posterior: MockPosterior) -> None:
+        """
+        Args:
+            posterior
+        """
         super(Model, self).__init__()
         self._posterior = posterior
 
@@ -191,7 +201,7 @@ class MockModel(Model):
 class MockAcquisitionFunction:
     r"""Mock acquisition function object that implements dummy methods."""
 
-    def __init__(self):
+    def __init__(self):  # noqa: D107
         self.model = None
         self.X_pending = None
 

--- a/botorch/utils/torch.py
+++ b/botorch/utils/torch.py
@@ -56,7 +56,9 @@ class BufferDict(Module):
     def __init__(self, buffers=None):
         """
         Args:
-            buffers: Defaults to None.
+            buffers: A mapping (dictionary) from string to :class:`~torch.Tensor`, or
+                an iterable of key-value pairs of type (string, :class:`~torch.Tensor`).
+                Defaults to None.
         """
         super(BufferDict, self).__init__()
         if buffers is not None:

--- a/botorch/utils/torch.py
+++ b/botorch/utils/torch.py
@@ -54,11 +54,10 @@ class BufferDict(Module):
     """
 
     def __init__(self, buffers=None):
-        """
+        r"""
         Args:
             buffers: A mapping (dictionary) from string to :class:`~torch.Tensor`, or
                 an iterable of key-value pairs of type (string, :class:`~torch.Tensor`).
-                Defaults to None.
         """
         super(BufferDict, self).__init__()
         if buffers is not None:

--- a/botorch/utils/torch.py
+++ b/botorch/utils/torch.py
@@ -54,6 +54,10 @@ class BufferDict(Module):
     """
 
     def __init__(self, buffers=None):
+        """
+        Args:
+            buffers: Defaults to None.
+        """
         super(BufferDict, self).__init__()
         if buffers is not None:
             self.update(buffers)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,10 @@
 [flake8]
 # E203: black and flake8 disagree on whitespace before ':'
 # W503: black and flake8 disagree on how to place operators
-ignore = E203, W503
+# D: all docstring checks (from flake8-docstrings)
+ignore = E203, W503, D
+# D107: check that every __init__ has a docstring
+select = D107
 max-line-length = 88
 exclude =
   build, dist, tutorials, website

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [flake8]
 # E203: black and flake8 disagree on whitespace before ':'
 # W503: black and flake8 disagree on how to place operators
-# D: all docstring checks (from flake8-docstrings)
+# D: Don't run any docstring checks
 ignore = E203, W503, D
-# D107: check that every __init__ has a docstring
-select = D107
+# Do run D107: Missing docstring in public method `__init__`
+extend-select = D107
 max-line-length = 88
 exclude =
   build, dist, tutorials, website

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,13 @@
 [flake8]
 # E203: black and flake8 disagree on whitespace before ':'
 # W503: black and flake8 disagree on how to place operators
-# D: Don't run any docstring checks
+# D: Don't run any docstring checks, except those specified in extend-select
 ignore = E203, W503, D
-# Do run D107: Missing docstring in public method `__init__`
-extend-select = D107
+# D107: Missing docstring in public method `__init__`
+# D417: Missing argument descriptions in the docstring
+# D3*: Quotes issues
+# D207, D208, D214, D215: indentation
+extend-select = D107, D417, D3, D207, D208, D214, D215
 max-line-length = 88
 exclude =
   build, dist, tutorials, website

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
 # Requirements
 TEST_REQUIRES = ["pytest", "pytest-cov"]
 
-FMT_REQUIRES = ["flake8", "ufmt"]
+FMT_REQUIRES = ["flake8", "ufmt", "flake8-docstrings"]
 
 # Read in the pinned versions of the formatting tools
 root_dir = os.path.dirname(__file__)

--- a/test/acquisition/test_max_value_entropy_search.py
+++ b/test/acquisition/test_max_value_entropy_search.py
@@ -33,6 +33,11 @@ class MESMockModel(MockModel):
     r"""Mock object that implements dummy methods and feeds through specified outputs"""
 
     def __init__(self, num_outputs=1, batch_shape=None):
+        """
+        Args:
+            num_outputs: Defaults to 1.
+            batch_shape: Defaults to None.
+        """
         super().__init__(None)
         self._num_outputs = num_outputs
         self._batch_shape = torch.Size() if batch_shape is None else batch_shape

--- a/test/acquisition/test_max_value_entropy_search.py
+++ b/test/acquisition/test_max_value_entropy_search.py
@@ -33,12 +33,11 @@ class MESMockModel(MockModel):
     r"""Mock object that implements dummy methods and feeds through specified outputs"""
 
     def __init__(self, num_outputs=1, batch_shape=None):
-        """
+        r"""
         Args:
-            num_outputs: Number of outputs. Defaults to 1.
-            batch_shape: The batch shape of the model. See
-                `botorch.models.model.Model.batch_shape` for a full description.
-                Defaults to None.
+            num_outputs: The number of outputs.
+            batch_shape: The batch shape of the model. For details see
+                `botorch.models.model.Model.batch_shape`.
         """
         super().__init__(None)
         self._num_outputs = num_outputs

--- a/test/acquisition/test_max_value_entropy_search.py
+++ b/test/acquisition/test_max_value_entropy_search.py
@@ -35,8 +35,10 @@ class MESMockModel(MockModel):
     def __init__(self, num_outputs=1, batch_shape=None):
         """
         Args:
-            num_outputs: Defaults to 1.
-            batch_shape: Defaults to None.
+            num_outputs: Number of outputs. Defaults to 1.
+            batch_shape: The batch shape of the model. See
+                `botorch.models.model.Model.batch_shape` for a full description.
+                Defaults to None.
         """
         super().__init__(None)
         self._num_outputs = num_outputs

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -24,7 +24,7 @@ from torch.distributions.multivariate_normal import MultivariateNormal
 class DummyModel(GPyTorchModel):
     num_outputs = 1
 
-    def __init__(self):
+    def __init__(self):  # noqa: D107
         super(GPyTorchModel, self).__init__()
 
     def subset_output(self, idcs: List[int]) -> Model:

--- a/test/models/test_deterministic.py
+++ b/test/models/test_deterministic.py
@@ -29,8 +29,14 @@ class DummyDeterministicModel(DeterministicModel):
     def __init__(self, outcome_transform, input_transform):
         """
         Args:
-            outcome_transform
-            input_transform
+            outcome_transform: An outcome transform that is applied to the
+                training data during instantiation and to the posterior during
+                inference (that is, the `Posterior` obtained by calling
+                `.posterior` on the model will be on the original scale).
+            input_transform: An input transform that is applied in the model's
+                forward pass. Only input transforms are allowed which do not
+                transform the categorical dimensions. This can be achieved
+                by using the `indices` argument when constructing the transform.
         """
         super().__init__()
         self.input_transform = input_transform

--- a/test/models/test_deterministic.py
+++ b/test/models/test_deterministic.py
@@ -27,7 +27,7 @@ class DummyDeterministicModel(DeterministicModel):
     r"""A dummy deterministic model that uses transforms."""
 
     def __init__(self, outcome_transform, input_transform):
-        """
+        r"""
         Args:
             outcome_transform: An outcome transform that is applied to the
                 training data during instantiation and to the posterior during

--- a/test/models/test_deterministic.py
+++ b/test/models/test_deterministic.py
@@ -27,6 +27,11 @@ class DummyDeterministicModel(DeterministicModel):
     r"""A dummy deterministic model that uses transforms."""
 
     def __init__(self, outcome_transform, input_transform):
+        """
+        Args:
+            outcome_transform
+            input_transform
+        """
         super().__init__()
         self.input_transform = input_transform
         self.outcome_transform = outcome_transform

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -36,7 +36,7 @@ from torch import Tensor
 
 class SimpleInputTransform(InputTransform, torch.nn.Module):
     def __init__(self, transform_on_train: bool) -> None:
-        """
+        r"""
         Args:
             transform_on_train: A boolean indicating whether to apply the
                 transform in train() mode.
@@ -56,13 +56,13 @@ class SimpleGPyTorchModel(GPyTorchModel, ExactGP):
     last_fantasize_flag: bool = False
 
     def __init__(self, train_X, train_Y, outcome_transform=None, input_transform=None):
-        """
+        r"""
         Args:
             train_X: A tensor of inputs, passed to self.transform_inputs.
             train_Y: Passed to outcome_transform.
-            outcome_transform: Transform applied to train_Y. Defaults to None.
+            outcome_transform: Transform applied to train_Y.
             input_transform: A Module that performs the input transformation, passed to
-                self.transform_inputs. Defaults to None.
+                self.transform_inputs.
         """
         with torch.no_grad():
             transformed_X = self.transform_inputs(
@@ -136,9 +136,9 @@ class SimpleBatchedMultiOutputGPyTorchModel(BatchedMultiOutputGPyTorchModel, Exa
 
 class SimpleModelListGPyTorchModel(IndependentModelList, ModelListGPyTorchModel):
     def __init__(self, *gp_models: GPyTorchModel):
-        """
+        r"""
         Args:
-            gp_models: Arbitrary number of GPyTorchModels
+            gp_models: Arbitrary number of GPyTorchModels.
         """
         super().__init__(*gp_models)
 

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -38,7 +38,8 @@ class SimpleInputTransform(InputTransform, torch.nn.Module):
     def __init__(self, transform_on_train: bool) -> None:
         """
         Args:
-            transform_on_train
+            transform_on_train: A boolean indicating whether to apply the
+                transform in train() mode.
         """
         super().__init__()
         self.transform_on_train = transform_on_train
@@ -57,10 +58,11 @@ class SimpleGPyTorchModel(GPyTorchModel, ExactGP):
     def __init__(self, train_X, train_Y, outcome_transform=None, input_transform=None):
         """
         Args:
-            train_X
-            train_Y
-            outcome_transform: Defaults to None.
-            input_transform: Defaults to None.
+            train_X: A tensor of inputs, passed to self.transform_inputs.
+            train_Y: Passed to outcome_transform.
+            outcome_transform: Transform applied to train_Y. Defaults to None.
+            input_transform: A Module that performs the input transformation, passed to
+                self.transform_inputs. Defaults to None.
         """
         with torch.no_grad():
             transformed_X = self.transform_inputs(
@@ -96,10 +98,11 @@ class SimpleBatchedMultiOutputGPyTorchModel(BatchedMultiOutputGPyTorchModel, Exa
     def __init__(self, train_X, train_Y, outcome_transform=None, input_transform=None):
         """
         Args:
-            train_X
-            train_Y
-            outcome_transform: Defaults to None.
-            input_transform: Defaults to None.
+            train_X: A tensor of inputs, passed to self.transform_inputs.
+            train_Y: Passed to outcome_transform.
+            outcome_transform: Transform applied to train_Y. Defaults to None.
+            input_transform: A Module that performs the input transformation, passed to
+                self.transform_inputs. Defaults to None.
         """
         with torch.no_grad():
             transformed_X = self.transform_inputs(

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -96,13 +96,13 @@ class SimpleGPyTorchModel(GPyTorchModel, ExactGP):
 
 class SimpleBatchedMultiOutputGPyTorchModel(BatchedMultiOutputGPyTorchModel, ExactGP):
     def __init__(self, train_X, train_Y, outcome_transform=None, input_transform=None):
-        """
+        r"""
         Args:
             train_X: A tensor of inputs, passed to self.transform_inputs.
             train_Y: Passed to outcome_transform.
-            outcome_transform: Transform applied to train_Y. Defaults to None.
+            outcome_transform: Transform applied to train_Y.
             input_transform: A Module that performs the input transformation, passed to
-                self.transform_inputs. Defaults to None.
+                self.transform_inputs.
         """
         with torch.no_grad():
             transformed_X = self.transform_inputs(

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -36,6 +36,10 @@ from torch import Tensor
 
 class SimpleInputTransform(InputTransform, torch.nn.Module):
     def __init__(self, transform_on_train: bool) -> None:
+        """
+        Args:
+            transform_on_train
+        """
         super().__init__()
         self.transform_on_train = transform_on_train
         self.transform_on_eval = True
@@ -51,6 +55,13 @@ class SimpleGPyTorchModel(GPyTorchModel, ExactGP):
     last_fantasize_flag: bool = False
 
     def __init__(self, train_X, train_Y, outcome_transform=None, input_transform=None):
+        """
+        Args:
+            train_X
+            train_Y
+            outcome_transform: Defaults to None.
+            input_transform: Defaults to None.
+        """
         with torch.no_grad():
             transformed_X = self.transform_inputs(
                 X=train_X, input_transform=input_transform
@@ -83,6 +94,13 @@ class SimpleGPyTorchModel(GPyTorchModel, ExactGP):
 
 class SimpleBatchedMultiOutputGPyTorchModel(BatchedMultiOutputGPyTorchModel, ExactGP):
     def __init__(self, train_X, train_Y, outcome_transform=None, input_transform=None):
+        """
+        Args:
+            train_X
+            train_Y
+            outcome_transform: Defaults to None.
+            input_transform: Defaults to None.
+        """
         with torch.no_grad():
             transformed_X = self.transform_inputs(
                 X=train_X, input_transform=input_transform
@@ -115,6 +133,10 @@ class SimpleBatchedMultiOutputGPyTorchModel(BatchedMultiOutputGPyTorchModel, Exa
 
 class SimpleModelListGPyTorchModel(IndependentModelList, ModelListGPyTorchModel):
     def __init__(self, *gp_models: GPyTorchModel):
+        """
+        Args:
+            gp_models: Arbitrary number of GPyTorchModels
+        """
         super().__init__(*gp_models)
 
 

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -43,18 +43,12 @@ def get_test_warp(indices, **kwargs):
 
 
 class NotSoAbstractInputTransform(InputTransform, Module):
-    def __init__(
+    def __init__(  # noqa: D107
         self,
         transform_on_train,
         transform_on_eval,
         transform_on_fantasize=True,
     ):
-        """
-        Args:
-            transform_on_train
-            transform_on_eval
-            transform_on_fantasize: Defaults to True.
-        """
         super().__init__()
         self.transform_on_train = transform_on_train
         self.transform_on_eval = transform_on_eval

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -49,6 +49,12 @@ class NotSoAbstractInputTransform(InputTransform, Module):
         transform_on_eval,
         transform_on_fantasize=True,
     ):
+        """
+        Args:
+            transform_on_train
+            transform_on_eval
+            transform_on_fantasize: Defaults to True.
+        """
         super().__init__()
         self.transform_on_train = transform_on_train
         self.transform_on_eval = transform_on_eval

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -39,6 +39,10 @@ class MockOneShotAcquisitionFunction(
     MockAcquisitionFunction, OneShotAcquisitionFunction
 ):
     def __init__(self, num_fantasies=2):
+        """
+        Args:
+            num_fantasies: Defaults to 2.
+        """
         super().__init__()
         self.num_fantasies = num_fantasies
 
@@ -54,6 +58,10 @@ class MockOneShotAcquisitionFunction(
 
 class SquaredAcquisitionFunction(AcquisitionFunction):
     def __init__(self, model=None):
+        """
+        Args:
+            model: Defaults to None.
+        """
         super().__init__(model=model)
 
     def forward(self, X):

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -41,7 +41,7 @@ class MockOneShotAcquisitionFunction(
     def __init__(self, num_fantasies=2):
         """
         Args:
-            num_fantasies: Defaults to 2.
+            num_fantasies: Number of fantasies. Defaults to 2.
         """
         super().__init__()
         self.num_fantasies = num_fantasies
@@ -60,7 +60,7 @@ class SquaredAcquisitionFunction(AcquisitionFunction):
     def __init__(self, model=None):
         """
         Args:
-            model: Defaults to None.
+            model: A fitted model. Defaults to None.
         """
         super().__init__(model=model)
 

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -39,9 +39,9 @@ class MockOneShotAcquisitionFunction(
     MockAcquisitionFunction, OneShotAcquisitionFunction
 ):
     def __init__(self, num_fantasies=2):
-        """
+        r"""
         Args:
-            num_fantasies: Number of fantasies. Defaults to 2.
+            num_fantasies: The number of fantasies.
         """
         super().__init__()
         self.num_fantasies = num_fantasies

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -57,11 +57,7 @@ class MockOneShotAcquisitionFunction(
 
 
 class SquaredAcquisitionFunction(AcquisitionFunction):
-    def __init__(self, model=None):
-        """
-        Args:
-            model: A fitted model. Defaults to None.
-        """
+    def __init__(self, model=None):  # noqa: D107
         super().__init__(model=model)
 
     def forward(self, X):


### PR DESCRIPTION
## Motivation
See #1306 for context.

When a class lacks an `__init__` docstring and has a super class, Sphinx will render the super class's docstring, which makes the documentation on botorch.org confusing and often incorrect. 

[x] Add D107 check from `flake8-docstrings` to prevent this issue from recurring, and [several others](https://github.com/pytorch/botorch/pull/1313#issuecomment-1186030721) that seem useful
[x] Check that the newly added checks (and nothing else) are correctly triggered in Actions
[x] Move `args` block from class to `__init__` docstrings (see #1306 for context)
[x] Add `__init__` docstrings where they are missing
[x] Update [CONTRIBUTING.md](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests) to explain usage and installation of `flake8` with `flake8-docstrings`
[x] Build website and read it over

#1306 also requires making ABCs and other classes that should not be instantiated private. That is not done in this PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes. Violated the guideline to fork so that I can test Actions.

## Test Plan
[x] [Actions run](https://github.com/pytorch/botorch/runs/7364978964?check_suite_focus=true#logs) identifies classes missing `__init__` docstrings
[x] After fixing the docstrings, there are no more lint issues in Actions