### PR TITLE
Raise error for unsupported outcome transforms in `ModelListGPyTorchModel`

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -472,6 +472,11 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
 
         m = len(idcs)
         new_model = deepcopy(self)
+
+        subset_everything = self.num_outputs == 1 and m == 1 and idcs[0] == 0
+        if subset_everything:
+            return new_model
+
         tidxr = torch.tensor(idcs, device=new_model.train_targets.device)
         idxr = tidxr if m > 1 else idcs[0]
         new_tail_bs = torch.Size([m]) if m > 1 else torch.Size()

--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -617,10 +617,10 @@ class ModelListGPyTorchModel(GPyTorchModel, ModelList, ABC):
         # apply output transforms of individual models if present
         mvns = []
         for i, mvn in mvn_gen:
-            try:
+            if hasattr(self.models[i], "outcome_transform"):
                 oct = self.models[i].outcome_transform
                 tf_mvn = oct.untransform_posterior(GPyTorchPosterior(mvn)).distribution
-            except AttributeError:
+            else:
                 tf_mvn = mvn
             mvns.append(tf_mvn)
         # return result as a GPyTorchPosteriors/FullyBayesianPosterior

--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -497,7 +497,7 @@ class Log(OutcomeTransform):
             )
         return Y_utf, Yvar
 
-    def untransform_posterior(self, posterior: Posterior) -> Posterior:
+    def untransform_posterior(self, posterior: Posterior) -> TransformedPosterior:
         r"""Un-transform the log-transformed posterior.
 
         Args:
@@ -626,7 +626,7 @@ class Power(OutcomeTransform):
             )
         return Y_utf, Yvar
 
-    def untransform_posterior(self, posterior: Posterior) -> Posterior:
+    def untransform_posterior(self, posterior: Posterior) -> TransformedPosterior:
         r"""Un-transform the power-transformed posterior.
 
         Args:
@@ -750,7 +750,7 @@ class Bilog(OutcomeTransform):
             )
         return Y_utf, Yvar
 
-    def untransform_posterior(self, posterior: Posterior) -> Posterior:
+    def untransform_posterior(self, posterior: Posterior) -> TransformedPosterior:
         r"""Un-transform the bilog-transformed posterior.
 
         Args:

--- a/botorch/posteriors/gpytorch.py
+++ b/botorch/posteriors/gpytorch.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import warnings
 
 from contextlib import ExitStack
-from typing import Optional, Tuple
+from typing import Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
 from botorch.exceptions.errors import BotorchTensorDimensionError
@@ -28,6 +28,9 @@ from linear_operator.operators import (
 )
 from torch import Tensor
 from torch.distributions import Normal
+
+if TYPE_CHECKING:
+    from botorch.posteriors.posterior_list import PosteriorList  # pragma: no cover
 
 
 class GPyTorchPosterior(TorchPosterior):
@@ -233,10 +236,26 @@ class GPyTorchPosterior(TorchPosterior):
         return marginal.log_prob(value).exp()
 
 
-def scalarize_posterior(
-    posterior: GPyTorchPosterior, weights: Tensor, offset: float = 0.0
-) -> GPyTorchPosterior:
-    r"""Affine transformation of a multi-output posterior.
+def _validate_scalarize_inputs(weights: Tensor, m: int) -> None:
+    if weights.ndim > 1:
+        raise BotorchTensorDimensionError("`weights` must be one-dimensional")
+    if m != weights.size(0):
+        raise RuntimeError(
+            f"Output shape not equal to that of weights. Output shape is {m} and "
+            f"weights are {weights.shape}"
+        )
+
+
+def scalarize_posterior_gpytorch(
+    posterior: GPyTorchPosterior,
+    weights: Tensor,
+    offset: float = 0.0,
+) -> Tuple[Tensor, LinearOperator]:
+    r"""Helper function for `scalarize_posterior`, producing a mean and
+    variance.
+
+    This mean and variance are consumed by `scalarize_posterior` to produce
+    a `GPyTorchPosterior`.
 
     Args:
         posterior: The posterior over `m` outcomes to be scalarized.
@@ -255,23 +274,21 @@ def scalarize_posterior(
         >>> X = torch.rand(1, 2)
         >>> posterior = model.posterior(X)
         >>> weights = torch.tensor([0.5, 0.25])
-        >>> new_posterior = scalarize_posterior(posterior, weights=weights)
+        >>> mean, cov = scalarize_posterior_gpytorch(posterior, weights=weights)
+        >>> mvn = MultivariateNormal(mean, cov)
+        >>> new_posterior = GPyTorchPosterior
     """
