### PR TITLE
[DRAFT] Add memory limit to tutorial evaluation

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import resource
 import subprocess
 import sys
 import tempfile
@@ -42,8 +41,13 @@ IGNORE_SMOKE_TEST_ONLY = {  # only used in smoke tests
 }
 
 
-def _limit_memory(soft: int, hard: int = resource.RLIM_INFINITY) -> None:
+def _limit_memory(soft: int, hard: Optional[int] = None) -> None:
     """Limit the memory usage of a running python process"""
+    import resource
+    
+    if hard is None:
+        hard = resource.RLIM_INFINITY
+    
     resource.setrlimit(resource.RLIMIT_AS, (soft, hard))
 
 


### PR DESCRIPTION
Add memory limit to tutorial evaluation in `run_tutorials`. 

Context: https://github.com/pytorch/botorch/pull/1588#issuecomment-1366194396

Note: This is causing weird errors on my M1 Mac, putting this up as a PR to test on the CI machines.