### PR TITLE
Fix cont_kernel_factory signature

### DIFF
--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -62,7 +62,9 @@ class MixedSingleTaskGP(SingleTaskGP):
         train_X: Tensor,
         train_Y: Tensor,
         cat_dims: List[int],
-        cont_kernel_factory: Optional[Callable[[int, List[int]], Kernel]] = None,
+        cont_kernel_factory: Optional[
+            Callable[[torch.Size, int, List[int]], Kernel]
+        ] = None,
         likelihood: Optional[Likelihood] = None,
         outcome_transform: Optional[OutcomeTransform] = None,  # TODO
         input_transform: Optional[InputTransform] = None,  # TODO
@@ -74,8 +76,8 @@ class MixedSingleTaskGP(SingleTaskGP):
             train_Y: A `batch_shape x n x m` tensor of training observations.
             cat_dims: A list of indices corresponding to the columns of
                 the input `X` that should be considered categorical features.
-            cont_kernel_factory: A method that accepts `ard_num_dims` and
-                `active_dims` arguments and returns an instantiated GPyTorch
+            cont_kernel_factory: A method that accepts  `batch_shape`, `ard_num_dims`,
+                and `active_dims` arguments and returns an instantiated GPyTorch
                 `Kernel` object to be used as the base kernel for the continuous
                 dimensions. If omitted, this model uses a Matern-2.5 kernel as
                 the kernel for the ordinal parameters.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

There was a bug in the signature and docstring for the `cont_kernel_factory` argument in `MixedSingleTaskGP`. The `batch_shape` argument was missing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Not needed.
