### PR TITLE
Change defaults MC Samples to 512

### DIFF
--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -43,7 +43,7 @@ def get_acquisition_function(
     posterior_transform: Optional[PosteriorTransform] = None,
     X_pending: Optional[Tensor] = None,
     constraints: Optional[List[Callable[[Tensor], Tensor]]] = None,
-    mc_samples: int = 500,
+    mc_samples: int = 512,
     seed: Optional[int] = None,
     **kwargs,
 ) -> monte_carlo.MCAcquisitionFunction:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

I just recognized that in `get_acquisition_function` a default of 500 mc samples is used, but when one initializes an MC acquisition function directly a default of 512 samples is used: https://github.com/pytorch/botorch/blob/8ecc903392b21ad9468c9b45f26b867d51378461/botorch/acquisition/acquisition.py#L149 I think it makes sense to keep things consistent. In addition, I think it is recommended for sobol sampling to use a sampling size which corresponds to basis 2. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Only default value is changed. No tests necessary.

