### PR TITLE
Fix typo in tutorials ignorelist; add SASBO and scalable_constrained_bo to ignorelist because they are timing out

### DIFF
--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run_tutorials_with_smoke_test:
-    name: Run tutorials with smoke test on latest PyTorch / GPyTorch / Ax
+    name: Run tutorials without smoke test on latest PyTorch / GPyTorch / Ax
     uses: ./.github/workflows/reusable_tutorials.yml
     with:
       smoke_test: false

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -13,6 +13,6 @@ jobs:
     name: Run tutorials with smoke test on latest PyTorch / GPyTorch / Ax
     uses: ./.github/workflows/reusable_tutorials.yml
     with:
-      smoke_test: true
+      smoke_test: false
       use_stable_pytorch_gpytorch: false
       use_stable_ax: false

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -10,9 +10,9 @@ on:
 
 jobs:
   run_tutorials_with_smoke_test:
-    name: Run tutorials without smoke test on latest PyTorch / GPyTorch / Ax
+    name: Run tutorials with smoke test on latest PyTorch / GPyTorch / Ax
     uses: ./.github/workflows/reusable_tutorials.yml
     with:
-      smoke_test: false
+      smoke_test: true
       use_stable_pytorch_gpytorch: false
       use_stable_ax: false

--- a/scripts/build_and_verify_conda_package.sh
+++ b/scripts/build_and_verify_conda_package.sh
@@ -7,7 +7,7 @@
 # Get version number (created dynamically via setuptools-scm)
 BOTORCH_VERSION=$(python -m setuptools_scm)
 if [[ $? != "0" ]]; then
