### PR TITLE
Increasing code sharing of `AnalyticAcquisitionFunctions`

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -11,6 +11,8 @@ Monte-Carlo sampling.
 
 from __future__ import annotations
 
+import math
+
 from abc import ABC
 from copy import deepcopy
 from typing import Dict, Optional, Tuple, Union
@@ -25,6 +27,9 @@ from botorch.models.model import Model
 from botorch.utils.transforms import convert_to_target_pre_hook, t_batch_mode_transform
 from torch import Tensor
 from torch.distributions import Normal
+
+
+_sqrt_2pi = math.sqrt(2 * math.pi)
 
 
 class AnalyticAcquisitionFunction(AcquisitionFunction, ABC):
@@ -71,6 +76,87 @@ class AnalyticAcquisitionFunction(AcquisitionFunction, ABC):
             "Analytic acquisition functions do not account for X_pending yet."
         )
 
+    def _mean_and_sigma(
+        self, X: Tensor, compute_sigma: bool = True, min_var: float = 1e-12
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        """Computes the first and second moments of the model posterior.
+
+        Args:
+            X: `batch_shape x q x d`-dim Tensor of model inputs.
+            compute_sigma: Boolean indicating whether or not to compute the second
+                moment (default: True).
+            min_var: The minimum value the variance is clamped too. Should be positive.
+
+        Returns:
+            A tuple of tensors containing the first and second moments of the model
+            posterior. Removes the last two dimensions if they have size one. Only
+            returns a single tensor of means if compute_sigma is True.
+        """
+        self.to(device=X.device)  # ensures buffers / parameters are on the same device
+        posterior = self.model.posterior(
+            X=X, posterior_transform=self.posterior_transform
+        )
+        mean = posterior.mean.squeeze(-2).squeeze(-1)  # removing redundant dimensions
+        if not compute_sigma:
+            return mean, None
+        sigma = posterior.variance.clamp_min(min_var).sqrt().view(mean.shape)
+        return mean, sigma
+
+
+class ProbabilityOfImprovement(AnalyticAcquisitionFunction):
+    r"""Single-outcome Probability of Improvement.
+
+    Probability of improvement over the current best observed value, computed
+    using the analytic formula under a Normal posterior distribution. Only
+    supports the case of q=1. Requires the posterior to be Gaussian. The model
+    must be single-outcome.
+
+    `PI(x) = P(y >= best_f), y ~ f(x)`
+
+    Example:
+        >>> model = SingleTaskGP(train_X, train_Y)
+        >>> PI = ProbabilityOfImprovement(model, best_f=0.2)
+        >>> pi = PI(test_X)
+    """
+
+    def __init__(
+        self,
+        model: Model,
+        best_f: Union[float, Tensor],
+        posterior_transform: Optional[PosteriorTransform] = None,
+        maximize: bool = True,
+        **kwargs,
+    ):
+        r"""Single-outcome Probability of Improvement.
+
+        Args:
+            model: A fitted single-outcome model.
+            best_f: Either a scalar or a `b`-dim Tensor (batch mode) representing
+                the best function value observed so far (assumed noiseless).
+            posterior_transform: A PosteriorTransform. If using a multi-output model,
+                a PosteriorTransform that transforms the multi-output posterior into a
+                single-output posterior is required.
+            maximize: If True, consider the problem a maximization problem.
+        """
+        super().__init__(model=model, posterior_transform=posterior_transform, **kwargs)
+        self.register_buffer("best_f", torch.as_tensor(best_f))
+        self.maximize = maximize
+
+    @t_batch_mode_transform(expected_q=1)
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Evaluate the Probability of Improvement on the candidate set X.
+
+        Args:
+            X: A `(b1 x ... bk) x 1 x d`-dim batched tensor of `d`-dim design points.
+
+        Returns:
+            A `(b1 x ... bk)`-dim tensor of Probability of Improvement values at the
+            given design points `X`.
+        """
+        mean, sigma = self._mean_and_sigma(X)
+        u = _scaled_improvement(mean, sigma, self.best_f, self.maximize)
+        return torch.special.ndtr(u)
+
 
 class ExpectedImprovement(AnalyticAcquisitionFunction):
     r"""Single-outcome Expected Improvement (analytic).
@@ -97,7 +183,7 @@ class ExpectedImprovement(AnalyticAcquisitionFunction):
         posterior_transform: Optional[PosteriorTransform] = None,
         maximize: bool = True,
         **kwargs,
-    ) -> None:
+    ):
         r"""Single-outcome Expected Improvement (analytic).
 
         Args:
@@ -110,10 +196,8 @@ class ExpectedImprovement(AnalyticAcquisitionFunction):
             maximize: If True, consider the problem a maximization problem.
         """
         super().__init__(model=model, posterior_transform=posterior_transform, **kwargs)
