### PR TITLE
Fix unit tests failues caused by upstream breaking changes

### DIFF
--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -156,7 +156,7 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP):
             )
             self._subset_batch_dict = {
                 "likelihood.noise_covar.raw_noise": -2,
-                "mean_module.constant": -2,
+                "mean_module.raw_constant": -1,
                 "covar_module.raw_outputscale": -1,
                 "covar_module.base_kernel.raw_lengthscale": -3,
             }

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -271,7 +271,7 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP):
                 outputscale_prior=GammaPrior(2.0, 0.15),
             )
             self._subset_batch_dict = {
-                "mean_module.constant": -2,
+                "mean_module.raw_constant": -1,
                 "covar_module.raw_outputscale": -1,
                 "covar_module.base_kernel.raw_lengthscale": -3,
             }

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -131,7 +131,7 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         )
         self._subset_batch_dict = {
             "likelihood.noise_covar.raw_noise": -2,
-            "mean_module.constant": -2,
+            "mean_module.raw_constant": -1,
             "covar_module.raw_outputscale": -1,
             **subset_batch_dict,
         }
@@ -240,7 +240,7 @@ class FixedNoiseMultiFidelityGP(FixedNoiseGP):
         )
         self._subset_batch_dict = {
             "likelihood.noise_covar.raw_noise": -2,
-            "mean_module.constant": -2,
+            "mean_module.raw_constant": -1,
             "covar_module.raw_outputscale": -1,
             **subset_batch_dict,
         }

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -443,8 +443,8 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
             "likelihood.noise_covar.raw_noise": torch.tensor(
                 [[0.0895], [0.2594]], dtype=torch.float64
             ),
-            "mean_module.constant": torch.tensor(
-                [[-0.4545], [-0.1285]], dtype=torch.float64
+            "mean_module.raw_constant": torch.tensor(
+                [-0.4545, -0.1285], dtype=torch.float64
             ),
             "covar_module.raw_outputscale": torch.tensor(
                 [1.4876, 1.4897], dtype=torch.float64

--- a/test/models/test_contextual.py
+++ b/test/models/test_contextual.py
@@ -17,7 +17,7 @@ from gpytorch.means import ConstantMean
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 
 
-class ContextualGPTest(BotorchTestCase):
+class TestContextualGP(BotorchTestCase):
     def test_SACGP(self):
         for dtype in (torch.float, torch.double):
             train_X = torch.tensor(
@@ -45,7 +45,7 @@ class ContextualGPTest(BotorchTestCase):
             num_of_lengthscales = 0
             num_of_outputscales = 0
             for param_name, param in model.named_parameters():
-                if param_name == "mean_module.constant":
+                if param_name == "mean_module.raw_constant":
                     num_of_mean += param.data.shape.numel()
                 elif "raw_lengthscale" in param_name:
                     num_of_lengthscales += param.data.shape.numel()

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -190,7 +190,7 @@ class TestFullyBayesianSingleTaskGP(BotorchTestCase):
                 model, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
             )
             self.assertIsInstance(model.mean_module, ConstantMean)
-            self.assertEqual(model.mean_module.constant.shape, torch.Size([3]))
+            self.assertEqual(model.mean_module.raw_constant.shape, torch.Size([3]))
             self.assertIsInstance(model.covar_module, ScaleKernel)
             self.assertEqual(model.covar_module.outputscale.shape, torch.Size([3]))
             self.assertIsInstance(model.covar_module.base_kernel, MaternKernel)
@@ -465,7 +465,7 @@ class TestFullyBayesianSingleTaskGP(BotorchTestCase):
             )
             self.assertTrue(
                 torch.allclose(
-                    model.mean_module.constant.data,
+                    model.mean_module.raw_constant.data,
                     mcmc_samples["mean"],
                 )
             )

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -96,7 +96,7 @@ class TestFullyBayesianSingleTaskGP(BotorchTestCase):
         mcmc_samples = {
             "lengthscale": torch.rand(num_samples, 1, dim, **tkwargs),
             "outputscale": torch.rand(num_samples, **tkwargs),
-            "mean": torch.randn(num_samples, 1, **tkwargs),
+            "mean": torch.randn(num_samples, **tkwargs),
         }
         if infer_noise:
             mcmc_samples["noise"] = torch.rand(num_samples, 1, **tkwargs)
@@ -190,7 +190,7 @@ class TestFullyBayesianSingleTaskGP(BotorchTestCase):
                 model, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
             )
             self.assertIsInstance(model.mean_module, ConstantMean)
