### PR TITLE
Support SAAS ensemble models in RFFs

### DIFF
--- a/botorch/utils/gp_sampling.py
+++ b/botorch/utils/gp_sampling.py
@@ -462,7 +462,7 @@ def get_gp_samples(
         phi_X = basis(train_X)
         # Sample weights from bayesian linear model.
         # weights.sample().shape == (n_samples, batch_shape_input, num_rff_features)
-        sigma_sq = _model.likelihood.noise
+        sigma_sq = _model.likelihood.noise.mean(dim=-1, keepdim=True)
         if len(basis.kernel_batch_shape) > 0:
             sigma_sq = sigma_sq.unsqueeze(-2)
         mvn = get_weights_posterior(

--- a/botorch/utils/transforms.py
+++ b/botorch/utils/transforms.py
@@ -192,11 +192,17 @@ def is_fully_bayesian(model: Model) -> bool:
         SaasFullyBayesianMultiTaskGP,
     ]
 
-    if any(isinstance(model, m_cls) for m_cls in full_bayesian_model_cls):
+    if any(
+        isinstance(model, m_cls) or getattr(model, "is_fully_bayesian", False)
+        for m_cls in full_bayesian_model_cls
+    ):
         return True
     elif isinstance(model, ModelList):
         for m in model.models:
-            if any(isinstance(m, m_cls) for m_cls in full_bayesian_model_cls):
+            if any(
+                isinstance(m, m_cls) or getattr(model, "is_fully_bayesian", False)
+                for m_cls in full_bayesian_model_cls
+            ):
                 return True
             elif isinstance(m, ModelListGP) and any(
                 isinstance(m_sub, m_cls)


### PR DESCRIPTION
Summary: RFFs currently support batched models but not batched evaluation (without the model batch dimension unsqueezed) of RFFs constructed from batched models. This prevents their use in acquisition functions. The changes here make it possible to construct an RFF from a SAAS ensemble model and use it in acquisition functions.

Reviewed By: Balandat

Differential Revision: D41569212

