### PR TITLE
Properly invoke `setuptools_scm`

### DIFF
--- a/.conda/build_conda.sh
+++ b/.conda/build_conda.sh
@@ -7,7 +7,7 @@
 # we cannot use relative paths here, since setuptools_scm options in
 # pyproject.toml cannot dynamically determine the root dir
 cd .. || exit
-BOTORCH_VERSION="$(python setup.py --version)"
+BOTORCH_VERSION="$(python -m setuptools_scm)"
 export BOTORCH_VERSION
 cd .conda || exit
 

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -15,7 +15,7 @@ requirements:
   host:
     - python>=3.7
     - setuptools
-    - setuptools-scm
+    - setuptools_scm
   run:
     - pytorch >=1.10
     - gpytorch >=1.7

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Deploy to anaconda.org
       shell: bash -l {0}
       run: |
-        botorch_version=$(python setup.py --version)
+        botorch_version=$(python -m setuptools_scm)
         build_dir="$(pwd)/.conda/conda_build/noarch"
         pkg_file="${build_dir}/botorch-${botorch_version}-0.tar.bz2"
         anaconda -t ${{ secrets.ANACONDA_UPLOAD_TOKEN }} upload -u pytorch $pkg_file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm", "wheel"]
+requires = ["setuptools", "setuptools_scm[toml]", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/scripts/build_and_verify_conda_package.sh
+++ b/scripts/build_and_verify_conda_package.sh
@@ -6,6 +6,11 @@
 
 # Get version number (created dynamically via setuptools-scm)
 BOTORCH_VERSION=$(python -m setuptools_scm)
+if [[ $? != "0" ]]; then
+  echo "Determininig version via setuptools_scm failed."
+  echo "Make sure that setuptools_scm is installed in your python environment."
+  exit 1
+fi
 # Export env var (this is used in .conda/meta.yaml)
 export BOTORCH_VERSION
 

--- a/scripts/build_and_verify_conda_package.sh
+++ b/scripts/build_and_verify_conda_package.sh
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # Get version number (created dynamically via setuptools-scm)
-BOTORCH_VERSION=$(python setup.py --version)
+BOTORCH_VERSION=$(python -m setuptools_scm)
 # Export env var (this is used in .conda/meta.yaml)
 export BOTORCH_VERSION
 

--- a/scripts/build_and_verify_py_packages.sh
+++ b/scripts/build_and_verify_py_packages.sh
@@ -6,6 +6,11 @@
 
 # Get version number (created dynamically via setuptools-scm)
 version=$(python -m setuptools_scm)
+if [[ $? != "0" ]]; then
+  echo "Determininig version via setuptools_scm failed."
+  echo "Make sure that setuptools_scm is installed in your python environment."
+  exit 1
+fi
 cur_dir=$(pwd)
 
 # set up temporary working directory

--- a/scripts/build_and_verify_py_packages.sh
+++ b/scripts/build_and_verify_py_packages.sh
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # Get version number (created dynamically via setuptools-scm)
-version=$(python setup.py --version)
+version=$(python -m setuptools_scm)
 cur_dir=$(pwd)
 
 # set up temporary working directory

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ setup(
     long_description_content_type="text/markdown",
     python_requires=">=3.7",
     packages=find_packages(exclude=["test", "test.*"]),
-    setup_requires=["setuptools", "setuptools_scm", "wheel"],
     install_requires=[
         "torch>=1.10",
         "gpytorch>=1.7",

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
     long_description_content_type="text/markdown",
     python_requires=">=3.7",
     packages=find_packages(exclude=["test", "test.*"]),
+    setup_requires=["setuptools", "setuptools_scm", "wheel"],
     install_requires=[
         "torch>=1.10",
         "gpytorch>=1.7",


### PR DESCRIPTION
Previously, running things like `python setup.py --version` would just return 0.0.0 if `setuptools_scm` was not installed. 

This use of setuptools_scm is deprecated, this PR changes things to run `python -m setuptools_scm` as suggested here: https://github.com/pypa/setuptools_scm#pyprojecttoml-usage

This way, a missing setuptools_scm installation will raise an error ("No module named...") rather than "inferring" a version 0.0.0. 