### PR TITLE
Turn off fast computations by default

### DIFF
--- a/botorch/__init__.py
+++ b/botorch/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import gpytorch.settings as gp_settings
+import linear_operator.settings as linop_settings
 from botorch import (
     acquisition,
     exceptions,
@@ -24,13 +26,28 @@ from botorch.generation.gen import (
     gen_candidates_torch,
     get_best_candidates,
 )
+from botorch.logging import logger
 from botorch.utils import manual_seed
-
 
 try:
     from botorch.version import version as __version__
 except Exception:  # pragma: no cover
     __version__ = "Unknown"  # pragma: no cover
+
+logger.info(
+    "Turning off `fast_computations` in linear operator and increasing "
+    "`max_cholesky_size` and `max_eager_kernel_size` to 4096, and "
+    "`cholesky_max_tries` to 6. The approximate computations available in "
+    "GPyTorch aim to speed up GP training and inference in large data "
+    "regime but they are generally not robust enough to be used in a BO-loop. "
+    "See gpytorch.settings & linear_operator.settings for more details."
+)
+linop_settings._fast_covar_root_decomposition._default = False
+linop_settings._fast_log_prob._default = False
+linop_settings._fast_solves._default = False
+linop_settings.cholesky_max_tries._global_value = 6
+linop_settings.max_cholesky_size._global_value = 4096
+gp_settings.max_eager_kernel_size._global_value = 4096
 
 
 __all__ = [

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -6,6 +6,8 @@
 
 import warnings
 
+import gpytorch.settings as gp_settings
+import linear_operator.settings as linop_settings
 from botorch import settings
 from botorch.exceptions import BotorchWarning
 from botorch.utils.testing import BotorchTestCase
@@ -46,3 +48,13 @@ class TestSettings(BotorchTestCase):
         with warnings.catch_warnings(record=True) as ws:
             warnings.warn("test", BotorchWarning)
         self.assertEqual(len(ws), 0)
+
+
+class TestDefaultGPyTorchLinOpSettings(BotorchTestCase):
+    def test_default_gpytorch_linop_settings(self):
+        self.assertTrue(linop_settings._fast_covar_root_decomposition.off())
+        self.assertTrue(linop_settings._fast_log_prob.off())
+        self.assertTrue(linop_settings._fast_solves.off())
+        self.assertEqual(linop_settings.cholesky_max_tries.value(), 6)
+        self.assertEqual(linop_settings.max_cholesky_size.value(), 4096)
+        self.assertEqual(gp_settings.max_eager_kernel_size.value(), 4096)


### PR DESCRIPTION
Summary: These have been leading to many bugs in Ax and BoTorch without any clear benefit for most of our use cases. Since these are advanced features, it makes sense to require an advanced user to opt-in rather than leaving them enabled by default.

Differential Revision: D41829982

