### PR TITLE
Remove deprecated AcquisitionObjective

### DIFF
--- a/botorch/acquisition/acquisition.py
+++ b/botorch/acquisition/acquisition.py
@@ -38,35 +38,6 @@ class AcquisitionFunction(Module, ABC):
         super().__init__()
         self.model: Model = model
 
-    @classmethod
-    def _deprecate_acqf_objective(
-        cls,
-        posterior_transform: Optional[Callable[[Posterior], Posterior]],
-        objective: Optional[Module],
-    ) -> Optional[Callable[[Posterior], Posterior]]:
-        from botorch.acquisition.objective import (
-            ScalarizedObjective,
-            ScalarizedPosteriorTransform,
-        )
-
-        if objective is None:
-            return posterior_transform
-        warnings.warn(
-            f"{cls.__name__} got a non-MC `objective`. The non-MC "
-            "AcquisitionObjectives and the `objective` argument to"
-            "AnalyticAcquisitionFunctions are DEPRECATED and will be removed in the"
-            "next version. Use `posterior_transform` instead.",
-            DeprecationWarning,
-        )
-        if not isinstance(objective, ScalarizedObjective):
-            raise UnsupportedError(
-                f"{cls.__name__} only supports ScalarizedObjective "
-                "(DEPRECATED) type objectives."
-            )
-        return ScalarizedPosteriorTransform(
-            weights=objective.weights, offset=objective.offset
-        )
-
     def set_X_pending(self, X_pending: Optional[Tensor] = None) -> None:
         r"""Informs the acquisition function about pending design points.
 

--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -39,7 +39,6 @@ class AnalyticAcquisitionFunction(AcquisitionFunction, ABC):
         self,
         model: Model,
         posterior_transform: Optional[PosteriorTransform] = None,
-        **kwargs,
     ) -> None:
         r"""Base constructor for analytic acquisition functions.
 
@@ -50,10 +49,6 @@ class AnalyticAcquisitionFunction(AcquisitionFunction, ABC):
                 single-output posterior is required.
         """
         super().__init__(model=model)
-        posterior_transform = self._deprecate_acqf_objective(
-            posterior_transform=posterior_transform,
-            objective=kwargs.get("objective"),
-        )
         if posterior_transform is None:
             if model.num_outputs != 1:
                 raise UnsupportedError(

--- a/botorch/acquisition/knowledge_gradient.py
+++ b/botorch/acquisition/knowledge_gradient.py
@@ -127,18 +127,7 @@ class qKnowledgeGradient(MCAcquisitionFunction, OneShotAcquisitionFunction):
         elif objective is not None and not isinstance(
             objective, MCAcquisitionObjective
         ):
-            # TODO: clean this up after removing AcquisitionObjective.
-            if posterior_transform is None:
-                posterior_transform = self._deprecate_acqf_objective(
-                    posterior_transform=posterior_transform,
-                    objective=objective,
-                )
-                objective = None
-            else:
-                raise RuntimeError(
-                    "Got both a non-MC objective (DEPRECATED) and a posterior "
-                    "transform. Use only a posterior transform instead."
-                )
+            raise UnsupportedError  # TODO
         if objective is None and model.num_outputs != 1:
             if posterior_transform is None:
                 raise UnsupportedError(

--- a/botorch/acquisition/multi_objective/objective.py
+++ b/botorch/acquisition/multi_objective/objective.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 
 import torch
 from botorch.acquisition.objective import (
-    AcquisitionObjective,
     GenericMCObjective,
     MCAcquisitionObjective,
 )

--- a/botorch/acquisition/multi_step_lookahead.py
+++ b/botorch/acquisition/multi_step_lookahead.py
@@ -114,19 +114,6 @@ class qMultiStepLookahead(MCAcquisitionFunction, OneShotAcquisitionFunction):
                 will be applied on fantasy batch dimensions as well, meaning that base
                 samples are the same in all subtrees starting from the same level.
         """
-        if not isinstance(objective, MCAcquisitionObjective):
-            # TODO: clean this up after removing AcquisitionObjective.
-            if posterior_transform is None:
-                posterior_transform = self._deprecate_acqf_objective(
-                    posterior_transform=posterior_transform,
-                    objective=objective,
-                )
-                objective = None
-            else:
-                raise RuntimeError(
-                    "Got both a non-MC objective (DEPRECATED) and a posterior "
-                    "transform. Use only a posterior transform instead."
-                )
         super(MCAcquisitionFunction, self).__init__(model=model)
         self.batch_sizes = batch_sizes
         if not ((num_fantasies is None) ^ (samplers is None)):

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -26,16 +26,6 @@ from torch import Tensor
 from torch.nn import Module
 
 
