### PR TITLE
Deprecating GPyTorch's `NanError`, `NotPSDError`, `psd_safe_cholesky` in favor of LinearOperators's versions

### DIFF
--- a/botorch/acquisition/cached_cholesky.py
+++ b/botorch/acquisition/cached_cholesky.py
@@ -29,7 +29,7 @@ from gpytorch import settings as gpt_settings
 from gpytorch.distributions.multitask_multivariate_normal import (
     MultitaskMultivariateNormal,
 )
-from gpytorch.utils.errors import NanError, NotPSDError
+from linear_operator.utils.errors import NanError, NotPSDError
 from torch import Tensor
 
 

--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -46,8 +46,9 @@ from botorch.models.model import Model
 from botorch.models.utils import check_no_nans
 from botorch.sampling.samplers import SobolQMCNormalSampler
 from botorch.utils.transforms import match_batch_shape, t_batch_mode_transform
-from gpytorch.functions import inv_quad
-from gpytorch.utils.cholesky import psd_safe_cholesky
+
+from linear_operator.functions import inv_quad
+from linear_operator.utils.cholesky import psd_safe_cholesky
 from scipy.optimize import brentq
 from scipy.stats import norm
 from torch import Tensor

--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -25,7 +25,7 @@ from botorch.optim.utils import sample_all_priors
 from botorch.settings import debug
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
-from gpytorch.utils.errors import NotPSDError
+from linear_operator.utils.errors import NotPSDError
 from pyro.infer.mcmc import MCMC, NUTS
 
 

--- a/botorch/models/pairwise_gp.py
+++ b/botorch/models/pairwise_gp.py
@@ -47,8 +47,8 @@ from gpytorch.models.gp import GP
 from gpytorch.module import Module
 from gpytorch.priors.smoothed_box_prior import SmoothedBoxPrior
 from gpytorch.priors.torch_priors import GammaPrior
-from gpytorch.utils.cholesky import psd_safe_cholesky
 from linear_operator.operators import LinearOperator
+from linear_operator.utils.cholesky import psd_safe_cholesky
 from scipy import optimize
 from torch import float32, float64, Tensor
 from torch.nn.modules.module import _IncompatibleKeys

--- a/botorch/optim/utils.py
+++ b/botorch/optim/utils.py
@@ -25,7 +25,7 @@ from botorch.optim.numpy_converter import set_params_with_array, TorchAttr
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
-from gpytorch.utils.errors import NanError, NotPSDError
+from linear_operator.utils.errors import NanError, NotPSDError
 from torch import Tensor
 
 

--- a/botorch/utils/gp_sampling.py
+++ b/botorch/utils/gp_sampling.py
@@ -18,7 +18,7 @@ from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import MultiTaskGP
 from botorch.utils.sampling import manual_seed
 from gpytorch.kernels import Kernel, MaternKernel, RBFKernel, ScaleKernel
-from gpytorch.utils.cholesky import psd_safe_cholesky
+from linear_operator.utils.cholesky import psd_safe_cholesky
 from torch import Tensor
 from torch.distributions import MultivariateNormal
 from torch.nn import Module

--- a/botorch/utils/low_rank.py
+++ b/botorch/utils/low_rank.py
@@ -13,10 +13,10 @@ from botorch.posteriors.gpytorch import GPyTorchPosterior
 from gpytorch.distributions.multitask_multivariate_normal import (
     MultitaskMultivariateNormal,
 )
-
-from gpytorch.utils.cholesky import psd_safe_cholesky
-from gpytorch.utils.errors import NanError, NotPSDError
 from linear_operator.operators import BlockDiagLinearOperator, LinearOperator
+
+from linear_operator.utils.cholesky import psd_safe_cholesky
+from linear_operator.utils.errors import NanError, NotPSDError
 from torch import Tensor
 
 

--- a/test/acquisition/test_cached_cholesky.py
+++ b/test/acquisition/test_cached_cholesky.py
@@ -20,7 +20,7 @@ from botorch.models.higher_order_gp import HigherOrderGP
 from botorch.sampling.samplers import IIDNormalSampler
 from botorch.utils.low_rank import extract_batch_covar
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
-from gpytorch.utils.errors import NanError, NotPSDError
+from linear_operator.utils.errors import NanError, NotPSDError
 
 CHOLESKY_PATH = "linear_operator.operators._linear_operator.psd_safe_cholesky"
 EXTRACT_BATCH_COVAR_PATH = "botorch.acquisition.cached_cholesky.extract_batch_covar"

--- a/test/optim/test_utils.py
+++ b/test/optim/test_utils.py
@@ -49,7 +49,7 @@ from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
 from gpytorch.priors.prior import Prior
 from gpytorch.priors.torch_priors import GammaPrior
-from gpytorch.utils.errors import NanError, NotPSDError
+from linear_operator.utils.errors import NanError, NotPSDError
 
 
 class DummyPrior(Prior):

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -28,8 +28,8 @@ from gpytorch.constraints import GreaterThan, Interval
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
-from gpytorch.utils.errors import NanError, NotPSDError
 from gpytorch.utils.warnings import NumericalWarning
+from linear_operator.utils.errors import NanError, NotPSDError
 from scipy.optimize import OptimizeResult
 
 

--- a/test/utils/test_low_rank.py
+++ b/test/utils/test_low_rank.py
@@ -16,8 +16,8 @@ from botorch.utils.testing import BotorchTestCase
 from gpytorch.distributions.multitask_multivariate_normal import (
     MultitaskMultivariateNormal,
 )
-from gpytorch.utils.errors import NanError, NotPSDError
 from linear_operator.operators import BlockDiagLinearOperator, to_linear_operator
+from linear_operator.utils.errors import NanError, NotPSDError
 
 
 class TestExtractBatchCovar(BotorchTestCase):


### PR DESCRIPTION
Summary: Due to the recent migration to LinearOperators, we get a number of deprecation warnings, suggesting to switch from gpytorch versions of certain functions and objects to their LinearOperator equivalents. This diff aims to move all occurences of `NanError`, `NotPSDError`, `psd_safe_cholesky` in BoTorch to the new versions, thereby minimizing the number of deprecation warnings.

Reviewed By: Balandat

Differential Revision: D39287750

