### PR TITLE
Bump newest python version in GHA workflows to 3.10

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - pytorch >=1.11
     - gpytorch >=1.9.0
     - scipy
-    - pyro-ppl >=1.8.1
+    - pyro-ppl >=1.8.2
 
 test:
   imports:

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -86,7 +86,7 @@ jobs:
         conda install -y -c pytorch pytorch cpuonly
         conda install -y scipy sphinx pytest flake8
         conda install -y -c gpytorch gpytorch
-        conda install -y -c conda-forge pyro-ppl>=1.8.1
+        conda install -y -c conda-forge pyro-ppl>=1.8.2
         conda config --set anaconda_upload no
     - name: Build and verify conda package
       shell: bash -l {0}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Optimization simply use Ax.
 - Python >= 3.8
 - PyTorch >= 1.11
 - gpytorch >= 1.9.0
-- pyro-ppl >= 1.8.1
+- pyro-ppl >= 1.8.2
 - scipy
 - multiple-dispatch
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -18,7 +18,7 @@ Before jumping the gun, we recommend you start with the high-level
 - gpytorch >= 1.9.0
 - scipy
 - multiple-dispatch
-- pyro-ppl >= 1.8.1
+- pyro-ppl >= 1.8.2
 
 BoTorch is easily installed via
 [Anaconda](https://www.anaconda.com/distribution/#download-section) (recommended)

--- a/environment.yml
+++ b/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - pytorch>=1.11
   - gpytorch>-1.9.0
   - scipy
-  - pyro-ppl>=1.8.1
+  - pyro-ppl>=1.8.2

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "gpytorch>=1.9.0",
         "scipy",
         "multipledispatch",
-        "pyro-ppl>=1.8.1",
+        "pyro-ppl>=1.8.2",
     ],
     extras_require={
         "dev": DEV_REQUIRES,


### PR DESCRIPTION
Pyro with 1.8.2 now properly supports python 3.10, and so should we. This is to ensure that the CI tests run on both the min and max supported versions.