### PR TITLE
Reduce repetition in test_model_list_gp_regression

### DIFF
--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -52,6 +52,8 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel, FantasizeMixin):
         """
         super().__init__(*gp_models)
 
+    # pyre-fixme[14]: Inconsistent override. Here `X` is a List[Tensor], but in the
+    # parent method it's a Tensor.
     def condition_on_observations(
         self, X: List[Tensor], Y: Tensor, **kwargs: Any
     ) -> ModelListGP:


### PR DESCRIPTION
Summary: `TestModelListGP.test_ModelListGP` and `TestModelListGP.test_ModelListGP_fixed_noise` share almost all of their code, so I put most of their code in one helper method they both call, with the parts that depend on whether there is fixed nosie remaining in `TestModelListGP.test_ModelListGP`  and `TestModelListGP.test_ModelListGP_fixed_noise`. This adds testing for `test_ModelListGP_fixed_noise` that it was missing but `test_ModelListGP` had.

Differential Revision: D41508834

