### PR TITLE
Expanding on docstrings in BoTorch `Model`

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -46,8 +46,21 @@ TFantasizeMixin = TypeVar("TFantasizeMixin", bound="FantasizeMixin")
 class Model(Module, ABC):
     r"""Abstract base class for BoTorch models.
 
-    Model cannot be used directly; it only defines an API for other BoTorch
+    `Model` cannot be used directly; it only defines an API for other BoTorch
     models.
+
+    `Model` subclasses `torch.nn.Module`. While a `Module` is most typically
+    encountered as a representation of a neural network layer, it can be used more
+    generally: see `documentation<NN>`_ on custom NN Modules.
+
+    Subclassing `Module` provides several pieces of  useful functionality: Attributes
+    of `Tensor` or `Module` type are automatically registered so they can be moved
+    and/or cast with `to`, automatically differentiated, and used with CUDA. Also,
+    `Model` subclasses are callable, provided that they implement a `forward` method. In
+    BoTorch, this typically computes the prior latent distribution at a point, e.g.
+    `multivariate_normal = SingleTaskGP(x)`.
+
+    .. _NN: https://pytorch.org/tutorials/beginner/examples_nn/polynomial_module.html
 
     Args:
         _has_transformed_inputs: A boolean denoting whether `train_inputs` are currently
@@ -215,7 +228,8 @@ class Model(Module, ABC):
         return super().eval()
 
     def train(self, mode: bool = True) -> Model:
-        r"""Puts the model in `train` mode and reverts to the original inputs.
+        r"""Put the model in `train` mode. Reverts to the original inputs if in `train`
+        mode (`mode=True`) or sets transformed inputs if in `eval` mode (`mode=False`).
 
         Args:
             mode: A boolean denoting whether to put in `train` or `eval` mode.

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -6,7 +6,7 @@
 
 r"""Abstract base module for all BoTorch models.
 
-The base API module contains `Model`, the abstract base class for all BoTorch models,
+This module contains `Model`, the abstract base class for all BoTorch models,
 and `ModelList`, a container for a list of Models.
 """
 

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -6,8 +6,8 @@
 
 r"""Abstract base module for all BoTorch models.
 
-Contains `Model`, the abstract base class for all BoTorch models, and
-`ModelList`, a container for a list of Models.
+The base API module contains `Model`, the abstract base class for all BoTorch models,
+and `ModelList`, a container for a list of Models.
 """
 
 from __future__ import annotations
@@ -46,21 +46,18 @@ TFantasizeMixin = TypeVar("TFantasizeMixin", bound="FantasizeMixin")
 class Model(Module, ABC):
     r"""Abstract base class for BoTorch models.
 
-    `Model` cannot be used directly; it only defines an API for other BoTorch
-    models.
+    The `Model` base class cannot be used directly; it only defines an API for other
+    BoTorch models.
 
     `Model` subclasses `torch.nn.Module`. While a `Module` is most typically
     encountered as a representation of a neural network layer, it can be used more
-    generally: see `documentation<NN>`_ on custom NN Modules.
+    generally: see
+    `documentation <https://pytorch.org/tutorials/beginner/examples_nn/polynomial_module.html>`_
+    on custom NN Modules.
 
-    Subclassing `Module` provides several pieces of  useful functionality: Attributes
-    of `Tensor` or `Module` type are automatically registered so they can be moved
-    and/or cast with `to`, automatically differentiated, and used with CUDA. Also,
-    `Model` subclasses are callable, provided that they implement a `forward` method. In
-    BoTorch, this typically computes the prior latent distribution at a point, e.g.
-    `multivariate_normal = SingleTaskGP(x)`.
-
-    .. _NN: https://pytorch.org/tutorials/beginner/examples_nn/polynomial_module.html
+    `Module` provides several pieces of useful functionality: A `Model`'s attributes of
+    `Tensor` or `Module` type are automatically registered so they can be moved and/or
+     cast with the `to` method, automatically differentiated, and used with CUDA.
 
     Args:
         _has_transformed_inputs: A boolean denoting whether `train_inputs` are currently
@@ -69,7 +66,7 @@ class Model(Module, ABC):
             `_revert_to_original_inputs`. Note that this is necessary since
             transform / untransform cycle introduces numerical errors which lead
             to upstream errors during training.
-    """
+    """  # noqa: E501
 
     _has_transformed_inputs: bool = False
     _original_train_inputs: Optional[Tensor] = None

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -57,7 +57,7 @@ class Model(Module, ABC):
 
     `Module` provides several pieces of useful functionality: A `Model`'s attributes of
     `Tensor` or `Module` type are automatically registered so they can be moved and/or
-     cast with the `to` method, automatically differentiated, and used with CUDA.
+    cast with the `to` method, automatically differentiated, and used with CUDA.
 
     Args:
         _has_transformed_inputs: A boolean denoting whether `train_inputs` are currently


### PR DESCRIPTION
Summary: Added content to docstrings in BoTorch `Model` to help people who may either be unfamiliar with torch `Module` or with what its methods (such as "forward") mean in the context of BoTorch models.

Differential Revision: D41221005

