### PR TITLE
Fix test_stable GHA workflow

### DIFF
--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -36,13 +36,14 @@ jobs:
         pip install git+https://github.com/cornellius-gp/linear_operator.git
         pip install git+https://github.com/cornellius-gp/gpytorch.git
     - if: ${{ inputs.use_stable_pytorch_gpytorch }}
-      name: Install min required PyTorch & GPyTorch
+      name: Install min required PyTorch, GPyTorch, and linear_operator
       run: |
         python setup.py egg_info
         req_txt="botorch.egg-info/requires.txt"
-        min_torch_version=$(grep '\btorch>=' ${req_txt} | sed 's/[^0-9.]//g')
-        min_gpytorch_version=$(grep '\bgpytorch>=' ${req_txt} | sed 's/[^0-9.]//g')
-        pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" torchvision
+        min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
+        min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
+        min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
+        pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}" torchvision
     - name: Install BoTorch with tutorials dependencies
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -56,7 +56,7 @@ jobs:
         pytest -ra
 
   tests-and-coverage-min-req-pip:
-    name: Tests and coverage min req. torch & gpytorch versions (pip, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Tests and coverage min req. torch, gpytorch & linear_operator versions (pip, Python ${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -73,9 +73,10 @@ jobs:
       run: |
         python setup.py egg_info
         req_txt="botorch.egg-info/requires.txt"
-        min_torch_version=$(grep '\btorch>=' ${req_txt} | sed 's/[^0-9.]//g')
-        min_gpytorch_version=$(grep '\bgpytorch>=' ${req_txt} | sed 's/[^0-9.]//g')
-        pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}"
+        min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
+        min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
+        min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
+        pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"
         pip install .[test]
     - name: Unit tests and coverage
       run: |


### PR DESCRIPTION
We do some grepping magic to extract the versions from `botorch.egg-info/requires.txt` after running `python setup.py egg_info`. This was not properly working when pinning a version to an exact match. This fixes that by allowing both `>=` and `==` version specification in the grep rexexp.