### PR TITLE
Allow latest botorch version for Ax in website deployment flows

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -82,9 +82,9 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        conda install -y setuptools_scm multipledispatch conda-build conda-verify anaconda-client
+        conda install -y setuptools_scm conda-build conda-verify anaconda-client
+        conda install -y scipy sphinx pytest flake8 multipledispatch
         conda install -y -c pytorch pytorch cpuonly
-        conda install -y scipy sphinx pytest flake8
         conda install -y -c gpytorch gpytorch
         conda install -y -c conda-forge pyro-ppl>=1.8.2
         conda config --set anaconda_upload no
@@ -114,8 +114,9 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       # there may not be a compatible Ax pip version, so we use the development version
+      env:
+        ALLOW_BOTORCH_LATEST: true  # allow Ax to install w/ new BoTorch release
       run: |
-        pip install gpytorch
         pip install .[dev]
         pip install git+https://github.com/facebook/Ax.git
         pip install .[tutorials]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,6 +122,8 @@ jobs:
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - name: Install dependencies
+      env:
+        ALLOW_BOTORCH_LATEST: true  # allow Ax to install w/ new BoTorch release
       run: |
         pip install git+https://github.com/cornellius-gp/linear_operator.git
         pip install git+https://github.com/cornellius-gp/gpytorch.git


### PR DESCRIPTION
Prior to this change, installing Ax could have resulted in removing the installed botorch version and downgrading it to the version pinned in the Ax setup.py. This change avoids this issue.