-    if weights.ndim > 1:
-        raise BotorchTensorDimensionError("`weights` must be one-dimensional")
     mean = posterior.mean
     q, m = mean.shape[-2:]
+    _validate_scalarize_inputs(weights, m)
     batch_shape = mean.shape[:-2]
-    if m != weights.size(0):
-        raise RuntimeError("Output shape not equal to that of weights")
     mvn = posterior.distribution
     cov = mvn.lazy_covariance_matrix if mvn.islazy else mvn.covariance_matrix
 
     if m == 1:  # just scaling, no scalarization necessary
         new_mean = offset + (weights[0] * mean).view(*batch_shape, q)
         new_cov = weights[0] ** 2 * cov
-        new_mvn = MultivariateNormal(new_mean, new_cov)
-        return GPyTorchPosterior(new_mvn)
+        return new_mean, new_cov
 
     new_mean = offset + (mean @ weights).view(*batch_shape, q)
 
@@ -292,8 +309,7 @@ def scalarize_posterior(
                         for i in range(cov.base_linear_op.size(-3))
                     ]
                 )
-                new_mvn = MultivariateNormal(new_mean, new_cov)
-                return GPyTorchPosterior(new_mvn)
+                return new_mean, new_cov
 
             w_cov = torch.repeat_interleave(weights, q).unsqueeze(0)
             sum_shape = batch_shape + torch.Size([m, q, m, q])
@@ -307,5 +323,70 @@ def scalarize_posterior(
             cov_scaled = cov_scaled.to_dense()
         new_cov = cov_scaled.view(sum_shape).sum(dim=sum_dims[0]).sum(dim=sum_dims[1])
 
-    new_mvn = MultivariateNormal(new_mean, new_cov)
-    return GPyTorchPosterior(new_mvn)
+    return new_mean, new_cov
+
+
+def scalarize_posterior(
+    posterior: Union[GPyTorchPosterior, PosteriorList],
+    weights: Tensor,
+    offset: float = 0.0,
+) -> GPyTorchPosterior:
+    r"""Affine transformation of a multi-output posterior.
+
+    Args:
+        posterior: The posterior over `m` outcomes to be scalarized.
+            Supports `t`-batching. Can be either a `GPyTorchPosterior`,
+            or a `PosteriorList` that contains GPyTorchPosteriors all with q=1.
+        weights: A tensor of weights of size `m`.
+        offset: The offset of the affine transformation.
+
+    Returns:
+        The transformed (single-output) posterior. If the input posterior has
+            mean `mu` and covariance matrix `Sigma`, this posterior has mean
+            `weights^T * mu` and variance `weights^T Sigma w`.
+
+    Example:
+        Example for a model with two outcomes:
+
+        >>> X = torch.rand(1, 2)
+        >>> posterior = model.posterior(X)
+        >>> weights = torch.tensor([0.5, 0.25])
+        >>> new_posterior = scalarize_posterior(posterior, weights=weights)
+    """
+    # GPyTorchPosterior case
+    if hasattr(posterior, "distribution"):
+        mean, cov = scalarize_posterior_gpytorch(posterior, weights, offset)
+        mvn = MultivariateNormal(mean, cov)
+        return GPyTorchPosterior(mvn)
+
+    # PosteriorList case
+    if not hasattr(posterior, "posteriors"):
+        raise NotImplementedError(
+            "scalarize_posterior only works with a posterior that has an attribute "
+            "`distribution`, such as a GPyTorchPosterior, or a posterior that contains "
+            "sub-posteriors in an attribute `posteriors`, as in a PosteriorList."
+        )
+
+    mean = posterior.mean
+    q, m = mean.shape[-2:]
+
+    _validate_scalarize_inputs(weights, m)
+    batch_shape = mean.shape[:-2]
+
+    if q != 1:
+        raise NotImplementedError(
+            "scalarize_posterior only works with a PosteriorList if each sub-posterior "
+            "has q=1."
+        )
+
+    means = [post.mean for post in posterior.posteriors]
+    if {mean.shape[-1] for mean in means} != {1}:
+        raise NotImplementedError(
+            "scalarize_posterior only works with a PosteriorList if each sub-posterior "
+            "has one outcome."
+        )
+
+    new_mean = offset + (mean @ weights).view(*batch_shape, q)
+    new_cov = (posterior.variance @ (weights**2))[:, None]
+    mvn = MultivariateNormal(new_mean, new_cov)
+    return GPyTorchPosterior(mvn)

--- a/test/models/test_deterministic.py
+++ b/test/models/test_deterministic.py
@@ -143,7 +143,7 @@ class TestDeterministicModels(BotorchTestCase):
         test_X = torch.rand(3, 2)
         post_tf = ScalarizedPosteriorTransform(weights=torch.rand(2))
         # expect error due to post_tf expecting an MVN
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(NotImplementedError):
             model.posterior(test_X, posterior_transform=post_tf)
 
     def test_PosteriorMeanModel(self):

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -349,6 +349,12 @@ class TestSingleTaskGP(BotorchTestCase):
                     p_sub.variance, p.variance[..., [0]], atol=1e-4, rtol=1e-4
                 )
             )
