### PR TITLE
Model docs

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -67,7 +67,7 @@ NEG_INF = -(torch.tensor(float("inf")))
 
 
 class ApproximateGPyTorchModel(GPyTorchModel):
-    """
+    r"""
     Botorch wrapper class for various (variational) approximate GP models in
     GPyTorch.
 

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -67,6 +67,14 @@ NEG_INF = -(torch.tensor(float("inf")))
 
 
 class ApproximateGPyTorchModel(GPyTorchModel):
+    """
+    Botorch wrapper class for various (variational) approximate GP models in
+    GPyTorch.
+
+    This can either include stochastic variational GPs (SVGPs) or
+    variational implementations of weight space approximate GPs.
+    """
+
     def __init__(
         self,
         model: Optional[ApproximateGP] = None,
@@ -76,14 +84,10 @@ class ApproximateGPyTorchModel(GPyTorchModel):
         **kwargs,
     ) -> None:
         r"""
-        Botorch wrapper class for various (variational) approximate GP models in
-        gpytorch. This can either include stochastic variational GPs (SVGPs) or
-        variational implementations of weight space approximate GPs.
-
         Args:
             model: Instance of gpytorch.approximate GP models. If omitted,
                 constructs a `_SingleTaskVariationalGP`.
-            likelihood: Instance of a GPyYorch likelihood. If omitted, uses a
+            likelihood: Instance of a GPyTorch likelihood. If omitted, uses a
                 either a `GaussianLikelihood` (if `num_outputs=1`) or a
                 `MultitaskGaussianLikelihood`(if `num_outputs>1`).
             num_outputs: Number of outputs expected for the GP model.

--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -216,7 +216,7 @@ class PosteriorMeanModel(DeterministicModel):
 
 
 class FixedSingleSampleModel(DeterministicModel):
-    """
+    r"""
     A deterministic model defined by a single sample `w`.
 
     Given a base model `f` and a fixed sample `w`, the model always outputs

--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -201,9 +201,10 @@ class AffineDeterministicModel(DeterministicModel):
 
 
 class PosteriorMeanModel(DeterministicModel):
-    def __init__(self, model: Model) -> None:
-        r"""A deterministic model that always return the posterior mean.
+    """A deterministic model that always returns the posterior mean."""
 
+    def __init__(self, model: Model) -> None:
+        r"""
         Args:
             model: The base model.
         """
@@ -215,15 +216,18 @@ class PosteriorMeanModel(DeterministicModel):
 
 
 class FixedSingleSampleModel(DeterministicModel):
+    """
+    A deterministic model defined by a single sample `w`.
+
+    Given a base model `f` and a fixed sample `w`, the model always outputs
+
+        y = f_mean(x) + f_stddev(x) * w
+
+    We assume the outcomes are uncorrelated here.
+    """
+
     def __init__(self, model: Model, w: Optional[Tensor] = None) -> None:
-        r"""A deterministic model defined by a single sample w.
-
-        Given a base model f and a fixed sample w, the model always outputs
-
-            y = f_mean(x) + f_stddev(x) * w
-
-        We assume the outcomes are uncorrelated here.
-
+        r"""
         Args:
             model: The base model.
             w: A 1-d tensor with length model.num_outputs.

--- a/docs/models.md
+++ b/docs/models.md
@@ -18,7 +18,7 @@ module, BoTorch’s Monte Carlo-based acquisition functions are compatible with
 any model that conforms to the `Model` interface, whether user-implemented or provided.
 
 Under the hood, BoTorch models are PyTorch `Modules` that implement
