### PR TITLE
Use `get_default_partitioning_alpha` for NEHVI input constructor

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -826,7 +826,7 @@ def construct_inputs_qNEHVI(
         "X_pending": kwargs.get("X_pending"),
         "eta": kwargs.get("eta", 1e-3),
         "prune_baseline": kwargs.get("prune_baseline", True),
-        "alpha": kwargs.get("alpha", 0.0),
+        "alpha": kwargs.get("alpha", get_default_partitioning_alpha(model.num_outputs)),
         "cache_pending": kwargs.get("cache_pending", True),
         "max_iep": kwargs.get("max_iep", 0),
         "incremental_nehvi": kwargs.get("incremental_nehvi", True),

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -690,6 +690,7 @@ class TestMultiObjectiveAcquisitionFunctionInputConstructors(
         c = get_acqf_input_constructor(qNoisyExpectedHypervolumeImprovement)
         objective_thresholds = torch.rand(2)
         mock_model = mock.Mock()
+        mock_model.num_outputs = 2
 
         # Test defaults
         kwargs = c(
@@ -792,6 +793,15 @@ class TestMultiObjectiveAcquisitionFunctionInputConstructors(
             )
             self.assertIs(kwargs["objective"], obj)
             self.assertTrue(torch.equal(kwargs["ref_point"], expected_obj_t))
+
+        # Test default alpha for many objectives/
+        mock_model.num_outputs = 5
+        kwargs = c(
+            model=mock_model,
+            training_data=self.blockX_blockY,
+            objective_thresholds=objective_thresholds,
+        )
+        self.assertEqual(kwargs["alpha"], 1e-3)
 
     def test_construct_inputs_kg(self):
         current_value = torch.tensor(1.23)


### PR DESCRIPTION
Summary: This brings Ax MBM behavior on par with legacy models.

Differential Revision: D41087000

