### PR TITLE
Follow-ups from D40783106 (fantasize refactor)

### DIFF
--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -8,7 +8,7 @@ r"""Multi-task Gaussian Process Regression models with fully Bayesian inference.
 """
 
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NoReturn, Optional, Tuple
 
 import pyro
 import torch
@@ -299,6 +299,9 @@ class SaasFullyBayesianMultiTaskGP(FixedNoiseMultiTaskGP):
         self._check_if_fitted()
         return torch.Size([self.num_mcmc_samples])
 
+    def fantasize(self, *args, **kwargs) -> NoReturn:
+        raise NotImplementedError("Fantasize is not implemented!")
+
     def _check_if_fitted(self):
         r"""Raise an exception if the model hasn't been fitted."""
         if self.covar_module is None:
@@ -321,6 +324,8 @@ class SaasFullyBayesianMultiTaskGP(FixedNoiseMultiTaskGP):
             self.latent_features,
         ) = self.pyro_model.load_mcmc_samples(mcmc_samples=mcmc_samples)
 
+    # pyre-fixme[14]: Inconsistent override of
+    # BatchedMultiOutputGPyTorchModel.posterior
     def posterior(
         self,
         X: Tensor,
@@ -345,6 +350,7 @@ class SaasFullyBayesianMultiTaskGP(FixedNoiseMultiTaskGP):
         posterior = FullyBayesianPosterior(mvn=posterior.mvn)
         return posterior
 
+    # pyre-fixme[14]: Inconsistent override
     def forward(self, X: Tensor) -> MultivariateNormal:
         self._check_if_fitted()
         X = X.unsqueeze(MCMC_DIM)
@@ -373,6 +379,7 @@ class SaasFullyBayesianMultiTaskGP(FixedNoiseMultiTaskGP):
         return MultivariateNormal(mean_x, covar)
 
     @classmethod
+    # pyre-fixme[14]: Inconsistent override of `MultiTaskGP.construct_inputs`
     def construct_inputs(
         cls,
         training_data: Dict[str, SupervisedDataset],

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -28,6 +28,7 @@ import torch
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.gp_regression import MIN_INFERRED_NOISE_LEVEL
 from botorch.models.gpytorch import GPyTorchModel, MultiTaskGPyTorchModel
+from botorch.models.model import FantasizeMixin
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
 from botorch.posteriors.multitask import MultitaskGPPosterior
@@ -71,7 +72,7 @@ from linear_operator.operators import (
 from torch import Tensor
 
 
-class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel):
+class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
     r"""Multi-Task GP model using an ICM kernel, inferring observation noise.
 
     Multi-task exact GP that uses a simple ICM kernel. Can be single-output or
@@ -377,7 +378,7 @@ class FixedNoiseMultiTaskGP(MultiTaskGP):
         self.to(train_X)
 
 
-class KroneckerMultiTaskGP(ExactGP, GPyTorchModel):
+class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
     """Multi-task GP with Kronecker structure, using an ICM kernel.
 
     This model assumes the "block design" case, i.e., it requires that all tasks

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -159,6 +159,16 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                 task_feature=4,
             )
         train_X, train_Y, train_Yvar, model = self._get_data_and_model(**tkwargs)
+        sampler = IIDNormalSampler(num_samples=2)
+        with self.assertRaisesRegex(
+            NotImplementedError, "Fantasize is not implemented!"
+        ):
+            model.fantasize(
+                X=torch.cat(
+                    [torch.rand(5, 4, **tkwargs), torch.ones(5, 1, **tkwargs)], dim=1
+                ),
+                sampler=sampler,
+            )
 
         # Make sure an exception is raised if the model has not been fitted
         not_fitted_error_msg = (

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -454,11 +454,22 @@ class TestHeteroskedasticSingleTaskGP(TestSingleTaskGP):
         model = HeteroskedasticSingleTaskGP(**model_kwargs)
         return model, model_kwargs
 
-    def test_custom_init(self):
-        pass
+    def test_custom_init(self) -> None:
+        """
+        This test exists because `TestHeteroskedasticSingleTaskGP` inherits from
+        `TestSingleTaskGP`, which has a `test_custom_init` method that isn't relevant
+        for `TestHeteroskedasticSingleTaskGP`.
+        """
 
     def test_gp(self):
         super().test_gp(double_only=True)
+
+    def test_fantasize(self) -> None:
+        """
+        This test exists because `TestHeteroskedasticSingleTaskGP` inherits from
+        `TestSingleTaskGP`, which has a `fantasize` method that isn't relevant
+        for `TestHeteroskedasticSingleTaskGP`.
+        """
 
     def test_heteroskedastic_likelihood(self):
         for batch_shape, m, dtype in itertools.product(
@@ -479,10 +490,6 @@ class TestHeteroskedasticSingleTaskGP(TestSingleTaskGP):
     def test_condition_on_observations(self):
         with self.assertRaises(NotImplementedError):
             super().test_condition_on_observations()
-
-    def test_fantasize(self):
-        with self.assertRaises(NotImplementedError):
-            super().test_fantasize()
 
     def test_subset_model(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Summary:
see T137147547
[x] Make `HeteroskedasticSingleTaskGP` not a subclass of `SingleTaskGP` since it can't `fantasize`
[x] Make `SaasFullyBayesianSingleTaskGP` not a subclass of `SingleTaskGP` since it can't `fantasize`
[x] Make `MultiTaskGP` have a `fantasize` method (debatable! it used to have one, but wasn't used)
[x] Restore `fantasize` method with `NotImplementedError` to `SaasFullyBayesianMultiTaskGP` (as a result of adding `fantasize` to `MultiTaskGP`)
[x] Make `KroneckerMultiTaskGP` have a `fantasize` method (debatable! it used to have one, but wasn't used)
[x] Clean up some especially annoying type errors so I can use Pyre for my own use

Differential Revision: D41053234

