### PR TITLE
Pull out "fantasize" function so it isn't so widely inherited -- for discussion!

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -37,7 +37,6 @@ from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
 from botorch.models.utils import validate_input_scaling
 from botorch.posteriors.gpytorch import GPyTorchPosterior
-from botorch.sampling import MCSampler
 from gpytorch.constraints import GreaterThan
 from gpytorch.distributions import MultivariateNormal
 from gpytorch.kernels import Kernel, MaternKernel, ScaleKernel
@@ -142,11 +141,6 @@ class ApproximateGPyTorchModel(GPyTorchModel):
         if self.training:
             X = self.transform_inputs(X)
         return self.model(X)
-
-    def fantasize(self, X, sampler=MCSampler, observation_noise=True, *args, **kwargs):
-        raise NotImplementedError(
-            "Fantasization of approximate GPs has not been implemented yet."
-        )
 
 
 class _SingleTaskVariationalGP(ApproximateGP):

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -33,17 +33,16 @@ References:
 
 import math
 from abc import abstractmethod
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import pyro
 import torch
 from botorch.acquisition.objective import PosteriorTransform
-from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
 from botorch.models.utils import validate_input_scaling
 from botorch.posteriors.fully_bayesian import FullyBayesianPosterior, MCMC_DIM
-from botorch.sampling.samplers import MCSampler
 from gpytorch.constraints import GreaterThan
 from gpytorch.distributions.multivariate_normal import MultivariateNormal
 from gpytorch.kernels import MaternKernel, ScaleKernel
@@ -417,15 +416,6 @@ class SaasFullyBayesianSingleTaskGP(SingleTaskGP):
         if self.num_outputs > 1:
             aug_batch_shape += torch.Size([self.num_outputs])
         return aug_batch_shape
-
-    def fantasize(
-        self,
-        X: Tensor,
-        sampler: MCSampler,
-        observation_noise: Union[bool, Tensor] = True,
-        **kwargs: Any,
-    ) -> FixedNoiseGP:
-        raise NotImplementedError("Fantasize is not implemented!")
 
     def train(self, mode: bool = True) -> None:
         r"""Puts the model in `train` mode."""

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -8,7 +8,7 @@ r"""Multi-task Gaussian Process Regression models with fully Bayesian inference.
 """
 
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 import pyro
 import torch
@@ -24,7 +24,6 @@ from botorch.models.multitask import FixedNoiseMultiTaskGP
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
 from botorch.posteriors.fully_bayesian import FullyBayesianPosterior, MCMC_DIM
-from botorch.sampling.samplers import MCSampler
 from botorch.utils.datasets import SupervisedDataset
 from gpytorch.distributions.multivariate_normal import MultivariateNormal
 from gpytorch.kernels import MaternKernel
@@ -299,15 +298,6 @@ class SaasFullyBayesianMultiTaskGP(FixedNoiseMultiTaskGP):
         over input data at this point."""
         self._check_if_fitted()
         return torch.Size([self.num_mcmc_samples])
-
-    def fantasize(
-        self,
-        X: Tensor,
-        sampler: MCSampler,
-        observation_noise: Union[bool, Tensor] = True,
-        **kwargs: Any,
-    ) -> FixedNoiseMultiTaskGP:
-        raise NotImplementedError("Fantasize is not implemented!")
 
     def _check_if_fitted(self):
         r"""Raise an exception if the model hasn't been fitted."""

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -21,6 +21,7 @@ from typing import Any, List, Optional, Tuple, Union
 import torch
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
+from botorch.models.model import FantasizeMixin
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform, Standardize
 from botorch.models.utils import gpt_posterior_settings
@@ -138,7 +139,7 @@ class FlattenedStandardize(Standardize):
         )
 
 
-class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP):
+class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
     r"""
     A model for high-dimensional output regression.
 

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -15,11 +15,12 @@ from typing import Any, List
 
 from botorch.exceptions.errors import BotorchTensorDimensionError
 from botorch.models.gpytorch import GPyTorchModel, ModelListGPyTorchModel
+from botorch.models.model import FantasizeMixin
 from gpytorch.models import IndependentModelList
 from torch import Tensor
 
 
-class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
+class ModelListGP(IndependentModelList, ModelListGPyTorchModel, FantasizeMixin):
     r"""A multi-output GP model with independent GPs for the outputs.
 
     This model supports different-shaped training inputs for each of its

