### PR TITLE
Increase the jitter a bit more gently in _psd_safe_pyro_mvn_sample

### DIFF
--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -120,7 +120,7 @@ def _psd_safe_pyro_mvn_sample(
                 # Not-PSD can be also caught in Distribution.__init__ during parameter
                 # validation, which raises a ValueError. Only catch those errors.
                 raise e
-            jitter = jitter * (10**i)
+            jitter = jitter * 10
             warnings.warn(
                 "Received a linear algebra error while sampling with Pyro. Adding a "
                 f"jitter of {jitter} to the covariance matrix and retrying.",


### PR DESCRIPTION
Summary: Title. The previous version could increase the jitter up to 9999999999999.998, which was due to a misinterpretation of the GPyTorch psd_safe_cholesky implementation.

Reviewed By: dme65

Differential Revision: D42051933

