### PR TITLE
Add workflow_dispatch event to reusable tutorials workflow

### DIFF
--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -1,6 +1,20 @@
 name: Reusable Tutorials Workflow
 
 on:
+  workflow_dispatch:
+    inputs:
+      smoke_test:
+        required: false
+        type: boolean
+        default: true
+      use_stable_pytorch_gpytorch:
+        required: false
+        type: boolean
+        default: false
+      use_stable_ax:
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       smoke_test:

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -4,17 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       smoke_test:
-        required: false
+        required: true
         type: boolean
-        default: true
       use_stable_pytorch_gpytorch:
-        required: false
+        required: true
         type: boolean
-        default: false
       use_stable_ax:
-        required: false
+        required: true
         type: boolean
-        default: false
   workflow_call:
     inputs:
       smoke_test:


### PR DESCRIPTION
This will allow us to manually run the reusable tutorial workflow against selected branches.