### PR TITLE
Suppress dtype warnings in unit tests

### DIFF
--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -45,6 +45,11 @@ class BotorchTestCase(TestCase):
         warnings.resetwarnings()
         settings.debug._set_state(False)
         warnings.simplefilter("always", append=True)
+        warnings.filterwarnings(
+            "ignore",
+            message="The model inputs are of type",
+            category=UserWarning,
+        )
 
 
 class BaseTestProblemBaseTestCase:


### PR DESCRIPTION
Summary: The dtype warnings were being raised a few too many times when running unit tests. This adds a filter to ignore them.

Differential Revision: D41757594

