### PR TITLE
[hotfix] made link 'anonymous' to prevent rst error causing Actions to fail

### DIFF
--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -8,7 +8,7 @@ r"""
 Multi-Fidelity Gaussian Process Regression models based on GPyTorch models.
 
 For more on Multi-Fidelity BO, see the
-`tutorial <https://botorch.org/tutorials/discrete_multi_fidelity_bo>`_.
+`tutorial <https://botorch.org/tutorials/discrete_multi_fidelity_bo>`__.
 
 A common use case of multi-fidelity regression modeling is optimizing a
 "high-fidelity" function that is expensive to simulate when you have access to


### PR DESCRIPTION
## Motivation

The "docs" CI was failing with the following warning:
```
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/botorch/models/gp_regression_fidelity.py:docstring of botorch.models.gp_regression_fidelity.FixedNoiseMultiFidelityGP.construct_inputs:5: WARNING: Duplicate explicit target name: "tutorial".
```
This is actually a harmless warning. The link still works fine. This PR will just make Actions stop complaining.

This happens because [RST doesn't like having different links with the same name](https://github.com/sphinx-doc/sphinx/issues/3921). I would guess that multiple recent PRs linked to "tutorial," which is why it wasn't caught by the CI for a single PR. The solution is to make the link "anonymous" by adding an underscore. 

## Test Plan

Built the docs and made sure the link still worked.