--- a/botorch/models/pairwise_gp.py
+++ b/botorch/models/pairwise_gp.py
@@ -32,7 +32,7 @@ from botorch.models.likelihoods.pairwise import (
     PairwiseLikelihood,
     PairwiseProbitLikelihood,
 )
-from botorch.models.model import Model
+from botorch.models.model import FantasizeMixin, Model
 from botorch.models.transforms.input import InputTransform
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.posterior import Posterior
@@ -44,7 +44,6 @@ from gpytorch.kernels.scale_kernel import ScaleKernel
 from gpytorch.means.constant_mean import ConstantMean
 from gpytorch.mlls import MarginalLogLikelihood
 from gpytorch.models.gp import GP
-from gpytorch.module import Module
 from gpytorch.priors.smoothed_box_prior import SmoothedBoxPrior
 from gpytorch.priors.torch_priors import GammaPrior
 from linear_operator.operators import LinearOperator, RootLinearOperator
@@ -54,7 +53,12 @@ from torch import float32, float64, Tensor
 from torch.nn.modules.module import _IncompatibleKeys
 
 
-class PairwiseGP(Model, GP):
+# Why we subclass GP even though it provides no functionality:
+# if this subclassing is removed, we get the following GPyTorch error:
+# "RuntimeError: All MarginalLogLikelihood objects must be given a GP object as
+# a model. If you are using a more complicated model involving a GP, pass the
+# underlying GP object as the model, not a full PyTorch module."
+class PairwiseGP(Model, GP, FantasizeMixin):
     r"""Probit GP for preference learning with Laplace approximation
 
     A probit-likelihood GP that learns via pairwise comparison data, using a
@@ -100,7 +104,7 @@ class PairwiseGP(Model, GP):
         datapoints: Tensor,
         comparisons: Tensor,
         likelihood: Optional[PairwiseLikelihood] = None,
-        covar_module: Optional[Module] = None,
+        covar_module: Optional[ScaleKernel] = None,
         input_transform: Optional[InputTransform] = None,
         **kwargs,
     ) -> None:

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -15,7 +15,7 @@ from unittest import TestCase
 import torch
 from botorch import settings
 from botorch.acquisition.objective import PosteriorTransform
-from botorch.models.model import Model
+from botorch.models.model import FantasizeMixin, Model
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.posterior import Posterior
 from botorch.test_functions.base import BaseTestProblem
@@ -157,7 +157,7 @@ class MockPosterior(Posterior):
         return self._samples.expand(sample_shape + self._samples.shape)
 
 
-class MockModel(Model):
+class MockModel(Model, FantasizeMixin):
     r"""Mock object that implements dummy methods and feeds through specified outputs"""
 
     def __init__(self, posterior: MockPosterior) -> None:  # noqa: D107

--- a/test/models/test_approximate_gp.py
+++ b/test/models/test_approximate_gp.py
@@ -15,7 +15,6 @@ from botorch.models.approximate_gp import (
 from botorch.models.transforms.input import Normalize
 from botorch.models.transforms.outcome import Log
 from botorch.posteriors import GPyTorchPosterior, TransformedPosterior
-from botorch.sampling import IIDNormalSampler
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.likelihoods import GaussianLikelihood, MultitaskGaussianLikelihood
 from gpytorch.mlls import VariationalELBO
@@ -134,14 +133,9 @@ class TestSingleTaskVariationalGP(BotorchTestCase):
                     batched_model.likelihood, MultitaskGaussianLikelihood
                 )
 
-    def test_likelihood_and_fantasize(self):
+    def test_likelihood(self):
         self.assertIsInstance(self.model.likelihood, GaussianLikelihood)
         self.assertTrue(self.model._is_custom_likelihood, True)
-
-        test_X = torch.randn(5, 1, device=self.device)
-
-        with self.assertRaises(NotImplementedError):
-            self.model.fantasize(test_X, sampler=IIDNormalSampler(num_samples=32))
 
     def test_initializations(self):
         train_X = torch.rand(15, 1, device=self.device)

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -156,11 +156,7 @@ class TestFullyBayesianSingleTaskGP(BotorchTestCase):
         train_X, train_Y, train_Yvar, model = self._get_data_and_model(
             infer_noise=True, **tkwargs
         )
-        sampler = IIDNormalSampler(num_samples=2)
-        with self.assertRaisesRegex(
-            NotImplementedError, "Fantasize is not implemented!"
-        ):
-            model.fantasize(X=torch.rand(5, 4, **tkwargs), sampler=sampler)
+
         # Make sure an exception is raised if the model has not been fitted
         not_fitted_error_msg = (
             "Model has not been fitted. You need to call "

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -159,16 +159,7 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                 task_feature=4,
             )
         train_X, train_Y, train_Yvar, model = self._get_data_and_model(**tkwargs)
-        sampler = IIDNormalSampler(num_samples=2)
-        with self.assertRaisesRegex(
-            NotImplementedError, "Fantasize is not implemented!"
-        ):
-            model.fantasize(
-                X=torch.cat(
-                    [torch.rand(5, 4, **tkwargs), torch.ones(5, 1, **tkwargs)], dim=1
-                ),
-                sampler=sampler,
-            )
+
         # Make sure an exception is raised if the model has not been fitted
         not_fitted_error_msg = (
             "Model has not been fitted. You need to call "

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -22,6 +22,7 @@ from botorch.models.gpytorch import (
     GPyTorchModel,
     ModelListGPyTorchModel,
 )
+from botorch.models.model import FantasizeMixin
 from botorch.models.transforms import Standardize
 from botorch.models.transforms.input import ChainedInputTransform, InputTransform
 from botorch.models.utils import fantasize
@@ -55,7 +56,7 @@ class SimpleInputTransform(InputTransform, torch.nn.Module):
         return X + self.add_value
 
 
-class SimpleGPyTorchModel(GPyTorchModel, ExactGP):
+class SimpleGPyTorchModel(GPyTorchModel, ExactGP, FantasizeMixin):
     last_fantasize_flag: bool = False
 
     def __init__(self, train_X, train_Y, outcome_transform=None, input_transform=None):
@@ -97,7 +98,9 @@ class SimpleGPyTorchModel(GPyTorchModel, ExactGP):
         return MultivariateNormal(mean_x, covar_x)
 
 
-class SimpleBatchedMultiOutputGPyTorchModel(BatchedMultiOutputGPyTorchModel, ExactGP):
+class SimpleBatchedMultiOutputGPyTorchModel(
+    BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin
+):
     _batch_shape: Optional[torch.Size] = None
 
     def __init__(self, train_X, train_Y, outcome_transform=None, input_transform=None):


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

The `Model` base class has a `fantasize` method, but it isn't actually possible to `fantasize` from all models. For some models, `fantasize` fails with a `NotImplementedError` even though the docstring implies it should work. This is confusing (e.g. #1459 ). Another disadvantage is that codecov doesn't require tests for all of the many `fantasize` methods that exist, only for the base one -- which can't be called, since it is abstract.

This PR removes the "fantasize" method from the `Model` base class. Instead, there is a `fantasize` function that is called by the few classes that do actually use and/or test `fantasize`.

Pros:
- decreases the "surface area" of BoTorch and prevents misuse of methods that we didn't really intend to exist
- Allows codecov to surface where we aren't actually testing methods (I expect it to fail)

Cons:
-  `fantasize` still exists but doesn't work in `HeteroskedasticSingleTaskGP` because it inherits from `SingleTaskGP` (a further refactor can fix that)
- Could remove `fantasize` from classes where it _should_ exist (despite not being used or tested within BoTorch)
- Somewhat more verbose

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
[x] Codecov
[x] Unit tests should pass
[x] No new Pyre errors introduced
