### PR TITLE
make eta configurable

### DIFF
--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -103,6 +103,12 @@ class MultiObjectiveMCAcquisitionFunction(AcquisitionFunction, MCSamplerMixin, A
                 `sample_shape x batch-shape x q x m` to a Tensor of dimension
                 `sample_shape x batch-shape x q`, where negative values imply
                 feasibility.
+            eta: The temperature parameter for the sigmoid function used for the
+                differentiable approximation of the constraints. In case of a float the
+                same eta is used for every constraint in constraints. In case of a
+                tensor the length of the tensor must match the number of provided
+                constraints. The i-th constraint is then estimated with the i-th
+                eta value.
             X_pending:  A `m x d`-dim Tensor of `m` design points that have
                 points that have been submitted for function evaluation
                 but have not yet been evaluated.

--- a/botorch/acquisition/multi_objective/multi_fidelity.py
+++ b/botorch/acquisition/multi_objective/multi_fidelity.py
@@ -46,7 +46,7 @@ class MOMF(qExpectedHypervolumeImprovement):
         sampler: Optional[MCSampler] = None,
         objective: Optional[MCMultiOutputObjective] = None,
         constraints: Optional[List[Callable[[Tensor], Tensor]]] = None,
-        eta: Optional[Union[Tensor, float]] = 10e-3,
+        eta: Optional[Union[Tensor, float]] = 1e-3,
         X_pending: Optional[Tensor] = None,
         cost_call: Callable[Tensor, Tensor] = None,
         **kwargs: Any,

--- a/botorch/acquisition/multi_objective/multi_fidelity.py
+++ b/botorch/acquisition/multi_objective/multi_fidelity.py
@@ -46,9 +46,9 @@ class MOMF(qExpectedHypervolumeImprovement):
         sampler: Optional[MCSampler] = None,
         objective: Optional[MCMultiOutputObjective] = None,
         constraints: Optional[List[Callable[[Tensor], Tensor]]] = None,
+        eta: Optional[Union[Tensor, float]] = 10e-3,
         X_pending: Optional[Tensor] = None,
         cost_call: Callable[Tensor, Tensor] = None,
-        eta: float = 1e-3,
         **kwargs: Any,
     ) -> None:
         r"""MOMF acquisition function supporting m>=2 outcomes.
@@ -98,7 +98,11 @@ class MOMF(qExpectedHypervolumeImprovement):
                 `batch_shape x q x m`. Defaults to an AffineCostModel with
                 `C(s) = 1 + s`.
             eta: The temperature parameter for the sigmoid function used for the
-                differentiable approximation of the constraints.
+                differentiable approximation of the constraints. In case of a float the
+                same eta is used for every constraint in constraints. In case of a
+                tensor the length of the tensor must match the number of provided
+                constraints. The i-th constraint is then estimated with the i-th
+                eta value.
         """
 
         if len(ref_point) != partitioning.num_outcomes:
@@ -119,6 +123,7 @@ class MOMF(qExpectedHypervolumeImprovement):
             sampler=sampler,
             objective=objective,
             constraints=constraints,
+            eta=eta,
             X_pending=X_pending,
         )
 

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -453,7 +453,7 @@ class ConstrainedMCObjective(GenericMCObjective):
         objective: Callable[[Tensor, Optional[Tensor]], Tensor],
         constraints: List[Callable[[Tensor], Tensor]],
         infeasible_cost: Union[Tensor, float] = 0.0,
-        eta: float = 1e-3,
+        eta: Union[Tensor, float] = 1e-3,
     ) -> None:
         r"""
         Args:
@@ -472,6 +472,8 @@ class ConstrainedMCObjective(GenericMCObjective):
         """
         super().__init__(objective=objective)
         self.constraints = constraints
+        if type(eta) != Tensor:
+            eta = [eta for _ in range(len(constraints))]
         self.register_buffer("eta", torch.as_tensor(eta))
         self.register_buffer("infeasible_cost", torch.as_tensor(infeasible_cost))
 

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -473,8 +473,8 @@ class ConstrainedMCObjective(GenericMCObjective):
         super().__init__(objective=objective)
         self.constraints = constraints
         if type(eta) != Tensor:
-            eta = [eta for _ in range(len(constraints))]
-        self.register_buffer("eta", torch.as_tensor(eta))
+            eta = torch.full(len(constraints), eta)
+        self.register_buffer("eta", eta)
         self.register_buffer("infeasible_cost", torch.as_tensor(infeasible_cost))
 
     def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -468,12 +468,16 @@ class ConstrainedMCObjective(GenericMCObjective):
             infeasible_cost: The cost of a design if all associated samples are
                 infeasible.
             eta: The temperature parameter of the sigmoid function approximating