+        self.register_buffer("best_f", torch.as_tensor(best_f))
         self.maximize = maximize
-        if not torch.is_tensor(best_f):
-            best_f = torch.tensor(best_f)
-        self.register_buffer("best_f", best_f)
 
     @t_batch_mode_transform(expected_q=1, assert_output_shape=False)
     def forward(self, X: Tensor) -> Tensor:
@@ -129,213 +213,9 @@ class ExpectedImprovement(AnalyticAcquisitionFunction):
             A `(b1 x ... bk)`-dim tensor of Expected Improvement values at the
             given design points `X`.
         """
-        self.best_f = self.best_f.to(X)
-        posterior = self.model.posterior(
-            X=X, posterior_transform=self.posterior_transform
-        )
-        mean = posterior.mean
-        # deal with batch evaluation and broadcasting
-        view_shape = mean.shape[:-2] if mean.shape[-2] == 1 else mean.shape[:-1]
-        mean = mean.view(view_shape)
-        sigma = posterior.variance.clamp_min(1e-9).sqrt().view(view_shape)
-        u = (mean - self.best_f.expand_as(mean)) / sigma
-        if not self.maximize:
-            u = -u
-        normal = Normal(torch.zeros_like(u), torch.ones_like(u))
-        ucdf = normal.cdf(u)
-        updf = torch.exp(normal.log_prob(u))
-        ei = sigma * (updf + u * ucdf)
-        return ei
-
-
-class PosteriorMean(AnalyticAcquisitionFunction):
-    r"""Single-outcome Posterior Mean.
-
-    Only supports the case of q=1. Requires the model's posterior to have a
-    `mean` property. The model must be single-outcome.
-
-    Example:
-        >>> model = SingleTaskGP(train_X, train_Y)
-        >>> PM = PosteriorMean(model)
-        >>> pm = PM(test_X)
-    """
-
-    def __init__(
-        self,
-        model: Model,
-        posterior_transform: Optional[PosteriorTransform] = None,
-        maximize: bool = True,
-    ) -> None:
-        r"""Single-outcome Posterior Mean.
-
-        Args:
-            model: A fitted single-outcome GP model (must be in batch mode if
-                candidate sets X will be)
-            posterior_transform: A PosteriorTransform. If using a multi-output model,
-                a PosteriorTransform that transforms the multi-output posterior into a
-                single-output posterior is required.
-            maximize: If True, consider the problem a maximization problem. Note
-                that if `maximize=False`, the posterior mean is negated. As a
-                consequence `optimize_acqf(PosteriorMean(gp, maximize=False))`
-                does actually return -1 * minimum of the posterior mean.
-        """
-        super().__init__(model=model, posterior_transform=posterior_transform)
-        self.maximize = maximize
-
-    @t_batch_mode_transform(expected_q=1)
-    def forward(self, X: Tensor) -> Tensor:
-        r"""Evaluate the posterior mean on the candidate set X.
-
-        Args:
-            X: A `(b1 x ... bk) x 1 x d`-dim batched tensor of `d`-dim design points.
-
-        Returns:
-            A `(b1 x ... bk)`-dim tensor of Posterior Mean values at the
-            given design points `X`.
-        """
-        posterior = self.model.posterior(
-            X=X, posterior_transform=self.posterior_transform
-        )
-        mean = posterior.mean
-        view_shape = mean.shape[:-2] if mean.shape[-2] == 1 else mean.shape[:-1]
-        pm = posterior.mean.view(view_shape)
-        return pm if self.maximize else -1 * pm
-
-
-class ProbabilityOfImprovement(AnalyticAcquisitionFunction):
-    r"""Single-outcome Probability of Improvement.
-
-    Probability of improvement over the current best observed value, computed
-    using the analytic formula under a Normal posterior distribution. Only
-    supports the case of q=1. Requires the posterior to be Gaussian. The model
-    must be single-outcome.
-
-    `PI(x) = P(y >= best_f), y ~ f(x)`
-
-    Example:
-        >>> model = SingleTaskGP(train_X, train_Y)
-        >>> PI = ProbabilityOfImprovement(model, best_f=0.2)
-        >>> pi = PI(test_X)
-    """
-
-    def __init__(
-        self,
-        model: Model,
-        best_f: Union[float, Tensor],
-        posterior_transform: Optional[PosteriorTransform] = None,
-        maximize: bool = True,
-        **kwargs,
-    ) -> None:
-        r"""Single-outcome analytic Probability of Improvement.
-
-        Args:
-            model: A fitted single-outcome model.
-            best_f: Either a scalar or a `b`-dim Tensor (batch mode) representing
-                the best function value observed so far (assumed noiseless).
-            posterior_transform: A PosteriorTransform. If using a multi-output model,
-                a PosteriorTransform that transforms the multi-output posterior into a
-                single-output posterior is required.
-            maximize: If True, consider the problem a maximization problem.
-        """
-        super().__init__(model=model, posterior_transform=posterior_transform, **kwargs)
-        self.maximize = maximize
-        if not torch.is_tensor(best_f):
-            best_f = torch.tensor(best_f)
-        self.register_buffer("best_f", best_f)
-
-    @t_batch_mode_transform(expected_q=1)
-    def forward(self, X: Tensor) -> Tensor:
-        r"""Evaluate the Probability of Improvement on the candidate set X.
-
-        Args:
-            X: A `(b1 x ... bk) x 1 x d`-dim batched tensor of `d`-dim design points.
-
-        Returns:
-            A `(b1 x ... bk)`-dim tensor of Probability of Improvement values at the
-            given design points `X`.
-        """
-        self.best_f = self.best_f.to(X)
-        posterior = self.model.posterior(
-            X=X, posterior_transform=self.posterior_transform
-        )
-        mean, sigma = posterior.mean, posterior.variance.sqrt().clamp_min(1e-9)
-        view_shape = mean.shape[:-2] if mean.shape[-2] == 1 else mean.shape[:-1]
-        mean = mean.view(view_shape)
-        sigma = sigma.view(view_shape)
-        u = (mean - self.best_f.expand_as(mean)) / sigma
-        if not self.maximize:
-            u = -u
-        normal = Normal(torch.zeros_like(u), torch.ones_like(u))
-        return normal.cdf(u)
-
-
-class UpperConfidenceBound(AnalyticAcquisitionFunction):
-    r"""Single-outcome Upper Confidence Bound (UCB).
-
-    Analytic upper confidence bound that comprises of the posterior mean plus an
-    additional term: the posterior standard deviation weighted by a trade-off
-    parameter, `beta`. Only supports the case of `q=1` (i.e. greedy, non-batch
-    selection of design points). The model must be single-outcome.
-
-    `UCB(x) = mu(x) + sqrt(beta) * sigma(x)`, where `mu` and `sigma` are the
-    posterior mean and standard deviation, respectively.
-
-    Example:
-        >>> model = SingleTaskGP(train_X, train_Y)
-        >>> UCB = UpperConfidenceBound(model, beta=0.2)
-        >>> ucb = UCB(test_X)
-    """
-
-    def __init__(
-        self,
-        model: Model,
-        beta: Union[float, Tensor],
-        posterior_transform: Optional[PosteriorTransform] = None,
-        maximize: bool = True,
-        **kwargs,
-    ) -> None:
-        r"""Single-outcome Upper Confidence Bound.
-
-        Args:
-            model: A fitted single-outcome GP model (must be in batch mode if
-                candidate sets X will be)
-            beta: Either a scalar or a one-dim tensor with `b` elements (batch mode)
-                representing the trade-off parameter between mean and covariance
-            posterior_transform: A PosteriorTransform. If using a multi-output model,
-                a PosteriorTransform that transforms the multi-output posterior into a
-                single-output posterior is required.
-            maximize: If True, consider the problem a maximization problem.
-        """
-        super().__init__(model=model, posterior_transform=posterior_transform, **kwargs)
-        self.maximize = maximize
-        if not torch.is_tensor(beta):
-            beta = torch.tensor(beta)
-        self.register_buffer("beta", beta)
-
-    @t_batch_mode_transform(expected_q=1)
-    def forward(self, X: Tensor) -> Tensor:
-        r"""Evaluate the Upper Confidence Bound on the candidate set X.
-
-        Args:
-            X: A `(b1 x ... bk) x 1 x d`-dim batched tensor of `d`-dim design points.
-
-        Returns:
-            A `(b1 x ... bk)`-dim tensor of Upper Confidence Bound values at the
-            given design points `X`.
-        """
-        self.beta = self.beta.to(X)
-        posterior = self.model.posterior(
-            X=X, posterior_transform=self.posterior_transform
-        )
-        mean = posterior.mean
-        view_shape = mean.shape[:-2] if mean.shape[-2] == 1 else mean.shape[:-1]
-        mean = mean.view(view_shape)
-        variance = posterior.variance.view(view_shape)
-        delta = (self.beta.expand_as(mean) * variance).sqrt()
-        if self.maximize:
-            return mean + delta
-        else:
-            return -mean + delta
+        mean, sigma = self._mean_and_sigma(X)
+        u = _scaled_improvement(mean, sigma, self.best_f, self.maximize)
+        return sigma * _ei_helper(u)
 
 
 class ConstrainedExpectedImprovement(AnalyticAcquisitionFunction):
@@ -403,30 +283,13 @@ class ConstrainedExpectedImprovement(AnalyticAcquisitionFunction):
             A `(b)`-dim Tensor of Expected Improvement values at the given
             design points `X`.
         """
