### PR TITLE
Lower bound noise in SaasPyroModel (#1338)

### DIFF
--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -243,7 +243,7 @@ class SaasPyroModel(PyroModel):
     def sample_noise(self, **tkwargs: Any) -> Tensor:
         r"""Sample the noise variance."""
         if self.train_Yvar is None:
-            return pyro.sample(
+            return MIN_INFERRED_NOISE_LEVEL + pyro.sample(
                 "noise",
                 pyro.distributions.Gamma(
                     torch.tensor(0.9, **tkwargs),


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/Ax/pull/1338

Inspecting some models where we get the Cholesky errors, I found that the noise is around 1e-14 - 1e-15, which is very small. Adding a lower bound to the noise seems to let the model fit without errors.

Reviewed By: dme65

Differential Revision: D42177954

