### PR TITLE
Expanded docstrings for models in modules "model",  "gp_regression", "deterministic", and "cost"

### DIFF
--- a/botorch/models/cost.py
+++ b/botorch/models/cost.py
@@ -7,11 +7,10 @@
 r"""
 Cost models to be used with multi-fidelity optimization.
 
-Cost models are deterministic models, useful for defining known cost functions
-when the cost of an evaluation is heterogeneous in fidelity. For a full worked
-example, see the
-`tutorial <https://botorch.org/tutorials/multi_fidelity_bo>`_
-on continuous multi-fidelity Bayesian Optimization.
+Cost are useful for defining known cost functions when the cost of an evaluation
+is heterogeneous in fidelity. For a full worked example, see the
+`tutorial <https://botorch.org/tutorials/multi_fidelity_bo>`_ on continuous
+multi-fidelity Bayesian Optimization.
 """
 
 from __future__ import annotations
@@ -24,12 +23,16 @@ from torch import Tensor
 
 
 class AffineFidelityCostModel(DeterministicModel):
-    r"""Affine cost model operating on fidelity parameters.
+    r"""Deterministic, affine cost model operating on fidelity parameters.
 
     For each (q-batch) element of a candidate set `X`, this module computes a
     cost of the form
 
         cost = fixed_cost + sum_j weights[j] * X[fidelity_dims[j]]
+
+    For a full worked example, see the
+    `tutorial <https://botorch.org/tutorials/multi_fidelity_bo>`_ on continuous
+    multi-fidelity Bayesian Optimization.
 
     Example:
         >>> from botorch.models import AffineFidelityCostModel

--- a/botorch/models/cost.py
+++ b/botorch/models/cost.py
@@ -6,6 +6,12 @@
 
 r"""
 Cost models to be used with multi-fidelity optimization.
+
+Cost models are deterministic models, useful for defining known cost functions
+when the cost of an evaluation is heterogeneous in fidelity. For a full worked
+example, see the
+`tutorial <https://botorch.org/tutorials/multi_fidelity_bo>`_
+on continuous multi-fidelity Bayesian Optimization.
 """
 
 from __future__ import annotations
@@ -24,6 +30,14 @@ class AffineFidelityCostModel(DeterministicModel):
     cost of the form
 
         cost = fixed_cost + sum_j weights[j] * X[fidelity_dims[j]]
+
+    Example:
+        >>> from botorch.models import AffineFidelityCostModel
+        >>> from botorch.acquisition.cost_aware import InverseCostWeightedUtility
+        >>> cost_model = AffineFidelityCostModel(
+        >>>    fidelity_weights={6: 1.0}, fixed_cost=5.0
+        >>> )
+        >>> cost_aware_utility = InverseCostWeightedUtility(cost_model=cost_model)
     """
 
     def __init__(
@@ -31,13 +45,12 @@ class AffineFidelityCostModel(DeterministicModel):
         fidelity_weights: Optional[Dict[int, float]] = None,
         fixed_cost: float = 0.01,
     ) -> None:
-        r"""Affine cost model operating on fidelity parameters.
-
+        r"""
         Args:
             fidelity_weights: A dictionary mapping a subset of columns of `X`
-                (the fidelity parameters) to it's associated weight in the
+                (the fidelity parameters) to its associated weight in the
                 affine cost expression. If omitted, assumes that the last
-                column of X is the fidelity parameter with a weight of 1.0.
+                column of `X` is the fidelity parameter with a weight of 1.0.
             fixed_cost: The fixed cost of running a single candidate point (i.e.
                 an element of a q-batch).
         """

