### PR TITLE
Add Constraint Active Search tutorial to ignore list

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -23,6 +23,9 @@ IGNORE = {  # ignored in smoke tests and full runs
     "vae_mnist.ipynb",  # requires setting paths to local data
     "bope.ipynb",  # flaky, keeps failing the workflows
     "preference_bo.ipynb",  # failing. Fix planned
+    # Causing the tutorials to crash when run without smoke test. Likely OOM.
+    # Fix planned.
+    "constraint_active_search",
 }
 IGNORE_SMOKE_TEST_ONLY = {  # only used in smoke tests
     "thompson_sampling.ipynb",  # very slow without KeOps + GPU


### PR DESCRIPTION
## Motivation

The tutorials have been failing in the nightly cron for several days. [Binary search](https://github.com/pytorch/botorch/pull/1581) identifies the constraint active search tutorial as the culprit. I suspect this is an OOM. I plan to fix it after the holidays, but since that will be over a week (optimistically) let's ignore it for now.

## Test Plan

Manually trigger cron on this branch and make sure it passes.

## Related PRs

#1581  debugs this.
