### PR TITLE
Fix batch_shape property of ModelListGPyTorchModel

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -508,7 +508,7 @@ class ModelListGPyTorchModel(GPyTorchModel, ModelList, ABC):
         to the `posterior` method returns a Posterior object over an output of
         shape `broadcast(test_batch_shape, model.batch_shape) x q x m`.
         """
-        batch_shapes = {ti[0].shape[:-2] for ti in self.train_inputs}
+        batch_shapes = {m.batch_shape for m in self.models}
         if len(batch_shapes) > 1:
             msg = (
                 f"Component models of {self.__class__.__name__} have different "

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -304,6 +304,8 @@ class TestFullyBayesianSingleTaskGP(BotorchTestCase):
                     mean, var = posterior.mean, posterior.variance
                     self.assertEqual(mean.shape, expected_shape)
                     self.assertEqual(var.shape, expected_shape)
+                # This check is only for ModelListGP.
+                self.assertEqual(model_list.batch_shape, model.batch_shape)
 
             # Mixing fully Bayesian models with different batch shapes isn't supported
             _, _, _, model2 = self._get_data_and_model(


### PR DESCRIPTION
Summary: Previously, this was assuming the submodel batch shape is same as the input batch shape, which is not true for SAAS models. With this update, the batch shape correctly reflects the batch shape of the underlying models.

Differential Revision: D40165810

