### PR TITLE
Expanding on docstrings for gp_regression_fidelity, gp_regression_mixed, higher_order_gp, model_list_gp_regression, and multitask

### DIFF
--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -12,11 +12,11 @@ For more on Multi-Fidelity BO, see the
 
 A common use case of multi-fidelity regression modeling is optimizing a
 "high-fidelity" function that is expensive to simulate when you have access to
-one or more cheaper "lower-fidelity" version(s) that is not fully accurate but is correlated
-with the high-fidelity function. The multi-fidelity model models both the low-
-and high-fidelity functions together, including the correlation between them,
-which can help you predict and optimize the high-fidelity
-function without having to do too many expensive high-fidelity evaluations.
+one or more cheaper "lower-fidelity" versions that are not fully accurate but
+are correlated with the high-fidelity function. The multi-fidelity model models
+both the low- and high-fidelity functions together, including the correlation
+between them, which can help you predict and optimize the high-fidelity function
+without having to do too many expensive high-fidelity evaluations.
 
 .. [Wu2019mf]
     J. Wu, S. Toscano-Palmerin, P. I. Frazier, and A. G. Wilson. Practical

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -12,7 +12,7 @@ For more on Multi-Fidelity BO, see the
 
 A common use case of multi-fidelity regression modeling is optimizing a
 "high-fidelity" function that is expensive to simulate when you have access to
-a cheaper "low-fidelity" version that is not fully accurate but is correlated
+one or more cheaper "lower-fidelity" version(s) that is not fully accurate but is correlated
 with the high-fidelity function. The multi-fidelity model models both the low-
 and high-fidelity functions together, including the correlation between them,
 which can help you predict and optimize the high-fidelity

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -5,7 +5,18 @@
 # LICENSE file in the root directory of this source tree.
 
 r"""
-Gaussian Process Regression models based on GPyTorch models.
+Multi-Fidelity Gaussian Process Regression models based on GPyTorch models.
+
+For more on Multi-Fidelity BO, see the
+`tutorial <https://botorch.org/tutorials/discrete_multi_fidelity_bo>`_.
+
+A common use case of multi-fidelity regression modeling is optimizing a
+"high-fidelity" function that is expensive to simulate when you have access to
+a cheaper "low-fidelity" version that is not fully accurate but is correlated
+with the high-fidelity function. The multi-fidelity model models both the low-
+and high-fidelity functions together, including the correlation between them,
+which can help you predict and optimize the high-fidelity
+function without having to do too many expensive high-fidelity evaluations.
 
 .. [Wu2019mf]
     J. Wu, S. Toscano-Palmerin, P. I. Frazier, and A. G. Wilson. Practical

--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -28,7 +28,9 @@ from torch import Tensor
 class MixedSingleTaskGP(SingleTaskGP):
     r"""A single-task exact GP model for mixed search spaces.
 
