### PR TITLE
Adding `AffineInputTransform`

### DIFF
--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 import torch
 from botorch.exceptions.errors import BotorchTensorDimensionError
 from botorch.models.transforms.input import (
+    AffineInputTransform,
     AppendFeatures,
     ChainedInputTransform,
     FilterFeatures,
@@ -124,6 +125,15 @@ class TestInputTransforms(BotorchTestCase):
         self.assertTrue(torch.equal(ipt5(X), X_tf))
         with fantasize():
             self.assertTrue(torch.equal(ipt5(X), X))
+
+        # testing one line of AffineInputTransform
+        # that doesn't have coverage otherwise
+        d = 3
+        coefficient, offset = torch.ones(d), torch.zeros(d)
+        affine = AffineInputTransform(d, coefficient, offset)
+        X = torch.randn(2, d)
+        with self.assertRaises(NotImplementedError):
+            affine._update_coefficients(X)
 
     def test_normalize(self):
         for dtype in (torch.float, torch.double):


### PR DESCRIPTION
Summary:
This diff adds `AffineInputTransform`, which applies `(x-b)/a` to an input `x`. Since this generalizes both `Normalize` and `Standardize`, this diff also makes them derived classes of the new class, leading to code sharing between the three classes.

Background: For concrete strength prediction, the `log(t + 1`) transformation of the time dimension greatly improves predictive accuracy and uncertainty callibration. It further holds promise for the learning curve prediction problem. Instead of directly implementing the custom transformation, I wrote this generalized affine transformation, which can be composed with `log` to yield the desired transformation.

Reviewed By: saitcakmak

Differential Revision: D40043491