+            # test subsetting each of the outputs (follows a different code branch)
+            subset_all_model = model.subset_output([0, 1])
+            p_sub_all = subset_all_model.posterior(X)
+            self.assertTrue(torch.allclose(p_sub_all.mean, p.mean))
+            # subsetting should still return a copy
+            self.assertNotEqual(model, subset_all_model)
 
     def test_construct_inputs(self):
         for batch_shape, dtype in itertools.product(

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -9,12 +9,12 @@ import warnings
 
 import torch
 from botorch.acquisition.objective import ScalarizedPosteriorTransform
-from botorch.exceptions.errors import BotorchTensorDimensionError
+from botorch.exceptions.errors import BotorchTensorDimensionError, UnsupportedError
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.fit import fit_gpytorch_mll
 from botorch.models import ModelListGP
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
-from botorch.models.transforms import Standardize
+from botorch.models.transforms import ChainedOutcomeTransform, Log, Standardize
 from botorch.models.transforms.input import Normalize
 from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling.normal import IIDNormalSampler
@@ -28,14 +28,34 @@ from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikeliho
 from gpytorch.priors import GammaPrior
 
 
-def _get_model(fixed_noise=False, use_octf=False, use_intf=False, **tkwargs):
+def _get_model(
+    fixed_noise=False, outcome_transform: str = "None", use_intf=False, **tkwargs
+) -> ModelListGP:
     train_x1, train_y1 = _get_random_data(
         batch_shape=torch.Size(), m=1, n=10, **tkwargs
     )
+
+    train_y1 = torch.exp(train_y1)
     train_x2, train_y2 = _get_random_data(
         batch_shape=torch.Size(), m=1, n=11, **tkwargs
     )
-    octfs = [Standardize(m=1), Standardize(m=1)] if use_octf else [None, None]
+    if outcome_transform == "Standardize":
+        octfs = [Standardize(m=1), Standardize(m=1)]
+    elif outcome_transform == "Log":
+        octfs = [Log(), Standardize(m=1)]
+    elif outcome_transform == "Chained":
+        octfs = [
+            ChainedOutcomeTransform(
+                chained=ChainedOutcomeTransform(log=Log(), standardize=Standardize(m=1))
+            ),
+            None,
+        ]
+    elif outcome_transform == "None":
+        octfs = [None, None]
+    else:
+        raise KeyError(
+            "outcome_transform must be one of 'Standardize', 'Log', or 'None'."
+        )
     intfs = [Normalize(d=1), Normalize(d=1)] if use_intf else [None, None]
     if fixed_noise:
         train_y1_var = 0.1 + 0.1 * torch.rand_like(train_y1, **tkwargs)
@@ -73,10 +93,12 @@ def _get_model(fixed_noise=False, use_octf=False, use_intf=False, **tkwargs):
 
 class TestModelListGP(BotorchTestCase):
     def _base_test_ModelListGP(
-        self, fixed_noise: bool, dtype, use_octf: bool
+        self, fixed_noise: bool, dtype, outcome_transform: str
     ) -> ModelListGP:
         tkwargs = {"device": self.device, "dtype": dtype}
-        model = _get_model(fixed_noise=fixed_noise, use_octf=use_octf, **tkwargs)
+        model = _get_model(
+            fixed_noise=fixed_noise, outcome_transform=outcome_transform, **tkwargs
+        )
         self.assertIsInstance(model, ModelListGP)
         self.assertIsInstance(model.likelihood, LikelihoodList)
         for m in model.models:
@@ -85,7 +107,7 @@ class TestModelListGP(BotorchTestCase):
             matern_kernel = m.covar_module.base_kernel
             self.assertIsInstance(matern_kernel, MaternKernel)
             self.assertIsInstance(matern_kernel.lengthscale_prior, GammaPrior)
-            if use_octf:
+            if outcome_transform != "None":
                 self.assertIsInstance(m.outcome_transform, Standardize)
 
         # test constructing likelihood wrapper
@@ -122,8 +144,13 @@ class TestModelListGP(BotorchTestCase):
         test_x = torch.tensor([[0.25], [0.75]], **tkwargs)
         posterior = model.posterior(test_x)
         self.assertIsInstance(posterior, GPyTorchPosterior)
+        submodel = model.models[0]
+        p0 = submodel.posterior(test_x)
+        self.assertTrue(torch.allclose(posterior.mean[:, [0]], p0.mean))
+        self.assertTrue(torch.allclose(posterior.variance[:, [0]], p0.variance))
+
         self.assertIsInstance(posterior.distribution, MultitaskMultivariateNormal)
-        if use_octf:
+        if outcome_transform != "None":
             # ensure un-transformation is applied
             submodel = model.models[0]
             p0 = submodel.posterior(test_x)
@@ -187,12 +214,12 @@ class TestModelListGP(BotorchTestCase):
         return model
 
     def test_ModelListGP(self) -> None:
-        for dtype, use_octf in itertools.product(
-            (torch.float, torch.double), (False, True)
+        for dtype, outcome_transform in itertools.product(
+            (torch.float, torch.double), ("None", "Standardize")
         ):
 
             model = self._base_test_ModelListGP(
-                fixed_noise=False, dtype=dtype, use_octf=use_octf
+                fixed_noise=False, dtype=dtype, outcome_transform=outcome_transform
             )
             tkwargs = {"device": self.device, "dtype": dtype}
 
@@ -204,11 +231,11 @@ class TestModelListGP(BotorchTestCase):
 
     def test_ModelListGP_fixed_noise(self) -> None:
 
-        for dtype, use_octf in itertools.product(
-            (torch.float, torch.double), (False, True)
+        for dtype, outcome_transform in itertools.product(
+            (torch.float, torch.double), ("None", "Standardize")
         ):
             model = self._base_test_ModelListGP(
-                fixed_noise=True, dtype=dtype, use_octf=use_octf
+                fixed_noise=True, dtype=dtype, outcome_transform=outcome_transform
             )
             tkwargs = {"device": self.device, "dtype": dtype}
             f_x = [torch.rand(2, 1, **tkwargs) for _ in range(2)]
@@ -219,6 +246,22 @@ class TestModelListGP(BotorchTestCase):
                 model.condition_on_observations(
                     f_x, f_y, noise=torch.rand(2, 3, **tkwargs)
                 )
+
+    def test_ModelListGP_raises_when_incompatible_transform(self) -> None:
+        with self.assertRaisesRegex(
+            UnsupportedError,
+            "Sub-model 0 has an outcome transform of type Log. This is not "
+            "supported for ModelListGP; please use ModelList instead.",
+        ):
+            _get_model(fixed_noise=False, outcome_transform="Log")
+
+        with self.assertRaisesRegex(
+            UnsupportedError,
+            "Sub-model 0 has a ChainedOutcomeTransform that contains a "
+            "transform of type Log. This is not supported for ModelListGP; "
+            "please use ModelList instead.",
+        ):
+            _get_model(fixed_noise=False, outcome_transform="Chained")
 
     def test_ModelListGP_single(self):
         tkwargs = {"device": self.device, "dtype": torch.float}

--- a/test/posteriors/test_posteriorlist.py
+++ b/test/posteriors/test_posteriorlist.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+
+import torch
+from botorch.posteriors.gpytorch import scalarize_posterior
+from botorch.posteriors.posterior_list import PosteriorList
+from botorch.utils.testing import _get_test_posterior, BotorchTestCase
+
+
+class TestPosteriorList(BotorchTestCase):
+    def test_scalarize_posterior_two_posteriors(self) -> None:
+        """
+        Test that when a PosteriorList has two posteriors, result of
+        `scalarize_posterior` matches quantitative expectations, analyitically
+        computed by hand.
+        """
+        m = 1
+        for batch_shape, lazy, dtype in itertools.product(
+            ([], [3]), (False, True), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+
+            posterior = _get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
+            posterior_list = PosteriorList(posterior, posterior)
+            scalarized_posterior = scalarize_posterior(
+                posterior, weights=torch.ones(1, **tkwargs)
+            )
+
+            scalarized_posterior_list = scalarize_posterior(
+                posterior_list, weights=torch.arange(1, 3, **tkwargs)
+            )
+            # 1 * orig mean + 2 * orig mean
+            self.assertTrue(
+                torch.allclose(
+                    scalarized_posterior.mean * 3, scalarized_posterior_list.mean
+                )
+            )
+            # 1 * orig var + 2^2 * orig var
+            self.assertTrue(
+                torch.allclose(
+                    scalarized_posterior.variance * 5,
+                    scalarized_posterior_list.variance,
+                )
+            )
+
+    def test_scalarize_posterior_one_posterior(self) -> None:
+        """
+        Test that when a PosteriorList has one posterior, result of
+        `scalarize_posterior` matches result of calling `scalarize_posterior`
+        on that posterior.
+        """
+        m = 1
+        for batch_shape, lazy, dtype in itertools.product(
+            ([], [3]), (False, True), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            offset = torch.rand(1).item()
+            weights = torch.randn(m, **tkwargs)
+            # Make sure the weights are not too small.
+            while torch.any(weights.abs() < 0.1):
+                weights = torch.randn(m, **tkwargs)
+            # test q=1
+            posterior = _get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
+            posterior_list = PosteriorList(posterior)
+            new_posterior = scalarize_posterior(posterior, weights, offset)
+            new_post_from_list = scalarize_posterior(posterior_list, weights, offset)
+            self.assertEqual(new_posterior.mean.shape, new_post_from_list.mean.shape)
+            self.assertTrue(torch.allclose(new_posterior.mean, new_post_from_list.mean))
+            self.assertTrue(
+                torch.allclose(new_posterior.variance, new_post_from_list.variance)
+            )
+
+    def test_scalarize_posterior_raises_not_implemented(self) -> None:
+        """
+        Test that `scalarize_posterior` raises `NotImplementedError` when provided
+        input shapes that are not supported for `PosteriorList`.
+        """
+        for batch_shape, m, lazy, dtype in itertools.product(
+            ([], [3]), (1, 2), (False, True), (torch.float, torch.double)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            offset = torch.rand(1).item()
+            weights = torch.randn(m, **tkwargs)
+            # Make sure the weights are not too small.
+            while torch.any(weights.abs() < 0.1):
+                weights = torch.randn(m, **tkwargs)
+            # test q=1
+            posterior = _get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
+            posterior_list = PosteriorList(posterior)
+            if m > 1:
+                with self.assertRaisesRegex(
+                    NotImplementedError,
+                    "scalarize_posterior only works with a PosteriorList if each "
+                    "sub-posterior has one outcome.",
+                ):
+                    scalarize_posterior(posterior_list, weights, offset)
+
+            # test q=2, interleaved
+            q = 2
+            posterior = _get_test_posterior(
+                batch_shape, q=q, m=m, lazy=lazy, interleaved=True, **tkwargs
+            )
+            posterior_list = PosteriorList(posterior)
+            with self.assertRaisesRegex(
+                NotImplementedError,
+                "scalarize_posterior only works with a PosteriorList if each "
+                "sub-posterior has q=1.",
+            ):
+                scalarize_posterior(posterior_list, weights, offset)
+
+            # test q=2, non-interleaved
+            # test independent special case as well
+            for independent in (False, True) if m > 1 else (False,):
+                posterior = _get_test_posterior(
+                    batch_shape,
+                    q=q,
+                    m=m,
+                    lazy=lazy,
+                    interleaved=False,
+                    independent=independent,
+                    **tkwargs,
+                )
+                posterior_list = PosteriorList(posterior)
+                with self.assertRaisesRegex(
+                    NotImplementedError,
+                    "scalarize_posterior only works with a PosteriorList if each "
+                    "sub-posterior has q=1.",
+                ):
+                    scalarize_posterior(posterior_list, weights, offset)


### PR DESCRIPTION
Summary: See https://github.com/pytorch/botorch/issues/1519 . A `ModelListGP` does not work with certain outcome transforms. this will now raise an `UnsupportedError` and recommend use of `ModelList` instead.

Differential Revision: D41860896

