### PR TITLE
More informative errors for wrong index dtype

### DIFF
--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -888,6 +888,9 @@ def get_polytope_samples(
     """
     # create tensors representing linear inequality constraints
     # of the form Ax >= b.
+    # TODO: remove this error handling functionality in a few releases. 
+    # Context: BoTorch inadvertently supported indices with unusual dtypes. 
+    # This is now not supported.
     index_dtype_error = (
         "Normalizing {var_name} failed. Check that the first "
         "element of {var_name} is the correct dtype following "
@@ -899,14 +902,14 @@ def get_polytope_samples(
         try:
             # non-standard dtypes used to be supported for indices in constraints;
             # this is no longer true
-            constraints_ = normalize_linear_constraints(bounds, inequality_constraints)
+            constraints = normalize_linear_constraints(bounds, inequality_constraints)
         except IndexError as e:
             msg = index_dtype_error.format(var_name="`inequality_constraints`")
             raise ValueError(msg) from e
 
         A, b = sparse_to_dense_constraints(
             d=bounds.shape[-1],
-            constraints=constraints_,
+            constraints=constraints,
         )
         # Note the inequality constraints are of the form Ax >= b,
         # but PolytopeSampler expects inequality constraints of the
@@ -918,7 +921,7 @@ def get_polytope_samples(
         try:
             # non-standard dtypes used to be supported for indices in constraints;
             # this is no longer true
-            constraints_ = normalize_linear_constraints(bounds, equality_constraints)
+            constraints = normalize_linear_constraints(bounds, equality_constraints)
         except IndexError as e:
             msg = index_dtype_error.format(var_name="`equality_constraints`")
             raise ValueError(msg) from e
@@ -926,7 +929,7 @@ def get_polytope_samples(
         # normalize_linear_constraints is called to solve this issue:
         # https://github.com/pytorch/botorch/issues/1225
         dense_equality_constraints = sparse_to_dense_constraints(
-            d=bounds.shape[-1], constraints=constraints_
+            d=bounds.shape[-1], constraints=constraints
         )
     else:
         dense_equality_constraints = None

--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -888,8 +888,8 @@ def get_polytope_samples(
     """
     # create tensors representing linear inequality constraints
     # of the form Ax >= b.
-    # TODO: remove this error handling functionality in a few releases. 
-    # Context: BoTorch inadvertently supported indices with unusual dtypes. 
+    # TODO: remove this error handling functionality in a few releases.
+    # Context: BoTorch inadvertently supported indices with unusual dtypes.
     # This is now not supported.
     index_dtype_error = (
         "Normalizing {var_name} failed. Check that the first "

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -271,73 +271,86 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                 )
 
     def test_gen_batch_initial_conditions_constraints(self):
-        for dtype in (torch.float, torch.double):
-            bounds = torch.tensor([[0, 0], [1, 1]], device=self.device, dtype=dtype)
-            inequality_constraints = [
-                (
-                    torch.tensor([1], device=self.device, dtype=torch.int64),
-                    torch.tensor([-4], device=self.device, dtype=dtype),
-                    torch.tensor(-3, device=self.device, dtype=dtype),
-                )
-            ]
-            equality_constraints = [
-                (
-                    torch.tensor([0], device=self.device, dtype=torch.int64),
-                    torch.tensor([1], device=self.device, dtype=dtype),
-                    torch.tensor(0.5, device=self.device, dtype=dtype),
-                )
-            ]
-            for nonnegative, seed, init_batch_limit, ffs in product(
-                [True, False], [None, 1234], [None, 1], [None, {0: 0.5}]
-            ):
-                mock_acqf = MockAcquisitionFunction()
-                with mock.patch.object(
+
+        for dtype, nonnegative, seed, init_batch_limit, ffs in product(
+            [torch.float, torch.double],
+            [True, False],
+            [None, 1234],
+            [None, 1],
+            [None, {0: 0.5}],
+        ):
+            mock_acqf = MockAcquisitionFunction()
+            with (
+                self.subTest(
+                    dtype=dtype,
+                    nonnegative=nonnegative,
+                    seed=seed,
+                    init_batch_limit=init_batch_limit,
+                    ffs=ffs,
+                ),
+                mock.patch.object(
                     MockAcquisitionFunction,
                     "__call__",
                     wraps=mock_acqf.__call__,
-                ) as mock_acqf_call:
-                    batch_initial_conditions = gen_batch_initial_conditions(
-                        acq_function=mock_acqf,
-                        bounds=bounds,
-                        q=1,
-                        num_restarts=2,
-                        raw_samples=10,
-                        options={
-                            "nonnegative": nonnegative,
-                            "eta": 0.01,
-                            "alpha": 0.1,
-                            "seed": seed,
-                            "init_batch_limit": init_batch_limit,
-                            "thinning": 2,
-                            "n_burnin": 3,
-                        },
-                        inequality_constraints=inequality_constraints,
-                        equality_constraints=equality_constraints,
+                ),
+            ):
+                bounds = torch.tensor([[0, 0], [1, 1]], device=self.device, dtype=dtype)
+                inequality_constraints = [
+                    (
+                        torch.tensor([1], device=self.device, dtype=torch.int64),
+                        torch.tensor([-4], device=self.device, dtype=dtype),
+                        torch.tensor(-3, device=self.device, dtype=dtype),
                     )
-                    expected_shape = torch.Size([2, 1, 2])
-                    self.assertEqual(batch_initial_conditions.shape, expected_shape)
-                    self.assertEqual(batch_initial_conditions.device, bounds.device)
-                    self.assertEqual(batch_initial_conditions.dtype, bounds.dtype)
-                    batch_shape = (
-                        torch.Size([])
-                        if init_batch_limit is None
-                        else torch.Size([init_batch_limit])
+                ]
+                equality_constraints = [
+                    (
+                        torch.tensor([0], device=self.device, dtype=torch.int64),
+                        torch.tensor([1], device=self.device, dtype=dtype),
+                        torch.tensor(0.5, device=self.device, dtype=dtype),
                     )
-                    raw_samps = mock_acqf_call.call_args[0][0]
-                    batch_shape = (
-                        torch.Size([10])
-                        if init_batch_limit is None
-                        else torch.Size([init_batch_limit])
-                    )
-                    expected_raw_samps_shape = batch_shape + torch.Size([1, 2])
-                    self.assertEqual(raw_samps.shape, expected_raw_samps_shape)
-                    self.assertTrue((raw_samps[..., 0] == 0.5).all())
-                    self.assertTrue((-4 * raw_samps[..., 1] >= -3).all())
-                    if ffs is not None:
-                        for idx, val in ffs.items():
-                            self.assertTrue(
-                                torch.all(batch_initial_conditions[..., idx] == val)
-                            )
+                ]
+                batch_initial_conditions = gen_batch_initial_conditions(
+                    acq_function=mock_acqf,
+                    bounds=bounds,
+                    q=1,
+                    num_restarts=2,
+                    raw_samples=10,
+                    options={
+                        "nonnegative": nonnegative,
+                        "eta": 0.01,
+                        "alpha": 0.1,
+                        "seed": seed,
+                        "init_batch_limit": init_batch_limit,
+                        "thinning": 2,
+                        "n_burnin": 3,
+                    },
+                    inequality_constraints=inequality_constraints,
+                    equality_constraints=equality_constraints,
+                )
+                expected_shape = torch.Size([2, 1, 2])
+                self.assertEqual(batch_initial_conditions.shape, expected_shape)
+                self.assertEqual(batch_initial_conditions.device, bounds.device)
+                self.assertEqual(batch_initial_conditions.dtype, bounds.dtype)
+                batch_shape = (
+                    torch.Size([])
+                    if init_batch_limit is None
+                    else torch.Size([init_batch_limit])
+                )
+                raw_samps = mock_acqf.__call__.call_args[0][0]
+                batch_shape = (
+                    torch.Size([10])
+                    if init_batch_limit is None
+                    else torch.Size([init_batch_limit])
+                )
+                expected_raw_samps_shape = batch_shape + torch.Size([1, 2])
+                self.assertEqual(raw_samps.shape, expected_raw_samps_shape)
+                self.assertTrue((raw_samps[..., 0] == 0.5).all())
+                self.assertTrue((-4 * raw_samps[..., 1] >= -3).all())
+                if ffs is not None:
+                    for idx, val in ffs.items():
+                        self.assertTrue(
+                            torch.all(batch_initial_conditions[..., idx] == val)
+                        )
 
     def test_error_equality_constraints_with_sample_around_best(self):
         tkwargs = {"device": self.device, "dtype": torch.double}


### PR DESCRIPTION
## Motivation

This is fixing a very minor issue and I've probably already spent too much time on it. Unless anyone feels really strongly about this, I'd prefer to either have this quickly either accepted or rejected rather than spend a while iterating on revisions.

In the past it was possible to use indexers with dtypes that torch does not accept as indexers via `equality_constraints` and `inequality_constraints`. This was never really intended behavior and stopped being supported in #1341 (discussed in #1225 ) . This PR makes errors more informative if someone does try to use the wrong dtypes, since the existing error message did not make clear where the error came from.

I aslo refactored a test in test_initalizers.py.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit tests for errors raised

## Related PRs

#1341 
