### PR TITLE
Pin gpytorch to 1.8.1 after LinearOperator PR merge

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - setuptools_scm
   run:
     - pytorch >=1.10
-    - gpytorch >=1.8.1
+    - gpytorch ==1.8.1
     - scipy
     - pyro-ppl >=1.8.0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install .[dev]
         # NOTE: nbconvert 6.4.4 is incompatible with jinja2 3.1.0.
         # We can unpin this with a future release of nbconvert.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install .[test]
     - name: Unit tests and coverage
       run: |
@@ -51,7 +51,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install .[test]
         pip install --upgrade build setuptools setuptools_scm wheel
     - name: Extract reduced version and save to env var
@@ -98,7 +98,7 @@ jobs:
         conda config --set anaconda_upload no
         conda install -y -c pytorch-nightly pytorch cpuonly
         conda install -y -c conda-forge pyro-ppl>=1.8.0
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
     - name: Build and verify conda package
       shell: bash -l {0}
       run: |
@@ -120,7 +120,7 @@ jobs:
       run: git fetch --prune --unshallow
     - name: Install dependencies
       run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install .[dev]
         pip install git+https://github.com/facebook/Ax.git
         # NOTE: nbconvert 6.4.4 is incompatible with jinja2 3.1.0.

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -33,7 +33,7 @@ jobs:
       name: Install latest PyTorch & GPyTorch
       run: |
         pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
     - if: ${{ inputs.use_stable_pytorch_gpytorch }}
       name: Install min required PyTorch & GPyTorch
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install .[test]
     - name: Unit tests and coverage
       run: |
@@ -57,7 +57,7 @@ jobs:
       run: |
         conda install -y -c pytorch-nightly pytorch cpuonly
         conda install -y pip scipy sphinx pytest flake8
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install .[test]
     - name: Unit tests
       shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Optimization simply use Ax.
 **Installation Requirements**
 - Python >= 3.7
 - PyTorch >= 1.10
-- gpytorch >= 1.8.1
+- gpytorch == 1.8.1
 - pyro-ppl >= 1.8.0
 - scipy
 - multiple-dispatch

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,7 +15,7 @@ Before jumping the gun, we recommend you start with the high-level
 
 - Python >= 3.7
 - PyTorch >= 1.10
-- gpytorch >= 1.8.1
+- gpytorch == 1.8.1
 - scipy
 - multiple-dispatch
 - pyro-ppl >= 1.8.0

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,6 @@ channels:
   - conda-forge
 dependencies:
   - pytorch>=1.10
-  - gpytorch>=1.8.1
+  - gpytorch==1.8.1
   - scipy
   - pyro-ppl>=1.8.0

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     packages=find_packages(exclude=["test", "test.*"]),
     install_requires=[
         "torch>=1.10",
-        "gpytorch>=1.8.1",
+        "gpytorch==1.8.1",
         "scipy",
         "multipledispatch",
         "pyro-ppl>=1.8.0",


### PR DESCRIPTION
https://github.com/cornellius-gp/gpytorch/pull/2027 was a massive change to gpytorch and broke our CI (and other things).
This PR pins gpytorch to the release made right prior to this being merged in to give us some time to fix these.