### PR TITLE
Update publish_site script to use https for git clone

### DIFF
--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -62,8 +62,8 @@ if [[ $DOCUSAURUS_BOT == true ]]; then
   git clone https://docusaurus-bot@github.com/pytorch/botorch.git botorch-main
   git clone --branch gh-pages https://docusaurus-bot@github.com/pytorch/botorch.git botorch-gh-pages
 else
-  git clone git@github.com:pytorch/botorch.git botorch-main
-  git clone --branch gh-pages git@github.com:pytorch/botorch.git botorch-gh-pages
+  git clone https://github.com/pytorch/botorch.git botorch-main
+  git clone --branch gh-pages https://github.com/pytorch/botorch.git botorch-gh-pages
 fi
 
 # A few notes about the script below:


### PR DESCRIPTION
The current script throws a weird permission error due to the use of git@github pattern. With this change, the script works for manually publishing the website.