-                the constraint.
+                the constraint. Can be either a float or a 1-dim tensor. In case
+                of a float the same eta is used for every constraint in
+                constraints. In case of a tensor the length of the tensor must
+                match the number of provided constraints. The i-th constraint is
+                then estimated with the i-th eta value.
         """
         super().__init__(objective=objective)
         self.constraints = constraints
         if type(eta) != Tensor:
-            eta = torch.full(len(constraints), eta)
+            eta = torch.full((len(constraints),), eta)
         self.register_buffer("eta", eta)
         self.register_buffer("infeasible_cost", torch.as_tensor(infeasible_cost))
 

--- a/botorch/utils/objective.py
+++ b/botorch/utils/objective.py
@@ -84,7 +84,7 @@ def apply_constraints_nonnegative_soft(
         A `n_samples x b x q (x m')`-dim tensor of feasibility-weighted objectives.
     """
     if type(eta) != Tensor:
-        eta = torch.as_tensor([eta for _ in range(len(constraints))])
+        eta = torch.full(len(constraints), eta)
     obj = obj.clamp_min(0)  # Enforce non-negativity with constraints
     for constraint, e in zip(constraints, eta):
         constraint_eval = soft_eval_constraint(constraint(samples), eta=e)

--- a/botorch/utils/objective.py
+++ b/botorch/utils/objective.py
@@ -111,7 +111,7 @@ def soft_eval_constraint(lhs: Tensor, eta: float = 1e-3) -> Tensor:
     Args:
         lhs: The left hand side of the constraint `lhs <= 0`.
         eta: The temperature parameter of the softmax function. As eta
-            grows larger, this approximates the Heaviside step function.
+            decreases, this approximates the Heaviside step function.
 
     Returns:
         Element-wise 'soft' feasibility indicator of the same shape as `lhs`.

--- a/botorch/utils/objective.py
+++ b/botorch/utils/objective.py
@@ -91,7 +91,7 @@ def apply_constraints_nonnegative_soft(
         eta = torch.full((len(constraints),), eta)
     if len(eta) != len(constraints):
         raise ValueError(
-            "Number of provided constraints and numer of provided etas does not match."
+            "Number of provided constraints and number of provided etas do not match."
         )
     obj = obj.clamp_min(0)  # Enforce non-negativity with constraints
     for constraint, e in zip(constraints, eta):

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -1117,8 +1117,8 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             )
             mm = MockModel(MockPosterior(samples=baseline_samples))
             X = torch.zeros(1, 1, **tkwargs)
-            # test zero slack multiple constraints
-            for eta in (1e-1, 1e-2):
+            # test zero slack multiple constraints, multiple etas
+            for eta in [1e-1, 1e-2, torch.tensor([1.0, 10.0])]:
                 # set the MockPosterior to use samples over baseline points
                 mm._posterior._samples = baseline_samples
                 sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
@@ -1139,27 +1139,6 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                 mm._posterior._samples = samples
                 res = acqf(X)
                 self.assertAlmostEqual(res.item(), 0.5 * 0.5 * 1.5, places=4)
-            # test zero slack multiple constraints, multiple etas
-            # set the MockPosterior to use samples over baseline points
-            mm._posterior._samples = baseline_samples
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm,
-                ref_point=ref_point,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                constraints=[
-                    lambda Z: torch.zeros_like(Z[..., -1]),
-                    lambda Z: torch.zeros_like(Z[..., -1]),
-                ],
-                eta=torch.tensor([1.0, 10.0]),
-                cache_root=False,
-            )
-            # set the MockPosterior to use samples over baseline points and new
-            # candidates
-            mm._posterior._samples = samples
-            res = acqf(X)
-            self.assertAlmostEqual(res.item(), 0.5 * 0.5 * 1.5, places=4)
             # test zero slack single constraint
             for eta in (1e-1, 1e-2):
                 # set the MockPosterior to use samples over baseline points

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -1274,28 +1274,11 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             # test multiple constraints one eta with
             # this crashes for large etas, and I do not why
             # set the MockPosterior to use samples over baseline points
