### PR TITLE
Typo in mixed gp docstring

### DIFF
--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -76,7 +76,7 @@ class MixedSingleTaskGP(SingleTaskGP):
                 the input `X` that should be considered categorical features.
             cont_kernel_factory: A method that accepts `ard_num_dims` and
                 `active_dims` arguments and returns an instantiated GPyTorch
-                `Kernel` object to be used as the ase kernel for the continuous
+                `Kernel` object to be used as the base kernel for the continuous
                 dimensions. If omitted, this model uses a Matern-2.5 kernel as
                 the kernel for the ordinal parameters.
             likelihood: A likelihood. If omitted, use a standard


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR fixes a typo in the doctring of mixed GP.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Not needed for typo fix.