-the light-weight [`Model`](../api/models.html#model-apis) interface. 
+the light-weight [`Model`](../api/models.html#model-apis) interface.
 When working with GPs, [`GPyTorchModel`](../api/models.html#module-botorch.models.gp_regression)
 provides a base class for conveniently wrapping GPyTorch models.
 
@@ -67,7 +67,7 @@ not been modeled. Use these models if you have estimates of the noise in
 your observations (e.g. observations may be averages over individual samples
 in which case you would provide the mean as observation and the standard
 error of the mean as the noise estimate), or if you know your observations are
-noiseless (by passing a zero noise level). 
+noiseless (by passing a zero noise level).
 
 * *Heteroskedastic*: Noise is provided as an input and is modeled to allow for
 predicting noise out-of-sample. Models like `HeteroskedasticSingleTaskGP`

--- a/docs/models.md
+++ b/docs/models.md
@@ -9,34 +9,28 @@ In BoTorch, a `Model` maps a set of design points to a posterior probability
 distribution of its output(s) over the design points.
 
 In BO, the model used is traditionally a Gaussian Process (GP),
-in which case the posterior distribution, by definition is a multivariate
-normal. However, with the exception of some of the analytic acquisition
-functions in the
+in which case the posterior distribution is a multivariate
+normal. While of BoTorch’s existing models are GP models, **BoTorch makes no
+assumption on the model being a GP** or the posterior being multivariate normal.
+With the exception of some of the analytic acquisition functions in the
 [`botorch.acquisition.analytic`](../api/acquisition.html#botorch-acquisition-analytic)
-module, **BoTorch makes no assumption on the model being a GP**, or on the
-posterior being a multivariate normal. The only requirement for using
-BoTorch's Monte-Carlo based acquisition functions is that the model returns a
-[`Posterior`](../api/posteriors.html#posterior) object that implements an
-`rsample()` method for sampling from the posterior of the model. If you wish to
-use gradient-based optimization algorithms, the model should allow
-back-propagating gradients through the samples to the model input.
-
-
-## The BoTorch Model Interface
-
-BoTorch models are PyTorch modules that implement the light-weight
-[`Model`](../api/models.html#model) interface. A BoTorch `Model` requires only
-a single `posterior()` method that takes in a Tensor `X` of design points,
-and returns a [`Posterior`](../api/posteriors.html#posterior) object describing
-the (joint) probability distribution of the model output(s) over the design
-points in `X`.
-
+module,BoTorch’s Monte Carlo-based acquisition functions are compatible with
+any model that conforms to the `Model` interface, whether user-implemented or provided.
+ 
+Under the hood, BoTorch models are PyTorch `Modules` that implement the that
+implement the light-weight
+[`Model`](../api/models.html#model) interface. When working with GPs,
 When working with GPs, [`GPyTorchModel`](../api/models.html#gpytorchmodel)
 provides a base class for conveniently wrapping GPyTorch models.
+
+Users can extend `Model` and `GPyTorchModel` to generate their own models. 
+For more on implementing your own models, see 
+[Implementing Custom Models](## Implement Custom Models) below.
 
 
 ## Terminology
 
+### Multi-Output and Multi-Task
 Models may have multiple outputs, multiple inputs, and may exploit correlation
 between different inputs. BoTorch uses the following terminology to
 distinguish these model types:
@@ -52,6 +46,18 @@ Note the following:
 * Conversely, a multi-output (MO) model may or may not be a multi-task model.
 * If a model is both, we refer to it as a multi-task-multi-output (MTMO) model.
 
+### Noise: Homoskedastic, fixed, and heteroskedastic
+Noise can be treated in several different ways:
+
+* *Homoskedastic*: Noise is not provided as an input and is inferred, with a
+constant variance that does not depend on `X`. Many models, such as
+`SingleTaskGP`, take this approach.
+
+* *Fixed*: Noise is provided as an input and is not fit. In “fixed” models like `FixedNoiseGP`, noise cannot be predicted out-of-sample.
+
+* *Heteroskedastic*: Noise is provided as an input and is modeled to allow for
+predicting noise out-of-sample. Models like `HeteroskedasticSingleTaskGP`
+take this approach.
 
 ## Standard BoTorch Models
 
@@ -64,10 +70,14 @@ required for each output, use a [`ModelListGP`](../api/models.html#modellistgp)
 instead.
 * [`SingleTaskGP`](../api/models.html#singletaskgp): a single-task
   exact GP that infers a homoskedastic noise level (no noise observations).
-* [`FixedNoiseGP`](../api/models.html#fixednoisegp): a single-task exact GP that
-uses fixed observation noise levels (requires noise observations).
+  This is among the most commonly used models.
+* [`FixedNoiseGP`](../api/models.html#fixednoisegp): a single-task exact GP,
+  differing only from SingleTaskGP in that it that
+  uses fixed observation noise levels (requires noise observations).
+  `FixedNoiseGP` is also among the most commonly used models.
 * [`HeteroskedasticSingleTaskGP`](../api/models.html#heteropskedasticsingletaskgp):
-  a single-task exact GP that models heteroskedastic noise using an additional
+  a single-task exact GP, 
+  differing from FixedNoiseGP in that it models heteroskedastic noise using an additional
   internal GP model (requires noise observations).
 * [`SaasFullyBayesianSingleTaskGP`](../api/models.html#saasfullybayesiansingletaskgp):
   a fully Bayesian single-task GP with the SAAS prior. This model is suitable for
@@ -92,6 +102,20 @@ Discovery (ARD), and have reasonable priors on hyperparameters that make them
 work well in settings where the **input features are normalized to the unit
 cube** and the **observations are standardized** (zero mean, unit variance).
 
+## Other useful models
+
+* [`SaasFullyBayesianSingleTaskGP`](../api/models.html#saasfullybayesiansingletaskgp):
+  A fully Bayesian model, learning a posterior distribution over each hyperparameter.
+  The fully Bayesian method generally results in a better and more well-calibrated
+  model than `SingleTaskGP`, but is more computationally intensive.
+* [`SingleTaskMultiFidelityGP`](../api/models.html#singletaskmultifidelitygp) and 
+  [`FixedNoiseMultiFidelityGP`](../api/models.html#fixednoisemultifidelitygp):
+  Models for multi-fidelity optimization.  For more on Multi-Fidelity BO, see the
+  `tutorial <https://botorch.org/tutorials/discrete_multi_fidelity_bo>`_.
+* [`HigherOrderGP`](../api/models.html#higherordergp): A GP model with
+  matrix-valued predictions, such as images or grids of images.
+* [`PairwiseGP`](../api/models.html#pairwisegp): A probit-likelihood GP that
+  learns via pairwise comparison data.
 
 ## Implementing Custom Models
 
@@ -106,6 +130,15 @@ more specialized use cases. The light-weight nature of BoTorch's Model API makes
 this easy to do. See the
 [Using a custom BoTorch model in Ax](../tutorials/custom_botorch_model_in_ax)
 tutorial for an example.
+
+The BoTorch `Model` interface is light-weight and easy to extend. The only
+requirement for using BoTorch's Monte-Carlo based acquisition functions is that
+the model has a `posterior` method. It takes in a Tensor X of design points, and
+returns a Posterior object describing the (joint) probability distribution of
+the model output(s) over the design points in X.  The `Posterior` object must
+implement an `rsample()` method for sampling from the posterior of the model.
+If you wish to use gradient-based optimization algorithms, the model should
+allow back-propagating gradients through the samples to the model input.
 
 If you happen to implement a model that would be useful for other
 researchers as well (and involves more than just swapping out the Matérn kernel

--- a/docs/models.md
+++ b/docs/models.md
@@ -16,7 +16,7 @@ With the exception of some of the analytic acquisition functions in the
 [`botorch.acquisition.analytic`](../api/acquisition.html#analytic-acquisition-function-api)
 module, BoTorch’s Monte Carlo-based acquisition functions are compatible with
 any model that conforms to the `Model` interface, whether user-implemented or provided.
- 
+
 Under the hood,
 BoTorch models are PyTorch `Modules` that implement the that
 implement the light-weight
@@ -24,8 +24,8 @@ implement the light-weight
 When working with GPs, [`GPyTorchModel`](../api/models.html#module-botorch.models.gp_regression)
 provides a base class for conveniently wrapping GPyTorch models.
 
-Users can extend `Model` and `GPyTorchModel` to generate their own models. 
-For more on implementing your own models, see 
+Users can extend `Model` and `GPyTorchModel` to generate their own models.
+For more on implementing your own models, see
 [Implementing Custom Models](#implementing-custom-models) below.
 
 
@@ -119,7 +119,7 @@ cube** and the **observations are standardized** (zero mean, unit variance).
 * [`ModelList`](../api/models.html#botorch.models.model.ModelList): a multi-output model in which outcomes
   are modeled independently, as in `ModelListGP`, but the component models do not all
   need to be GPyTorch models.
-* [`SingleTaskMultiFidelityGP`](../api/models.html#botorch.models.gp_regression_fidelity.SingleTaskMultiFidelityGP) and 
+* [`SingleTaskMultiFidelityGP`](../api/models.html#botorch.models.gp_regression_fidelity.SingleTaskMultiFidelityGP) and
   [`FixedNoiseMultiFidelityGP`](../api/models.html#botorch.models.gp_regression_fidelity.FixedNoiseMultiFidelityGP):
   Models for multi-fidelity optimization.  For more on Multi-Fidelity BO, see the
   [tutorial](../tutorials/discrete_multi_fidelity_bo).
@@ -129,8 +129,8 @@ cube** and the **observations are standardized** (zero mean, unit variance).
   learns via pairwise comparison data, useful for preference learning.
 * [`ApproximateGPyTorchModel`](../api/models.html#botorch.models.approximate_gp.ApproximateGPyTorchModel): for
   efficient computation when data is large or responses are non-Gaussian.
-* [Deterministic models](../api/models.html#module-botorch.models.deterministic), such as 
-  [`AffineDeterministicModel`](../api/models.html#botorch.models.deterministic.AffineDeterministicModel), 
+* [Deterministic models](../api/models.html#module-botorch.models.deterministic), such as
+  [`AffineDeterministicModel`](../api/models.html#botorch.models.deterministic.AffineDeterministicModel),
   [`AffineFidelityCostModel`](../api/models.html#botorch.models.cost.AffineFidelityCostModel),
   [`FixedSingleSampleModel`](../api/models.html#botorch.models.deterministic.FixedSingleSampleModel),
   [`GenericDeterministicModel`](../api/models.html#botorch.models.deterministic.GenericDeterministicModel),
@@ -138,7 +138,7 @@ cube** and the **observations are standardized** (zero mean, unit variance).
   [`PosteriorMeanModel`](../api/models.html#botorch.models.deterministic.PosteriorMeanModel)
   express known input-output relationships; they conform
   to the BoTorch `Model` API, so they can easily be used in conjunction with other
-  BoTorch models. Deterministic models are 
+  BoTorch models. Deterministic models are
   useful for multi-objective optimization with known objective
   functions and for encoding cost functions for cost-aware acquisition.
 * [`SingleTaskVariationalGP`](../api/models.html#botorch.models.approximate_gp.SingleTaskVariationalGP): an

--- a/docs/models.md
+++ b/docs/models.md
@@ -17,10 +17,8 @@ With the exception of some of the analytic acquisition functions in the
 module, BoTorch’s Monte Carlo-based acquisition functions are compatible with
 any model that conforms to the `Model` interface, whether user-implemented or provided.
 
-Under the hood,
-BoTorch models are PyTorch `Modules` that implement the that
-implement the light-weight
-[`Model`](../api/models.html#model-apis) interface. When working with GPs,
+Under the hood, BoTorch models are PyTorch `Modules` that implement
+the light-weight [`Model`](../api/models.html#model-apis) interface. 
 When working with GPs, [`GPyTorchModel`](../api/models.html#module-botorch.models.gp_regression)
 provides a base class for conveniently wrapping GPyTorch models.
 
@@ -60,9 +58,16 @@ Noise can be treated in several different ways:
 
 * *Homoskedastic*: Noise is not provided as an input and is inferred, with a
 constant variance that does not depend on `X`. Many models, such as
-`SingleTaskGP`, take this approach.
+`SingleTaskGP`, take this approach. Use these models if you know that
+your observations are noisy, but not how noisy.
 
-* *Fixed*: Noise is provided as an input and is not fit. In “fixed” models like `FixedNoiseGP`, noise cannot be predicted out-of-sample because it has not been modeled.
+* *Fixed*: Noise is provided as an input and is not fit. In “fixed noise” models
+like `FixedNoiseGP`, noise cannot be predicted out-of-sample because it has
+not been modeled. Use these models if you have estimates of the noise in
+your observations (e.g. observations may be averages over individual samples
+in which case you would provide the mean as observation and the standard
+error of the mean as the noise estimate), or if you know your observations are
+noiseless (by passing a zero noise level). 
 
 * *Heteroskedastic*: Noise is provided as an input and is modeled to allow for
 predicting noise out-of-sample. Models like `HeteroskedasticSingleTaskGP`
@@ -116,9 +121,9 @@ cube** and the **observations are standardized** (zero mean, unit variance).
 
 ## Other useful models
 
-* [`ModelList`](../api/models.html#botorch.models.model.ModelList): a multi-output model in which outcomes
-  are modeled independently, as in `ModelListGP`, but the component models do not all
-  need to be GPyTorch models.
+* [`ModelList`](../api/models.html#botorch.models.model.ModelList): a multi-output model container
+  in which outcomes are modeled independently by individual `Model`s (as in `ModelListGP`, but the
+  component models do not all need to be GPyTorch models).
 * [`SingleTaskMultiFidelityGP`](../api/models.html#botorch.models.gp_regression_fidelity.SingleTaskMultiFidelityGP) and
   [`FixedNoiseMultiFidelityGP`](../api/models.html#botorch.models.gp_regression_fidelity.FixedNoiseMultiFidelityGP):
   Models for multi-fidelity optimization.  For more on Multi-Fidelity BO, see the
@@ -132,7 +137,6 @@ cube** and the **observations are standardized** (zero mean, unit variance).
 * [Deterministic models](../api/models.html#module-botorch.models.deterministic), such as
   [`AffineDeterministicModel`](../api/models.html#botorch.models.deterministic.AffineDeterministicModel),
   [`AffineFidelityCostModel`](../api/models.html#botorch.models.cost.AffineFidelityCostModel),
-  [`FixedSingleSampleModel`](../api/models.html#botorch.models.deterministic.FixedSingleSampleModel),
   [`GenericDeterministicModel`](../api/models.html#botorch.models.deterministic.GenericDeterministicModel),
   and
   [`PosteriorMeanModel`](../api/models.html#botorch.models.deterministic.PosteriorMeanModel)

--- a/docs/models.md
+++ b/docs/models.md
@@ -13,20 +13,20 @@ in which case the posterior distribution is a multivariate
 normal. While BoTorch supports many GP models, **BoTorch makes no
 assumption on the model being a GP** or the posterior being multivariate normal.
 With the exception of some of the analytic acquisition functions in the
-[`botorch.acquisition.analytic`](../api/acquisition.html#botorch-acquisition-analytic)
+[`botorch.acquisition.analytic`](../api/acquisition.html#analytic-acquisition-function-api)
 module, BoTorch’s Monte Carlo-based acquisition functions are compatible with
 any model that conforms to the `Model` interface, whether user-implemented or provided.
  
 Under the hood,
 BoTorch models are PyTorch `Modules` that implement the that
 implement the light-weight
-[`Model`](../api/models.html#model) interface. When working with GPs,
-When working with GPs, [`GPyTorchModel`](../api/models.html#gpytorchmodel)
+[`Model`](../api/models.html#model-apis) interface. When working with GPs,
+When working with GPs, [`GPyTorchModel`](../api/models.html#module-botorch.models.gp_regression)
 provides a base class for conveniently wrapping GPyTorch models.
 
 Users can extend `Model` and `GPyTorchModel` to generate their own models. 
 For more on implementing your own models, see 
-[Implementing Custom Models](#Implementing-Custom-Models) below.
+[Implementing Custom Models](#implementing-custom-models) below.
 
 
 ## Terminology
@@ -75,32 +75,39 @@ BoTorch provides several GPyTorch models to cover most standard BO use cases:
 ### Single-Task GPs
 These models use the same training data for all outputs and assume conditional
 independence of the outputs given the input. If different training data is
-required for each output, use a [`ModelListGP`](../api/models.html#modellistgp)
+required for each output, use a [`ModelListGP`](../api/models.html#module-botorch.models.model_list_gp_regression)
 instead.
-* [`SingleTaskGP`](../api/models.html#singletaskgp): a single-task
+* [`SingleTaskGP`](../api/models.html#botorch.models.gp_regression.SingleTaskGP): a single-task
   exact GP that infers a homoskedastic noise level (no noise observations).
-* [`FixedNoiseGP`](../api/models.html#fixednoisegp): a single-task exact GP that
-uses fixed observation noise levels (requires noise observations).
-* [`HeteroskedasticSingleTaskGP`](../api/models.html#heteropskedasticsingletaskgp):
-  a single-task exact GP that models heteroskedastic noise using an additional
-  internal GP model (requires noise observations).
-* [`SaasFullyBayesianSingleTaskGP`](../api/models.html#saasfullybayesiansingletaskgp):
+* [`FixedNoiseGP`](../api/models.html#botorch.models.gp_regression.FixedNoiseGP): a single-task exact GP that
+  differs from `SingleTaskGP` in using
+  fixed observation noise levels. It requires noise observations.
+* [`HeteroskedasticSingleTaskGP`](../api/models.html#botorch.models.gp_regression.HeteroskedasticSingleTaskGP):
+  a single-task exact GP that differs from `SingleTaskGP` and `FixedNoiseGP`
+  in that it models heteroskedastic noise using an additional
+  internal GP model. It requires noise observations.
+* [`MixedSingleTaskGP`](../api/models.html#botorch.models.gp_regression_mixed.MixedSingleTaskGP): a single-task exact
+  GP that supports mixed search spaces, which combine discrete and continuous features.
+* [`SaasFullyBayesianSingleTaskGP`](../api/models.html#botorch.models.fully_bayesian.SaasFullyBayesianSingleTaskGP):
   a fully Bayesian single-task GP with the SAAS prior. This model is suitable for
   sample-efficient high-dimensional Bayesian optimization.
 
 ### Model List of Single-Task GPs
-* [`ModelListGP`](../api/models.html#modellistgp): A multi-output model in
+* [`ModelListGP`](../api/models.html#module-botorch.models.model_list_gp_regression): A multi-output model in
   which outcomes are modeled independently, given a list of any type of
   single-task GP. This model should be used when the same training data is not
   used for all outputs.
 
 ### Multi-Task GPs
-* [`MultiTaskGP`](../api/models.html#multitaskgp): a Hadamard multi-task,
+* [`MultiTaskGP`](../api/models.html#module-botorch.models.multitask): a Hadamard multi-task,
   multi-output GP using an ICM kernel, inferring a homoskedastic noise level (does not
   require noise observations).
-* [`FixedNoiseMultiTaskGP`](../api/models.html#fixednoisemultitaskgp):
+* [`FixedNoiseMultiTaskGP`](../api/models.html#botorch.models.multitask.FixedNoiseMultiTaskGP):
   a Hadamard multi-task, multi-output GP using an ICM kernel, with fixed
   observation noise levels (requires noise observations).
+* [`KroneckerMultiTaskGP`](../api/models.html#botorch.models.multitask.KroneckerMultiTaskGP): A multi-task,
+  multi-output GP using an ICM kernel, with Kronecker structure. Useful for
+  multi-fidelity optimization.
 
 All of the above models use Matérn 5/2 kernels with Automatic Relevance
 Discovery (ARD), and have reasonable priors on hyperparameters that make them
@@ -109,14 +116,35 @@ cube** and the **observations are standardized** (zero mean, unit variance).
 
 ## Other useful models
 
-* [`SingleTaskMultiFidelityGP`](../api/models.html#singletaskmultifidelitygp) and 
-  [`FixedNoiseMultiFidelityGP`](../api/models.html#fixednoisemultifidelitygp):
+* [`ModelList`](../api/models.html#botorch.models.model.ModelList): a multi-output model in which outcomes
+  are modeled independently, as in `ModelListGP`, but the component models do not all
+  need to be GPyTorch models.
+* [`SingleTaskMultiFidelityGP`](../api/models.html#botorch.models.gp_regression_fidelity.SingleTaskMultiFidelityGP) and 
+  [`FixedNoiseMultiFidelityGP`](../api/models.html#botorch.models.gp_regression_fidelity.FixedNoiseMultiFidelityGP):
   Models for multi-fidelity optimization.  For more on Multi-Fidelity BO, see the
-  [tutorial](https://botorch.org/tutorials/discrete_multi_fidelity_bo>).
-* [`HigherOrderGP`](../api/models.html#higherordergp): A GP model with
+  [tutorial](../tutorials/discrete_multi_fidelity_bo).
+* [`HigherOrderGP`](../api/models.html#botorch.models.higher_order_gp.HigherOrderGP): A GP model with
   matrix-valued predictions, such as images or grids of images.
-* [`PairwiseGP`](../api/models.html#pairwisegp): A probit-likelihood GP that
+* [`PairwiseGP`](../api/models.html#module-botorch.models.pairwise_gp): A probit-likelihood GP that
   learns via pairwise comparison data, useful for preference learning.
+* [`ApproximateGPyTorchModel`](../api/models.html#botorch.models.approximate_gp.ApproximateGPyTorchModel): for
+  efficient computation when data is large or responses are non-Gaussian.
+* [Deterministic models](../api/models.html#module-botorch.models.deterministic), such as 
+  [`AffineDeterministicModel`](../api/models.html#botorch.models.deterministic.AffineDeterministicModel), 
+  [`AffineFidelityCostModel`](../api/models.html#botorch.models.cost.AffineFidelityCostModel),
+  [`FixedSingleSampleModel`](../api/models.html#botorch.models.deterministic.FixedSingleSampleModel),
+  [`GenericDeterministicModel`](../api/models.html#botorch.models.deterministic.GenericDeterministicModel),
+  and
+  [`PosteriorMeanModel`](../api/models.html#botorch.models.deterministic.PosteriorMeanModel)
+  express known input-output relationships; they conform
+  to the BoTorch `Model` API, so they can easily be used in conjunction with other
+  BoTorch models. Deterministic models are 
+  useful for multi-objective optimization with known objective
+  functions and for encoding cost functions for cost-aware acquisition.
+* [`SingleTaskVariationalGP`](../api/models.html#botorch.models.approximate_gp.SingleTaskVariationalGP): an
+  approximate model for faster computation when you have a lot of data or your responses
+  are non-Gaussian.
+
 
 ## Implementing Custom Models
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -17,7 +17,8 @@ With the exception of some of the analytic acquisition functions in the
 module, BoTorch’s Monte Carlo-based acquisition functions are compatible with
 any model that conforms to the `Model` interface, whether user-implemented or provided.
  
-Under the hood, BoTorch models are PyTorch `Modules` that implement the that
+Under the hood,
+BoTorch models are PyTorch `Modules` that implement the that
 implement the light-weight
 [`Model`](../api/models.html#model) interface. When working with GPs,
 When working with GPs, [`GPyTorchModel`](../api/models.html#gpytorchmodel)
@@ -31,14 +32,13 @@ For more on implementing your own models, see
 ## Terminology
 
 ### Multi-Output and Multi-Task
-A `Model` -- as in the BoTorch object -- may have
+A `Model` (as in the BoTorch object) may have
 multiple outputs, multiple inputs, and may exploit correlation
 between different inputs. BoTorch uses the following terminology to
-distinguish these types of `Model`:
+distinguish these model types:
 
 * *Multi-Output Model*: a `Model` with multiple
-  outputs.
-  Most BoTorch `Model`s are multi-output.
+  outputs. Most BoTorch `Model`s are multi-output.
 * *Multi-Task Model*: a `Model` making use of a logical grouping of
   inputs/observations (as in the underlying process). For example, there could
   be multiple tasks where each task has a different fidelity.
@@ -79,26 +79,24 @@ required for each output, use a [`ModelListGP`](../api/models.html#modellistgp)
 instead.
 * [`SingleTaskGP`](../api/models.html#singletaskgp): a single-task
   exact GP that infers a homoskedastic noise level (no noise observations).
-  This is among the most commonly used models.
-* [`FixedNoiseGP`](../api/models.html#fixednoisegp): a single-task exact GP,
-  differing only from SingleTaskGP in that it that
-  uses fixed, observed noise levels, which the user must input.
-  `FixedNoiseGP` is also among the most commonly used models.
+* [`FixedNoiseGP`](../api/models.html#fixednoisegp): a single-task exact GP that
+uses fixed observation noise levels (requires noise observations).
 * [`HeteroskedasticSingleTaskGP`](../api/models.html#heteropskedasticsingletaskgp):
-  a single-task exact GP, 
-  differing from `FixedNoiseGP` in that it models heteroskedastic noise using an additional
-  internal GP model. Noise observations must be provided.
+  a single-task exact GP that models heteroskedastic noise using an additional
+  internal GP model (requires noise observations).
+* [`SaasFullyBayesianSingleTaskGP`](../api/models.html#saasfullybayesiansingletaskgp):
+  a fully Bayesian single-task GP with the SAAS prior. This model is suitable for
+  sample-efficient high-dimensional Bayesian optimization.
 
 ### Model List of Single-Task GPs
 * [`ModelListGP`](../api/models.html#modellistgp): A multi-output model in
   which outcomes are modeled independently, given a list of any type of
-  single-task GP. This model should be used rather than one of the above models when different outputs use different training
-  data.
+  single-task GP. This model should be used when the same training data is not
+  used for all outputs.
 
 ### Multi-Task GPs
 * [`MultiTaskGP`](../api/models.html#multitaskgp): a Hadamard multi-task,
-  multi-output GP using an ICM kernel, inferring a
-  homoskedastic noise level (does not
+  multi-output GP using an ICM kernel, inferring a homoskedastic noise level (does not
   require noise observations).
 * [`FixedNoiseMultiTaskGP`](../api/models.html#fixednoisemultitaskgp):
   a Hadamard multi-task, multi-output GP using an ICM kernel, with fixed
@@ -111,10 +109,6 @@ cube** and the **observations are standardized** (zero mean, unit variance).
 
 ## Other useful models
 
-* [`SaasFullyBayesianSingleTaskGP`](../api/models.html#saasfullybayesiansingletaskgp):
-  A fully Bayesian model, learning a posterior distribution over each hyperparameter.
-  The fully Bayesian method generally results in a better and more well-calibrated
-  model than `SingleTaskGP`, but is more computationally intensive.
 * [`SingleTaskMultiFidelityGP`](../api/models.html#singletaskmultifidelitygp) and 
   [`FixedNoiseMultiFidelityGP`](../api/models.html#fixednoisemultifidelitygp):
   Models for multi-fidelity optimization.  For more on Multi-Fidelity BO, see the
@@ -122,7 +116,7 @@ cube** and the **observations are standardized** (zero mean, unit variance).
 * [`HigherOrderGP`](../api/models.html#higherordergp): A GP model with
   matrix-valued predictions, such as images or grids of images.
 * [`PairwiseGP`](../api/models.html#pairwisegp): A probit-likelihood GP that
-  learns via pairwise comparison data.
+  learns via pairwise comparison data, useful for preference learning.
 
 ## Implementing Custom Models
 
@@ -140,9 +134,9 @@ tutorial for an example.
 
 The BoTorch `Model` interface is light-weight and easy to extend. The only
 requirement for using BoTorch's Monte-Carlo based acquisition functions is that
-the model has a `posterior` method. It takes in a Tensor X of design points, and
+the model has a `posterior` method. It takes in a Tensor `X` of design points, and
 returns a Posterior object describing the (joint) probability distribution of
-the model output(s) over the design points in X.  The `Posterior` object must
+the model output(s) over the design points in `X`.  The `Posterior` object must
 implement an `rsample()` method for sampling from the posterior of the model.
 If you wish to use gradient-based optimization algorithms, the model should
 allow back-propagating gradients through the samples to the model input.


### PR DESCRIPTION
## Motivation

* Added material to  `docs/models.md`, which is rendered [here](https://botorch.org/docs/models), adding a short summary for each model and extra context.  See #732 
* Made sure a couple classes have docstrings 
* Fixed broken links

## Test Plan
* I collected a list of models that are either are in `botorch.models.__init__.py` or are non-abstract subclasses of `Model`, and made sure they are are all documented in `models.md`. This does exclude some models, such as contextual models.
* Built the website and read it over
* Clicked every link and made sure it worked
