### PR TITLE
Register torch.linalg.LinAlgError to pyro exception handling

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - linear_operator ==0.2.0
     - scipy
     - multipledispatch
-    - pyro-ppl >=1.8.2
+    - pyro-ppl >=1.8.4
 
 test:
   imports:

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -86,7 +86,7 @@ jobs:
         conda install -y scipy sphinx pytest flake8 multipledispatch
         conda install -y -c pytorch pytorch cpuonly
         conda install -y -c gpytorch gpytorch
-        conda install -y -c conda-forge pyro-ppl>=1.8.2
+        conda install -y -c conda-forge pyro-ppl>=1.8.4
         conda config --set anaconda_upload no
     - name: Build and verify conda package
       shell: bash -l {0}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -105,7 +105,7 @@ jobs:
         conda install -y scipy multipledispatch setuptools_scm conda-build conda-verify
         conda config --set anaconda_upload no
         conda install -y -c pytorch-nightly pytorch cpuonly
-        conda install -y -c conda-forge pyro-ppl>=1.8.2
+        conda install -y -c conda-forge pyro-ppl>=1.8.4
         pip install git+https://github.com/cornellius-gp/linear_operator.git
         pip install git+https://github.com/cornellius-gp/gpytorch.git
     - name: Build and verify conda package

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -48,7 +48,7 @@ jobs:
         conda install -y -c pytorch pytorch cpuonly
         conda install -y pip scipy pytest
         conda install -y -c gpytorch gpytorch
-        conda install -y -c conda-forge pyro-ppl>=1.8.2
+        conda install -y -c conda-forge pyro-ppl>=1.8.4
         pip install .[test]
     - name: Unit tests
       shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Optimization simply use Ax.
 - PyTorch >= 1.11
 - gpytorch == 1.9.0
 - linear_operator == 0.2.0
-- pyro-ppl >= 1.8.2
+- pyro-ppl >= 1.8.4
 - scipy
 - multiple-dispatch
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -19,7 +19,7 @@ Before jumping the gun, we recommend you start with the high-level
 - linear_operator == 0.2.0
 - scipy
 - multiple-dispatch
-- pyro-ppl >= 1.8.2
+- pyro-ppl >= 1.8.4
 
 BoTorch is easily installed via
 [Anaconda](https://www.anaconda.com/distribution/#download-section) (recommended)

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - linear_operator==0.2.0
   - scipy
   - multipledispatch
-  - pyro-ppl>=1.8.2
+  - pyro-ppl>=1.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 multipledispatch
 scipy
 torch>=1.11,<2.0
-pyro-ppl>=1.8.2
+pyro-ppl>=1.8.4
 gpytorch==1.9.0
 linear_operator==0.2.0


### PR DESCRIPTION
Summary: Uses draft changes from https://github.com/pyro-ppl/pyro/pull/3168 (part of pyro 1.8.4 pulled in via D42331876) to register handling of `torch.linalg.LinAlgError` and the `ValueError` that can be raised in the torch distribution's `__init__()`

Differential Revision: D42159791

