### PR TITLE
Fix nightly PyPI upload test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,9 +67,13 @@ jobs:
         no_local_version=$(python -m setuptools_scm | cut -d "+" -f 1)
         echo "SETUPTOOLS_SCM_PRETEND_VERSION=${no_local_version}" >> $GITHUB_ENV
     - name: Build packages (wheel and source distribution)
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         python -m build --sdist --wheel
     - name: Verify packages
+      env:
+        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         ./scripts/build_and_verify_py_packages.sh
     - name: Deploy to Test PyPI


### PR DESCRIPTION
This was using the pinned version of GPyTorch & linear operator, leading to failures.

Test plan: PyPI upload test now passes
https://github.com/pytorch/botorch/actions/runs/3842548266/jobs/6543945107