--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -8,7 +8,11 @@ r"""
 Deterministic Models: Simple wrappers that allow the usage of deterministic
 mappings via the BoTorch Model and Posterior APIs.
 
-Deterministic models are useful for defining known cost functions for
+Deterministic models are useful for expressing known input-output relationships
+within the BoTorch Model API. This is useful e.g. for multi-objective optimization
+with known objective functions (e.g. the number of parameters of a Neural Network
+in the context of Neural Architecture Search is usually a known function of the 
+architecture configuration), or to encode cost functions for
 cost-aware acquisition utilities. Cost-aware optimization is desirable when
 evaluations have a cost that is heterogeneous, either in the inputs `X` or in a
 particular fidelity parameter that directly encodes the fidelity of the

--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -9,10 +9,10 @@ Deterministic Models: Simple wrappers that allow the usage of deterministic
 mappings via the BoTorch Model and Posterior APIs.
 
 Deterministic models are useful for expressing known input-output relationships
-within the BoTorch Model API. This is useful e.g. for multi-objective optimization
-with known objective functions (e.g. the number of parameters of a Neural Network
-in the context of Neural Architecture Search is usually a known function of the 
-architecture configuration), or to encode cost functions for
+within the BoTorch Model API. This is useful e.g. for multi-objective
+optimization with known objective functions (e.g. the number of parameters of a
+Neural Network in the context of Neural Architecture Search is usually a known
+function of the architecture configuration), or to encode cost functions for
 cost-aware acquisition utilities. Cost-aware optimization is desirable when
 evaluations have a cost that is heterogeneous, either in the inputs `X` or in a
 particular fidelity parameter that directly encodes the fidelity of the

--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -5,9 +5,19 @@
 # LICENSE file in the root directory of this source tree.
 
 r"""
-Deterministic Models. Simple wrappers that allow the usage of deterministic
-mappings via the BoTorch Model and Posterior APIs. Useful e.g. for defining
-known cost functions for cost-aware acquisition utilities.
+Deterministic Models: Simple wrappers that allow the usage of deterministic
+mappings via the BoTorch Model and Posterior APIs.
+
+Deterministic models are useful for defining known cost functions for
+cost-aware acquisition utilities. Cost-aware optimization is desirable when
+evaluations have a cost that is heterogeneous, either in the inputs `X` or in a
+particular fidelity parameter that directly encodes the fidelity of the
+observation. `GenericDeterministicModel` supports arbitrary deterministic
+functions, while `AffineFidelityCostModel` is a particular cost model for
+multi-fidelity optimization. Other use cases of deterministic models include
+representing approximate GP sample paths, e.g. random Fourier features obtained
+with `get_gp_samples`, which allows them to be substituted in acquisition
+functions or in other places where a `Model` is expected.
 """
 
 from __future__ import annotations

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -194,9 +194,9 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
     provide variance estimates, perhaps from bootstrapping. In any case, these
     noise levels must be provided to `FixedNoiseGP` as `train_Yvar`.
 
-    `FixedNoiseGP` is also commonly used when the observations are known to be noise-free.
-    Noise-free observations can be modeled using arbitrarily small noise values, such as
-    `train_Yvar=torch.full_like(train_Y, 1e-6)`.
+    `FixedNoiseGP` is also commonly used when the observations are known to be
+    noise-free.  Noise-free observations can be modeled using arbitrarily small
+    noise values, such as `train_Yvar=torch.full_like(train_Y, 1e-6)`.
 
     `FixedNoiseGP` cannot predict noise levels out of sample. If this is needed,
     use `HeteroskedasticSingleTaskGP`, which will create another model for the

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -22,10 +22,10 @@ batching to model outputs independently.
 
 These models all support multiple outputs. However, as single-task models,
 `SingleTaskGP`, `FixedNoiseGP`, and `HeteroskedasticSingleTaskGP` should be
-used only when the output(s) are independent and all use the same training data.
+used only when the outputs are independent and all use the same training data.
 If outputs are independent and outputs have different training data, use the
-ModelListGP. When modeling correlations between outputs, use a multi-task
-model like MultiTaskGP.
+`ModelListGP`. When modeling correlations between outputs, use a multi-task
+model like `MultiTaskGP`.
 """
 
 from __future__ import annotations
@@ -181,10 +181,9 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
 
     A single-task exact GP that uses fixed observation noise levels, differing from
     `SingleTaskGP` only in that noise levels are provided rather than inferred.
