### PR TITLE
Use https for pip github install on website

### DIFF
--- a/scripts/versions.js
+++ b/scripts/versions.js
@@ -53,7 +53,7 @@ function Versions(props) {
                 </td>
                 <td>
                   <code>
-                    pip install git+ssh://git@github.com/pytorch/botorch.git
+                    pip install https://github.com/pytorch/botorch.git
                   </code>
                 </td>
                 <td>

--- a/scripts/versions.js
+++ b/scripts/versions.js
@@ -53,7 +53,7 @@ function Versions(props) {
                 </td>
                 <td>
                   <code>
-                    pip install https://github.com/pytorch/botorch.git
+                    pip install git+https://github.com/pytorch/botorch.git
                   </code>
                 </td>
                 <td>


### PR DESCRIPTION
By default people should just use https for git install, no need to go through ssh. Quick follow-up to #1314