### PR TITLE
Make a reusable website publish workflow

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -102,27 +102,7 @@ jobs:
 
   publish-versioned-website:
     name: Publish versioned website
-    runs-on: ubuntu-latest
     needs: [package-deploy-pypi, package-deploy-conda]
-    strategy:
-      fail-fast: true
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      # there may not be a compatible Ax pip version, so we use the development version
-      env:
-        ALLOW_BOTORCH_LATEST: true  # allow Ax to install w/ new BoTorch release
-      run: |
-        pip install .[dev]
-        pip install git+https://github.com/facebook/Ax.git
-        pip install .[tutorials]
-        pip install beautifulsoup4 ipython nbconvert jinja2
-    - name: Publish latest website
-      env:
-        DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}
-      run: |
-        ./scripts/publish_site.sh -d -v ${{ github.event.release.tag_name }}
+    uses: ./.github/workflows/reusable_website.yml
+    with:
+      publish_versioned_website: true

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -106,3 +106,4 @@ jobs:
     uses: ./.github/workflows/reusable_website.yml
     with:
       publish_versioned_website: true
+      release_tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -115,36 +115,10 @@ jobs:
 
   publish-latest-website:
     name: Publish latest website
-    runs-on: ubuntu-latest
     needs: [tests-and-coverage-nightly, package-test-deploy-pypi, package-conda]
-    strategy:
-      fail-fast: true
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Fetch all history for all tags and branches
-      run: git fetch --prune --unshallow
-    - name: Install dependencies
-      env:
-        ALLOW_LATEST_GPYTORCH_LINOP: true
-        ALLOW_BOTORCH_LATEST: true  # allow Ax to install w/ new BoTorch release
-      run: |
-        pip install git+https://github.com/cornellius-gp/linear_operator.git
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install .[dev]
-        pip install git+https://github.com/facebook/Ax.git
-        pip install beautifulsoup4 ipython nbconvert jinja2
-    - name: Unit tests
-      run: |
-        pytest -ra
-    - name: Publish latest website
-      env:
-        DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}
-      run: |
-        ./scripts/publish_site.sh -d
+    uses: ./.github/workflows/reusable_website.yml
+    with:
+      publish_versioned_website: false
 
   run_tutorials:
     name: Run tutorials without smoke test on latest PyTorch / GPyTorch / Ax

--- a/.github/workflows/reusable_website.yml
+++ b/.github/workflows/reusable_website.yml
@@ -32,25 +32,18 @@ jobs:
         python-version: 3.8
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
-    - if: ${{ inputs.publish_versioned_website }}    
-      name: Install dependencies for versioned website
-      # there may not be a compatible Ax pip version, so we use the development version
-      env:
-        ALLOW_BOTORCH_LATEST: true  # allow Ax to install w/ new BoTorch release
-      run: |
-        pip install .[dev]
-        pip install git+https://github.com/facebook/Ax.git
-        pip install .[tutorials]
-        pip install beautifulsoup4 ipython nbconvert jinja2
     - if: ${{ !inputs.publish_versioned_website }}    
-      name: Install dependencies for latest website
-      env:
-        ALLOW_LATEST_GPYTORCH_LINOP: true
-        ALLOW_BOTORCH_LATEST: true  # allow Ax to install w/ new BoTorch release
+      name: Install latest GPyTorch and Linear Operator
       run: |
         pip install git+https://github.com/cornellius-gp/linear_operator.git
         pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install .[dev]
+    - name: Install common dependencies
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
+        ALLOW_BOTORCH_LATEST: true  # Allow Ax to install w/ new BoTorch release.
+      run: |
+        pip install ."[dev, tutorials]"
+        # There may not be a compatible Ax pip version, so we use the development version.
         pip install git+https://github.com/facebook/Ax.git
         pip install beautifulsoup4 ipython nbconvert jinja2
     - if: ${{ inputs.publish_versioned_website }}

--- a/.github/workflows/reusable_website.yml
+++ b/.github/workflows/reusable_website.yml
@@ -1,0 +1,57 @@
+name: Reusable Publish Website Workflow
+
+on:
+  workflow_call:
+    inputs:
+      publish_versioned_website:
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  publish-website:
+    name: Publish website
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+    - name: Fetch all history for all tags and branches
+      run: git fetch --prune --unshallow
+    - if: ${{ inputs.publish_versioned_website }}    
+      name: Install dependencies for versioned website
+      # there may not be a compatible Ax pip version, so we use the development version
+      env:
+        ALLOW_BOTORCH_LATEST: true  # allow Ax to install w/ new BoTorch release
+      run: |
+        pip install .[dev]
+        pip install git+https://github.com/facebook/Ax.git
+        pip install .[tutorials]
+        pip install beautifulsoup4 ipython nbconvert jinja2
+    - if: ${{ !inputs.publish_versioned_website }}    
+      name: Install dependencies for latest website
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
+        ALLOW_BOTORCH_LATEST: true  # allow Ax to install w/ new BoTorch release
+      run: |
+        pip install git+https://github.com/cornellius-gp/linear_operator.git
+        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install .[dev]
+        pip install git+https://github.com/facebook/Ax.git
+        pip install beautifulsoup4 ipython nbconvert jinja2
+    - if: ${{ inputs.publish_versioned_website }}
+      name: Publish versioned website
+      env:
+        DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}
+      run: |
+        ./scripts/publish_site.sh -d -v ${{ github.event.release.tag_name }}
+    - if: ${{ !inputs.publish_versioned_website }}
+      name: Publish latest website
+      env:
+        DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}
+      run: |
+        ./scripts/publish_site.sh -d

--- a/.github/workflows/reusable_website.yml
+++ b/.github/workflows/reusable_website.yml
@@ -2,12 +2,21 @@ name: Reusable Publish Website Workflow
 
 on:
   workflow_dispatch:
+    inputs:
+      publish_versioned_website:
+        required: true
+        type: boolean
+      release_tag:
+        required: false
+        type: string
   workflow_call:
     inputs:
       publish_versioned_website:
         required: true
         type: boolean
-        default: false
+      release_tag:
+        required: false
+        type: string
 
 jobs:
   publish-website:
@@ -49,7 +58,7 @@ jobs:
       env:
         DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}
       run: |
-        ./scripts/publish_site.sh -d -v ${{ github.event.release.tag_name }}
+        ./scripts/publish_site.sh -d -v ${{ inputs.release_tag }}
     - if: ${{ !inputs.publish_versioned_website }}
       name: Publish latest website
       env:

--- a/.github/workflows/reusable_website.yml
+++ b/.github/workflows/reusable_website.yml
@@ -1,6 +1,7 @@
 name: Reusable Publish Website Workflow
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       publish_versioned_website:


### PR DESCRIPTION
Whenever automated release process fails, manually publishing the updated website takes a good bit of time. This will hopefully reduce it to a couple clicks. Cleaning up the workflows a bit is a bonus!