### PR TITLE
Debugging why tutorials are failing

### DIFF
--- a/scripts/build_and_verify_conda_package.sh
+++ b/scripts/build_and_verify_conda_package.sh
@@ -7,7 +7,7 @@
 # Get version number (created dynamically via setuptools-scm)
 BOTORCH_VERSION=$(python -m setuptools_scm)
 if [[ $? != "0" ]]; then
-  echo "Determininig version via setuptools_scm failed."
+  echo "Determining version via setuptools_scm failed."
   echo "Make sure that setuptools_scm is installed in your python environment."
   exit 1
 fi

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -91,28 +91,7 @@ def run_tutorials(
     include_ignored: bool = False,
     smoke_test: bool = False,
 ) -> None:
-    print(f"Running tutorials in {'smoke test' if smoke_test else 'standard'} mode.")
-    if not smoke_test:
-        print("This may take a long time...")
-    tutorial_dir = Path(repo_dir).joinpath("tutorials")
-    num_runs = 0
-    num_errors = 0
-    ignored_tutorials = IGNORE if smoke_test else IGNORE | IGNORE_SMOKE_TEST_ONLY
-    for tutorial in tutorial_dir.iterdir():
-        if not tutorial.is_file or tutorial.suffix != ".ipynb":
-            continue
-        if not include_ignored and tutorial.name in ignored_tutorials:
-            print(f"Ignoring tutorial {tutorial.name}.")
-            continue
-        num_runs += 1
-        error = run_tutorial(tutorial, smoke_test=smoke_test)
-        if error is not None:
-            num_errors += 1
-            print(error)
-    if num_errors > 0:
-        raise RuntimeError(
-            f"Running {num_runs} tutorials resulted in {num_errors} errors."
-        )
+    return
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Tutorials (without smoke test, in the nightly cron) are failing with the following unehlpful error:

```
Run python scripts/run_tutorials.py -p "$(pwd)"
  python scripts/run_tutorials.py -p "$(pwd)"
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.8.15/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.8.15/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.15/x64
    Python[2](https://github.com/pytorch/botorch/actions/runs/3748516328/jobs/6372306196#step:11:2)_ROOT_DIR: /opt/hostedtoolcache/Python/[3](https://github.com/pytorch/botorch/actions/runs/3748516328/jobs/6372306196#step:11:3).8.15/x6[4](https://github.com/pytorch/botorch/actions/runs/3748516328/jobs/6372306196#step:11:4)
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.1[5](https://github.com/pytorch/botorch/actions/runs/3748516328/jobs/6372306196#step:11:5)/x[6](https://github.com/pytorch/botorch/actions/runs/3748516328/jobs/6372306196#step:11:6)4
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.[8](https://github.com/pytorch/botorch/actions/runs/3748516328/jobs/6372306196#step:11:8).15/x64/lib
Error: Process completed with exit code 143.
```
143 is a generic exit code that means something died. My suspicion is that one of the tutorials is causing an OOM, which would cause Python to crash without a helpful stack trace.

## Test Plan

Just debugging. Turning all tutorials off to test the hypothesis that one of the tutorials is causing an issue (rather than the setup). If that is true, I guess I'll binary search to find out which one it was.
