### PR TITLE
fixing `test_fit_gpytorch_model` for Python versions before 3.8

### DIFF
--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -220,7 +220,8 @@ class TestFitGPyTorchModel(BotorchTestCase):
             )
             self.assertGreater(model.covar_module.raw_outputscale.abs().item(), 1e-3)
 
-            # end-to-end testing that fit_gpytorch_model passes the options to scipy minimize
+            # end-to-end testing that fit_gpytorch_model passes
+            # the options to scipy minimize
             if optimizer == fit_gpytorch_scipy:
                 options["maxiter"] = 3
                 scipy_minimize_mock = mock.Mock(wraps=scipy.optimize.minimize)
@@ -228,7 +229,9 @@ class TestFitGPyTorchModel(BotorchTestCase):
                     fit_gpytorch_model(
                         mll, optimizer=optimizer, options=options, max_retries=1
                     )
-                kwargs = scipy_minimize_mock.call_args.kwargs
+                # second element of call_args tuple are kwargs can
+                # be retrieved with call_args.kwargs in Python >= 3.8
+                kwargs = scipy_minimize_mock.call_args[1]
                 # testing maxiter separately to give more informative failures
                 self.assertEqual(kwargs["options"]["maxiter"], options["maxiter"])
                 self.assertEqual(kwargs["options"], options)


### PR DESCRIPTION
Summary: [The previous PR](https://github.com/pytorch/botorch/pull/1350) introduced a new test that failed when run on Python 3.7. This was because it used the `kwargs` property of the [`call_args` property of mocks](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.call_args), which was introduced in Python version 3.8. This changes the syntax to be compatible with earlier Python versions.

Differential Revision: D38762058