-    This model uses a kernel that combines a CategoricalKernel (based on
+    This model is similar to SingleTaskGP, but supports mixed search spaces,
+    which combine discrete and continuous features, as well as solely discrete
+    spaces. It uses a kernel that combines a CategoricalKernel (based on
     Hamming distances) and a regular kernel into a kernel of the form
 
         K((x1, c1), (x2, c2)) =
@@ -42,7 +44,7 @@ class MixedSingleTaskGP(SingleTaskGP):
     Since this model does not provide gradients for the categorical features,
     optimization of the acquisition function will need to be performed in
     a mixed fashion, i.e., treating the categorical features properly as
-    discrete optimization variables.
+    discrete optimization variables. We recommend using `optimize_acqf_mixed.`
 
     Example:
         >>> train_X = torch.cat(
@@ -73,7 +75,7 @@ class MixedSingleTaskGP(SingleTaskGP):
             cat_dims: A list of indices corresponding to the columns of
                 the input `X` that should be considered categorical features.
             cont_kernel_factory: A method that accepts `ard_num_dims` and
-                `active_dims` arguments and returns an instatiated GPyTorch
+                `active_dims` arguments and returns an instantiated GPyTorch
                 `Kernel` object to be used as the ase kernel for the continuous
                 dimensions. If omitted, this model uses a Matern-2.5 kernel as
                 the kernel for the ordinal parameters.

--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -28,7 +28,7 @@ from torch import Tensor
 class MixedSingleTaskGP(SingleTaskGP):
     r"""A single-task exact GP model for mixed search spaces.
 
-    This model is similar to SingleTaskGP, but supports mixed search spaces,
+    This model is similar to `SingleTaskGP`, but supports mixed search spaces,
     which combine discrete and continuous features, as well as solely discrete
     spaces. It uses a kernel that combines a CategoricalKernel (based on
     Hamming distances) and a regular kernel into a kernel of the form

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -142,7 +142,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
     r"""
     A model for high-dimensional output regression.
 
-    As described in [Zhe2019hogp]. “Higher-order” means that the predictions
+    As described in [Zhe2019hogp]_. “Higher-order” means that the predictions
     are matrices (tensors) with at least two dimensions, such as images or
     grids of images, or measurements taken from a region of at least two
     dimensions.

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -140,9 +140,23 @@ class FlattenedStandardize(Standardize):
 
 class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
     r"""
-    A Higher order Gaussian process model (HOGP) (predictions are matrices/tensors) as
-    described in [Zhe2019hogp]_. The posterior uses Matheron's rule [Doucet2010sampl]_
+    A model for high-dimensional output regression.
+
+    As described in [Zhe2019hogp]. “Higher-order” means that the predictions
+    are matrices (tensors) with at least two dimensions, such as images or
+    grids of images, or measurements taken from a region of at least two
+    dimensions.
+    The posterior uses Matheron's rule [Doucet2010sampl]_
     as described in [Maddox2021bohdo]_.
+
+    `HigherOrderGP` differs from a "vector” multi-output model in that it uses
+    Kronecker algebra to obtain parsimonious covariance matrices for these
+    outputs (see `KroneckerMultiTaskGP` for more information). For example,
+    imagine a 10 x 20 x 30 grid of images. If we were to vectorize the
+    resulting 6,000 data points in order to use them in a non-higher-order GP,
+    they would have a 6,000 x 6,000 covariance matrix, with 36 million entries.
+    The Kronecker structure allows representing this as a product of 10x10,
+    20x20, and 30x30 covariance matrices, with only 1,400 entries.
     """
 
     def __init__(
@@ -157,8 +171,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
         outcome_transform: Optional[OutcomeTransform] = None,
         input_transform: Optional[InputTransform] = None,
     ):
-        r"""A HigherOrderGP model for high-dim output regression.
-
+        r"""
         Args:
             train_X: A `batch_shape x n x d`-dim tensor of training inputs.
             train_Y: A `batch_shape x n x output_shape`-dim tensor of training targets.

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -23,21 +23,24 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
     r"""A multi-output GP model with independent GPs for the outputs.
 
     This model supports different-shaped training inputs for each of its
-    sub-models. It can be used with any BoTorch models.
+    sub-models. It can be used with any GPyTorch models, and the models can be
+    of different types. Use this model when you have independent output(s) with
+    different training data. When modeling correlations between outputs, use
+    `MultiTaskGP`.
 
     Internally, this model is just a list of individual models, but it implements
     the same input/output interface as all other BoTorch models. This makes it
     very flexible and convenient to work with. The sequential evaluation comes
     at a performance cost though - if you are using a block design (i.e. the
     same number of training example for each output, and a similar model
-    structure, you should consider using a batched GP model instead).
+    structure, you should consider using a batched GP model instead, such as
+    `SingleTaskGP` with batched inputs).
     """
 
     def __init__(self, *gp_models: GPyTorchModel) -> None:
-        r"""A multi-output GP model with independent GPs for the outputs.
-
+        r"""
         Args:
-            *gp_models: An variable number of single-output BoTorch models.
+            *gp_models: An variable number of single-output GPyTorch models.
                 If models have input/output transforms, these are honored
                 individually for each model.
 

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -23,10 +23,10 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
     r"""A multi-output GP model with independent GPs for the outputs.
 
     This model supports different-shaped training inputs for each of its
-    sub-models. It can be used with any number of single-output `GPyTorchModel`s, and the models can be
-    of different types. Use this model when you have independent output(s) with
-    different training data. When modeling correlations between outputs, use
-    `MultiTaskGP`.
+    sub-models. It can be used with any number of single-output
+    `GPyTorchModel`\s and the models can be of different types. Use this model
+    when you have independent outputs with different training data. When
+    modeling correlations between outputs, use `MultiTaskGP`.
 
     Internally, this model is just a list of individual models, but it implements
     the same input/output interface as all other BoTorch models. This makes it
@@ -40,7 +40,7 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
     def __init__(self, *gp_models: GPyTorchModel) -> None:
         r"""
         Args:
-            *gp_models: A number of single-output `GPyTorchModel`s.
+            *gp_models: A number of single-output `GPyTorchModel`\s.
                 If models have input/output transforms, these are honored
                 individually for each model.
 

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -23,7 +23,7 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
     r"""A multi-output GP model with independent GPs for the outputs.
 
     This model supports different-shaped training inputs for each of its
-    sub-models. It can be used with any GPyTorch models, and the models can be
+    sub-models. It can be used with any number of single-output `GPyTorchModel`s, and the models can be
     of different types. Use this model when you have independent output(s) with
     different training data. When modeling correlations between outputs, use
     `MultiTaskGP`.
@@ -40,7 +40,7 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
     def __init__(self, *gp_models: GPyTorchModel) -> None:
         r"""
         Args:
-            *gp_models: An variable number of single-output GPyTorch models.
+            *gp_models: A number of single-output `GPyTorchModel`s.
                 If models have input/output transforms, these are honored
                 individually for each model.
 

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -293,8 +293,8 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel):
 class FixedNoiseMultiTaskGP(MultiTaskGP):
     r"""Multi-Task GP model using an ICM kernel, with known observation noise.
 
-    This is the fixed-noise version of `MultiTaskGP` -– that is, 
-    `FixedNoiseMultiTaskGP` is to `MultiTaskGP` as `FixedNoiseGP` is to 
+    This is the fixed-noise version of `MultiTaskGP` -– that is,
+    `FixedNoiseMultiTaskGP` is to `MultiTaskGP` as `FixedNoiseGP` is to
     `SingleTaskGP`. It can be single-output or
     multi-output. This model uses relatively strong priors on the base Kernel
     hyperparameters, which work best when covariates are normalized to the unit


### PR DESCRIPTION
NOTE: I am making several PRs each expanding on model documentation. I am trying to identify the best subject-matter experts for each as a reviewer. In this case this is @danielrjiang for multi-fideilty, @saitcakmak  for higher-order models, @sdaulton for ModelListGP, and @Balandat for multi-task models. Please let me know if someone else would be a better fit.

## Motivation

Make it easier for people to understand what the different models do and figure out which one is righ tfor their use case

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Asked relevant experts for more info where existing documentation was unclear
- Built the docs and made sure they rendered okay

## Related PRs

#1327 (similar changes to different modules; neither depends on the other)
