### PR TITLE
Update PyPA "publish to PyPi" github action

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -58,7 +58,7 @@ jobs:
       run: |
         ./scripts/build_and_verify_py_packages.sh
     - name: Deploy to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         ./scripts/build_and_verify_py_packages.sh
     - name: Deploy to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_TOKEN }}


### PR DESCRIPTION
Current `master` version of the PyPA "publish to PyPi" github action is unsupported: https://github.com/pytorch/botorch/actions/runs/2874668079

Update version to `release/v1` as suggested.