### PR TITLE
Deprecating `torch.triangular_solve`

### DIFF
--- a/botorch/utils/gp_sampling.py
+++ b/botorch/utils/gp_sampling.py
@@ -373,9 +373,10 @@ def get_weights_posterior(X: Tensor, y: Tensor, sigma_sq: Tensor) -> Multivariat
         L_A = psd_safe_cholesky(A)
         # solve L_A @ u = I
         Iw = torch.eye(L_A.shape[-1], dtype=X.dtype, device=X.device)
-        u = torch.triangular_solve(Iw, L_A, upper=False).solution
+        u = torch.linalg.solve_triangular(L_A, Iw, upper=False)
+
         # solve L_A^T @ S = u
-        A_inv = torch.triangular_solve(u, L_A.transpose(-2, -1)).solution
+        A_inv = torch.linalg.solve_triangular(L_A.transpose(-2, -1), u, upper=True)
         m = (A_inv @ X_trans @ y.unsqueeze(-1)).squeeze(-1)
         L = psd_safe_cholesky(A_inv * sigma_sq)
         return MultivariateNormal(loc=m, scale_tril=L)

--- a/test/utils/test_low_rank.py
+++ b/test/utils/test_low_rank.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from unittest import mock
-
 import torch
 from botorch.exceptions.errors import BotorchError
 from botorch.models.gp_regression import SingleTaskGP
@@ -17,7 +15,7 @@ from gpytorch.distributions.multitask_multivariate_normal import (
     MultitaskMultivariateNormal,
 )
 from linear_operator.operators import BlockDiagLinearOperator, to_linear_operator
-from linear_operator.utils.errors import NanError, NotPSDError
+from linear_operator.utils.errors import NanError
 
 
 class TestExtractBatchCovar(BotorchTestCase):
@@ -200,32 +198,3 @@ class TestSampleCachedCholesky(BotorchTestCase):
                                     base_samples=sampler.base_samples.detach().clone(),
                                     sample_shape=sampler.sample_shape,
                                 )
-                            # test triangular solve raising RuntimeError
-                            test_posterior.mvn.loc = torch.full_like(
-                                test_posterior.mvn.loc, 0.0
-                            )
-                            base_samples = sampler.base_samples.detach().clone()
-                            with mock.patch(
-                                "botorch.utils.low_rank.torch.triangular_solve",
-                                side_effect=RuntimeError("singular"),
-                            ):
-                                with self.assertRaises(NotPSDError):
-                                    sample_cached_cholesky(
-                                        posterior=test_posterior,
-                                        baseline_L=baseline_L,
-                                        q=q,
-                                        base_samples=base_samples,
-                                        sample_shape=sampler.sample_shape,
-                                    )
-                            with mock.patch(
-                                "botorch.utils.low_rank.torch.triangular_solve",
-                                side_effect=RuntimeError(""),
-                            ):
-                                with self.assertRaises(RuntimeError):
-                                    sample_cached_cholesky(
-                                        posterior=test_posterior,
-                                        baseline_L=baseline_L,
-                                        q=q,
-                                        base_samples=base_samples,
-                                        sample_shape=sampler.sample_shape,
-                                    )


### PR DESCRIPTION
Summary: Deprecating `torch.triangular_solve` in favor of `torch.linalg.solve_triangular`. Note: the order of the arguments change.

Reviewed By: Balandat

Differential Revision: D39324704

