### PR TITLE
Add a warning when using float dtype

### DIFF
--- a/test/generation/test_sampling.py
+++ b/test/generation/test_sampling.py
@@ -228,9 +228,15 @@ class TestConstrainedMaxPosteriorSampling(BotorchTestCase):
                 mp = MockPosterior(None)
                 with mock.patch.object(MockModel, "posterior", return_value=mp):
                     mm = MockModel(None)
-                    c_model1 = SingleTaskGP(X, torch.randn(X.shape[0:-1]).unsqueeze(-1))
-                    c_model2 = SingleTaskGP(X, torch.randn(X.shape[0:-1]).unsqueeze(-1))
-                    c_model3 = SingleTaskGP(X, torch.randn(X.shape[0:-1]).unsqueeze(-1))
+                    c_model1 = SingleTaskGP(
+                        X, torch.randn(X.shape[0:-1], **tkwargs).unsqueeze(-1)
+                    )
+                    c_model2 = SingleTaskGP(
+                        X, torch.randn(X.shape[0:-1], **tkwargs).unsqueeze(-1)
+                    )
+                    c_model3 = SingleTaskGP(
+                        X, torch.randn(X.shape[0:-1], **tkwargs).unsqueeze(-1)
+                    )
                     cmms1 = MockModel(MockPosterior(mean=None))
                     cmms2 = ModelListGP(c_model1, c_model2)
                     cmms3 = ModelListGP(c_model1, c_model2, c_model3)

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -15,6 +15,7 @@ from botorch.exceptions import (
     BotorchTensorDimensionError,
     BotorchTensorDimensionWarning,
 )
+from botorch.exceptions.errors import InputDataError
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.gpytorch import (
     BatchedMultiOutputGPyTorchModel,
@@ -313,6 +314,12 @@ class TestGPyTorchModel(BotorchTestCase):
         post_tf = ScalarizedPosteriorTransform(weights=torch.zeros(1, **tkwargs))
         post = model.posterior(torch.rand(3, 1, **tkwargs), posterior_transform=post_tf)
         self.assertTrue(torch.equal(post.mean, torch.zeros(3, 1, **tkwargs)))
+
+    def test_float_warning_and_dtype_error(self):
+        with self.assertWarnsRegex(UserWarning, "double precision"):
+            SimpleGPyTorchModel(torch.rand(5, 1), torch.randn(5, 1))
+        with self.assertRaisesRegex(InputDataError, "same dtype"):
+            SimpleGPyTorchModel(torch.rand(5, 1), torch.randn(5, 1, dtype=torch.double))
 
 
 class TestBatchedMultiOutputGPyTorchModel(BotorchTestCase):

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -36,11 +36,9 @@ NOISE = [
 class TestEndToEnd(BotorchTestCase):
     def _setUp(self, double=False):
         dtype = torch.double if double else torch.float
-        train_x = torch.linspace(0, 1, 10, device=self.device, dtype=dtype).unsqueeze(
-            -1
-        )
+        train_x = torch.linspace(0, 1, 10, device=self.device, dtype=dtype).view(-1, 1)
         train_y = torch.sin(train_x * (2 * math.pi))
-        train_yvar = torch.tensor(0.1**2, device=self.device)
+        train_yvar = torch.tensor(0.1**2, device=self.device, dtype=dtype)
         noise = torch.tensor(NOISE, device=self.device, dtype=dtype)
         self.train_x = train_x
         self.train_y = train_y + noise


### PR DESCRIPTION
Summary: We commonly see issues with users running into numerical errors when using float inputs. This adds a dtype check in `_validate_tensor_args`, which is used in the constructor of a large number of models, warning the users if they're not using double, and pointing them to https://github.com/pytorch/botorch/discussions/1444. Feel free to edit & add more details / examples to the discussion!

Differential Revision: D40199087

