### PR TITLE
Introducing `LogExpectedImprovement`

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -24,12 +24,17 @@ from botorch.exceptions import UnsupportedError
 from botorch.models.gp_regression import FixedNoiseGP
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model import Model
+from botorch.utils.constants import get_constants_like
+from botorch.utils.probability.utils import log_phi, ndtr as Phi, phi
+from botorch.utils.safe_math import log1mexp
 from botorch.utils.transforms import convert_to_target_pre_hook, t_batch_mode_transform
 from torch import Tensor
 from torch.distributions import Normal
 
-
 _sqrt_2pi = math.sqrt(2 * math.pi)
+# the following two numbers are needed for _log_ei_helper
+_neg_inv_sqrt2 = -(2**-0.5)
+_log_sqrt_pi_div_2 = math.log(math.pi / 2) / 2
 
 
 class AnalyticAcquisitionFunction(AcquisitionFunction, ABC):
@@ -155,7 +160,7 @@ class ProbabilityOfImprovement(AnalyticAcquisitionFunction):
         """
         mean, sigma = self._mean_and_sigma(X)
         u = _scaled_improvement(mean, sigma, self.best_f, self.maximize)
-        return torch.special.ndtr(u)
+        return Phi(u)
 
 
 class ExpectedImprovement(AnalyticAcquisitionFunction):
@@ -168,12 +173,18 @@ class ExpectedImprovement(AnalyticAcquisitionFunction):
     `variance` properties). Only supports the case of `q=1`. The model must be
     single-outcome.
 
-    `EI(x) = E(max(y - best_f, 0)), y ~ f(x)`
+    `EI(x) = E(max(f(x) - best_f, 0)),`
+
+    where the expectation is taken over the value of stochastic function `f` at `x`.
 
     Example:
         >>> model = SingleTaskGP(train_X, train_Y)
         >>> EI = ExpectedImprovement(model, best_f=0.2)
         >>> ei = EI(test_X)
+
+    NOTE: It is *strongly* recommended to use LogExpectedImprovement instead of regular
+    EI, because it solves the vanishing gradient problem by taking special care of
+    numerical computations and can lead to substantially improved BO performance.
     """
 
     def __init__(
@@ -216,6 +227,66 @@ class ExpectedImprovement(AnalyticAcquisitionFunction):
         mean, sigma = self._mean_and_sigma(X)
         u = _scaled_improvement(mean, sigma, self.best_f, self.maximize)
         return sigma * _ei_helper(u)
+
+
+class LogExpectedImprovement(AnalyticAcquisitionFunction):
+    r"""Logarithm of single-outcome Expected Improvement (analytic).
+
+    Computes the logarithm of the classic Expected Improvement acquisition function, in
+    a numerically robust manner. In particular, the implementation takes special care
+    to avoid numerical issues in the computation of the acquisition value and its
+    gradient in regions where improvement is predicted to be virtually impossible.
+
+    `LogEI(x) = log(E(max(f(x) - best_f, 0))),`
+
+    where the expectation is taken over the value of stochastic function `f` at `x`.
+
+    Example:
+        >>> model = SingleTaskGP(train_X, train_Y)
+        >>> LogEI = LogExpectedImprovement(model, best_f=0.2)
+        >>> ei = LogEI(test_X)
+    """
+
+    def __init__(
+        self,
+        model: Model,
+        best_f: Union[float, Tensor],
+        posterior_transform: Optional[PosteriorTransform] = None,
+        maximize: bool = True,
+        **kwargs,
+    ):
+        r"""Logarithm of single-outcome Expected Improvement (analytic).
+
+        Args:
+            model: A fitted single-outcome model.
+            best_f: Either a scalar or a `b`-dim Tensor (batch mode) representing
+                the best function value observed so far (assumed noiseless).
+            posterior_transform: A PosteriorTransform. If using a multi-output model,
+                a PosteriorTransform that transforms the multi-output posterior into a
+                single-output posterior is required.
+            maximize: If True, consider the problem a maximization problem.
+        """
+        super().__init__(model=model, posterior_transform=posterior_transform, **kwargs)
+        self.register_buffer("best_f", torch.as_tensor(best_f))
+        self.maximize = maximize
+
+    @t_batch_mode_transform(expected_q=1, assert_output_shape=False)
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Evaluate logarithm of Expected Improvement on the candidate set X.
+
+        Args:
+            X: A `(b1 x ... bk) x 1 x d`-dim batched tensor of `d`-dim design points.
+                Expected Improvement is computed for each point individually,
+                i.e., what is considered are the marginal posteriors, not the
+                joint.
+
+        Returns:
+            A `(b1 x ... bk)`-dim tensor of the logarithm of the Expected Improvement
+            values at the given design points `X`.
+        """
+        mean, sigma = self._mean_and_sigma(X)
+        u = _scaled_improvement(mean, sigma, self.best_f, self.maximize)
+        return _log_ei_helper(u) + sigma.log()
 
 
 class ConstrainedExpectedImprovement(AnalyticAcquisitionFunction):
@@ -565,7 +636,7 @@ class PosteriorMean(AnalyticAcquisitionFunction):
             maximize: If True, consider the problem a maximization problem. Note
                 that if `maximize=False`, the posterior mean is negated. As a
                 consequence `optimize_acqf(PosteriorMean(gp, maximize=False))`
-                does actually return -1 * minimum of the posterior mean.
+                actually returns -1 * minimum of the posterior mean.
         """
         super().__init__(model=model, posterior_transform=posterior_transform)
         self.maximize = maximize
@@ -642,9 +713,88 @@ def _ei_helper(u: Tensor) -> Tensor:
     """Computes phi(u) + u * Phi(u), where phi and Phi are the standard normal
     pdf and cdf, respectively. This is used to compute Expected Improvement.
     """
-    ucdf = torch.special.ndtr(u)
-    updf = torch.exp(-u.square() / 2) / _sqrt_2pi
-    return updf + u * ucdf
+    return phi(u) + u * Phi(u)
+
+
+def _log_ei_helper(u: Tensor) -> Tensor:
+    """Accurately computes log(phi(u) + u * Phi(u)) in a differentiable manner for u in
+    [-10^100, 10^100] in double precision, and [-10^20, 10^20] in single precision.
+    Beyond these intervals, a basic squaring of u can lead to floating point overflow.
+    In contrast, the implementation in _ei_helper only yields usable gradients down to
+    u ~ -10. As a consequence, _log_ei_helper improves the range of inputs for which a
+    backward pass yields usable gradients by many orders of magnitude.
+    """
+    if not (u.dtype == torch.float32 or u.dtype == torch.float64):
+        raise TypeError(
+            f"LogExpectedImprovement only supports torch.float32 and torch.float64 "
+            f"dtypes, but received {u.dtype = }."
+        )
+    # The function has two branching decisions. The first is u < bound, and in this
+    # case, just taking the logarithm of the naive _ei_helper implementation works.
+    bound = -1
+    u_upper = u.masked_fill(u < bound, bound)  # mask u to avoid NaNs in gradients
+    log_ei_upper = _ei_helper(u_upper).log()
+
+    # When u <= bound, we need to be more careful and rearrange the EI formula as
+    # log(phi(u)) + log(1 - exp(w)), where w = log(abs(u) * Phi(u) / phi(u)).
+    # To this end, a second branch is necessary, depending on whether or not u is
+    # smaller than approximately the negative inverse square root of the machine
+    # precision. Below this point, numerical issues in computing log(1 - exp(w)) occur
+    # as w approches zero from below, even though the relative contribution to log_ei
+    # vanishes in machine precision at that point.
+    neg_inv_sqrt_eps = -1e6 if u.dtype == torch.float64 else -1e3
+
+    # mask u for to avoid NaNs in gradients in first and second branch
+    u_lower = u.masked_fill(u > bound, bound)
+    u_eps = u_lower.masked_fill(u < neg_inv_sqrt_eps, neg_inv_sqrt_eps)
+    # compute the logarithm of abs(u) * Phi(u) / phi(u) for moderately large negative u
+    w = _log_abs_u_Phi_div_phi(u_eps)
+
+    # 1) Now, we use a special implementation of log(1 - exp(w)) for moderately
+    # large negative numbers, and
+    # 2) capture the leading order of log(1 - exp(w)) for very large negative numbers.
+    # The second special case is technically only required for single precision numbers
+    # but does "the right thing" regardless.
+    log_ei_lower = log_phi(u) + (
+        torch.where(
+            u > neg_inv_sqrt_eps,
+            log1mexp(w),
+            # The contribution of the next term relative to log_phi vanishes when
+            # w_lower << eps but captures the leading order of the log1mexp term.
+            -2 * u_lower.abs().log(),
+        )
+    )
+    return torch.where(u > bound, log_ei_upper, log_ei_lower)
+
+
+def _log_abs_u_Phi_div_phi(u: Tensor) -> Tensor:
+    """Computes log(abs(u) * Phi(u) / phi(u)), where phi and Phi are the normal pdf
+    and cdf, respectively. The function is valid for u < 0.
+
+    NOTE: In single precision arithmetic, the function becomes numerically unstable for
+    u < -1e3. For this reason, a second branch in _log_ei_helper is necessary to handle
+    this regime, where this function approaches -abs(u)^-2 asymptotically.
+
+    The implementation is based on the following implementation of the logarithm of
+    the scaled complementary error function (i.e. erfcx). Since we only require the
+    positive branch for _log_ei_helper, _log_abs_u_Phi_div_phi does not have a branch,
+    but is only valid for u < 0 (so that _neg_inv_sqrt2 * u > 0).
+
+        def logerfcx(x: Tensor) -> Tensor:
+            return torch.where(
+                x < 0,
+                torch.erfc(x.masked_fill(x > 0, 0)).log() + x**2,
+                torch.special.erfcx(x.masked_fill(x < 0, 0)).log(),
+        )
+
+    Further, it is important for numerical accuracy to move u.abs() into the
+    logarithm, rather than adding u.abs().log() to logerfcx. This is the reason
+    for the rather complex name of this function: _log_abs_u_Phi_div_phi.
+    """
+    # get_constants_like allocates tensors with the appropriate dtype and device and
+    # caches the result, which improves efficiency.
+    a, b = get_constants_like(values=(_neg_inv_sqrt2, _log_sqrt_pi_div_2), ref=u)
+    return torch.log(torch.special.erfcx(a * u) * u.abs()) + b
 
 
 def _construct_dist(means: Tensor, sigmas: Tensor, inds: Tensor) -> Normal:

--- a/botorch/utils/probability/utils.py
+++ b/botorch/utils/probability/utils.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import math
+
 from functools import lru_cache
 from math import pi
 from numbers import Number
@@ -19,6 +21,7 @@ CaseNd = Tuple[Callable[[], BoolTensor], Callable[[BoolTensor], Tensor]]
 
 _inv_sqrt_2pi = (2 * pi) ** -0.5
 _neg_inv_sqrt2 = -(2**-0.5)
+_log_sqrt_2pi = math.log(2 * pi) / 2
 STANDARDIZED_RANGE: Tuple[float, float] = (-1e6, 1e6)
 
 
@@ -130,6 +133,12 @@ def phi(x: Tensor) -> Tensor:
     r"""Standard normal PDF."""
     inv_sqrt_2pi, neg_half = get_constants_like((_inv_sqrt_2pi, -0.5), x)
     return inv_sqrt_2pi * (neg_half * x.square()).exp()
+
+
+def log_phi(x: Tensor) -> Tensor:
+    r"""Logarithm of standard normal pdf"""
+    log_sqrt_2pi, neg_half = get_constants_like((_log_sqrt_2pi, -0.5), x)
+    return neg_half * x.square() - log_sqrt_2pi
 
 
 def swap_along_dim_(


### PR DESCRIPTION
Summary:
This commit introduces `LogExpectedImprovement`, which computes the logarithm of the Expected Improvement acquisition function. By taking special care of numerics, it avoids numerical issues that affect `ExpectedImprovement` when evaluated at points that with high certainty do not yield improvement. In contrast, `LogExpectedImprovement` computes both values and gradients in a numerically stable fashion for points that don't yield improvement down to at least **100 orders of magnitude** lower posterior standard deviation than vanilla EI in double precision. This allows optimizers to escape the "valley of death" - regions that the surrogate is certain are bad but for which EI does not yield gradients.

On the example test problem in N2901527, using `logEI` leads to better convergence compared to GPEI and similar performance as running homotopy on the target value without having to run homotopy iterations.
{F822088495}

Reviewed By: Balandat

Differential Revision: D41890063

