### PR TITLE
Replace deprecated np.bool with equivalent bool

### DIFF
--- a/botorch/optim/utils/numpy_utils.py
+++ b/botorch/optim/utils/numpy_utils.py
@@ -17,23 +17,19 @@ import torch
 from numpy import ndarray
 from torch import Tensor
 
-# Dictionaries mapping numpy to torch dtypes and vice-versa
-numpy_to_torch_dtype_dict = {
-    bool: torch.bool,
-    np.uint8: torch.uint8,
-    np.int8: torch.int8,
-    np.int16: torch.int16,
-    np.int32: torch.int32,
-    np.int64: torch.int64,
-    np.float16: torch.float16,
-    np.float32: torch.float32,
-    np.float64: torch.float64,
-    np.complex64: torch.complex64,
-    np.complex128: torch.complex128,
-}
 
 torch_to_numpy_dtype_dict = {
-    value: key for (key, value) in numpy_to_torch_dtype_dict.items()
+    torch.bool: bool,
+    torch.uint8: np.uint8,
+    torch.int8: np.int8,
+    torch.int16: np.int16,
+    torch.int32: np.int32,
+    torch.int64: np.int64,
+    torch.float16: np.float16,
+    torch.float32: np.float32,
+    torch.float64: np.float64,
+    torch.complex64: np.complex64,
+    torch.complex128: np.complex128,
 }
 
 

--- a/botorch/optim/utils/numpy_utils.py
+++ b/botorch/optim/utils/numpy_utils.py
@@ -19,7 +19,7 @@ from torch import Tensor
 
 # Dictionaries mapping numpy to torch dtypes and vice-versa
 numpy_to_torch_dtype_dict = {
-    np.bool: torch.bool,
+    bool: torch.bool,
     np.uint8: torch.uint8,
     np.int8: torch.int8,
     np.int16: torch.int16,

--- a/test/optim/utils/test_numpy_utils.py
+++ b/test/optim/utils/test_numpy_utils.py
@@ -16,6 +16,7 @@ from botorch.optim.closures.core import (
     set_tensors_from_ndarray_1d,
 )
 from botorch.optim.utils import get_bounds_as_ndarray
+from botorch.optim.utils.numpy_utils import torch_to_numpy_dtype_dict
 from botorch.utils.testing import BotorchTestCase
 from torch.nn import Parameter
 
@@ -53,6 +54,13 @@ class TestNumpyUtils(BotorchTestCase):
         mock_tensor.cpu.assert_called_once()
         mock_tensor.clone.assert_not_called()
         mock_tensor.numpy.assert_called_once()
+
+    def test_as_ndarray_dtypes(self) -> None:
+        for torch_dtype, np_dtype in torch_to_numpy_dtype_dict.items():
+            tens = torch.tensor(0, dtype=torch_dtype, device="cpu")
+            self.assertEqual(torch_dtype, tens.dtype)
+            self.assertEqual(tens.numpy().dtype, np_dtype)
+            self.assertEqual(as_ndarray(tens, np_dtype).dtype, np_dtype)
 
     def test_get_tensors_as_ndarray_1d(self):
         with self.assertRaisesRegex(RuntimeError, "Argument `tensors` .* is empty"):


### PR DESCRIPTION
## Motivation

`np.bool` has been removed in numpy 1.24.0, currently only available as a pre-release. This caused failures like [this one](https://github.com/pytorch/botorch/actions/runs/3542694073)

`np.bool` has always been equivalent to `bool`, so I replaced it with `bool`.

Surprisingly (to me), we are only running that version of numpy in the tutorials and are using an older version of unit tests, so tests all passed.

## Test Plan

Added a test that the dtype mapping in `torch_to_numpy_dtype_dict` matches the behavior of torch `.numpy()`