### PR TITLE
Introducing `LogProbabilityOfImprovement`

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -35,6 +35,7 @@ from botorch.acquisition.analytic import (
     LogConstrainedExpectedImprovement,
     LogExpectedImprovement,
     LogNoisyExpectedImprovement,
+    LogProbabilityOfImprovement,
     NoisyExpectedImprovement,
     PosteriorMean,
     ProbabilityOfImprovement,
@@ -275,7 +276,10 @@ def construct_inputs_analytic_base(
 
 
 @acqf_input_constructor(
-    ExpectedImprovement, LogExpectedImprovement, ProbabilityOfImprovement
+    ExpectedImprovement,
+    LogExpectedImprovement,
+    ProbabilityOfImprovement,
+    LogProbabilityOfImprovement,
 )
 def construct_inputs_best_f(
     model: Model,


### PR DESCRIPTION
Summary: Follow-up on D41890063 (https://github.com/pytorch/botorch/commit/d819b2da6dd319e58b996d00ed2ac82ccbb542e3), finishing the logarithmification of improvement-based acquisition functions with `LogProbabilityOfImprovement`. This commit is easiest, since the only change is calling the numerically stable implementation of `log_ndtr` that was introduced in D42221100.

Differential Revision: D42250663

