### PR TITLE
Error out on NaN values in BoxDecomposition

### DIFF
--- a/botorch/utils/multi_objective/box_decompositions/box_decomposition.py
+++ b/botorch/utils/multi_objective/box_decompositions/box_decomposition.py
@@ -56,6 +56,11 @@ class BoxDecomposition(Module, ABC):
         self.num_outcomes = ref_point.shape[-1]
 
         if Y is not None:
+            if Y.isnan().any():
+                raise ValueError(
+                    "NaN inputs are not supported. Got Y with "
+                    f"{Y.isnan().sum()} NaN values."
+                )
             self._neg_Y = -Y
             self._validate_inputs()
             self._neg_pareto_Y = self._compute_pareto_Y()
@@ -172,6 +177,11 @@ class BoxDecomposition(Module, ABC):
         Returns:
             A boolean indicating if _neg_Y was initialized.
         """
+        if Y.isnan().any():
+            raise ValueError(
+                "NaN inputs are not supported. Got Y with "
+                f"{Y.isnan().sum()} NaN values."
+            )
         # multiply by -1, since internally we minimize.
         if self._neg_Y is not None:
             self._neg_Y = torch.cat([self._neg_Y, -Y], dim=-2)

--- a/test/utils/multi_objective/box_decompositions/test_box_decomposition.py
+++ b/test/utils/multi_objective/box_decompositions/test_box_decomposition.py
@@ -270,6 +270,18 @@ class TestBoxDecomposition(BotorchTestCase):
                 with self.assertRaises(NotImplementedError):
                     DummyFastPartitioning(ref_point=ref_point, Y=Y.unsqueeze(0))
 
+    def test_nan_values(self) -> None:
+        Y = torch.rand(10, 2)
+        Y[8:, 1] = float("nan")
+        ref_pt = torch.rand(2)
+        # On init.
+        with self.assertRaisesRegex(ValueError, "with 2 NaN values"):
+            DummyBoxDecomposition(ref_point=ref_pt, sort=True, Y=Y)
+        # On update.
+        bd = DummyBoxDecomposition(ref_point=ref_pt, sort=True)
+        with self.assertRaisesRegex(ValueError, "with 2 NaN values"):
+            bd.update(Y=Y)
+
 
 class TestBoxDecomposition_no_set_up(BotorchTestCase):
     def helper_hypervolume(self, Box_Decomp_cls: type) -> None:


### PR DESCRIPTION
Summary: In some cases, having NaN values can lead to partitioning evaluating to 0 hypervolume without any errors being raised. This is not a consistent behavior, and only happens with certain datasets and not others. Erroring out on NaN values seems like a safe solution.

Differential Revision: D41895761

