### PR TITLE
fixing `qProbabilityOfImprovement` when `best_f` is a `batch_shape` shaped tensor

### DIFF
--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -459,9 +459,9 @@ class qProbabilityOfImprovement(MCAcquisitionFunction):
             X=X, posterior_transform=self.posterior_transform
         )
         samples = self.sampler(posterior)
-        obj = self.objective(samples, X=X)
-        max_obj = obj.max(dim=-1)[0]
-        impr = max_obj - self.best_f.unsqueeze(-1).to(max_obj)
+        obj = self.objective(samples, X=X)  # `sample_shape x batch_shape x q`-dim
+        max_obj = obj.max(dim=-1)[0]  # `sample_shape x batch_shape`-dim
+        impr = max_obj - self.best_f.to(max_obj)
         val = torch.sigmoid(impr / self.tau).mean(dim=0)
         return val
 

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -156,6 +156,15 @@ class TestQExpectedImprovement(BotorchTestCase):
             self.assertEqual(res[0].item(), 1.0)
             self.assertEqual(res[1].item(), 0.0)
 
+            # test batch model, batched best_f values
+            sampler = IIDNormalSampler(num_samples=3)
+            acqf = qExpectedImprovement(
+                model=mm, best_f=torch.Tensor([0, 0]), sampler=sampler
+            )
+            res = acqf(X)
+            self.assertEqual(res[0].item(), 1.0)
+            self.assertEqual(res[1].item(), 0.0)
+
             # test shifting best_f value
             acqf = qExpectedImprovement(model=mm, best_f=-1, sampler=sampler)
             res = acqf(X)
@@ -659,6 +668,15 @@ class TestQProbabilityOfImprovement(BotorchTestCase):
             # test batch mode
             sampler = IIDNormalSampler(num_samples=2)
             acqf = qProbabilityOfImprovement(model=mm, best_f=0, sampler=sampler)
+            res = acqf(X)
+            self.assertEqual(res[0].item(), 1.0)
+            self.assertEqual(res[1].item(), 0.5)
+
+            # test batch model, batched best_f values
+            sampler = IIDNormalSampler(num_samples=3)
+            acqf = qProbabilityOfImprovement(
+                model=mm, best_f=torch.Tensor([0, 0]), sampler=sampler
+            )
             res = acqf(X)
             self.assertEqual(res[0].item(), 1.0)
             self.assertEqual(res[1].item(), 0.5)


### PR DESCRIPTION
Summary:
`qProbabilityOfImprovement` is reporting an error when the input `best_f` is a `batch_shape` shaped tensor.

See N2259928 for the error.

Fixed the issue by not applying `unsqueeze()` to `best_f` when computing the improvement.

Differential Revision: D38076823