-    This model also uses relatively strong priors on the Kernel
-    hyperparameters, which work
-    best when covariates are normalized to the unit cube and outcomes are
-    standardized (zero mean, unit variance).
+    This model also uses relatively strong priors on the Kernel hyperparameters,
+    which work best when covariates are normalized to the unit cube and outcomes
+    are standardized (zero mean, unit variance).
 
     This model works in batch mode (each batch having its own hyperparameters).
 
@@ -194,6 +193,10 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
     Another use case is simulation optimization, where the evaluation can
     provide variance estimates, perhaps from bootstrapping. In any case, these
     noise levels must be provided to `FixedNoiseGP` as `train_Yvar`.
+
+    `FixedNoiseGP` is also commonly used when the observations are known to be noise-free.
+    Noise-free observations can be modeled using arbitrarily small noise values, such as
+    `train_Yvar=torch.full_like(train_Y, 1e-6)`.
 
     `FixedNoiseGP` cannot predict noise levels out of sample. If this is needed,
     use `HeteroskedasticSingleTaskGP`, which will create another model for the

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -255,9 +255,9 @@ class Model(Module, ABC):
 class ModelList(Model):
     r"""A multi-output Model represented by a list of independent models.
 
-    A multi-output Model represented by a list of independent models. Any
+    All
     BoTorch models are acceptable as inputs. The cost of this flexibility is
-    that ModelList does not support all methods that may be implemented by its
+    that `ModelList` does not support all methods that may be implemented by its
     component models. One use case for `ModelList` is combining a regression
     model and a deterministic model in one multi-output container model, e.g.
     for cost-aware or multi-objective optimization where one of the outcomes is

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -4,7 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-r"""Abstract base module for all BoTorch models."""
+r"""Abstract base module for all BoTorch models.
+
+Contains `Model`, the abstract base class for all BoTorch models, and
+`ModelList`, a container for a list of Models.
+"""
 
 from __future__ import annotations
 
@@ -29,6 +33,9 @@ from torch.nn import Module, ModuleList
 
 class Model(Module, ABC):
     r"""Abstract base class for BoTorch models.
+
+    Model cannot be used directly; it only defines an API for other BoTorch
+    models.
 
     Args:
         _has_transformed_inputs: A boolean denoting whether `train_inputs` are currently
@@ -246,16 +253,24 @@ class Model(Module, ABC):
 
 
 class ModelList(Model):
-    r"""Container for a list of models."""
+    r"""A multi-output Model represented by a list of independent models.
+
+    A multi-output Model represented by a list of independent models. Any
+    BoTorch models are acceptable as inputs. The cost of this flexibility is
+    that ModelList does not support all methods that may be implemented by its
+    component models. One use case for `ModelList` is combining a regression
+    model and a deterministic model in one multi-output container model, e.g.
+    for cost-aware or multi-objective optimization where one of the outcomes is
+    a deterministic function of the inputs.
+    """
 
     def __init__(self, *models: Model) -> None:
-        r"""A multi-output Model represented by a list of independent models.
-
+        r"""
         Args:
             *models: A variable number of models.
 
         Example:
-            >>> m_1 = SingleTaskGP(train_X, train_Y
+            >>> m_1 = SingleTaskGP(train_X, train_Y)
             >>> m_2 = GenericDeterministicModel(lambda x: x.sum(dim=-1))
             >>> m_12 = ModelList(m_1, m_2)
             >>> m_12.predict(test_X)

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -10,7 +10,7 @@ botorch.models
 Model APIs
 -------------------------------------------
 
-Abstract Model API
+Base Model API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.models.model
     :members:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

NOTE: I am making several PRs each expanding on model documentation. I am trying to identify the best subject-matter expert for each as a reviewer; please let me know if someone else would be a better fit. In this case this is @danielrjiang for cost modeling, but a lot of the documentation in this PR here is for very commonly used models so many people would be good reviewers.

## Motivation

It can be hard for users to figure out which model to use because docstrings are not always as thorough as they could be.

There will be several PRs with docstrings for different model modules.

## Test Plan

- Asked experts for clarification on unclear model documentation
- Built the docs and confirmed that it rendered as expected with Sphinx