### PR TITLE
Support `0d`-features in `FixedFeatureAcquisitionFunction`

### DIFF
--- a/botorch/acquisition/fixed_feature.py
+++ b/botorch/acquisition/fixed_feature.py
@@ -73,6 +73,8 @@ class FixedFeatureAcquisitionFunction(AcquisitionFunction):
                     # likewise if any value uses cuda, use cuda for all values
                     dtype = value.dtype if value.dtype == torch.double else dtype
                     device = value.device if value.device.type == "cuda" else device
+                    if value.ndim == 0:  # since we can't broadcast with zero-d tensors
+                        value = value.unsqueeze(0)
                     new_values.append(value.detach().clone())
             # move all values to same device
             for i, val in enumerate(new_values):


### PR DESCRIPTION
Summary:
This commit adds support for `0d` value tensors in `FixedFeatureAcquisitionFunction`. In particular, this allows users to run `optimize_acqf` with the `fixed_features` keyword via the convenient syntax:
```
fixed_features=dict(zip(fixed_dims.tolist(), features[fixed_dims])),
```
which errors without this commit if `features` is a tensor.

Differential Revision: D41777838

