### PR TITLE
Fix RFF bug when using FixedNoiseGP models

### DIFF
--- a/botorch/utils/gp_sampling.py
+++ b/botorch/utils/gp_sampling.py
@@ -462,7 +462,7 @@ def get_gp_samples(
         phi_X = basis(train_X)
         # Sample weights from bayesian linear model.
         # weights.sample().shape == (n_samples, batch_shape_input, num_rff_features)
-        sigma_sq = _model.likelihood.noise
+        sigma_sq = _model.likelihood.noise.mean(dim=-1, keepdim=True)
         if len(basis.kernel_batch_shape) > 0:
             sigma_sq = sigma_sq.unsqueeze(-2)
         mvn = get_weights_posterior(


### PR DESCRIPTION
Summary: `_model.likelihood.noise` is a `... x d`-dim tensor for fixed noise models with `d`-dimensional `train_X`. This leads to errors when constructing the RFF. This updates the `sigma_sq` to use the mean across the input dimensions, which was used prior to https://github.com/pytorch/botorch/pull/1336.

Differential Revision: D41568680

