### PR TITLE
Error handling and restarting in optimization

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -212,18 +212,22 @@ def gen_candidates_scipy(
         options={k: v for k, v in options.items() if k not in ["method", "callback"]},
     )
 
-    if "success" not in res.keys():
-        warnings.warn(
-            "Optimization failed within `scipy.optimize.minimize` with no "
-            "status returned to `res.`",
-            OptimizationWarning,
-        )
+    if "success" not in res.keys() or "status" not in res.keys():
+        with warnings.catch_warnings():
+            warnings.simplefilter("always", category=OptimizationWarning)
+            warnings.warn(
+                "Optimization failed within `scipy.optimize.minimize` with no "
+                "status returned to `res.`",
+                OptimizationWarning,
+            )
     elif not res.success:
-        warnings.warn(
-            f"Optimization failed within `scipy.optimize.minimize` with status "
-            f"{res.status}.",
-            OptimizationWarning,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("always", category=OptimizationWarning)
+            warnings.warn(
+                f"Optimization failed within `scipy.optimize.minimize` with status "
+                f"{res.status}.",
+                OptimizationWarning,
+            )
     candidates = fix_features(
         X=torch.from_numpy(res.x).to(initial_conditions).reshape(shapeX),
         fixed_features=fixed_features,

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -26,7 +26,7 @@ from botorch.acquisition.knowledge_gradient import (
     qKnowledgeGradient,
 )
 from botorch.acquisition.utils import is_nonnegative
-from botorch.exceptions.errors import BotorchTensorDimensionError
+from botorch.exceptions.errors import BotorchTensorDimensionError, UnsupportedError
 from botorch.exceptions.warnings import (
     BadInitialCandidatesWarning,
     BotorchWarning,
@@ -104,6 +104,12 @@ def gen_batch_initial_conditions(
             "for generating initial conditions for optimization."
         )
     options = options or {}
+    sample_around_best = options.get("sample_around_best", False)
+    if sample_around_best and equality_constraints:
+        raise UnsupportedError(
+            "Option 'sample_around_best' is not supported when equality"
+            "constraints are present."
+        )
     seed: Optional[int] = options.get("seed")
     batch_limit: Optional[int] = options.get(
         "init_batch_limit", options.get("batch_limit")
@@ -160,7 +166,7 @@ def gen_batch_initial_conditions(
                     .cpu()
                 )
             # sample points around best
-            if options.get("sample_around_best", False):
+            if sample_around_best:
                 X_best_rnd = sample_points_around_best(
                     acq_function=acq_function,
                     n_discrete_points=n * q,

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -284,9 +284,7 @@ def optimize_acqf(
             f"warning(s):\n{[w.message for w in ws]}\nTrying again with a new "
             "set of initial conditions."
         )
-        with warnings.catch_warnings():
-            warnings.simplefilter("always", category=OptimizationWarning)
-            warnings.warn(first_warn_msg, OptimizationWarning)
+        warnings.warn(first_warn_msg, RuntimeWarning)
 
         if not initial_conditions_provided:
             batch_initial_conditions = _gen_initial_conditions()
@@ -297,13 +295,11 @@ def optimize_acqf(
                 (issubclass(w.category, OptimizationWarning) for w in ws)
             )
             if optimization_warning_raised:
-                with warnings.catch_warnings():
-                    warnings.simplefilter("always", category=OptimizationWarning)
-                    warnings.warn(
-                        "Optimization failed on the second try, after generating a "
-                        "new set of initial conditions.",
-                        OptimizationWarning,
-                    )
+                warnings.warn(
+                    "Optimization failed on the second try, after generating a "
+                    "new set of initial conditions.",
+                    RuntimeWarning,
+                )
 
     if post_processing_func is not None:
         batch_candidates = post_processing_func(batch_candidates)

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -193,7 +193,6 @@ def optimize_acqf(
         return X, acq_value
 
     if batch_initial_conditions is None:
-        # we go through this branch
         if nonlinear_inequality_constraints:
             raise NotImplementedError(
                 "`batch_initial_conditions` must be given if there are non-linear "
@@ -204,9 +203,6 @@ def optimize_acqf(
                 "Must specify `raw_samples` when `batch_initial_conditions` is `None`."
             )
 
-        # in this case it's not a qKnowledgeGradient
-        # ic_gen = gen_batch_initial_conditions
-        # we could set batch_initial_conditions to simplify; it's a tensor
         ic_gen = (
             gen_one_shot_kg_initial_conditions
             if isinstance(acq_function, qKnowledgeGradient)
@@ -230,7 +226,6 @@ def optimize_acqf(
     batch_candidates_list: List[Tensor] = []
     batch_acq_values_list: List[Tensor] = []
     batched_ics = batch_initial_conditions.split(batch_limit)
-    # we only do one iteration
     for i, batched_ics_ in enumerate(batched_ics):
         # optimize using random restart optimization
         batch_candidates_curr, batch_acq_values_curr = gen_candidates_scipy(
@@ -244,20 +239,16 @@ def optimize_acqf(
             nonlinear_inequality_constraints=nonlinear_inequality_constraints,
             fixed_features=fixed_features,
         )
-        # This is the violated equality constraint
-        print(batch_candidates_curr[:, 0, :3].sum(1))
         batch_candidates_list.append(batch_candidates_curr)
         batch_acq_values_list.append(batch_acq_values_curr)
         logger.info(f"Generated candidate batch {i+1} of {len(batched_ics)}.")
     batch_candidates = torch.cat(batch_candidates_list)
     batch_acq_values = torch.cat(batch_acq_values_list)
 
-    # we don't go down this branch
     if post_processing_func is not None:
         batch_candidates = post_processing_func(batch_candidates)
 
     if return_best_only:
-        # best is 0 (seems legit)
         best = torch.argmax(batch_acq_values.view(-1), dim=0)
         batch_candidates = batch_candidates[best]
         batch_acq_values = batch_acq_values[best]

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -10,6 +10,8 @@ Methods for optimizing acquisition functions.
 
 from __future__ import annotations
 
+import warnings
+
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -19,6 +21,7 @@ from botorch.acquisition.acquisition import (
 )
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
 from botorch.exceptions import InputDataError, UnsupportedError
+from botorch.exceptions.warnings import OptimizationWarning
 from botorch.generation.gen import gen_candidates_scipy
 from botorch.logging import logger
 from botorch.optim.initializers import (
@@ -192,7 +195,8 @@ def optimize_acqf(
             acq_value = acq_function(X)
         return X, acq_value
 
-    if batch_initial_conditions is None:
+    initial_conditions_provided = batch_initial_conditions is not None
+    if not initial_conditions_provided:
         if nonlinear_inequality_constraints:
             raise NotImplementedError(
                 "`batch_initial_conditions` must be given if there are non-linear "
@@ -203,6 +207,7 @@ def optimize_acqf(
                 "Must specify `raw_samples` when `batch_initial_conditions` is `None`."
             )
 
+    def _gen_initial_conditions() -> Tensor:
         ic_gen = (
             gen_one_shot_kg_initial_conditions
             if isinstance(acq_function, qKnowledgeGradient)
@@ -219,17 +224,22 @@ def optimize_acqf(
             inequality_constraints=inequality_constraints,
             equality_constraints=equality_constraints,
         )
+        return batch_initial_conditions
+
+    if not initial_conditions_provided:
+        batch_initial_conditions = _gen_initial_conditions()
 
     batch_limit: int = options.get(
         "batch_limit", num_restarts if not nonlinear_inequality_constraints else 1
     )
-    batch_candidates_list: List[Tensor] = []
-    batch_acq_values_list: List[Tensor] = []
-    batched_ics = batch_initial_conditions.split(batch_limit)
-    for i, batched_ics_ in enumerate(batched_ics):
-        # optimize using random restart optimization
-        batch_candidates_curr, batch_acq_values_curr = gen_candidates_scipy(
-            initial_conditions=batched_ics_,
+
+    def _optimize_batch_candidates() -> Tuple[Tensor, Tensor, List[Warning]]:
+        batch_candidates_list: List[Tensor] = []
+        batch_acq_values_list: List[Tensor] = []
+        batched_ics = batch_initial_conditions.split(batch_limit)
+        opt_warnings = []
+
+        scipy_kws = dict(
             acquisition_function=acq_function,
             lower_bounds=None if bounds[0].isinf().all() else bounds[0],
             upper_bounds=None if bounds[1].isinf().all() else bounds[1],
@@ -239,11 +249,60 @@ def optimize_acqf(
             nonlinear_inequality_constraints=nonlinear_inequality_constraints,
             fixed_features=fixed_features,
         )
-        batch_candidates_list.append(batch_candidates_curr)
-        batch_acq_values_list.append(batch_acq_values_curr)
-        logger.info(f"Generated candidate batch {i+1} of {len(batched_ics)}.")
-    batch_candidates = torch.cat(batch_candidates_list)
-    batch_acq_values = torch.cat(batch_acq_values_list)
+
+        for i, batched_ics_ in enumerate(batched_ics):
+            # optimize using random restart optimization
+            with warnings.catch_warnings(record=True) as ws:
+                warnings.simplefilter("always", category=OptimizationWarning)
+                batch_candidates_curr, batch_acq_values_curr = gen_candidates_scipy(
+                    initial_conditions=batched_ics_, **scipy_kws
+                )
+            opt_warnings += ws
+            batch_candidates_list.append(batch_candidates_curr)
+            batch_acq_values_list.append(batch_acq_values_curr)
+            logger.info(f"Generated candidate batch {i+1} of {len(batched_ics)}.")
+
+        batch_candidates = torch.cat(batch_candidates_list)
+        batch_acq_values = torch.cat(batch_acq_values_list)
+        return batch_candidates, batch_acq_values, opt_warnings
+
+    batch_candidates, batch_acq_values, ws = _optimize_batch_candidates()
+
+    optimization_warning_raised = any(
+        (issubclass(w.category, OptimizationWarning) for w in ws)
+    )
+    if optimization_warning_raised:
+        if initial_conditions_provided:
+            warnings.warn(
+                "Optimization failed in `gen_candidates_scipy` with the "
+                f"following warning(s):\n{[w.message for w in ws]}\nBecause "
+                "you specified `batch_initial_conditions`, optimization will "
+                "not be retried with new initial conditions and will proceed "
+                "with the current solution. Suggested remediation: Try again "
+                "with different `batch_initial_conditions`, or don't provide "
+                "`batch_initial_conditions.`",
+                OptimizationWarning,
+            )
+        else:
+            warnings.warn(
+                "Optimization failed in `gen_candidates_scipy` with the "
+                f"following warning(s):\n{[w.message for w in ws]}\nTrying "
+                "again with a new set of initial conditions.",
+                OptimizationWarning,
+            )
+            batch_initial_conditions = _gen_initial_conditions()
+
+            batch_candidates, batch_acq_values, ws = _optimize_batch_candidates()
+
+            optimization_warning_raised = any(
+                (issubclass(w.category, OptimizationWarning) for w in ws)
+            )
+            if optimization_warning_raised:
+                warnings.warn(
+                    "Optimization failed on the second try, after generating a "
+                    "new set of initial conditions.",
+                    OptimizationWarning,
+                )
 
     if post_processing_func is not None:
         batch_candidates = post_processing_func(batch_candidates)

--- a/test/generation/test_gen.py
+++ b/test/generation/test_gen.py
@@ -201,11 +201,12 @@ class TestGenCandidates(TestBaseCandidateGeneration):
             self.assertTrue(candidates[1].item() == 0.25)
 
     def test_gen_candidates_scipy_warns_opt_failure(self):
-        options = {"maxls": 1}
         with warnings.catch_warnings(record=True) as ws:
             warnings.simplefilter("always", category=OptimizationWarning)
-            self.test_gen_candidates(options=options)
-        expected_msg = "Optimization failed within `scipy.optimize.minimize` with "
+            self.test_gen_candidates(options={"maxls": 1})
+        expected_msg = (
+            "Optimization failed within `scipy.optimize.minimize` with status 2."
+        )
         expected_warning_raised = any(
             (
                 issubclass(w.category, OptimizationWarning)

--- a/test/generation/test_gen.py
+++ b/test/generation/test_gen.py
@@ -200,6 +200,21 @@ class TestGenCandidates(TestBaseCandidateGeneration):
             self.assertTrue(-EPS <= candidates[0] <= 1 + EPS)
             self.assertTrue(candidates[1].item() == 0.25)
 
+    def test_gen_candidates_scipy_warns_opt_failure(self):
+        options = {"maxls": 1}
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("always", category=OptimizationWarning)
+            self.test_gen_candidates(options=options)
+        expected_msg = "Optimization failed within `scipy.optimize.minimize` with "
+        expected_warning_raised = any(
+            (
+                issubclass(w.category, OptimizationWarning)
+                and expected_msg in str(w.message)
+                for w in ws
+            )
+        )
+        self.assertTrue(expected_warning_raised)
+
     def test_gen_candidates_torch_with_fixed_features(self):
         self.test_gen_candidates_with_fixed_features(
             gen_candidates=gen_candidates_torch, options={"disp": False}

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -14,7 +14,7 @@ from botorch.acquisition.acquisition import (
     AcquisitionFunction,
     OneShotAcquisitionFunction,
 )
-from botorch.exceptions import InputDataError, OptimizationWarning, UnsupportedError
+from botorch.exceptions import InputDataError, UnsupportedError
 from botorch.optim.optimize import (
     _filter_infeasible,
     _filter_invalid,
@@ -359,8 +359,7 @@ class TestOptimizeAcqf(BotorchTestCase):
         )
         expected_warning_raised = any(
             (
-                issubclass(w.category, OptimizationWarning)
-                and message in str(w.message)
+                issubclass(w.category, RuntimeWarning) and message in str(w.message)
                 for w in ws
             )
         )
@@ -404,8 +403,7 @@ class TestOptimizeAcqf(BotorchTestCase):
         )
         expected_warning_raised = any(
             (
-                issubclass(w.category, OptimizationWarning)
-                and message in str(w.message)
+                issubclass(w.category, RuntimeWarning) and message in str(w.message)
                 for w in ws
             )
         )
@@ -458,15 +456,13 @@ class TestOptimizeAcqf(BotorchTestCase):
         )
         first_expected_warning_raised = any(
             (
-                issubclass(w.category, OptimizationWarning)
-                and message_1 in str(w.message)
+                issubclass(w.category, RuntimeWarning) and message_1 in str(w.message)
                 for w in ws
             )
         )
         second_expected_warning_raised = any(
             (
-                issubclass(w.category, OptimizationWarning)
-                and message_2 in str(w.message)
+                issubclass(w.category, RuntimeWarning) and message_2 in str(w.message)
                 for w in ws
             )
         )

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -338,7 +338,6 @@ class TestOptimizeAcqf(BotorchTestCase):
         initial_conditions = 1e-8 * torch.ones((num_restarts, raw_samples, dim))
         torch.manual_seed(0)
         with warnings.catch_warnings(record=True) as ws:
-            warnings.simplefilter("always", category=OptimizationWarning)
             batch_candidates, acq_value_list = optimize_acqf(
                 acq_function=SinOneOverXAcqusitionFunction(),
                 bounds=torch.stack([-1 * torch.ones(dim), torch.ones(dim)]),
@@ -387,7 +386,6 @@ class TestOptimizeAcqf(BotorchTestCase):
         torch.manual_seed(5)
 
         with warnings.catch_warnings(record=True) as ws:
-            warnings.simplefilter("always", category=OptimizationWarning)
             batch_candidates, acq_value_list = optimize_acqf(
                 acq_function=SinOneOverXAcqusitionFunction(),
                 bounds=bounds,
@@ -435,7 +433,6 @@ class TestOptimizeAcqf(BotorchTestCase):
         )
 
         with warnings.catch_warnings(record=True) as ws:
-            warnings.simplefilter("always", category=OptimizationWarning)
             torch.manual_seed(230)
             batch_candidates, acq_value_list = optimize_acqf(
                 acq_function=SinOneOverXAcqusitionFunction(),
@@ -525,7 +522,12 @@ class TestOptimizeAcqf(BotorchTestCase):
             # Make sure we return the initial solution if SLSQP fails to return
             # a feasible point.
             with mock.patch("botorch.generation.gen.minimize") as mock_minimize:
-                mock_minimize.return_value = OptimizeResult(x=np.array([4, 4, 4]))
+                # By setting "success" to True and "status" to 0, we prevent a
+                # warning that `minimize` failed, which isn't the behavior
+                # we're looking to test here.
+                mock_minimize.return_value = OptimizeResult(
+                    x=np.array([4, 4, 4]), success=True, status=0
+                )
                 candidates, acq_value = optimize_acqf(
                     acq_function=mock_acq_function,
                     bounds=bounds,

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -148,7 +148,6 @@ class TestFitGPyTorchModel(BotorchTestCase):
             # because of different scipy OptimizeResult.message type
             if optimizer == fit_gpytorch_scipy:
                 with warnings.catch_warnings(record=True) as ws, settings.debug(True):
-                    warnings.simplefilter("always", category=OptimizationWarning)
                     mll, info_dict = optimizer(
                         mll, options=options, track_iterations=False, method="slsqp"
                     )


### PR DESCRIPTION
## Motivation

Several issues were discussed in #1227:
- `scipy.optimize.minimize` and functions that call it can fail without warnings or errors.
- We allow use of `sample_around_best` with equality constraints even though it likely would not produce valid solutions.

Changes in this PR:
- Issue a warning in `gen_candidates_scipy` if Scipy reports that optimization failed.
- Raise an `UnsupportedError` in `gen_batch_inital_conditions` if the user tries to use the `"sample around best"` option in combination with equality constraints
- `optimize_acqf` catches optimization warnings from `gen_candidates_scipy`. If there are user-provided `batch_initial_conditions`, it raises a warning and suggests trying different initial conditions. Otherwise, it generates new initial conditions and tries again, generating another warning if it didn't work even on the second try.

I'd be curious to hear if people think that re-trying with new initial conditions could create a performance regression. That could happen if Scipy has been overly aggressive in tagging optimization runs as "failed" when they were actually good enough.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Test in `test_gen.py` for the optimization warning from `gen_candidates_scipy`
- Test that the appropriate `UnsupportedError` is raised in `gen_batch_initial_conditions`
Several tests that the appropriate warnings are raised and appropriate re-try happens in `optimize_acqf`:
- A case where it fails due to bad user-provided ICs
- A case where it fails due to bad ICs due to a bad seed, then succeeds on retry
- A case where it fails due to bad ICs due to a bad seed and fails again on retry
