### PR TITLE
Swap the order of Ax and BoTorch installation in tutorials workflow

### DIFF
--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -43,26 +43,24 @@ jobs:
         min_torch_version=$(grep '\btorch>=' ${req_txt} | sed 's/[^0-9.]//g')
         min_gpytorch_version=$(grep '\bgpytorch>=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" torchvision
+    - name: Install BoTorch with tutorials dependencies
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
+      run: |
+        pip install .[tutorials]
     - if: ${{ !inputs.use_stable_ax }}
       name: Install latest Ax
       env:
         # This is so Ax's setup doesn't install a pinned BoTorch version.
         ALLOW_BOTORCH_LATEST: true
-        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         pip install git+https://github.com/facebook/Ax.git
     - if: ${{ inputs.use_stable_ax }}
       name: Install stable Ax
       env:
         ALLOW_BOTORCH_LATEST: true
-        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         pip install ax-platform --no-binary ax-platform
-    - name: Install BoTorch with tutorials dependencies
-      env:
-        ALLOW_LATEST_GPYTORCH_LINOP: true
-      run: |
-        pip install .[tutorials]
     - if: ${{ inputs.smoke_test }}
       name: Run tutorials with smoke test
       run: |


### PR DESCRIPTION
Without this, Ax installation step would install BoTorch from PyPI, which would ignore the `ALLOW_LATEST_GPYTORCH_LINOP` env var.