-            self.assertEqual(model.mean_module.constant.shape, torch.Size([3, 1]))
+            self.assertEqual(model.mean_module.constant.shape, torch.Size([3]))
             self.assertIsInstance(model.covar_module, ScaleKernel)
             self.assertEqual(model.covar_module.outputscale.shape, torch.Size([3]))
             self.assertIsInstance(model.covar_module.base_kernel, MaternKernel)

--- a/test/optim/test_numpy_converter.py
+++ b/test/optim/test_numpy_converter.py
@@ -43,7 +43,7 @@ class TestModuleToArray(BotorchTestCase):
             expected_sizes = {
                 "likelihood.noise_covar.raw_noise": torch.Size([1]),
                 "model.covar_module.raw_lengthscale": torch.Size([1, 3]),
-                "model.mean_module.constant": torch.Size([1]),
+                "model.mean_module.raw_constant": torch.Size(),
             }
             self.assertEqual(set(pdict.keys()), set(expected_sizes.keys()))
             for pname, val in pdict.items():
@@ -65,7 +65,7 @@ class TestModuleToArray(BotorchTestCase):
             mll = ExactMarginalLogLikelihood(likelihood, model)
             # test the basic case
             x, pdict, bounds = module_to_array(
-                module=mll, exclude={"model.mean_module.constant"}
+                module=mll, exclude={"model.mean_module.raw_constant"}
             )
             self.assertTrue(np.array_equal(x, np.zeros(4)))
             expected_sizes = {
@@ -98,7 +98,7 @@ class TestModuleToArray(BotorchTestCase):
             expected_sizes = {
                 "likelihood.noise_covar.raw_noise": torch.Size([1]),
                 "model.covar_module.raw_lengthscale": torch.Size([1, 3]),
-                "model.mean_module.constant": torch.Size([1]),
+                "model.mean_module.raw_constant": torch.Size(),
             }
             self.assertEqual(set(pdict.keys()), set(expected_sizes.keys()))
             for pname, val in pdict.items():
@@ -106,7 +106,10 @@ class TestModuleToArray(BotorchTestCase):
                 self.assertEqual(val.shape, expected_sizes[pname])
                 self.assertEqual(val.device.type, self.device.type)
             lower_exp = np.full_like(x, 0.1)
-            for p in ("likelihood.noise_covar.raw_noise", "model.mean_module.constant"):
+            for p in (
+                "likelihood.noise_covar.raw_noise",
+                "model.mean_module.raw_constant",
+            ):
                 lower_exp[_get_index(pdict, p)] = -np.inf
             self.assertTrue(np.equal(bounds[0], lower_exp).all())
             self.assertTrue(np.equal(bounds[1], np.full_like(x, np.inf)).all())
@@ -132,7 +135,7 @@ class TestModuleToArray(BotorchTestCase):
             expected_sizes = {
                 "likelihood.noise_covar.raw_noise": torch.Size([1]),
                 "model.covar_module.raw_lengthscale": torch.Size([1, 3]),
-                "model.mean_module.constant": torch.Size([1]),
+                "model.mean_module.raw_constant": torch.Size(),
             }
             self.assertEqual(set(pdict.keys()), set(expected_sizes.keys()))
             for pname, val in pdict.items():
@@ -140,7 +143,7 @@ class TestModuleToArray(BotorchTestCase):
                 self.assertEqual(val.shape, expected_sizes[pname])
                 self.assertEqual(val.device.type, self.device.type)
             lower_exp = np.full_like(x, 0.1)
-            lower_exp[_get_index(pdict, "model.mean_module.constant")] = -np.inf
+            lower_exp[_get_index(pdict, "model.mean_module.raw_constant")] = -np.inf
             lower_exp[_get_index(pdict, "likelihood.noise_covar.raw_noise")] = 1e-5
             self.assertTrue(np.allclose(bounds[0], lower_exp))
             self.assertTrue(np.equal(bounds[1], np.full_like(x, np.inf)).all())
@@ -178,8 +181,8 @@ class TestSetParamsWithArray(BotorchTestCase):
             )
             self.assertTrue(
                 torch.equal(
-                    z["model.mean_module.constant"],
-                    torch.tensor([5.0], device=self.device, dtype=dtype),
+                    z["model.mean_module.raw_constant"],
+                    torch.tensor(5.0, device=self.device, dtype=dtype),
                 )
             )
 

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -176,10 +176,10 @@ class TestFitGPyTorchModel(BotorchTestCase):
 
             # test excluding a parameter
             mll = self._getModel(double=double)
