### PR TITLE
Introducing `LogConstrainedExpectedImprovement`

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -32,6 +32,7 @@ from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.analytic import (
     ConstrainedExpectedImprovement,
     ExpectedImprovement,
+    LogConstrainedExpectedImprovement,
     LogExpectedImprovement,
     LogNoisyExpectedImprovement,
     NoisyExpectedImprovement,
@@ -346,7 +347,9 @@ def construct_inputs_ucb(
     return {**base_inputs, "beta": beta, "maximize": maximize}
 
 
-@acqf_input_constructor(ConstrainedExpectedImprovement)
+@acqf_input_constructor(
+    ConstrainedExpectedImprovement, LogConstrainedExpectedImprovement
+)
 def construct_inputs_constrained_ei(
     model: Model,
     training_data: MaybeDict[SupervisedDataset],

--- a/botorch/utils/safe_math.py
+++ b/botorch/utils/safe_math.py
@@ -66,9 +66,9 @@ def log1mexp(x: Tensor) -> Tensor:
     See [Maechler2012accurate]_ for details.
     """
     log2 = get_constants_like(values=_log2, ref=x)
-    mask = -log2 < x  # x < 0
+    is_small = -log2 < x  # x < 0
     return torch.where(
-        mask,
+        is_small,
         (-x.expm1()).log(),
         (-x.exp()).log1p(),
     )

--- a/test/utils/probability/test_utils.py
+++ b/test/utils/probability/test_utils.py
@@ -7,7 +7,8 @@
 from __future__ import annotations
 
 import torch
-from botorch.utils.probability import utils
+from botorch.utils.probability import ndtr, utils
+from botorch.utils.probability.utils import log_ndtr, log_phi, log_prob_normal_in, phi
 from botorch.utils.testing import BotorchTestCase
 from numpy.polynomial.legendre import leggauss as numpy_leggauss
 
@@ -143,3 +144,92 @@ class TestProbabilityUtils(BotorchTestCase):
 
         with self.assertRaisesRegex(ValueError, "at most 1-dimensional"):
             utils.swap_along_dim_(values.view(-1), i=i_lidx, j=j, dim=0)
+
+    def test_gaussian_probabilities(self):
+        # testing Gaussian probability functions
+        n = 16
+        for dtype in (torch.float, torch.double):
+            rtol = 1e-12 if dtype == torch.double else 1e-6
+            x = 3 * torch.randn(n, device=self.device, dtype=dtype)
+            # first, test consistency between regular and log versions
+            self.assertTrue(torch.allclose(phi(x), log_phi(x).exp(), rtol=rtol))
+            self.assertTrue(torch.allclose(ndtr(x), log_ndtr(x).exp(), rtol=rtol))
+
+            # test limit behavior of log_ndtr
+            digits = 100 if dtype == torch.float64 else 20
+            # zero = torch.tensor([0], dtype=dtype, device=self.device)
+            ten = torch.tensor(10, dtype=dtype, device=self.device)
+            digits_tensor = torch.arange(0, digits, dtype=dtype, device=self.device)
+            # large negative values
+            x_large_neg = -(ten ** digits_tensor.flip(-1))  # goes from -1e100 to -1
+            x_large_pos = ten**digits_tensor  # goes from 1 to 1e100
+            x = torch.cat((x_large_neg, x_large_pos))
+            x.requires_grad = True
+
+            torch_log_ndtr_x = torch.special.log_ndtr(x)
+            log_ndtr_x = log_ndtr(x)
+            self.assertTrue(torch.allclose(log_ndtr_x, torch_log_ndtr_x, rtol=rtol))
+
+            # let's test gradients too
+            # first, note that the standard implementation exhibits numerical problems:
+            # 1) it contains -Inf for reasonable parameter ranges, and
+            # 2) the gradient is not strictly increasing, even ignoring Infs, and
+            # takes non-sensical values (i.e. ~4e-01 at x = -1e100 in single precision,
+            # and similar for some large negative x in double precision).
+            torch_log_ndtr_x = torch.special.log_ndtr(x)
+            torch_log_ndtr_x.sum().backward()
+            torch_grad = x.grad.clone()
+            self.assertTrue(torch_grad.isinf().any())
+
+            # in contrast, our implementation permits numerically accurate gradients
+            # throughout the testest range:
+            x.grad[:] = 0  # zero out gradient
+            log_ndtr_x.sum().backward()
+            grad = x.grad.clone()
+            # it does not contain Infs or NaNs
+            self.assertFalse(grad.isinf().any())
+            self.assertFalse(grad.isnan().any())
+            # gradients are non-negative everywhere (approach zero as x goes to inf)
+            self.assertTrue((grad[:digits] > 0).all())
+            self.assertTrue((grad[digits:] >= 0).all())
+            # gradients are strictly decreasing for x < 0
+            self.assertTrue((grad.diff()[:digits] < 0).all())
+            self.assertTrue((grad.diff()[digits:] <= 0).all())
+
+            n = 16
+            # first test is easiest: a < 0 < b
+            a = -5 / 2 * torch.rand(n, dtype=dtype, device=self.device) - 1 / 2
+            b = 5 / 2 * torch.rand(n, dtype=dtype, device=self.device) + 1 / 2
+            self.assertTrue(
+                torch.allclose(
+                    log_prob_normal_in(a, b).exp(), ndtr(b) - ndtr(a), rtol=rtol
+                )
+            )
+
+            # 0 < a < b, uses the a < b < 0 under the hood
+            a = ten ** digits_tensor[:-1]
+            b = ten ** digits_tensor[-1]
+            a.requires_grad, b.requires_grad = True, True
+            log_prob = log_prob_normal_in(a, b)
+            self.assertTrue((log_prob < 0).all())
+            self.assertTrue((log_prob.diff() < 0).all())
+
+            # test gradients
+            log_prob.sum().backward()
+            # checking that both gradients give non-Inf, non-NaN results everywhere
+            self.assertFalse(a.grad.isinf().any())
+            self.assertFalse(a.grad.isnan().any())
+            self.assertFalse(b.grad.isinf().any())
+            self.assertFalse(b.grad.isnan().any())
+            # since the upper bound is satisfied, relevant gradients are in lower bound
+            self.assertTrue((a.grad.diff() < 0).all())
+
+            # testing error raising for invalid inputs
+            with self.assertRaises(ValueError):
+                a = torch.randn(3, 4, dtype=dtype, device=self.device)
+                b = torch.randn(3, 4, dtype=dtype, device=self.device)
+                a[2, 3] = b[2, 3]
+                log_prob_normal_in(a, b)
+
+        with self.assertRaises(TypeError):
+            log_ndtr(torch.tensor(1.0, dtype=torch.float16, device=self.device))


### PR DESCRIPTION
Summary:
Follow-up on D41890063 (https://github.com/pytorch/botorch/commit/d819b2da6dd319e58b996d00ed2ac82ccbb542e3), continuing the logarithmification of improvement-based acquisition functions for `ConstrainedExpectedImprovement`. This commit implements `LogConstrainedExpectedImprovement`, which gives usable values and gradients far away (`>1e100` standard deviations for double precision) from the best previously observed value *and* far away from the currently estimated feasible region. In contrast, regular `ConstrainedExpectedImprovement` is numerically zero if the current point is far from the estimated feasible region or has a value that is worse by around 10 standard deviations from the best observed point, making gradient-based optimization difficult. This commit also adds two new numerical utilities:
1) `log_ndtr`, which fixes numerical issues of the backward pass of `torch.special.log_ndtr`, and
2) `log_prob_normal_in(a, b)`, which computes the log probability that a standard normal random variable falls in the interval `[a, b]` for a large range of values `a` and `b`,

both of which enable the computation of `LogConstrainedExpectedImprovement` and its gradients with numerical accuracy and stability.

Differential Revision: D42221100

