### PR TITLE
Make "device" attribute of contextual models a property instead

### DIFF
--- a/botorch/models/kernels/contextual_lcea.py
+++ b/botorch/models/kernels/contextual_lcea.py
@@ -61,7 +61,7 @@ class LCEAKernel(Kernel):
         self.decomposition = decomposition
         self.batch_shape = batch_shape
         self.train_embedding = train_embedding
-        self.device = device
+        self._device = device
 
         num_param = len(next(iter(decomposition.values())))
         self.context_list = list(decomposition.keys())
@@ -127,6 +127,10 @@ class LCEAKernel(Kernel):
             lambda m, v: m._set_outputscale_list(v),
         )
         self.register_constraint("raw_outputscale_list", Positive())
+
+    @property
+    def device(self) -> Optional[torch.device]:
+        return self._device
 
     @property
     def outputscale_list(self) -> Tensor:

--- a/botorch/models/kernels/contextual_sac.py
+++ b/botorch/models/kernels/contextual_sac.py
@@ -57,7 +57,7 @@ class SACKernel(Kernel):
 
         super().__init__(batch_shape=batch_shape)
         self.decomposition = decomposition
-        self.device = device
+        self._device = device
 
         num_param = len(next(iter(decomposition.values())))
         for active_parameters in decomposition.values():
@@ -85,6 +85,10 @@ class SACKernel(Kernel):
                 base_kernel=self.base_kernel, outputscale_prior=GammaPrior(2.0, 15.0)
             )
         self.kernel_dict = ModuleDict(self.kernel_dict)
+
+    @property
+    def device(self) -> Optional[torch.device]:
+        return self._device
 
     def forward(
         self,


### PR DESCRIPTION
## Motivation

As of https://github.com/cornellius-gp/gpytorch/pull/2234, the parent class of BoTorch kernels now has a property "device." This means that if a subclass tries to set `self.device`, it will error. This is why the BoTorch CI is currently breaking: https://github.com/pytorch/botorch/actions/runs/3841992968/jobs/6542850176

## Test Plan

Tests should pass