### PR TITLE
Allow dev versions of gpytorch & linear_operator for installation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,8 @@ jobs:
       with:
         python-version: "3.8"
     - name: Install dependencies
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         pip install git+https://github.com/cornellius-gp/linear_operator.git
         pip install git+https://github.com/cornellius-gp/gpytorch.git

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/linear_operator.git
@@ -50,6 +52,8 @@ jobs:
       with:
         python-version: 3.8
     - name: Install dependencies
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/linear_operator.git
@@ -93,6 +97,8 @@ jobs:
       run: git fetch --prune --unshallow
     - name: Install dependencies
       shell: bash -l {0}
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
       # Don't need most deps for conda build, but need them for testing
       # We do need setuptools_scm though to properly parse the version
       run: |
@@ -123,6 +129,7 @@ jobs:
       run: git fetch --prune --unshallow
     - name: Install dependencies
       env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
         ALLOW_BOTORCH_LATEST: true  # allow Ax to install w/ new BoTorch release
       run: |
         pip install git+https://github.com/cornellius-gp/linear_operator.git

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -31,6 +31,8 @@ jobs:
       run: git fetch --prune --unshallow
     - if: ${{ !inputs.use_stable_pytorch_gpytorch }}
       name: Install latest PyTorch & GPyTorch
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/linear_operator.git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/linear_operator.git
@@ -55,6 +57,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       shell: bash -l {0}
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         conda install -y -c pytorch-nightly pytorch cpuonly
         conda install -y pip scipy sphinx pytest flake8

--- a/README.md
+++ b/README.md
@@ -92,11 +92,13 @@ by following the [PyTorch installation instructions](https://pytorch.org/get-sta
 
 If you would like to try our bleeding edge features (and don't mind potentially
 running into the occasional bug here or there), you can install the latest
-development version directly from GitHub (this will also require installing
-the current GPyTorch development version):
+development version directly from GitHub. If you want to also install the
+current `gpytorch` and `linear_operator` development versions, you will need
+to ensure that the `ALLOW_LATEST_GPYTORCH_LINOP` environment variable is set):
 ```bash
 pip install --upgrade git+https://github.com/cornellius-gp/linear_operator.git
 pip install --upgrade git+https://github.com/cornellius-gp/gpytorch.git
+export ALLOW_LATEST_GPYTORCH_LINOP=true
 pip install --upgrade git+https://github.com/pytorch/botorch.git
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+multipledispatch
+scipy
+torch>=1.11
+pyro-ppl>=1.8.2
+gpytorch==1.9.0
+linear_operator==0.1.1

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
 # Assign root dir location for later use
 root_dir = os.path.dirname(__file__)
 
+
 def read_deps_from_file(filname):
     """Read in requirements file and return items as list of strings"""
     with open(os.path.join(root_dir, filname), "r") as fh:

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,23 @@ import sys
 
 from setuptools import find_packages, setup
 
-
+# Minimum required python version
 REQUIRED_MAJOR = 3
 REQUIRED_MINOR = 8
+
+# Requirements for testing, formatting, and tutorials
+TEST_REQUIRES = ["pytest", "pytest-cov"]
+FMT_REQUIRES = ["flake8", "ufmt", "flake8-docstrings"]
+TUTORIALS_REQUIRES = [
+    "ax-platform",
+    "cma",
+    "jupyter",
+    "kaleido",
+    "matplotlib",
+    "memory_profiler",
+    "pykeops",
+    "torchvision",
+]
 
 # Check for python version
 if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
@@ -26,31 +40,33 @@ if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
     )
     sys.exit(error)
 
-
-# Requirements
-TEST_REQUIRES = ["pytest", "pytest-cov"]
-
-FMT_REQUIRES = ["flake8", "ufmt", "flake8-docstrings"]
-
-# Read in the pinned versions of the formatting tools
+# Assign root dir location for later use
 root_dir = os.path.dirname(__file__)
-with open(os.path.join(root_dir, "requirements-fmt.txt"), "r") as fh:
-    FMT_REQUIRES += [
-        line.strip() for line in fh.readlines() if not line.startswith("#")
+
+def read_deps_from_file(filname):
+    """Read in requirements file and return items as list of strings"""
+    with open(os.path.join(root_dir, filname), "r") as fh:
+        return [
+            line.strip() for line in fh.readlines() if not line.startswith("#")
+        ]
+
+# Read in the requirements from the requirements.txt file
+install_requires = read_deps_from_file("requirements.txt")
+
+# Allow non-pinned (usually dev) versions
+if os.environ.get("ALLOW_LATEST_GPYTORCH_LINOP"):
+    # Allows a more recent previously installed version of gpytorch and linear_operator
+    # to remain. If there is no previously installed version, installs the latest release
+    install_requires = [
+        dep.replace("==", ">=") if "gpytorch" in dep or "linear_operator" in dep
+        else dep
+        for dep in install_requires
     ]
 
+# Read in pinned versions of the formatting tools
+FMT_REQUIRES += read_deps_from_file("requirements-fmt.txt")
+# Dev is test + formatting + docs generation
 DEV_REQUIRES = TEST_REQUIRES + FMT_REQUIRES + ["sphinx"]
-
-TUTORIALS_REQUIRES = [
-    "ax-platform",
-    "cma",
-    "jupyter",
-    "kaleido",
-    "matplotlib",
-    "memory_profiler",
-    "pykeops",
-    "torchvision",
-]
 
 # read in README.md as the long description
 with open(os.path.join(root_dir, "README.md"), "r") as fh:
@@ -80,14 +96,7 @@ setup(
     long_description_content_type="text/markdown",
     python_requires=">=3.8",
     packages=find_packages(exclude=["test", "test.*"]),
-    install_requires=[
-        "torch>=1.11",
-        "gpytorch==1.9.0",
-        "linear_operator==0.1.1",
-        "scipy",
-        "multipledispatch",
-        "pyro-ppl>=1.8.2",
-    ],
+    install_requires=install_requires,
     extras_require={
         "dev": DEV_REQUIRES,
         "test": TEST_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -46,19 +46,19 @@ root_dir = os.path.dirname(__file__)
 def read_deps_from_file(filname):
     """Read in requirements file and return items as list of strings"""
     with open(os.path.join(root_dir, filname), "r") as fh:
-        return [
-            line.strip() for line in fh.readlines() if not line.startswith("#")
-        ]
+        return [line.strip() for line in fh.readlines() if not line.startswith("#")]
+
 
 # Read in the requirements from the requirements.txt file
 install_requires = read_deps_from_file("requirements.txt")
 
-# Allow non-pinned (usually dev) versions
+# Allow non-pinned (usually dev) versions of gpytorch and linear_operator
 if os.environ.get("ALLOW_LATEST_GPYTORCH_LINOP"):
-    # Allows a more recent previously installed version of gpytorch and linear_operator
-    # to remain. If there is no previously installed version, installs the latest release
+    # Allows more recent previously installed versions. If there is no
+    # previously installed version, installs the latest release.
     install_requires = [
-        dep.replace("==", ">=") if "gpytorch" in dep or "linear_operator" in dep
+        dep.replace("==", ">=")
+        if "gpytorch" in dep or "linear_operator" in dep
         else dep
         for dep in install_requires
     ]


### PR DESCRIPTION
Previously, due to pinning `gpytorch` and `linear_operator` to specific versions in the requirements, we were always installing the respective release version, even when manually installing the current dev version prior (as was done in the github actions workflows).

This PR introduces support for automagically converting these specific pins into "at least" pins provided a `ALLOW_LATEST_GPYTORCH_LINOP` env var is set. This mirrors a similar setup for Ax.