### PR TITLE
Introducing `LogNoisyExpectedImprovement`

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -33,6 +33,7 @@ from botorch.acquisition.analytic import (
     ConstrainedExpectedImprovement,
     ExpectedImprovement,
     LogExpectedImprovement,
+    LogNoisyExpectedImprovement,
     NoisyExpectedImprovement,
     PosteriorMean,
     ProbabilityOfImprovement,
@@ -380,7 +381,7 @@ def construct_inputs_constrained_ei(
     raise NotImplementedError  # pragma: nocover
 
 
-@acqf_input_constructor(NoisyExpectedImprovement)
+@acqf_input_constructor(NoisyExpectedImprovement, LogNoisyExpectedImprovement)
 def construct_inputs_noisy_ei(
     model: Model,
     training_data: MaybeDict[SupervisedDataset],


### PR DESCRIPTION
Summary:
Follow up on D41890063 (https://github.com/pytorch/botorch/commit/d819b2da6dd319e58b996d00ed2ac82ccbb542e3), continuing the logarithmification of improvement-based acquisition functions.
Notably, the existing test case for `NEI` already exhibits acquisition values that are exactly zero and gradients on the order of machine epsilon. This is solved by `LogNEI`.

Reviewed By: Balandat

Differential Revision: D42109272