-class AcquisitionObjective(Module, ABC):
-    r"""Abstract base class for objectives.
-
-    DEPRECATED - This will be removed in the next version.
-
-    :meta private:
-    """
-    ...
-
-
 class PosteriorTransform(Module, ABC):
     r"""
     Abstract base class for objectives that transform the posterior.
@@ -130,23 +120,6 @@ class ScalarizedPosteriorTransform(PosteriorTransform):
         return scalarize_posterior(
             posterior=posterior, weights=self.weights, offset=self.offset
         )
-
-
-class ScalarizedObjective(ScalarizedPosteriorTransform, AcquisitionObjective):
-    """DEPRECATED - Use ScalarizedPosteriorTransform instead."""
-
-    def __init__(self, weights: Tensor, offset: float = 0.0) -> None:
-        r"""
-        Args:
-            weights: A one-dimensional tensor with `m` elements representing the
-                linear weights on the outputs.
-            offset: An offset to be added to posterior mean.
-        """
-        warnings.warn(
-            "ScalarizedObjective is deprecated and will be removed in the next "
-            "version. Use ScalarizedPosteriorTransform instead."
-        )
-        super().__init__(weights=weights, offset=offset)
 
 
 class ExpectationPosteriorTransform(PosteriorTransform):

--- a/botorch/generation/sampling.py
+++ b/botorch/generation/sampling.py
@@ -92,19 +92,6 @@ class MaxPosteriorSampling(SamplingStrategy):
         self.model = model
         if objective is None:
             objective = IdentityMCObjective()
-        elif not isinstance(objective, MCAcquisitionObjective):
-            # TODO: Clean up once ScalarizedObjective is removed.
-            if posterior_transform is not None:
-                raise RuntimeError(
-                    "A ScalarizedObjective (DEPRECATED) and a posterior transform "
-                    "are not supported at the same time. Use only a posterior "
-                    "transform instead."
-                )
-            else:
-                posterior_transform = ScalarizedPosteriorTransform(
-                    weights=objective.weights, offset=objective.offset
-                )
-                objective = IdentityMCObjective()
         self.objective = objective
         self.posterior_transform = posterior_transform
         self.replacement = replacement

--- a/botorch/utils/__init__.py
+++ b/botorch/utils/__init__.py
@@ -17,7 +17,6 @@ from botorch.utils.sampling import (
     manual_seed,
 )
 from botorch.utils.transforms import (
-    squeeze_last_dim,
     standardize,
     t_batch_mode_transform,
 )
@@ -35,7 +34,6 @@ __all__ = [
     "get_objective_weights_transform",
     "get_outcome_constraint_transforms",
     "manual_seed",
-    "squeeze_last_dim",
     "standardize",
     "t_batch_mode_transform",
 ]

--- a/botorch/utils/transforms.py
+++ b/botorch/utils/transforms.py
@@ -22,27 +22,6 @@ if TYPE_CHECKING:
     from botorch.model import Model  # pragma: no cover
 
 
-def squeeze_last_dim(Y: Tensor) -> Tensor:
-    r"""Squeeze the last dimension of a Tensor.
-
-    Args:
-        Y: A `... x d`-dim Tensor.
-
-    Returns:
-        The input tensor with last dimension squeezed.
-
-    Example:
-        >>> Y = torch.rand(4, 3)
-        >>> Y_squeezed = squeeze_last_dim(Y)
-    """
-    warnings.warn(
-        "`botorch.utils.transforms.squeeze_last_dim` is deprecated. "
-        "Simply use `.squeeze(-1)1 instead.",
-        DeprecationWarning,
-    )
-    return Y.squeeze(-1)
-
-
 def standardize(Y: Tensor) -> Tensor:
     r"""Standardizes (zero mean, unit variance) a tensor by dim=-2.
 

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -57,7 +57,6 @@ from botorch.acquisition.multi_objective.objective import (
 )
 from botorch.acquisition.multi_objective.utils import get_default_partitioning_alpha
 from botorch.acquisition.objective import (
-    AcquisitionObjective,
     LinearMCObjective,
     ScalarizedObjective,
     ScalarizedPosteriorTransform,
@@ -80,10 +79,6 @@ from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
 
 
 class DummyAcquisitionFunction(AcquisitionFunction):
-    ...
-
-
-class DummyObjective(AcquisitionObjective):
     ...
 
 
@@ -156,21 +151,6 @@ class TestInputConstructorUtils(InputConstructorBaseTestCase, BotorchTestCase):
         )
         best_f_expected = (multi_Y.sum(dim=-1)).max()
         self.assertEqual(best_f, best_f_expected)
-
-    def test_deprecate_objective_arg(self):
-        objective = ScalarizedObjective(weights=torch.ones(1))
-        post_tf = ScalarizedPosteriorTransform(weights=torch.zeros(1))
-        with self.assertRaises(RuntimeError):
-            _deprecate_objective_arg(posterior_transform=post_tf, objective=objective)
-        with self.assertWarns(DeprecationWarning):
-            new_tf = _deprecate_objective_arg(objective=objective)
-        self.assertTrue(torch.equal(new_tf.weights, objective.weights))
-        self.assertIsInstance(new_tf, ScalarizedPosteriorTransform)
-        new_tf = _deprecate_objective_arg(posterior_transform=post_tf)
-        self.assertEqual(id(new_tf), id(post_tf))
-        self.assertIsNone(_deprecate_objective_arg())
-        with self.assertRaises(UnsupportedError):
-            _deprecate_objective_arg(objective=DummyObjective())
 
     @mock.patch("botorch.acquisition.input_constructors.optimize_acqf")
     def test_optimize_objective(self, mock_optimize_acqf):


### PR DESCRIPTION
This has been marked deprecated for a while, time to do some cleanup.

Looks like `AnalyticMultiOutputObjective` still uses this though, so we'll need to remove `AnalyticMultiOutputObjective` and  update things to use posterior transforms instead.