### PR TITLE
Add preference_bo tutorial to ignore list

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -22,6 +22,7 @@ from nbconvert import PythonExporter
 IGNORE = {  # ignored in smoke tests and full runs
     "vae_mnist.ipynb",  # requires setting paths to local data
     "bope.ipynb",  # flaky, keeps failing the workflows
+    "preference_bo.ipynb",  # failing. Fix planned
 }
 IGNORE_SMOKE_TEST_ONLY = {  # only used in smoke tests
     "thompson_sampling.ipynb",  # very slow without KeOps + GPU


### PR DESCRIPTION
## Motivation

The preference_bo tutorial has been failing in the nightly cron for a while. Example failure: https://github.com/pytorch/botorch/actions/runs/3557829075/jobs/5976095917#step:11:18

@ItsMrLin plans a fix, but it's not completely trivial; in the mean time let's turn this off so we can get signal out of the nightly cron again.

## Test Plan

Manually trigger nightly cron and make sure that this tutorial doesn't run.