-            mm._posterior._samples = baseline_samples
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm,
-                ref_point=ref_point,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                constraints=[
-                    # lambda Z: torch.zeros_like(Z[..., -1]),
-                    lambda Z: torch.ones_like(Z[..., -1]),
-                ],
-                eta=1,
-                cache_root=False,
-            )
-            samples = torch.cat(
-                [
-                    baseline_samples.unsqueeze(0),
-                    torch.tensor([[[6.5, 4.5]]], **tkwargs),
-                ],
-                dim=1,
-            )
-            mm._posterior._samples = samples
+            acqf.constraints = [
+                # lambda Z: torch.zeros_like(Z[..., -1]),
+                lambda Z: torch.ones_like(Z[..., -1]),
+            ]
+            acqf.eta = torch.tensor([1.0])
             res = acqf(X)
 
             self.assertAlmostEqual(

--- a/test/acquisition/test_objective.py
+++ b/test/acquisition/test_objective.py
@@ -326,6 +326,21 @@ class TestConstrainedMCObjective(BotorchTestCase):
                 samples=samples,
                 infeasible_cost=torch.tensor([0.0], device=self.device, dtype=dtype),
             )
+            # one feasible, one infeasible different etas
+            obj = ConstrainedMCObjective(
+                objective=generic_obj,
+                constraints=[feasible_con, infeasible_con],
+                eta=torch.tensor([1, 10]),
+            )
+            samples = torch.randn(2, 1, device=self.device, dtype=dtype)
+            constrained_obj = generic_obj(samples)
+            constrained_obj = apply_constraints(
+                obj=constrained_obj,
+                constraints=[feasible_con, infeasible_con],
+                samples=samples,
+                eta=torch.tensor([1, 10]),
+                infeasible_cost=torch.tensor([0.0], device=self.device, dtype=dtype),
+            )
             self.assertTrue(torch.equal(obj(samples), constrained_obj))
             # one feasible, one infeasible, infeasible_cost
             obj = ConstrainedMCObjective(
@@ -340,6 +355,23 @@ class TestConstrainedMCObjective(BotorchTestCase):
                 constraints=[feasible_con, infeasible_con],
                 samples=samples,
                 infeasible_cost=5.0,
+            )
+            self.assertTrue(torch.equal(obj(samples), constrained_obj))
+            # one feasible, one infeasible, infeasible_cost, different eta
+            obj = ConstrainedMCObjective(
+                objective=generic_obj,
+                constraints=[feasible_con, infeasible_con],
+                infeasible_cost=5.0,
+                eta=torch.tensor([1, 10]),
+            )
+            samples = torch.randn(3, 2, device=self.device, dtype=dtype)
+            constrained_obj = generic_obj(samples)
+            constrained_obj = apply_constraints(
+                obj=constrained_obj,
+                constraints=[feasible_con, infeasible_con],
+                samples=samples,
+                infeasible_cost=5.0,
+                eta=torch.tensor([1, 10]),
             )
             self.assertTrue(torch.equal(obj(samples), constrained_obj))
             # one feasible, one infeasible, infeasible_cost, higher dimension

--- a/test/utils/test_objective.py
+++ b/test/utils/test_objective.py
@@ -19,6 +19,12 @@ def zeros_f(samples: Tensor) -> Tensor:
     return torch.zeros(samples.shape[0:-1], device=samples.device, dtype=samples.dtype)
 
 
+def nonzeros_f(samples: Tensor) -> Tensor:
+    t = torch.zeros(samples.shape[0:-1], device=samples.device, dtype=samples.dtype)
+    t[:] = 0.1
+    return t
+
+
 def minus_one_f(samples: Tensor) -> Tensor:
     return -(
         torch.ones(samples.shape[0:-1], device=samples.device, dtype=samples.dtype)
@@ -84,10 +90,47 @@ class TestApplyConstraints(BotorchTestCase):
                 infeasible_cost=0.0,
             )
             self.assertTrue(torch.equal(obj, samples * 0.5 * 0.5))
