### PR TITLE
Fix nightly_cron worflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,6 +128,7 @@ jobs:
         pip install .[dev]
         pip install git+https://github.com/facebook/Ax.git
         pip install beautifulsoup4 ipython nbconvert jinja2
+    - name: Unit tests
       run: |
         pytest -ra
     - name: Publish latest website


### PR DESCRIPTION
This line was mistakenly deleted in #1381. It currently leads to a "startup failure". See https://github.com/pytorch/botorch/actions/runs/3014394700

Test plan: nightly cron runs
https://github.com/pytorch/botorch/actions/runs/3017300402