### PR TITLE
add eta to get_acquisition_function

### DIFF
--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -392,6 +392,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
         self.assertTrue(acqf == mock_acqf.return_value)
         mock_acqf.assert_called_once_with(
             constraints=None,
+            eta=1e-3,
             model=self.model,
             objective=self.mo_objective,
             ref_point=self.ref_point,
@@ -452,6 +453,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
             X_pending=self.X_pending,
             mc_samples=self.mc_samples,
             constraints=[lambda Y: Y[..., -1]],
+            eta=1e-2,
             seed=2,
             ref_point=self.ref_point,
             Y=self.Y,
@@ -459,6 +461,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
         _, kwargs = mock_acqf.call_args
         partitioning = kwargs["partitioning"]
         self.assertEqual(partitioning.pareto_Y.shape[0], 0)
+        self.assertEqual(kwargs["eta"], 1e-2)
 
     @mock.patch(f"{moo_monte_carlo.__name__}.qNoisyExpectedHypervolumeImprovement")
     def test_GetQNEHVI(self, mock_acqf):
@@ -486,6 +489,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
         self.assertTrue(acqf == mock_acqf.return_value)
         mock_acqf.assert_called_once_with(
             constraints=None,
+            eta=1e-3,
             model=self.model,
             X_baseline=self.X_observed,
             objective=self.objective,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR adds the `eta` parameter for the constraints also to get_acquisition_function.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.

