### PR TITLE
fix docstring in ModelList

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -335,8 +335,7 @@ class FantasizeMixin(ABC):
 class ModelList(Model):
     r"""A multi-output Model represented by a list of independent models.
 
-    All
-    BoTorch models are acceptable as inputs. The cost of this flexibility is
+    All BoTorch models are acceptable as inputs. The cost of this flexibility is
     that `ModelList` does not support all methods that may be implemented by its
     component models. One use case for `ModelList` is combining a regression
     model and a deterministic model in one multi-output container model, e.g.
@@ -353,7 +352,7 @@ class ModelList(Model):
             >>> m_1 = SingleTaskGP(train_X, train_Y)
             >>> m_2 = GenericDeterministicModel(lambda x: x.sum(dim=-1))
             >>> m_12 = ModelList(m_1, m_2)
-            >>> m_12.predict(test_X)
+            >>> m_12.posterior(test_X)
         """
         super().__init__()
         self.models = ModuleList(models)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR fixes an error in the docstring of `ModelList`. There an example is shown in which a non-existent method named `predict` is called. I assume, the original intention was to call `posterior` there.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Only fix of a doc string, no additional tests needed.


