### PR TITLE
Smaller `to` syntax in `SobolQMCNormalSampler`

### DIFF
--- a/botorch/sampling/normal.py
+++ b/botorch/sampling/normal.py
@@ -200,7 +200,4 @@ class SobolQMCNormalSampler(NormalMCSampler):
             )
             base_samples = base_samples.view(target_shape)
             self.register_buffer("base_samples", base_samples)
-        if self.base_samples.device != posterior.device:
-            self.to(device=posterior.device)  # pragma: nocover
-        if self.base_samples.dtype != posterior.dtype:
-            self.to(dtype=posterior.dtype)
+        self.to(device=posterior.device, dtype=posterior.dtype)


### PR DESCRIPTION
Summary: `to` only allocates new tensors if they don't satisfy the `dtype` and `device` classes, so there is no a downside to calling `to` outside of the `if` statements. See the [docs here](https://pytorch.org/docs/stable/generated/torch.Tensor.to.html).

Differential Revision: D42163726

