### PR TITLE
Support for outcome transforms that return a TransformedPosterior in ModelListGP

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -391,7 +391,7 @@ class ModelList(Model):
         X: Tensor,
         output_indices: Optional[List[int]] = None,
         observation_noise: bool = False,
-        posterior_transform: Optional[Callable[[Posterior], Posterior]] = None,
+        posterior_transform: Optional[Callable[[PosteriorList], Posterior]] = None,
         **kwargs: Any,
     ) -> Posterior:
         r"""Computes the posterior over model outputs at the provided points.

--- a/botorch/posteriors/gpytorch.py
+++ b/botorch/posteriors/gpytorch.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 
 class GPyTorchPosterior(TorchPosterior):
     r"""A posterior based on GPyTorch's multi-variate Normal distributions."""
+    distribution: MultivariateNormal
 
     def __init__(
         self,

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -14,9 +14,9 @@ from botorch.exceptions.warnings import OptimizationWarning
 from botorch.fit import fit_gpytorch_mll
 from botorch.models import ModelListGP
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
-from botorch.models.transforms import Standardize
 from botorch.models.transforms.input import Normalize
-from botorch.posteriors import GPyTorchPosterior
+from botorch.models.transforms.outcome import ChainedOutcomeTransform, Log, Standardize
+from botorch.posteriors import GPyTorchPosterior, PosteriorList, TransformedPosterior
 from botorch.sampling.normal import IIDNormalSampler
 from botorch.utils.testing import _get_random_data, BotorchTestCase
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
@@ -28,14 +28,34 @@ from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikeliho
 from gpytorch.priors import GammaPrior
 
 
-def _get_model(fixed_noise=False, use_octf=False, use_intf=False, **tkwargs):
+def _get_model(
+    fixed_noise=False, outcome_transform: str = "None", use_intf=False, **tkwargs
+) -> ModelListGP:
     train_x1, train_y1 = _get_random_data(
         batch_shape=torch.Size(), m=1, n=10, **tkwargs
     )
+    train_y1 = torch.exp(train_y1)
     train_x2, train_y2 = _get_random_data(
         batch_shape=torch.Size(), m=1, n=11, **tkwargs
     )
-    octfs = [Standardize(m=1), Standardize(m=1)] if use_octf else [None, None]
+    if outcome_transform == "Standardize":
+        octfs = [Standardize(m=1), Standardize(m=1)]
+    elif outcome_transform == "Log":
+        octfs = [Log(), Standardize(m=1)]
+    elif outcome_transform == "Chained":
+        octfs = [
+            ChainedOutcomeTransform(
+                chained=ChainedOutcomeTransform(log=Log(), standardize=Standardize(m=1))
+            ),
+            Standardize(m=1),
+        ]
+    elif outcome_transform == "None":
+        octfs = [None, None]
+    else:
+        raise KeyError(  # pragma: no cover
+            "outcome_transform must be one of 'Standardize', 'Log', 'Chained', or "
+            "'None'."
+        )
     intfs = [Normalize(d=1), Normalize(d=1)] if use_intf else [None, None]
     if fixed_noise:
         train_y1_var = 0.1 + 0.1 * torch.rand_like(train_y1, **tkwargs)
@@ -73,10 +93,12 @@ def _get_model(fixed_noise=False, use_octf=False, use_intf=False, **tkwargs):
 
 class TestModelListGP(BotorchTestCase):
     def _base_test_ModelListGP(
-        self, fixed_noise: bool, dtype, use_octf: bool
+        self, fixed_noise: bool, dtype, outcome_transform: str
     ) -> ModelListGP:
         tkwargs = {"device": self.device, "dtype": dtype}
-        model = _get_model(fixed_noise=fixed_noise, use_octf=use_octf, **tkwargs)
+        model = _get_model(
+            fixed_noise=fixed_noise, outcome_transform=outcome_transform, **tkwargs
+        )
         self.assertIsInstance(model, ModelListGP)
         self.assertIsInstance(model.likelihood, LikelihoodList)
         for m in model.models:
@@ -85,8 +107,12 @@ class TestModelListGP(BotorchTestCase):
             matern_kernel = m.covar_module.base_kernel
             self.assertIsInstance(matern_kernel, MaternKernel)
             self.assertIsInstance(matern_kernel.lengthscale_prior, GammaPrior)
-            if use_octf:
-                self.assertIsInstance(m.outcome_transform, Standardize)
+            if outcome_transform != "None":
+                self.assertIsInstance(
+                    m.outcome_transform, (Log, Standardize, ChainedOutcomeTransform)
+                )
+            else:
+                assert not hasattr(m, "outcome_transform")
 
         # test constructing likelihood wrapper
         mll = SumMarginalLogLikelihood(model.likelihood, model)
@@ -121,9 +147,19 @@ class TestModelListGP(BotorchTestCase):
         # test posterior
         test_x = torch.tensor([[0.25], [0.75]], **tkwargs)
         posterior = model.posterior(test_x)
-        self.assertIsInstance(posterior, GPyTorchPosterior)
-        self.assertIsInstance(posterior.distribution, MultitaskMultivariateNormal)
-        if use_octf:
+        gpytorch_posterior_expected = outcome_transform in ("None", "Standardize")
+        expected_type = (
+            GPyTorchPosterior if gpytorch_posterior_expected else PosteriorList
+        )
+        self.assertIsInstance(posterior, expected_type)
+        submodel = model.models[0]
+        p0 = submodel.posterior(test_x)
+        self.assertTrue(torch.allclose(posterior.mean[:, [0]], p0.mean))
+        self.assertTrue(torch.allclose(posterior.variance[:, [0]], p0.variance))
+
+        if gpytorch_posterior_expected:
+            self.assertIsInstance(posterior.distribution, MultitaskMultivariateNormal)
+        if outcome_transform != "None":
             # ensure un-transformation is applied
             submodel = model.models[0]
             p0 = submodel.posterior(test_x)
@@ -136,8 +172,9 @@ class TestModelListGP(BotorchTestCase):
 
         # test output_indices
         posterior = model.posterior(test_x, output_indices=[0], observation_noise=True)
-        self.assertIsInstance(posterior, GPyTorchPosterior)
-        self.assertIsInstance(posterior.distribution, MultivariateNormal)
+        self.assertIsInstance(posterior, expected_type)
+        if gpytorch_posterior_expected:
+            self.assertIsInstance(posterior.distribution, MultivariateNormal)
 
         # test condition_on_observations
         f_x = [torch.rand(2, 1, **tkwargs) for _ in range(2)]
@@ -176,39 +213,50 @@ class TestModelListGP(BotorchTestCase):
         X = torch.rand(3, 1, **tkwargs)
         weights = torch.tensor([1, 2], **tkwargs)
         post_tf = ScalarizedPosteriorTransform(weights=weights)
-        posterior_tf = model.posterior(X, posterior_transform=post_tf)
-        self.assertTrue(
-            torch.allclose(
-                posterior_tf.mean,
-                model.posterior(X).mean @ weights.unsqueeze(-1),
+        if gpytorch_posterior_expected:
+            posterior_tf = model.posterior(X, posterior_transform=post_tf)
+            self.assertTrue(
+                torch.allclose(
+                    posterior_tf.mean,
+                    model.posterior(X).mean @ weights.unsqueeze(-1),
+                )
             )
-        )
 
         return model
 
     def test_ModelListGP(self) -> None:
-        for dtype, use_octf in itertools.product(
-            (torch.float, torch.double), (False, True)
+        for dtype, outcome_transform in itertools.product(
+            (torch.float, torch.double), ("None", "Standardize", "Log", "Chained")
         ):
 
             model = self._base_test_ModelListGP(
-                fixed_noise=False, dtype=dtype, use_octf=use_octf
+                fixed_noise=False, dtype=dtype, outcome_transform=outcome_transform
             )
             tkwargs = {"device": self.device, "dtype": dtype}
 
             # test observation_noise
             test_x = torch.tensor([[0.25], [0.75]], **tkwargs)
             posterior = model.posterior(test_x, observation_noise=True)
-            self.assertIsInstance(posterior, GPyTorchPosterior)
-            self.assertIsInstance(posterior.distribution, MultitaskMultivariateNormal)
+
+            gpytorch_posterior_expected = outcome_transform in ("None", "Standardize")
+            expected_type = (
+                GPyTorchPosterior if gpytorch_posterior_expected else PosteriorList
+            )
+            self.assertIsInstance(posterior, expected_type)
+            if gpytorch_posterior_expected:
+                self.assertIsInstance(
+                    posterior.distribution, MultitaskMultivariateNormal
+                )
+            else:
+                self.assertIsInstance(posterior.posteriors[0], TransformedPosterior)
 
     def test_ModelListGP_fixed_noise(self) -> None:
 
-        for dtype, use_octf in itertools.product(
-            (torch.float, torch.double), (False, True)
+        for dtype, outcome_transform in itertools.product(
+            (torch.float, torch.double), ("None", "Standardize")
         ):
             model = self._base_test_ModelListGP(
-                fixed_noise=True, dtype=dtype, use_octf=use_octf
+                fixed_noise=True, dtype=dtype, outcome_transform=outcome_transform
             )
             tkwargs = {"device": self.device, "dtype": dtype}
             f_x = [torch.rand(2, 1, **tkwargs) for _ in range(2)]


### PR DESCRIPTION
Summary:
Replaces D41860896, but adds support for the outcome transforms that weren't working for `ModelListGP.posterior` by calling `ModelList.posterior`.

See https://github.com/pytorch/botorch/issues/1519 for more context on the issue that this is fixing.

Reviewed By: Balandat

Differential Revision: D42019721

