### PR TITLE
Use method='highs' in scipy.optimize.linprog

### DIFF
--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -476,7 +476,13 @@ def find_interior_point(
     A_ub[-1, -1] = -1.0
 
     result = scipy.optimize.linprog(
-        c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=(None, None)
+        c=c,
+        A_ub=A_ub,
+        b_ub=b_ub,
+        A_eq=A_eq,
+        b_eq=b_eq,
+        bounds=(None, None),
+        method="highs",
     )
 
     if result.status == 3:
@@ -486,7 +492,13 @@ def find_interior_point(
         A_ub = np.concatenate([A_ub, A_s], axis=0)
         b_ub = np.concatenate([b_ub, np.ones(1)], axis=-1)
         result = scipy.optimize.linprog(
-            c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=(None, None)
+            c=c,
+            A_ub=A_ub,
+            b_ub=b_ub,
+            A_eq=A_eq,
+            b_eq=b_eq,
+            bounds=(None, None),
+            method="highs",
         )
 
     if result.status == 2:

--- a/test/utils/test_sampling.py
+++ b/test/utils/test_sampling.py
@@ -308,7 +308,7 @@ class TestSampleUtils(BotorchTestCase):
         A = np.array([[-1.0]])
         b = np.array([-3.0])
         x = find_interior_point(A=A, b=b)
-        self.assertAlmostEqual(x.item(), 6.201544, places=4)
+        self.assertAlmostEqual(x.item(), 5.0, places=4)
 
     def test_get_polytope_samples(self):
         tkwargs = {"device": self.device}


### PR DESCRIPTION
Fixes #1331.

From the scipy 1.9.0 release notes:

>The default method of scipy.optimize.linprog is now 'highs', not
'interior-point' (which is now deprecated), so callback functions and
some options are no longer supported with the default method. With the
default method, the x attribute of the returned OptimizeResult is
now None (instead of a non-optimal array) when an optimal solution
cannot be found (e.g. infeasible problem).

Since scipy 1.9.0 requires python 3.8+, we're seeing different behavior between on 3.7 vs. 3.8+. This PR explicitly passes in the new highs default method, making the behavior consistent across scipy versions. 