### PR TITLE
Build pypi packages with build

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -50,10 +50,10 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .[test]
-        pip install --upgrade setuptools setuptools_scm wheel
+        pip install --upgrade build setuptools setuptools_scm wheel
     - name: Build packages (wheel and source distribution)
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel
     - name: Verify packages
       run: |
         ./scripts/build_and_verify_py_packages.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
         pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[test]
-        pip install --upgrade setuptools setuptools_scm wheel
+        pip install --upgrade build setuptools setuptools_scm wheel
     - name: Extract reduced version and save to env var
       # strip the commit hash from the version to enable upload to pypi
       # env var will persist for subsequent steps
@@ -62,7 +62,7 @@ jobs:
         echo "SETUPTOOLS_SCM_PRETEND_VERSION=${no_local_version}" >> $GITHUB_ENV
     - name: Build packages (wheel and source distribution)
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel
     - name: Verify packages
       run: |
         ./scripts/build_and_verify_py_packages.sh

--- a/scripts/test_packaging.sh
+++ b/scripts/test_packaging.sh
@@ -11,13 +11,13 @@ conda update -y -n base -c defaults conda
 conda install -y pip
 
 # install python packaging deps
-pip install --upgrade setuptools wheel twine
+pip install --upgrade setuptools build wheel twine
 
 # install conda-build
 conda install -y conda-build
 
 # test python packaging
-python setup.py sdist bdist_wheel
+python -m build --sdist --wheel
 
 # test conda packaging
 conda config --show


### PR DESCRIPTION
Invoking `python setup.py sdist bdist_wheel` to build the packages is deprecated. This instead uses the PEP517-compliant build frontend `build` as per https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/