### PR TITLE
Put HOGP tutorial in ignorelist

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -28,6 +28,7 @@ IGNORE_SMOKE_TEST_ONLY = {  # only used in smoke tests
     "thompson_sampling.ipynb",  # very slow without KeOps + GPU
     "composite_mtbo.ipynb",  # TODO: very slow, figure out if we can make it faster
     "Multi_objective_multi_fidelity_BO.ipynb",  # TODO: very slow, speed up
+    "composite_bo_with_hogp.ipynb",  # TODO: OOMing the nightly cron, reduce memory usage.
 }
 
 


### PR DESCRIPTION
This seems to be OOMing the nightly cron. Let's skip it until we get around to reducing its memory usage. 

Test plan:

https://github.com/pytorch/botorch/actions/runs/3631828439 should pass.