### PR TITLE
Fix flake8 error: variable annotated but never used

### DIFF
--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -114,7 +114,6 @@ def gen_batch_initial_conditions(
     batch_limit: Optional[int] = options.get(
         "init_batch_limit", options.get("batch_limit")
     )
-    batch_initial_arms: Tensor
     factor, max_factor = 1, 5
     init_kwargs = {}
     device = bounds.device


### PR DESCRIPTION
Summary:
The github CI is failing on main due to a flake8 change. Example: https://github.com/pytorch/botorch/actions/runs/3536247218/jobs/5935101687

The error is "./botorch/optim/initializers.py:117:5: F842 local variable 'batch_initial_arms' is annotated but never used"

Differential Revision: D41510003