+            # nonnegative objective, two constraint explicit eta
+            obj = samples.clone()
+            obj = apply_constraints(
+                obj=obj,
+                constraints=[zeros_f, zeros_f],
+                samples=samples,
+                infeasible_cost=0.0,
+                eta=torch.tensor([10e-3, 10e-3]).to(**tkwargs),
+            )
+            self.assertTrue(torch.equal(obj, samples * 0.5 * 0.5))
+            # nonnegative objective, two constraint explicit different eta
+            obj = samples.clone()
+            obj = apply_constraints(
+                obj=obj,
+                constraints=[nonzeros_f, nonzeros_f],
+                samples=samples,
+                infeasible_cost=0.0,
+                eta=torch.tensor([10e-1, 10e-2]).to(**tkwargs),
+            )
+            self.assertTrue(
+                torch.allclose(
+                    obj,
+                    samples
+                    * torch.sigmoid(torch.as_tensor(-0.1) / 10e-1)
+                    * torch.sigmoid(torch.as_tensor(-0.1) / 10e-2),
+                )
+            )
             # negative objective, one constraint, infeasible_cost
             obj = samples.clone().clamp_min(-1.0)
             obj = apply_constraints(
                 obj=obj, constraints=[zeros_f], samples=samples, infeasible_cost=2.0
+            )
+            self.assertTrue(torch.allclose(obj, samples.clamp_min(-1.0) * 0.5 - 1.0))
+            # negative objective, one constraint, infeasible_cost, explicit eta
+            obj = samples.clone().clamp_min(-1.0)
+            obj = apply_constraints(
+                obj=obj,
+                constraints=[zeros_f],
+                samples=samples,
+                infeasible_cost=2.0,
+                eta=torch.tensor([10e-3]).to(**tkwargs),
             )
             self.assertTrue(torch.allclose(obj, samples.clamp_min(-1.0) * 0.5 - 1.0))
             # nonnegative objective, one constraint, eta = 0
@@ -99,6 +142,29 @@ class TestApplyConstraints(BotorchTestCase):
                     samples=samples,
                     infeasible_cost=0.0,
                     eta=0.0,
+                )
+
+    def test_apply_constraints_wrong_eta_dim(self):
+        tkwargs = {"device": self.device}
+        for dtype in (torch.float, torch.double):
+            tkwargs["dtype"] = dtype
+            samples = torch.rand(3, 2, **tkwargs)
+            obj = samples.clone()
+            with self.assertRaises(ValueError):
+                obj = apply_constraints(
+                    obj=obj,
+                    constraints=[zeros_f, zeros_f],
+                    samples=samples,
+                    infeasible_cost=0.0,
+                    eta=torch.tensor([0.1]).to(**tkwargs),
+                )
+            with self.assertRaises(ValueError):
+                obj = apply_constraints(
+                    obj=obj,
+                    constraints=[zeros_f, zeros_f],
+                    samples=samples,
+                    infeasible_cost=0.0,
+                    eta=torch.tensor([0.1, 0.1, 0.3]).to(**tkwargs),
                 )
 
 

--- a/test/utils/test_objective.py
+++ b/test/utils/test_objective.py
@@ -117,6 +117,24 @@ class TestApplyConstraints(BotorchTestCase):
                     * torch.sigmoid(torch.as_tensor(-0.1) / 10e-2),
                 )
             )
+            # nonnegative objective, two constraint explicit different eta
+            # use ones_f
+            obj = samples.clone()
+            obj = apply_constraints(
+                obj=obj,
+                constraints=[ones_f, ones_f],
+                samples=samples,
+                infeasible_cost=0.0,
+                eta=torch.tensor([1, 10]).to(**tkwargs),
+            )
+            self.assertTrue(
+                torch.allclose(
+                    obj,
+                    samples
+                    * torch.sigmoid(torch.as_tensor(-1.0) / 1.0)
+                    * torch.sigmoid(torch.as_tensor(-1.0) / 10.0),
+                )
+            )
             # negative objective, one constraint, infeasible_cost
             obj = samples.clone().clamp_min(-1.0)
             obj = apply_constraints(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

I recently looked into the output constraint implementation in botorch and figured out that it behave like our custom `Objective` implementation for handling of constraints, namely by multiplying by sigmoids. Currently, the only difference is that we work often with different `eta` values per constraint. I think this would be a nice feature also for `botorch`. 

This PR is still work in progress, as the `apply_constraints` method is used at a lot of different occasions though-out the codebase, and my question is if one want to keep backwards compatibility. In the current PR, I kept the backwards compatibility and made `eta` of type `Union[float, torch.Tensor]`. If one does this one has to always catch if just a float is provided and transform the float in a tensor of the same length as the list of constraint callables.

Another option would be to set `eta` as optional with default `None` and then just generate a tensor with the old default of 10e-3. 

Which solution would you prefer?

Depending on your suggestion, I would finalize the PR and implement the functionality of different `eta`s per constraint though-out the whole codebase. 

### Have you read the [Contributing Guidelines on pull requests]

Yes.

## Test Plan

Unit tests.
