### PR TITLE
Fixing `batch_shape` property of `SaasFullyBayesianSingleTaskGP`

### DIFF
--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -399,6 +399,14 @@ class SaasFullyBayesianSingleTaskGP(SingleTaskGP):
         self._check_if_fitted()
         return len(self.covar_module.outputscale)
 
+    @property
+    def batch_shape(self) -> torch.Size:
+        r"""Batch shape of the model, equal to the number of MCMC samples.
+        Note that `SaasFullyBayesianSingleTaskGP` does not support batching
+        over input data at this point."""
+        self._check_if_fitted()
+        return torch.Size([self.num_mcmc_samples])
+
     def fantasize(
         self,
         X: Tensor,

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -292,6 +292,14 @@ class SaasFullyBayesianMultiTaskGP(FixedNoiseMultiTaskGP):
         self._check_if_fitted()
         return len(self.covar_module.outputscale)
 
+    @property
+    def batch_shape(self) -> torch.Size:
+        r"""Batch shape of the model, equal to the number of MCMC samples.
+        Note that `SaasFullyBayesianMultiTaskGP` does not support batching
+        over input data at this point."""
+        self._check_if_fitted()
+        return torch.Size([self.num_mcmc_samples])
+
     def fantasize(
         self,
         X: Tensor,


### PR DESCRIPTION
Summary:
`SaasFullyBayesianSingleTaskGP` and `SaasFullyBayesianMultiTaskGP`'s
`batch_shape` returned `torch.Size([])`. This diff fixes this behavior to return ``torch.Size([num_mcmc_samples])`.

Reviewed By: saitcakmak, Balandat

Differential Revision: D39732001

