### PR TITLE
[Hotfix] Fixed flake8 failures due to docstring lines that were too long

### DIFF
--- a/botorch/utils/gp_sampling.py
+++ b/botorch/utils/gp_sampling.py
@@ -321,7 +321,8 @@ def get_deterministic_model_list(
     weights: List[Tensor],
     bases: List[RandomFourierFeatures],
 ) -> ModelList:
-    """Get a deterministic model list using the provided weights and bases for each output.
+    """Get a deterministic model list using the provided weights and bases for
+    each output.
 
     Args:
         weights: a list of weights with `m` elements

--- a/botorch/utils/low_rank.py
+++ b/botorch/utils/low_rank.py
@@ -86,7 +86,8 @@ def sample_cached_cholesky(
     sample_shape: torch.Size,
     max_tries: int = 6,
 ) -> Tensor:
-    r"""Get posterior samples at the `q` new points from the joint multi-output posterior.
+    r"""Get posterior samples at the `q` new points from the joint multi-output
+    posterior.
 
     Args:
         posterior: The joint posterior is over (X_baseline, X).

--- a/botorch/utils/multi_objective/box_decompositions/utils.py
+++ b/botorch/utils/multi_objective/box_decompositions/utils.py
@@ -222,7 +222,8 @@ def update_local_upper_bounds_incremental(
 def compute_non_dominated_hypercell_bounds_2d(
     pareto_Y_sorted: Tensor, ref_point: Tensor
 ) -> Tensor:
-    r"""Compute an axis-aligned partitioning of the non-dominated space for 2 objectives.
+    r"""Compute an axis-aligned partitioning of the non-dominated space for 2
+    objectives.
 
     Args:
         pareto_Y_sorted: A `(batch_shape) x n_pareto x 2`-dim tensor of pareto outcomes


### PR DESCRIPTION
## Motivation

Previously to this weekend, `flake8` was not detecting certain cases where lines were too long. Upon updating to 5.0.x over the weekend, it started noticing these and failing. The new behavior is correct, so there is no need to change 
 the behavior of `flake8`. This PR fixes those long lines.

Test failures: https://github.com/pytorch/botorch/runs/7614541181?check_suite_focus=true

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Actions

## Related PRs

None