### PR TITLE
Make behavior of Cholesky caching more clear

### DIFF
--- a/botorch/acquisition/cached_cholesky.py
+++ b/botorch/acquisition/cached_cholesky.py
@@ -103,7 +103,7 @@ class CachedCholeskyMCAcquisitionFunction(ABC):
     ) -> Tensor:
         r"""Cache Cholesky of the posterior covariance over f(X_baseline).
 
-        Because `LazyTensor.root_decomposition` is decorated with LinearOperator's
+        Because `LinearOperator.root_decomposition` is decorated with LinearOperator's
         @cached decorator, this function is doing a lot implicitly:
 
         1) Check if a root decomposition has already been cached to `lazy_covar`.

--- a/botorch/acquisition/cached_cholesky.py
+++ b/botorch/acquisition/cached_cholesky.py
@@ -97,11 +97,23 @@ class CachedCholeskyMCAcquisitionFunction(ABC):
             cache_root = False
         self._cache_root = cache_root
 
-    def _cache_root_decomposition(
+    def _compute_root_decomposition(
         self,
         posterior: Posterior,
-    ) -> None:
+    ) -> Tensor:
         r"""Cache Cholesky of the posterior covariance over f(X_baseline).
+
+        Because `LazyTensor.root_decomposition` is decorated with LinearOperator's
+        @cached decorator, this function is doing a lot implicitly:
+
+        1) Check if a root decomposition has already been cached to `lazy_covar`.
+          Note that it will not have been if `posterior.mvn` is a
+          `MultitaskMultivariateNormal`, since we construct `lazy_covar` in that
+          case.
+        2) If the root decomposition has not been found in the cache, compute it.
+        3) Write it to the cache of `lazy_covar`. Note that this will become inacessible
+          if `posterior.mvn` is a `MultitaskMultivariateNormal`, since in that case
+          `lazy_covar`'s scope is only this function.
 
         Args:
             posterior: The posterior over f(X_baseline).
@@ -112,8 +124,7 @@ class CachedCholeskyMCAcquisitionFunction(ABC):
             lazy_covar = posterior.mvn.lazy_covariance_matrix
         with gpt_settings.fast_computations.covar_root_decomposition(False):
             lazy_covar_root = lazy_covar.root_decomposition()
-            baseline_L = lazy_covar_root.root.to_dense()
-        self.register_buffer("_baseline_L", baseline_L)
+        return lazy_covar_root.root.to_dense()
 
     def _get_f_X_samples(self, posterior: GPyTorchPosterior, q_in: int) -> Tensor:
         r"""Get posterior samples at the `q_in` new points from the joint posterior.

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -545,7 +545,11 @@ class qNoisyExpectedHypervolumeImprovement(
             samples = self.base_sampler(posterior)
             # cache posterior
             if self._cache_root:
-                self._cache_root_decomposition(posterior=posterior)
+                # Note that this implicitly uses LinearOperator's caching to check if
+                # the proper root decomposition has already been cached to
+                # `posterior.mvn.lazy_covariance_matrix`, which it may have been in
+                # the call to `self.base_sampler`, and computes it if not found
+                self._baseline_L = self._compute_root_decomposition(posterior=posterior)
             obj = self.objective(samples, X=self.X_baseline)
             if self.constraints is not None:
                 feas = torch.stack(

--- a/test/acquisition/test_cached_cholesky.py
+++ b/test/acquisition/test_cached_cholesky.py
@@ -110,7 +110,9 @@ class TestCachedCholeskyMCAcquisitionFunction(BotorchTestCase):
                 with mock.patch(
                     CHOLESKY_PATH, return_value=baseline_L
                 ) as mock_cholesky:
-                    acqf._cache_root_decomposition(posterior=posterior)
+                    baseline_L_acqf = acqf._compute_root_decomposition(
+                        posterior=posterior
+                    )
                     mock_extract_batch_covar.assert_called_once_with(posterior.mvn)
                     mock_cholesky.assert_called_once()
             # test mvn
@@ -121,10 +123,12 @@ class TestCachedCholeskyMCAcquisitionFunction(BotorchTestCase):
                 with mock.patch(
                     CHOLESKY_PATH, return_value=baseline_L
                 ) as mock_cholesky:
-                    acqf._cache_root_decomposition(posterior=posterior)
+                    baseline_L_acqf = acqf._compute_root_decomposition(
+                        posterior=posterior
+                    )
                     mock_extract_batch_covar.assert_not_called()
                     mock_cholesky.assert_called_once()
-            self.assertTrue(torch.equal(acqf._baseline_L, baseline_L))
+            self.assertTrue(torch.equal(baseline_L_acqf, baseline_L))
 
     def test_get_f_X_samples(self):
         tkwargs = {"device": self.device}

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -577,7 +577,7 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
         pt = ScalarizedPosteriorTransform(weights=torch.tensor([-1]))
         with mock.patch.object(
             qNoisyExpectedImprovement,
-            "_cache_root_decomposition",
+            "_compute_root_decomposition",
         ) as mock_cache_root:
             acqf = qNoisyExpectedImprovement(
                 model=model,


### PR DESCRIPTION
## Motivation

General context: Caching is confusing and can lead to subtle issues. I have been trying to understand it better in order to reduce memory usage and improve runtime, since I've been seeing cache misses and tensors persisting longer than necessary. This PR doesn't fix that, but does make things a tiny bit more transparent.

Two things are making the "_cache_root_decomposition" method harder to understand than necessary:

1. It sets `self._baseline_L` and returns `None` rather than just returning `baseline_L`, so when someone sees a call to `_cache_root_decomposition` they will not immediately realize `self._baseline_L` has been set.
2. It is uses two different kinds of caching: it sets `self._baseline_L` and  it also invisibly uses LinearOperator's caching. 

This PR makes things more transparent by
* Adding comments
* Returning `baseline_L` rather than setting it as a side effect

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit tests
