### PR TITLE
Bump gpytorch min version to 1.9.0

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - setuptools_scm
   run:
     - pytorch >=1.11
-    - gpytorch >1.8.1
+    - gpytorch >=1.9.0
     - scipy
     - pyro-ppl >=1.8.1
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Optimization simply use Ax.
 **Installation Requirements**
 - Python >= 3.8
 - PyTorch >= 1.11
-- gpytorch > 1.8.1
+- gpytorch >= 1.9.0
 - pyro-ppl >= 1.8.1
 - scipy
 - multiple-dispatch

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,7 +15,7 @@ Before jumping the gun, we recommend you start with the high-level
 
 - Python >= 3.8
 - PyTorch >= 1.11
-- gpytorch > 1.8.1
+- gpytorch >= 1.9.0
 - scipy
 - multiple-dispatch
 - pyro-ppl >= 1.8.1

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,6 @@ channels:
   - conda-forge
 dependencies:
   - pytorch>=1.11
-  - gpytorch>1.8.1
+  - gpytorch>-1.9.0
   - scipy
   - pyro-ppl>=1.8.1

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     packages=find_packages(exclude=["test", "test.*"]),
     install_requires=[
         "torch>=1.11",
-        "gpytorch>=1.8.1",
+        "gpytorch>=1.9.0",
         "scipy",
         "multipledispatch",
         "pyro-ppl>=1.8.1",


### PR DESCRIPTION
Required for the recent adjustments to using LinearOperator in gpytorch.