### PR TITLE
Fix `ChainedInputTransform.equals`

### DIFF
--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -225,7 +225,7 @@ class ChainedInputTransform(InputTransform, ModuleDict):
             A boolean indicating if the other transform is equivalent.
         """
         return super().equals(other=other) and all(
-            t1 == t2 for t1, t2 in zip(self.values(), other.values())
+            t1.equals(t2) for t1, t2 in zip(self.values(), other.values())
         )
 
     def preprocess_transform(self, X: Tensor) -> Tensor:

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -506,6 +506,9 @@ class TestInputTransforms(BotorchTestCase):
             # change order
             other_tf = ChainedInputTransform(stz_learned=tf2, stz_fixed=tf1)
             self.assertFalse(tf.equals(other_tf))
+            # Identical transforms but different objects.
+            other_tf = ChainedInputTransform(stz_fixed=tf1, stz_learned=deepcopy(tf2))
+            self.assertTrue(tf.equals(other_tf))
 
             # test preprocess_transform
             tf2.transform_on_train = False


### PR DESCRIPTION
Summary: tf != deepcopy(tf) but tf.equals(deepcopy(tf)) (`__eq__` is not used due to hashing of torch Modules).

Differential Revision: D39519910