-  echo "Determininig version via setuptools_scm failed."
+  echo "Determining version via setuptools_scm failed."
   echo "Make sure that setuptools_scm is installed in your python environment."
   exit 1
 fi

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -103,8 +103,9 @@ def run_tutorials(
             continue
         if not include_ignored and tutorial.name in ignored_tutorials:
             continue
-        # the offending tutorial has (tutorial.name >= "con") and (tutorial.name < "m")
-        if not ((tutorial.name >= "cus") and (tutorial.name < "m")):
+        # the offending tutorial has (tutorial.name >= "con") and (tutorial.name < "cus")
+        # this would be either constraint_active_search or constrained_multi_bojective_bo
+        if "constraint_active" not in tutorial.name:
             continue
         print(f"running {tutorial.name}")
         num_runs += 1

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -102,10 +102,8 @@ def run_tutorials(
         if not tutorial.is_file or tutorial.suffix != ".ipynb":
             continue
         if not include_ignored and tutorial.name in ignored_tutorials:
-            print(f"Ignoring tutorial {tutorial.name}.")
             continue
-        if tutorial.name[:3] >= "con":
-            print(f"Not running {tutorial.name}")
+        if not ((tutorial.name >= "con") and (tutorial.name < "m")):
             continue
         print(f"running {tutorial.name}")
         num_runs += 1

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -26,6 +26,8 @@ IGNORE = {  # ignored in smoke tests and full runs
     # Causing the tutorials to crash when run without smoke test. Likely OOM.
     # Fix planned.
     "constraint_active_search.ipynb",
+    # Timing out
+    "saasbo.ipynb",
 }
 IGNORE_SMOKE_TEST_ONLY = {  # only used in smoke tests
     "thompson_sampling.ipynb",  # very slow without KeOps + GPU
@@ -107,7 +109,6 @@ def run_tutorials(
         if not include_ignored and tutorial.name in ignored_tutorials:
             print(f"Ignoring tutorial {tutorial.name}.")
             continue
-        print(f"running {tutorial.name}")
         num_runs += 1
         error = run_tutorial(tutorial, smoke_test=smoke_test)
         if error is not None:

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -91,7 +91,30 @@ def run_tutorials(
     include_ignored: bool = False,
     smoke_test: bool = False,
 ) -> None:
-    return
+    print(f"Running tutorials in {'smoke test' if smoke_test else 'standard'} mode.")
+    if not smoke_test:
+        print("This may take a long time...")
+    tutorial_dir = Path(repo_dir).joinpath("tutorials")
+    num_runs = 0
+    num_errors = 0
+    ignored_tutorials = IGNORE if smoke_test else IGNORE | IGNORE_SMOKE_TEST_ONLY
+    for tutorial in tutorial_dir.iterdir():
+        if not tutorial.is_file or tutorial.suffix != ".ipynb":
+            continue
+        if not include_ignored and tutorial.name in ignored_tutorials:
+            print(f"Ignoring tutorial {tutorial.name}.")
+            continue
+        if tutorial.name[0] >= "m":
+            continue
+        num_runs += 1
+        error = run_tutorial(tutorial, smoke_test=smoke_test)
+        if error is not None:
+            num_errors += 1
+            print(error)
+    if num_errors > 0:
+        raise RuntimeError(
+            f"Running {num_runs} tutorials resulted in {num_errors} errors."
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -28,6 +28,8 @@ IGNORE = {  # ignored in smoke tests and full runs
     "constraint_active_search.ipynb",
     # Timing out
     "saasbo.ipynb",
+    # Timing out
+    "scalable_constrained_bo.ipynb",
 }
 IGNORE_SMOKE_TEST_ONLY = {  # only used in smoke tests
     "thompson_sampling.ipynb",  # very slow without KeOps + GPU

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -104,8 +104,10 @@ def run_tutorials(
         if not include_ignored and tutorial.name in ignored_tutorials:
             print(f"Ignoring tutorial {tutorial.name}.")
             continue
-        if tutorial.name[0] >= "m":
+        if tutorial.name[:3] >= "con":
+            print(f"Not running {tutorial.name}")
             continue
+        print(f"running {tutorial.name}")
         num_runs += 1
         error = run_tutorial(tutorial, smoke_test=smoke_test)
         if error is not None:

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -25,7 +25,7 @@ IGNORE = {  # ignored in smoke tests and full runs
     "preference_bo.ipynb",  # failing. Fix planned
     # Causing the tutorials to crash when run without smoke test. Likely OOM.
     # Fix planned.
-    "constraint_active_search",
+    "constraint_active_search.ipynb",
 }
 IGNORE_SMOKE_TEST_ONLY = {  # only used in smoke tests
     "thompson_sampling.ipynb",  # very slow without KeOps + GPU
@@ -105,10 +105,7 @@ def run_tutorials(
         if not tutorial.is_file or tutorial.suffix != ".ipynb":
             continue
         if not include_ignored and tutorial.name in ignored_tutorials:
-            continue
-        # the offending tutorial has (tutorial.name >= "con") and (tutorial.name < "cus")
-        # this would be either constraint_active_search or constrained_multi_bojective_bo
-        if "constraint_active" not in tutorial.name:
+            print(f"Ignoring tutorial {tutorial.name}.")
             continue
         print(f"running {tutorial.name}")
         num_runs += 1

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -103,7 +103,8 @@ def run_tutorials(
             continue
         if not include_ignored and tutorial.name in ignored_tutorials:
             continue
-        if not ((tutorial.name >= "con") and (tutorial.name < "m")):
+        # the offending tutorial has (tutorial.name >= "con") and (tutorial.name < "m")
+        if not ((tutorial.name >= "cus") and (tutorial.name < "m")):
             continue
         print(f"running {tutorial.name}")
         num_runs += 1

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -91,28 +91,7 @@ def run_tutorials(
     include_ignored: bool = False,
     smoke_test: bool = False,
 ) -> None:
-    print(f"Running tutorials in {'smoke test' if smoke_test else 'standard'} mode.")
-    if not smoke_test:
-        print("This may take a long time...")
-    tutorial_dir = Path(repo_dir).joinpath("tutorials")
-    num_runs = 0
-    num_errors = 0
-    ignored_tutorials = IGNORE if smoke_test else IGNORE | IGNORE_SMOKE_TEST_ONLY
-    for tutorial in tutorial_dir.iterdir():
-        if not tutorial.is_file or tutorial.suffix != ".ipynb":
-            continue
-        if not include_ignored and tutorial.name in ignored_tutorials:
-            print(f"Ignoring tutorial {tutorial.name}.")
-            continue
-        num_runs += 1
-        error = run_tutorial(tutorial, smoke_test=smoke_test)
-        if error is not None:
-            num_errors += 1
-            print(error)
-    if num_errors > 0:
-        raise RuntimeError(
-            f"Running {num_runs} tutorials resulted in {num_errors} errors."
-        )
+    return
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

- Typo in #1588 
- scalable_constrained_bo timing out and causing a failure since Nighly Cron 708 (2 weeks ago) or earlier
- saasbo timing out and causing a failure at least some of the time since Nighly Cron 706 (2 weeks ago) or earlier

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Temporarily trigger actions to run tutorials without smoke test on PR so that we can confirm they will pass now

## Related PRs

#1588
