### PR TITLE
outcome_transform ignored for ModelListGP.fantasize

### DIFF
--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -51,6 +51,7 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
         """
         super().__init__(*gp_models)
 
+    # TODO: annotated return type doesn't match docstring
     def condition_on_observations(
         self, X: List[Tensor], Y: Tensor, **kwargs: Any
     ) -> ModelListGP:
@@ -83,6 +84,11 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
                 f"{self.num_outputs} outputs."
             )
         targets = [Y[..., i] for i in range(Y.shape[-1])]
+        for i, model in enumerate(self.models):
+            if hasattr(model, "outcome_transform"):
+                noise = kwargs.get("noise")
+                targets[i], noise = model.outcome_transform(targets[i], noise)
+
         # This should never trigger, posterior call would fail.
         assert len(targets) == len(X)
         if "noise" in kwargs:

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -51,7 +51,6 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
         """
         super().__init__(*gp_models)
 
-    # TODO: annotated return type doesn't match docstring
     def condition_on_observations(
         self, X: List[Tensor], Y: Tensor, **kwargs: Any
     ) -> ModelListGP:
@@ -69,9 +68,11 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
                 standard broadcasting semantics. If `Y` has fewer batch dimensions
                 than `X`, its is assumed that the missing batch dimensions are
                 the same for all `Y`.
+            kwargs: Keyword arguments passed to
+                `IndependentModelList.get_fantasy_model`.
 
         Returns:
-            A `ModelListGPyTorchModel` representing the original model
+            A `ModelListGP` representing the original model
             conditioned on the new observations `(X, Y)` (and possibly noise
             observations passed in via kwargs). Here the `i`-th model has
             `n_i + n'` training examples, where the `n'` training examples have

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -17,7 +17,7 @@ from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
 from botorch.models.transforms import Standardize
 from botorch.models.transforms.input import Normalize
 from botorch.posteriors import GPyTorchPosterior
-from botorch.sampling.samplers import IIDNormalSampler, SobolQMCNormalSampler
+from botorch.sampling.samplers import IIDNormalSampler
 from botorch.utils.testing import _get_random_data, BotorchTestCase
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
 from gpytorch.kernels import MaternKernel, ScaleKernel
@@ -358,11 +358,15 @@ class TestModelListGP(BotorchTestCase):
         Test that 'fantasize' on average recovers the true mean fn.
 
         This uses a setup as close as possible to deterministic (low fixed
-        noise, fantasizing at points already seen).
+        noise, fantasizing at points already seen). Even so, numerical results
+        can vary on different machines (not on different runs on the same
+        machine.) So tolerances need to be pretty loose.
+        This is okay because if the transform were not being
+        applied, the error would be very large (~100).
         """
         n_fants = 20
-        y_at_low_x = 1.0
-        y_at_high_x = -0.3
+        y_at_low_x = 100.0
+        y_at_high_x = -40.0
 
         X = torch.tensor([[0.0], [1.0]])
         Y = torch.tensor([[y_at_low_x], [y_at_high_x]])
@@ -373,10 +377,9 @@ class TestModelListGP(BotorchTestCase):
 
         model.posterior(torch.zeros((1, 1)))
 
-        fant = model.fantasize(
-            X, sampler=SobolQMCNormalSampler(n_fants, seed=0), noise=yvar
-        )
+        fant = model.fantasize(X, sampler=IIDNormalSampler(n_fants, seed=0), noise=yvar)
 
         fant_mean = fant.posterior(X).mean.mean(0).flatten().tolist()
-        self.assertAlmostEqual(fant_mean[0], y_at_low_x, delta=5e-4)
-        self.assertAlmostEqual(fant_mean[1], y_at_high_x, delta=6e-4)
+        self.assertAlmostEqual(fant_mean[0], y_at_low_x, delta=1)
+        # delta=1 is a 1% error (since y_at_low_x = 100)
+        self.assertAlmostEqual(fant_mean[1], y_at_high_x, delta=1)

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -364,8 +364,8 @@ class TestModelListGP(BotorchTestCase):
         y_at_low_x = 1.0
         y_at_high_x = -0.3
 
-        X = torch.tensor([0.0, 1.0])[:, None]
-        Y = torch.tensor([y_at_low_x, y_at_high_x])[:, None]
+        X = torch.tensor([[0.0], [1.0]])
+        Y = torch.tensor([[y_at_low_x], [y_at_high_x]])
         yvar = torch.full_like(Y, 1e-4)
         model = ModelListGP(
             FixedNoiseGP(X, Y, yvar, outcome_transform=Standardize(m=1))
@@ -375,6 +375,6 @@ class TestModelListGP(BotorchTestCase):
 
         fant = model.fantasize(X, sampler=IIDNormalSampler(n_fants, seed=0), noise=yvar)
 
-        fant_mean = fant.posterior(X).mean.mean(0).detach().numpy().flatten()
+        fant_mean = fant.posterior(X).mean.mean(0).flatten().tolist()
         self.assertAlmostEqual(fant_mean[0], y_at_low_x, delta=5e-4)
         self.assertAlmostEqual(fant_mean[1], y_at_high_x, delta=1e-3)

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -17,7 +17,7 @@ from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
 from botorch.models.transforms import Standardize
 from botorch.models.transforms.input import Normalize
 from botorch.posteriors import GPyTorchPosterior
-from botorch.sampling.samplers import IIDNormalSampler
+from botorch.sampling.samplers import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.testing import _get_random_data, BotorchTestCase
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
 from gpytorch.kernels import MaternKernel, ScaleKernel
@@ -373,8 +373,10 @@ class TestModelListGP(BotorchTestCase):
 
         model.posterior(torch.zeros((1, 1)))
 
-        fant = model.fantasize(X, sampler=IIDNormalSampler(n_fants, seed=0), noise=yvar)
+        fant = model.fantasize(
+            X, sampler=SobolQMCNormalSampler(n_fants, seed=0), noise=yvar
+        )
 
         fant_mean = fant.posterior(X).mean.mean(0).flatten().tolist()
         self.assertAlmostEqual(fant_mean[0], y_at_low_x, delta=5e-4)
-        self.assertAlmostEqual(fant_mean[1], y_at_high_x, delta=1e-3)
+        self.assertAlmostEqual(fant_mean[1], y_at_high_x, delta=6e-4)


### PR DESCRIPTION
This constitutes a very minimal solution to #1333 that I mean to improve. It could be tested more thoroughly and efficiently, and I (or any helpful reviewers :) ) should spend a little more time thinking about the logic.

## Motivation

#1333 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

[x] Test that with a large number of samples, the posterior mean of the original models is close to the average posterior mean of fantasy models.
[ ] Make this test more comprehensive -- try different dtypes and different types of `ModelListGP` component models
[x] Make this test more efficient -- ideally it shouldn't need such a large number of samples