-        self.best_f = self.best_f.to(X)
-        posterior = self.model.posterior(
-            X=X, posterior_transform=self.posterior_transform
-        )
-        means = posterior.mean.squeeze(dim=-2)  # (b) x m
-        sigmas = posterior.variance.squeeze(dim=-2).sqrt().clamp_min(1e-9)  # (b) x m
-
-        # (b) x 1
-        oi = self.objective_index
-        mean_obj = means[..., oi : oi + 1]
-        sigma_obj = sigmas[..., oi : oi + 1]
-        u = (mean_obj - self.best_f.expand_as(mean_obj)) / sigma_obj
-        if not self.maximize:
-            u = -u
-        normal = Normal(
-            torch.zeros(1, device=u.device, dtype=u.dtype),
-            torch.ones(1, device=u.device, dtype=u.dtype),
-        )
-        ei_pdf = torch.exp(normal.log_prob(u))  # (b) x 1
-        ei_cdf = normal.cdf(u)
-        ei = sigma_obj * (ei_pdf + u * ei_cdf)
+        means, sigmas = self._mean_and_sigma(X)  # (b) x 1 + (m = num constraints)
+        ind = self.objective_index
+        mean_obj, sigma_obj = means[..., ind : ind + 1], sigmas[..., ind : ind + 1]
+        u = _scaled_improvement(mean_obj, sigma_obj, self.best_f, self.maximize)
+        ei = sigma_obj * _ei_helper(u)
         prob_feas = self._compute_prob_feas(X=X, means=means, sigmas=sigmas)
