### PR TITLE
Fix some dependency declarations in conda setup

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - gpytorch ==1.9.0
     - linear_operator ==0.1.1
     - scipy
+    - multipledispatch
     - pyro-ppl >=1.8.2
 
 test:

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - pytorch>=1.11
   - gpytorch==1.9.0
-  - gpytorch==0.1.1
+  - linear_operator==0.1.1
   - scipy
+  - multipledispatch
   - pyro-ppl>=1.8.2


### PR DESCRIPTION
There was a bug that falsely specified two pinned gpytorch versions in the envronment.yml file. Further, this adds the multipledispatch dependency to both the meta.yml and environment.yml files.