-            original_raw_noise = mll.model.likelihood.noise_covar.raw_noise.item()
-            original_mean_module_constant = mll.model.mean_module.constant.item()
+            orig_raw_noise = mll.model.likelihood.noise_covar.raw_noise.item()
+            orig_mean_module_raw_constant = mll.model.mean_module.raw_constant.item()
             options["exclude"] = [
-                "model.mean_module.constant",
+                "model.mean_module.raw_constant",
                 "likelihood.noise_covar.raw_noise",
             ]
             mll = fit_gpytorch_model(
@@ -188,10 +188,10 @@ class TestFitGPyTorchModel(BotorchTestCase):
             model = mll.model
             # Make excluded params did not change
             self.assertEqual(
-                model.likelihood.noise_covar.raw_noise.item(), original_raw_noise
+                model.likelihood.noise_covar.raw_noise.item(), orig_raw_noise
             )
             self.assertEqual(
-                model.mean_module.constant.item(), original_mean_module_constant
+                model.mean_module.raw_constant.item(), orig_mean_module_raw_constant
             )
             # Make sure other params did change
             self.assertGreater(

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -105,7 +105,7 @@ class TestFitGPyTorchModel(BotorchTestCase):
             model = mll.model
             # Make sure all of the parameters changed
             self.assertGreater(model.likelihood.raw_noise.abs().item(), 1e-3)
-            self.assertLess(model.mean_module.constant.abs().item(), 0.1)
+            self.assertLess(model.mean_module.raw_constant.abs().item(), 0.1)
             self.assertGreater(
                 model.covar_module.base_kernel.raw_lengthscale.abs().item(), 0.1
             )
@@ -123,7 +123,7 @@ class TestFitGPyTorchModel(BotorchTestCase):
 
             model = mll.model
             self.assertGreaterEqual(model.likelihood.raw_noise.abs().item(), 1e-1)
-            self.assertLess(model.mean_module.constant.abs().item(), 0.1)
+            self.assertLess(model.mean_module.raw_constant.abs().item(), 0.1)
             self.assertGreater(
                 model.covar_module.base_kernel.raw_lengthscale.abs().item(), 0.1
             )
@@ -212,7 +212,7 @@ class TestFitGPyTorchModel(BotorchTestCase):
             model = mll.model
             # Make sure all of the parameters changed
             self.assertGreater(model.likelihood.raw_noise.abs().item(), 1e-3)
-            self.assertLess(model.mean_module.constant.abs().item(), 0.1)
+            self.assertLess(model.mean_module.raw_constant.abs().item(), 0.1)
             self.assertGreater(
                 model.covar_module.base_kernel.raw_lengthscale.abs().item(), 0.1
             )

--- a/test/utils/test_gp_sampling.py
+++ b/test/utils/test_gp_sampling.py
@@ -195,7 +195,7 @@ class TestGPDraw(BotorchTestCase):
             self.assertIsNotNone(gp._seed)
             # make sure model is actually deepcopied
             model.mean_module.constant = float("inf")
-            self.assertTrue(torch.equal(gp._model.mean_module.constant, mean))
+            self.assertTrue(torch.equal(gp._model.mean_module.raw_constant, mean))
             # test basic functionality
             test_X1 = torch.rand(1, 1, **tkwargs, requires_grad=True)
             Y1 = gp(test_X1)
@@ -234,14 +234,14 @@ class TestGPDraw(BotorchTestCase):
         for dtype in (torch.float, torch.double):
             tkwargs = {"device": self.device, "dtype": dtype}
             model, _, _ = _get_model(**tkwargs, multi_output=True)
-            mean = model.mean_module.constant.detach().clone()
+            mean = model.mean_module.raw_constant.detach().clone()
             gp = GPDraw(model)
             # test initialization
             self.assertIsNone(gp.Xs)
             self.assertIsNone(gp.Ys)
             # make sure model is actually deepcopied
             model.mean_module.constant = float("inf")
-            self.assertTrue(torch.equal(gp._model.mean_module.constant, mean))
+            self.assertTrue(torch.equal(gp._model.mean_module.raw_constant, mean))
             # test basic functionality
             test_X1 = torch.rand(1, 1, **tkwargs, requires_grad=True)
             Y1 = gp(test_X1)

--- a/test/utils/test_gp_sampling.py
+++ b/test/utils/test_gp_sampling.py
@@ -74,7 +74,7 @@ def _get_model(
             1.1000, **tkwargs
         ),
         "likelihood.noise_covar.noise_prior.rate": torch.tensor(0.0500, **tkwargs),
-        "mean_module.constant": torch.tensor([0.1398], **tkwargs),
+        "mean_module.raw_constant": torch.tensor(0.1398, **tkwargs),
         "covar_module.raw_outputscale": torch.tensor(0.6933, **tkwargs),
         "covar_module.base_kernel.raw_lengthscale": torch.tensor(
             [[-0.0444]], **tkwargs
@@ -111,8 +111,8 @@ def _get_model(
                 torch.tensor([0.0745], **tkwargs),
             ]
         )
-        state_dict["mean_module.constant"] = torch.stack(
-            [state_dict["mean_module.constant"], torch.tensor([0.3276], **tkwargs)]
+        state_dict["mean_module.raw_constant"] = torch.stack(
+            [state_dict["mean_module.raw_constant"], torch.tensor(0.3276, **tkwargs)]
         )
         state_dict["covar_module.raw_outputscale"] = torch.stack(
             [
@@ -134,7 +134,7 @@ def _get_model(
         state_dict["likelihood.noise_covar.raw_noise"] = torch.tensor(
             [[0.0214], [0.001]], **tkwargs
         )
-        state_dict["mean_module.constant"] = torch.tensor([[0.1398], [0.5]], **tkwargs)
+        state_dict["mean_module.raw_constant"] = torch.tensor([0.1398, 0.5], **tkwargs)
         state_dict["covar_module.raw_outputscale"] = torch.tensor(
             [0.6933, 1.0], **tkwargs
         )
@@ -153,8 +153,8 @@ def _get_model(
         state_dict["likelihood.noise_covar.raw_noise"] = torch.tensor(
             [[0.1743], [0.3132]] if multi_output else [0.1743], **tkwargs
         )
-        state_dict["mean_module.constant"] = torch.tensor(
-            [[0.2560], [0.6714]] if multi_output else [0.2555], **tkwargs
+        state_dict["mean_module.raw_constant"] = torch.tensor(
+            [0.2560, 0.6714] if multi_output else 0.2555, **tkwargs
         )
         state_dict["covar_module.raw_outputscale"] = torch.tensor(
             [2.4396, 2.6821] if multi_output else 2.4398, **tkwargs
@@ -187,14 +187,14 @@ class TestGPDraw(BotorchTestCase):
         for dtype in (torch.float, torch.double):
             tkwargs = {"device": self.device, "dtype": dtype}
             model, _, _ = _get_model(**tkwargs)
-            mean = model.mean_module.constant.detach().clone()
+            mean = model.mean_module.raw_constant.detach().clone()
             gp = GPDraw(model)
             # test initialization
             self.assertIsNone(gp.Xs)
             self.assertIsNone(gp.Ys)
             self.assertIsNotNone(gp._seed)
             # make sure model is actually deepcopied
-            model.mean_module.constant = None
+            model.mean_module.constant = float("inf")
             self.assertTrue(torch.equal(gp._model.mean_module.constant, mean))
             # test basic functionality
             test_X1 = torch.rand(1, 1, **tkwargs, requires_grad=True)
@@ -240,7 +240,7 @@ class TestGPDraw(BotorchTestCase):
             self.assertIsNone(gp.Xs)
             self.assertIsNone(gp.Ys)
             # make sure model is actually deepcopied
-            model.mean_module.constant = None
+            model.mean_module.constant = float("inf")
             self.assertTrue(torch.equal(gp._model.mean_module.constant, mean))
             # test basic functionality
             test_X1 = torch.rand(1, 1, **tkwargs, requires_grad=True)


### PR DESCRIPTION
https://github.com/cornellius-gp/gpytorch/pull/2082 changed the shape of the mean constant (and did some other things). These changes fix the resulting unit test breakages.