-        ei = ei.mul(prob_feas)
-        return ei.squeeze(dim=-1)
+        return ei.mul(prob_feas).squeeze(dim=-1)  # squeezing the constraint dimension
 
     def _preprocess_constraint_bounds(
         self, constraints: Dict[int, Tuple[Optional[float], Optional[float]]]
@@ -461,22 +324,15 @@ class ConstrainedExpectedImprovement(AnalyticAcquisitionFunction):
                 con_upper_inds.append(k)
                 con_upper.append(constraints[k][1])
         # tensor-based indexing is much faster than list-based advanced indexing
-        for k in [
-            "con_lower_inds",
-            "con_upper_inds",
-            "con_both_inds",
-            "con_both",
-            "con_lower",
-            "con_upper",
+        for name, indices in [
+            ("con_lower_inds", con_lower_inds),
+            ("con_upper_inds", con_upper_inds),
+            ("con_both_inds", con_both_inds),
+            ("con_both", con_both),
+            ("con_lower", con_lower),
+            ("con_upper", con_upper),
         ]:
-            self.register_buffer(k, tensor=None)
-
-        self.con_lower_inds = torch.tensor(con_lower_inds)
-        self.con_upper_inds = torch.tensor(con_upper_inds)
-        self.con_both_inds = torch.tensor(con_both_inds)
-        self.con_both = torch.tensor(con_both)
-        self.con_lower = torch.tensor(con_lower)
-        self.con_upper = torch.tensor(con_upper)
+            self.register_buffer(name, tensor=torch.as_tensor(indices))
 
     def _compute_prob_feas(self, X: Tensor, means: Tensor, sigmas: Tensor) -> Tensor:
         r"""Compute feasibility probability for each batch of X.
@@ -499,17 +355,14 @@ class ConstrainedExpectedImprovement(AnalyticAcquisitionFunction):
         prob_feas = torch.ones(output_shape, device=X.device, dtype=X.dtype)
 
         if len(self.con_lower_inds) > 0:
-            self.con_lower_inds = self.con_lower_inds.to(device=X.device)
             normal_lower = _construct_dist(means, sigmas, self.con_lower_inds)
             prob_l = 1 - normal_lower.cdf(self.con_lower)
             prob_feas = prob_feas.mul(torch.prod(prob_l, dim=-1, keepdim=True))
         if len(self.con_upper_inds) > 0:
-            self.con_upper_inds = self.con_upper_inds.to(device=X.device)
             normal_upper = _construct_dist(means, sigmas, self.con_upper_inds)
             prob_u = normal_upper.cdf(self.con_upper)
             prob_feas = prob_feas.mul(torch.prod(prob_u, dim=-1, keepdim=True))
         if len(self.con_both_inds) > 0:
-            self.con_both_inds = self.con_both_inds.to(device=X.device)
             normal_both = _construct_dist(means, sigmas, self.con_both_inds)
             prob_u = normal_both.cdf(self.con_both[:, 1])
             prob_l = normal_both.cdf(self.con_both[:, 0])
@@ -571,12 +424,7 @@ class NoisyExpectedImprovement(ExpectedImprovement):
         fantasy_model = _get_noiseless_fantasy_model(
             model=model, batch_X_observed=batch_X_observed, Y_fantasized=Y_fantasized
         )
-
-        if maximize:
-            best_f = Y_fantasized.max(dim=-1)[0]
-        else:
-            best_f = Y_fantasized.min(dim=-1)[0]
-
+        best_f, _ = Y_fantasized.max(dim=-1) if maximize else Y_fantasized.min(dim=-1)
         super().__init__(model=fantasy_model, best_f=best_f, maximize=maximize)
 
     def forward(self, X: Tensor) -> Tensor:
@@ -591,12 +439,6 @@ class NoisyExpectedImprovement(ExpectedImprovement):
         """
         # add batch dimension for broadcasting to fantasy models
         return super().forward(X.unsqueeze(-3)).mean(dim=-1)
-
-
-def _construct_dist(means: Tensor, sigmas: Tensor, inds: Tensor) -> Normal:
-    mean = means.index_select(dim=-1, index=inds)
-    sigma = sigmas.index_select(dim=-1, index=inds)
-    return Normal(loc=mean, scale=sigma)
 
 
 def _get_noiseless_fantasy_model(
@@ -638,6 +480,111 @@ def _get_noiseless_fantasy_model(
     return fantasy_model
 
 
+class UpperConfidenceBound(AnalyticAcquisitionFunction):
+    r"""Single-outcome Upper Confidence Bound (UCB).
+
+    Analytic upper confidence bound that comprises of the posterior mean plus an
+    additional term: the posterior standard deviation weighted by a trade-off
+    parameter, `beta`. Only supports the case of `q=1` (i.e. greedy, non-batch
+    selection of design points). The model must be single-outcome.
+
+    `UCB(x) = mu(x) + sqrt(beta) * sigma(x)`, where `mu` and `sigma` are the
+    posterior mean and standard deviation, respectively.
+
+    Example:
+        >>> model = SingleTaskGP(train_X, train_Y)
+        >>> UCB = UpperConfidenceBound(model, beta=0.2)
+        >>> ucb = UCB(test_X)
+    """
+
+    def __init__(
+        self,
+        model: Model,
+        beta: Union[float, Tensor],
+        posterior_transform: Optional[PosteriorTransform] = None,
+        maximize: bool = True,
+        **kwargs,
+    ) -> None:
+        r"""Single-outcome Upper Confidence Bound.
+
+        Args:
+            model: A fitted single-outcome GP model (must be in batch mode if
+                candidate sets X will be)
+            beta: Either a scalar or a one-dim tensor with `b` elements (batch mode)
+                representing the trade-off parameter between mean and covariance
+            posterior_transform: A PosteriorTransform. If using a multi-output model,
+                a PosteriorTransform that transforms the multi-output posterior into a
+                single-output posterior is required.
+            maximize: If True, consider the problem a maximization problem.
+        """
+        super().__init__(model=model, posterior_transform=posterior_transform, **kwargs)
+        self.register_buffer("beta", torch.as_tensor(beta))
+        self.maximize = maximize
+
+    @t_batch_mode_transform(expected_q=1)
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Evaluate the Upper Confidence Bound on the candidate set X.
+
+        Args:
+            X: A `(b1 x ... bk) x 1 x d`-dim batched tensor of `d`-dim design points.
+
+        Returns:
+            A `(b1 x ... bk)`-dim tensor of Upper Confidence Bound values at the
+            given design points `X`.
+        """
+        mean, sigma = self._mean_and_sigma(X)
+        return (mean if self.maximize else -mean) + self.beta.sqrt() * sigma
+
+
+class PosteriorMean(AnalyticAcquisitionFunction):
+    r"""Single-outcome Posterior Mean.
+
+    Only supports the case of q=1. Requires the model's posterior to have a
+    `mean` property. The model must be single-outcome.
+
+    Example:
+        >>> model = SingleTaskGP(train_X, train_Y)
+        >>> PM = PosteriorMean(model)
+        >>> pm = PM(test_X)
+    """
+
+    def __init__(
+        self,
+        model: Model,
+        posterior_transform: Optional[PosteriorTransform] = None,
+        maximize: bool = True,
+    ) -> None:
+        r"""Single-outcome Posterior Mean.
+
+        Args:
+            model: A fitted single-outcome GP model (must be in batch mode if
+                candidate sets X will be)
+            posterior_transform: A PosteriorTransform. If using a multi-output model,
+                a PosteriorTransform that transforms the multi-output posterior into a
+                single-output posterior is required.
+            maximize: If True, consider the problem a maximization problem. Note
+                that if `maximize=False`, the posterior mean is negated. As a
+                consequence `optimize_acqf(PosteriorMean(gp, maximize=False))`
+                does actually return -1 * minimum of the posterior mean.
+        """
+        super().__init__(model=model, posterior_transform=posterior_transform)
+        self.maximize = maximize
+
+    @t_batch_mode_transform(expected_q=1)
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Evaluate the posterior mean on the candidate set X.
+
+        Args:
+            X: A `(b1 x ... bk) x 1 x d`-dim batched tensor of `d`-dim design points.
+
+        Returns:
+            A `(b1 x ... bk)`-dim tensor of Posterior Mean values at the
+            given design points `X`.
+        """
+        mean, _ = self._mean_and_sigma(X, compute_sigma=False)
+        return mean if self.maximize else -mean
+
+
 class ScalarizedPosteriorMean(AnalyticAcquisitionFunction):
     r"""Scalarized Posterior Mean.
 
@@ -656,13 +603,14 @@ class ScalarizedPosteriorMean(AnalyticAcquisitionFunction):
 
         Args:
             model: A fitted single-outcome model.
-            weights: A tensor of shape `q` for scalarization.
+            weights: A tensor of shape `q` for scalarization. In order to minimize
+                the scalarized posterior mean, pass -weights.
             posterior_transform: A PosteriorTransform. If using a multi-output model,
                 a PosteriorTransform that transforms the multi-output posterior into a
                 single-output posterior is required.
         """
         super().__init__(model=model, posterior_transform=posterior_transform, **kwargs)
-        self.register_buffer("weights", weights.unsqueeze(dim=0))
+        self.register_buffer("weights", weights)
 
     @t_batch_mode_transform()
     def forward(self, X: Tensor) -> Tensor:
@@ -676,8 +624,33 @@ class ScalarizedPosteriorMean(AnalyticAcquisitionFunction):
             A `(b)`-dim Tensor of Posterior Mean values at the given design
             points `X`.
         """
-        posterior = self.model.posterior(
-            X=X, posterior_transform=self.posterior_transform
-        )
-        weighted_means = posterior.mean.squeeze(dim=-1) * self.weights
-        return weighted_means.sum(dim=-1)
+        return self._mean_and_sigma(X, compute_sigma=False)[0] @ self.weights
+
+
+# --------------- Helper functions for analytic acquisition functions. ---------------
+
+
+def _scaled_improvement(
+    mean: Tensor, sigma: Tensor, best_f: Tensor, maximize: bool
+) -> Tensor:
+    """Returns `u = (mean - best_f) / sigma`, -u if maximize == True."""
+    u = (mean - best_f) / sigma
+    return u if maximize else -u
+
+
+def _ei_helper(u: Tensor) -> Tensor:
+    """Computes phi(u) + u * Phi(u), where phi and Phi are the standard normal
+    pdf and cdf, respectively. This is used to compute Expected Improvement.
+    """
+    ucdf = torch.special.ndtr(u)
+    updf = torch.exp(-u.square() / 2) / _sqrt_2pi
+    return updf + u * ucdf
+
+
+def _construct_dist(means: Tensor, sigmas: Tensor, inds: Tensor) -> Normal:
+    """Constructs a torch.Normal distribution object with location parameter
+    means[... inds], and scale (i.e. standard deviation) sigmas[..., inds].
+    """
+    mean = means.index_select(dim=-1, index=inds)
+    sigma = sigmas.index_select(dim=-1, index=inds)
+    return Normal(loc=mean, scale=sigma)

--- a/test/acquisition/test_analytic.py
+++ b/test/acquisition/test_analytic.py
@@ -459,7 +459,7 @@ class TestConstrainedExpectedImprovement(BotorchTestCase):
 class TestNoisyExpectedImprovement(BotorchTestCase):
     def _get_model(self, dtype=torch.float):
         state_dict = {
-            "mean_module.constant": torch.tensor([-0.0066]),
+            "mean_module.raw_constant": torch.tensor([-0.0066]),
             "covar_module.raw_outputscale": torch.tensor(1.0143),
             "covar_module.base_kernel.raw_lengthscale": torch.tensor([[-0.99]]),
             "covar_module.base_kernel.lengthscale_prior.concentration": torch.tensor(


### PR DESCRIPTION
Summary:
This commit increases shared code between all `AnalyticAcquisitionFunction` classes by introducing a `_posterior_moments` function that combines universally used logic. It further adds `ImprovementAcquisitionFunction`, which unifies the constructor and specializes `_posterior_moments` for all improvement-based acquisition functions.

`_posterior_moments` also moves all parameters and buffers to the appropriate device, which was so far not the case for `ScalarizedPosteriorMean`, which also gets a `maximize` keyword argument to unify the interface with the other functions.

Differential Revision: D41880200

