### PR TITLE
Add sample_shape property to ListSampler

### DIFF
--- a/botorch/sampling/list_sampler.py
+++ b/botorch/sampling/list_sampler.py
@@ -10,8 +10,8 @@ A `SamplerList` for sampling from a `PosteriorList`.
 
 from __future__ import annotations
 
+import torch
 from botorch.exceptions.errors import UnsupportedError
-
 from botorch.posteriors.posterior_list import PosteriorList
 from botorch.sampling.base import MCSampler
 from torch import Tensor
@@ -37,6 +37,12 @@ class ListSampler(MCSampler):
             raise UnsupportedError(
                 "ListSampler requires all samplers to have the same sample shape."
             )
+
+    @property
+    def sample_shape(self) -> torch.Size:
+        r"""The sample shape of the underlying samplers."""
+        self._validate_samplers()
+        return self.samplers[0].sample_shape
 
     def forward(self, posterior: PosteriorList) -> Tensor:
         r"""Samples from the posteriors and concatenates the samples.

--- a/test/sampling/test_list_sampler.py
+++ b/test/sampling/test_list_sampler.py
@@ -24,6 +24,7 @@ class TestListSampler(BotorchTestCase):
         )
         self.assertIsInstance(sampler.samplers[0], IIDNormalSampler)
         self.assertIsInstance(sampler.samplers[1], StochasticSampler)
+        self.assertEqual(sampler.sample_shape, torch.Size([2]))
 
         # Test validation.
         with self.assertRaisesRegex(UnsupportedError, "all samplers to have the "):


### PR DESCRIPTION
Summary:
In some cases, we access sampler.sample_shape, which errors out with ListSampler. This adds a property that returns the sample shape of the underlying samplers.

See https://github.com/pytorch/botorch/issues/1623#issuecomment-1376306859

Differential Revision: D42421646

