### PR TITLE
Ensemble Posterior

### DIFF
--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -56,10 +56,8 @@ class DeterministicModel(EnsembleModel):
         pass  # pragma: no cover
 
     def forward_(self, X: Tensor) -> Tensor:
-        # in case of the deterministic model we have to append the sample
-        # dimension for backward compatibility
-        values = self.forward(X=X)
-        return values.unsqueeze(-1)
+        r"""Compatilizes the `DeterministicModel` with `EnsemblePosterior`"""
+        return self.forward(X=X).unsqueeze(-3)
 
 
 class GenericDeterministicModel(DeterministicModel):

--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -27,13 +27,11 @@ functions or in other places where a `Model` is expected.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Callable, List, Optional, Union
+from typing import Callable, List, Optional, Union
 
 import torch
-from botorch.acquisition.objective import PosteriorTransform
-from botorch.exceptions.errors import UnsupportedError
 from botorch.models.ensemble import EnsembleModel
-from botorch.posteriors.deterministic import DeterministicPosterior
+from botorch.models.model import Model
 from torch import Tensor
 
 

--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -56,7 +56,7 @@ class DeterministicModel(EnsembleModel):
         pass  # pragma: no cover
 
     def forward_(self, X: Tensor) -> Tensor:
-        # in case of the determinist model we have to append the sample
+        # in case of the deterministic model we have to append the sample
         # dimension for backward compatibility
         values = self.forward(X=X)
         return values.unsqueeze(-1)

--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -55,7 +55,7 @@ class DeterministicModel(EnsembleModel):
         """
         pass  # pragma: no cover
 
-    def forward_(self, X: Tensor) -> Tensor:
+    def _forward(self, X: Tensor) -> Tensor:
         r"""Compatibilizes the `DeterministicModel` with `EnsemblePosterior`"""
         return self.forward(X=X).unsqueeze(-3)
 

--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -25,19 +25,18 @@ functions or in other places where a `Model` is expected.
 """
 
 from __future__ import annotations
-
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Any, Callable, List, Optional, Union
 
 import torch
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.exceptions.errors import UnsupportedError
-from botorch.models.model import Model
+from botorch.models.ensemble import EnsembleModel
 from botorch.posteriors.deterministic import DeterministicPosterior
 from torch import Tensor
 
 
-class DeterministicModel(Model, ABC):
+class DeterministicModel(EnsembleModel):
     r"""
     Abstract base class for deterministic models.
 
@@ -57,55 +56,11 @@ class DeterministicModel(Model, ABC):
         """
         pass  # pragma: no cover
 
-    @property
-    def num_outputs(self) -> int:
-        r"""The number of outputs of the model."""
-        return self._num_outputs
-
-    def posterior(
-        self,
-        X: Tensor,
-        output_indices: Optional[List[int]] = None,
-        posterior_transform: Optional[PosteriorTransform] = None,
-        **kwargs: Any,
-    ) -> DeterministicPosterior:
-        r"""Compute the (deterministic) posterior at X.
-
-        Args:
-            X: A `batch_shape x n x d`-dim input tensor `X`.
-            output_indices: A list of indices, corresponding to the outputs over
-                which to compute the posterior. If omitted, computes the posterior
-                over all model outputs.
-            posterior_transform: An optional PosteriorTransform.
-
-        Returns:
-            A `DeterministicPosterior` object, representing `batch_shape` joint
-            posteriors over `n` points and the outputs selected by `output_indices`.
-        """
-        # Apply the input transforms in `eval` mode.
-        self.eval()
-        X = self.transform_inputs(X)
-        # Note: we use a Tensor instance check so that `observation_noise = True`
-        # just gets ignored. This avoids having to do a bunch of case distinctions
-        # when using a ModelList.
-        if isinstance(kwargs.get("observation_noise"), Tensor):
-            # TODO: Consider returning an MVN here instead
-            raise UnsupportedError(
-                "Deterministic models do not support observation noise."
-            )
-        values = self.forward(X)
-        # NOTE: The `outcome_transform` `untransform`s the predictions rather than the
-        # `posterior` (as is done in GP models). This is more general since it works
-        # even if the transform doesn't support `untransform_posterior`.
-        if hasattr(self, "outcome_transform"):
-            values, _ = self.outcome_transform.untransform(values)
-        if output_indices is not None:
-            values = values[..., output_indices]
-        posterior = DeterministicPosterior(values=values)
-        if posterior_transform is not None:
-            return posterior_transform(posterior)
-        else:
-            return posterior
+    def forward_(self, X: Tensor) -> Tensor:
+        # in case of the determinist model we have to append the sample
+        # dimension for backward compatibility
+        values = self.forward(X=X)
+        return values.unsqueeze(-1)
 
 
 class GenericDeterministicModel(DeterministicModel):

--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -56,7 +56,7 @@ class DeterministicModel(EnsembleModel):
         pass  # pragma: no cover
 
     def forward_(self, X: Tensor) -> Tensor:
-        r"""Compatilizes the `DeterministicModel` with `EnsemblePosterior`"""
+        r"""Compatibilizes the `DeterministicModel` with `EnsemblePosterior`"""
         return self.forward(X=X).unsqueeze(-3)
 
 

--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -25,6 +25,7 @@ functions or in other places where a `Model` is expected.
 """
 
 from __future__ import annotations
+
 from abc import abstractmethod
 from typing import Any, Callable, List, Optional, Union
 

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+Ensemble Models: Simple wrappers that allow the usage of ensembles
+via the BoTorch Model and Posterior APIs.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, List, Optional
+
+from botorch.acquisition.objective import PosteriorTransform
+from botorch.exceptions.errors import UnsupportedError
+from botorch.models.model import Model
+from botorch.posteriors.ensemble import EnsemblePosterior
+from torch import Tensor
+
+
+class EnsembleModel(Model, ABC):
+    r"""
+    Abstract base class for ensemble models.
+
+    :meta private:
+    """
+
+    @abstractmethod
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Compute the (ensemble) model output at X.
+
+        Args:
+            X: A `batch_shape x n x d`-dim input tensor `X`.
+
+        Returns:
+            A `batch_shape x n x m x s`-dimensional output tensor where
+            s is the size of the ensemble.
+        """
+        pass  # pragma: no cover
+
+    @property
+    def num_outputs(self) -> int:
+        r"""The number of outputs of the model."""
+        return self._num_outputs
+
+    @abstractmethod
+    @property
+    def size(self) -> int:
+        r"""The size of the ensemble model"""
+        pass
+
+    def posterior(
+        self,
+        X: Tensor,
+        output_indices: Optional[List[int]] = None,
+        posterior_transform: Optional[PosteriorTransform] = None,
+        **kwargs: Any,
+    ) -> EnsemblePosterior:
+        r"""Compute the ensemble posterior at X.
+
+        Args:
+            X: A `batch_shape x n x d`-dim input tensor `X`.
+            output_indices: A list of indices, corresponding to the outputs over
+                which to compute the posterior. If omitted, computes the posterior
+                over all model outputs.
+            posterior_transform: An optional PosteriorTransform.
+
+        Returns:
+            A `EnsemblePosterior` object, representing `batch_shape` joint
+            posteriors over `n` points and the outputs selected by `output_indices`.
+        """
+        # Apply the input transforms in `eval` mode.
+        self.eval()
+        X = self.transform_inputs(X)
+        # Note: we use a Tensor instance check so that `observation_noise = True`
+        # just gets ignored. This avoids having to do a bunch of case distinctions
+        # when using a ModelList.
+        if isinstance(kwargs.get("observation_noise"), Tensor):
+            # TODO: Consider returning an MVN here instead
+            raise UnsupportedError(
+                "Deterministic models do not support observation noise."
+            )
+        values = self.forward(X)
+        # NOTE: The `outcome_transform` `untransform`s the predictions rather than the
+        # `posterior` (as is done in GP models). This is more general since it works
+        # even if the transform doesn't support `untransform_posterior`.
+        if hasattr(self, "outcome_transform"):
+            values, _ = self.outcome_transform.untransform(values)
+        if output_indices is not None:
+            values = values[..., output_indices, :]
+        posterior = EnsemblePosterior(values=values)
+        if posterior_transform is not None:
+            return posterior_transform(posterior)
+        else:
+            return posterior

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -78,7 +78,7 @@ class EnsembleModel(Model, ABC):
         if isinstance(kwargs.get("observation_noise"), Tensor):
             # TODO: Consider returning an MVN here instead
             raise UnsupportedError(
-                "Deterministic models do not support observation noise."
+                "Ensemble models do not support observation noise."
             )
         values = self._forward(X)
         # NOTE: The `outcome_transform` `untransform`s the predictions rather than the

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -77,9 +77,7 @@ class EnsembleModel(Model, ABC):
         # when using a ModelList.
         if isinstance(kwargs.get("observation_noise"), Tensor):
             # TODO: Consider returning an MVN here instead
-            raise UnsupportedError(
-                "Ensemble models do not support observation noise."
-            )
+            raise UnsupportedError("Ensemble models do not support observation noise.")
         values = self._forward(X)
         # NOTE: The `outcome_transform` `untransform`s the predictions rather than the
         # `posterior` (as is done in GP models). This is more general since it works

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -41,6 +41,9 @@ class EnsembleModel(Model, ABC):
         """
         pass  # pragma: no cover
 
+    def forward_(self, X: Tensor) -> Tensor:
+        return self.forward(X=X)
+
     @property
     def num_outputs(self) -> int:
         r"""The number of outputs of the model."""
@@ -77,7 +80,7 @@ class EnsembleModel(Model, ABC):
             raise UnsupportedError(
                 "Deterministic models do not support observation noise."
             )
-        values = self.forward(X)
+        values = self.forward_(X)
         # NOTE: The `outcome_transform` `untransform`s the predictions rather than the
         # `posterior` (as is done in GP models). This is more general since it works
         # even if the transform doesn't support `untransform_posterior`.

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -59,7 +59,7 @@ class EnsembleModel(Model, ABC):
         r"""Compute the ensemble posterior at X.
 
         Args:
-            X: A `batch_shape x n x d`-dim input tensor `X`.
+            X: A `batch_shape x q x d`-dim input tensor `X`.
             output_indices: A list of indices, corresponding to the outputs over
                 which to compute the posterior. If omitted, computes the posterior
                 over all model outputs.

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -37,7 +37,7 @@ class EnsembleModel(Model, ABC):
 
         Returns:
             A `batch_shape x n x m x s`-dimensional output tensor where
-            s is the size of the ensemble.
+            `s` is the size of the ensemble.
         """
         pass  # pragma: no cover
 

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -36,7 +36,7 @@ class EnsembleModel(Model, ABC):
             X: A `batch_shape x n x d`-dim input tensor `X`.
 
         Returns:
-            A `batch_shape x n x m x s`-dimensional output tensor where
+            A `batch_shape x s x n x m`-dimensional output tensor where
             `s` is the size of the ensemble.
         """
         pass  # pragma: no cover
@@ -87,7 +87,7 @@ class EnsembleModel(Model, ABC):
         if hasattr(self, "outcome_transform"):
             values, _ = self.outcome_transform.untransform(values)
         if output_indices is not None:
-            values = values[..., output_indices, :]
+            values = values[..., output_indices]
         posterior = EnsemblePosterior(values=values)
         if posterior_transform is not None:
             return posterior_transform(posterior)

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -46,12 +46,6 @@ class EnsembleModel(Model, ABC):
         r"""The number of outputs of the model."""
         return self._num_outputs
 
-    @abstractmethod
-    @property
-    def size(self) -> int:
-        r"""The size of the ensemble model"""
-        pass
-
     def posterior(
         self,
         X: Tensor,

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -41,7 +41,7 @@ class EnsembleModel(Model, ABC):
         """
         pass  # pragma: no cover
 
-    def forward_(self, X: Tensor) -> Tensor:
+    def _forward(self, X: Tensor) -> Tensor:
         return self.forward(X=X)
 
     @property
@@ -80,7 +80,7 @@ class EnsembleModel(Model, ABC):
             raise UnsupportedError(
                 "Deterministic models do not support observation noise."
             )
-        values = self.forward_(X)
+        values = self._forward(X)
         # NOTE: The `outcome_transform` `untransform`s the predictions rather than the
         # `posterior` (as is done in GP models). This is more general since it works
         # even if the transform doesn't support `untransform_posterior`.

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -69,7 +69,7 @@ class EnsembleModel(Model, ABC):
             posterior_transform: An optional PosteriorTransform.
 
         Returns:
-            A `EnsemblePosterior` object, representing `batch_shape` joint
+            An `EnsemblePosterior` object, representing `batch_shape` joint
             posteriors over `n` points and the outputs selected by `output_indices`.
         """
         # Apply the input transforms in `eval` mode.

--- a/botorch/posteriors/deterministic.py
+++ b/botorch/posteriors/deterministic.py
@@ -12,6 +12,7 @@ models.
 from __future__ import annotations
 
 from typing import Optional
+from warnings import warn
 
 import torch
 from botorch.posteriors.posterior import Posterior
@@ -26,6 +27,11 @@ class DeterministicPosterior(Posterior):
         Args:
             values: Values of the samples produced by this posterior.
         """
+        warn(
+            "`DeterministicPosterior` is marked for deprecation, consider using "
+            "`EnsemblePosterior`.",
+            DeprecationWarning,
+        )
         self.values = values
 
     @property

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -111,4 +111,4 @@ class EnsemblePosterior(Posterior):
     ) -> Tensor:
         if base_samples.shape != sample_shape:
             raise ValueError("Base samples to not match sample shape.")
-        return self.values[..., base_samples].reshape(self._extended_shape)
+        return self.values[..., base_samples].reshape(self._extended_shape())

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+Ensemble posteriors. Used in conjunction with ensemble
+models.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from botorch.posteriors.posterior import Posterior
+from torch import Tensor
+
+
+class EnsemblePosterior(Posterior):
+    r"""Ensemble posterior."""
+
+    def __init__(self, values: Tensor) -> None:
+        r"""
+        Args:
+            values: Values of the samples produced by this posterior as
+                a (b) x q x m x s tensor where m is the output size of the
+                model and s is the ensemble size.
+        """
+        if values.ndim < 3:
+            raise ValueError("Values has to be at least three-dimensional.")
+        self.values = values
+
+    @property
+    def size(self) -> int:
+        r"""The size of the ensemble"""
+        return self.values.shape[-1]
+
+    @property
+    def device(self) -> torch.device:
+        r"""The torch device of the posterior."""
+        return self.values.device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        r"""The torch dtype of the posterior."""
+        return self.values.dtype
+
+    @property
+    def mean(self) -> Tensor:
+        r"""The mean of the posterior as a `(b) x n x m`-dim Tensor."""
+        return self.values.mean(dim=-1)
+
+    @property
+    def variance(self) -> Tensor:
+        r"""The variance of the posterior as a `(b) x n x m`-dim Tensor.
+
+        As this is a deterministic posterior, this is a tensor of zeros.
+        """
+        return self.values.var(dim=-1)
+
+    def _extended_shape(
+        self, sample_shape: torch.Size = torch.Size()  # noqa: B008
+    ) -> torch.Size:
+        r"""Returns the shape of the samples produced by the posterior with
+        the given `sample_shape`.
+        """
+        return sample_shape + self.values.shape
+
+    def rsample(
+        self,
+        sample_shape: Optional[torch.Size] = None,
+    ) -> Tensor:
+        r"""Sample from the posterior (with gradients).
+
+        For the deterministic posterior, this just returns the values expanded
+        to the requested shape.
+
+        Args:
+            sample_shape: A `torch.Size` object specifying the sample shape. To
+                draw `n` samples, set to `torch.Size([n])`. To draw `b` batches
+                of `n` samples each, set to `torch.Size([b, n])`.
+
+        Returns:
+            Samples from the posterior, a tensor of shape
+            `self._extended_shape(sample_shape=sample_shape)`.
+        """
+        if sample_shape is None:
+            sample_shape = torch.Size([1])
+        # sample_indices = torch.arange(0, sample_shape[0]).to(dtype=torch.int64)
+        # return self.values[..., sample_indices]
+        return self.values.expand(self._extended_shape(sample_shape))

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -33,8 +33,6 @@ class EnsemblePosterior(Posterior):
         """
         if values.ndim < 3:
             raise ValueError("Values has to be at least three-dimensional.")
-        if values.shape[-1] < 2:
-            raise ValueError("Ensemble size has to be at least two.")
         self.values = values
 
     @property
@@ -69,6 +67,8 @@ class EnsemblePosterior(Posterior):
 
         Computed as the sample variance across the ensemble outputs.
         """
+        if self.size == 1:
+            return torch.zeros_like(self.values[..., -1])
         return self.values.var(dim=-1)
 
     def _extended_shape(

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -134,7 +134,7 @@ class EnsemblePosterior(Posterior):
             `self._extended_shape(sample_shape=sample_shape)`.
         """
         if base_samples.shape != sample_shape:
-            raise ValueError("Base samples to not match sample shape.")
+            raise ValueError("Base samples do not match sample shape.")
         # move sample axis to front
         values = self.values.movedim(-3, 0)
         # sample from the first dimension of values

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -79,9 +79,7 @@ class EnsemblePosterior(Posterior):
         r"""Returns the shape of the samples produced by the posterior with
         the given `sample_shape`.
         """
-        mask = self.values.ndim * [True]
-        mask[-3] = False
-        return sample_shape + tuple(torch.tensor(self.values.shape)[mask].tolist())
+        return sample_shape + self.values.shape[:-3] + self.values.shape[-2:]
 
     def rsample(
         self,

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -30,6 +30,8 @@ class EnsemblePosterior(Posterior):
         """
         if values.ndim < 3:
             raise ValueError("Values has to be at least three-dimensional.")
+        if values.shape[-1] < 2:
+            raise ValueError("Ensemble size has to be at least two.")
         self.values = values
 
     @property

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -17,6 +17,10 @@ import torch
 from botorch.posteriors.posterior import Posterior
 from torch import Tensor
 
+r"""
+Posterior module to be used with ensemble models.
+"""
+
 
 class EnsemblePosterior(Posterior):
     r"""Ensemble posterior."""

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -99,8 +99,6 @@ class EnsemblePosterior(Posterior):
             num_samples=sample_shape.numel(),
             replacement=True,
         ).reshape(sample_shape)
-        # sample_indices = torch.arange(0, sample_shape[0]).to(dtype=torch.int64)
-        # return self.values[..., sample_indices]
         return self.rsample_from_base_samples(
             sample_shape=sample_shape, base_samples=base_samples
         )

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -16,10 +16,6 @@ import torch
 from botorch.posteriors.posterior import Posterior
 from torch import Tensor
 
-r"""
-Posterior module to be used with ensemble models.
-"""
-
 
 class EnsemblePosterior(Posterior):
     r"""Ensemble posterior, that should be used for ensemble models that compute

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -5,8 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 r"""
-Ensemble posteriors. Used in conjunction with ensemble
-models.
+Ensemble posteriors. Used in conjunction with ensemble models.
 """
 
 from __future__ import annotations

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -124,10 +124,10 @@ class EnsemblePosterior(Posterior):
                 draw `n` samples, set to `torch.Size([n])`. To draw `b` batches
                 of `n` samples each, set to `torch.Size([b, n])`.
             base_samples: A Tensor of indices as base samples of shape
-                `sample_shape x base_sample_shape`, typically obtained from
-                `IndexSampler`. This is used for deterministic optimization. The
-                predictions of the ensemble corresponding to the indices are then
-                sampled.
+                `sample_shape`, typically obtained from `IndexSampler`.
+                This is used for deterministic optimization. The predictions of
+                the ensemble corresponding to the indices are then sampled.
+
 
         Returns:
             Samples from the posterior, a tensor of shape

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -38,7 +38,7 @@ class EnsemblePosterior(Posterior):
         self.values = values
 
     @property
-    def size(self) -> int:
+    def ensemble_size(self) -> int:
         r"""The size of the ensemble"""
         return self.values.shape[-3]
 
@@ -46,7 +46,7 @@ class EnsemblePosterior(Posterior):
     def weights(self) -> Tensor:
         r"""The weights of the individual models in the ensemble.
         Equally weighted by default."""
-        return torch.ones(self.size) / self.size
+        return torch.ones(self.ensemble_size) / self.ensemble_size
 
     @property
     def device(self) -> torch.device:
@@ -69,7 +69,7 @@ class EnsemblePosterior(Posterior):
 
         Computed as the sample variance across the ensemble outputs.
         """
-        if self.size == 1:
+        if self.ensemble_size == 1:
             return torch.zeros_like(self.values.squeeze(-3))
         return self.values.var(dim=-3)
 

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -61,7 +61,7 @@ class EnsemblePosterior(Posterior):
     def variance(self) -> Tensor:
         r"""The variance of the posterior as a `(b) x n x m`-dim Tensor.
 
-        As this is a deterministic posterior, this is a tensor of zeros.
+        Computed as the sample variance across the ensemble outputs.
         """
         return self.values.var(dim=-1)
 

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -22,7 +22,9 @@ Posterior module to be used with ensemble models.
 
 
 class EnsemblePosterior(Posterior):
-    r"""Ensemble posterior."""
+    r"""Ensemble posterior, that should be used for ensemble models that compute
+    eagerly a finite number of samples per X value as for example a deep ensemble
+    or a random forest."""
 
     def __init__(self, values: Tensor) -> None:
         r"""

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -28,8 +28,8 @@ class EnsemblePosterior(Posterior):
         r"""
         Args:
             values: Values of the samples produced by this posterior as
-                a (b) x q x m x s tensor where m is the output size of the
-                model and s is the ensemble size.
+                a `(b) x q x m x s` tensor where `m` is the output size of the
+                model and `s` is the ensemble size.
         """
         if values.ndim < 3:
             raise ValueError("Values has to be at least three-dimensional.")

--- a/botorch/sampling/get_sampler.py
+++ b/botorch/sampling/get_sampler.py
@@ -10,9 +10,9 @@ from typing import Any, Type, Union
 import torch
 from botorch.logging import logger
 from botorch.posteriors.deterministic import DeterministicPosterior
+from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.posterior import Posterior
-from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.posteriors.posterior_list import PosteriorList
 from botorch.posteriors.torch import TorchPosterior
 from botorch.posteriors.transformed import TransformedPosterior

--- a/botorch/sampling/get_sampler.py
+++ b/botorch/sampling/get_sampler.py
@@ -17,6 +17,7 @@ from botorch.posteriors.posterior_list import PosteriorList
 from botorch.posteriors.torch import TorchPosterior
 from botorch.posteriors.transformed import TransformedPosterior
 from botorch.sampling.base import MCSampler
+from botorch.sampling.index_sampler import IndexSampler
 from botorch.sampling.list_sampler import ListSampler
 from botorch.sampling.normal import (
     IIDNormalSampler,
@@ -121,7 +122,7 @@ def _get_sampler_ensemble(
     posterior: EnsemblePosterior, sample_shape: torch.Size, **kwargs: Any
 ) -> MCSampler:
     r"""Get the dummy `StochasticSampler` for the `EnsemblePosterior`."""
-    return StochasticSampler(sample_shape=sample_shape, **kwargs)
+    return IndexSampler(sample_shape=sample_shape, **kwargs)
 
 
 @GetSampler.register(object)

--- a/botorch/sampling/get_sampler.py
+++ b/botorch/sampling/get_sampler.py
@@ -121,7 +121,7 @@ def _get_sampler_deterministic(
 def _get_sampler_ensemble(
     posterior: EnsemblePosterior, sample_shape: torch.Size, **kwargs: Any
 ) -> MCSampler:
-    r"""Get the dummy `StochasticSampler` for the `EnsemblePosterior`."""
+    r"""Get the dummy `IndexSampler` for the `EnsemblePosterior`."""
     return IndexSampler(sample_shape=sample_shape, **kwargs)
 
 

--- a/botorch/sampling/get_sampler.py
+++ b/botorch/sampling/get_sampler.py
@@ -12,6 +12,7 @@ from botorch.logging import logger
 from botorch.posteriors.deterministic import DeterministicPosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.posterior import Posterior
+from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.posteriors.posterior_list import PosteriorList
 from botorch.posteriors.torch import TorchPosterior
 from botorch.posteriors.transformed import TransformedPosterior
@@ -112,6 +113,14 @@ def _get_sampler_deterministic(
     posterior: DeterministicPosterior, sample_shape: torch.Size, **kwargs: Any
 ) -> MCSampler:
     r"""Get the dummy `StochasticSampler` for the `DeterministicPosterior`."""
+    return StochasticSampler(sample_shape=sample_shape, **kwargs)
+
+
+@GetSampler.register(EnsemblePosterior)
+def _get_sampler_ensemble(
+    posterior: EnsemblePosterior, sample_shape: torch.Size, **kwargs: Any
+) -> MCSampler:
+    r"""Get the dummy `StochasticSampler` for the `EnsemblePosterior`."""
     return StochasticSampler(sample_shape=sample_shape, **kwargs)
 
 

--- a/botorch/sampling/get_sampler.py
+++ b/botorch/sampling/get_sampler.py
@@ -121,7 +121,7 @@ def _get_sampler_deterministic(
 def _get_sampler_ensemble(
     posterior: EnsemblePosterior, sample_shape: torch.Size, **kwargs: Any
 ) -> MCSampler:
-    r"""Get the dummy `IndexSampler` for the `EnsemblePosterior`."""
+    r"""Get the `IndexSampler` for the `EnsemblePosterior`."""
     return IndexSampler(sample_shape=sample_shape, **kwargs)
 
 

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -24,7 +24,7 @@ class IndexSampler(MCSampler):
         if self.base_samples is None or self.base_samples.shape != self.sample_shape:
             with manual_seed(seed=self.seed):
                 base_samples = torch.multinomial(
-                    torch.ones(self.size) / self.size,
+                    posterior.weights,
                     num_samples=self.sample_shape.numel(),
                     replacement=True,
                 ).reshape(self.sample_shape)

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -20,7 +20,7 @@ class IndexSampler(MCSampler):
         )
         return samples
 
-    def _construct_base_samples(self, posterior: Posterior):
+    def _construct_base_samples(self, posterior: Posterior) -> None:
         if self.base_samples is None or self.base_samples.shape != self.sample_shape:
             with manual_seed(seed=self.seed):
                 base_samples = torch.multinomial(

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -54,6 +54,9 @@ class IndexSampler(MCSampler):
         if self.base_samples.device != posterior.device:
             self.to(device=posterior.device)  # pragma: nocover
 
-
-#        if self.base_samples.dtype != posterior.dtype:
-#            self.to(dtype=posterior.dtype)
+    def _update_base_samples(
+        self, posterior: Posterior, base_sampler: MCSampler
+    ) -> None:
+        r"""Null operation just needed for compatibility with
+        `CachedCholeskyAcquisitionFunction`."""
+        pass

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -9,6 +9,8 @@ Sampler to be used with `EnsemblePosteriors` to enable
 deterministic optimization of acquisition functions with ensemble models.
 """
 
+from __future__ import annotations
+
 import torch
 from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.sampling.base import MCSampler

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -36,7 +36,7 @@ class IndexSampler(MCSampler):
 
     def _construct_base_samples(self, posterior: Posterior) -> None:
         r"""Constructs base samples as indices to sample with them from
-        the Posterior
+        the Posterior.
 
         Args:
             posterior: The ensemble posterior to construct the base samples

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -55,7 +55,7 @@ class IndexSampler(MCSampler):
             self.to(device=posterior.device)  # pragma: nocover
 
     def _update_base_samples(
-        self, posterior: Posterior, base_sampler: MCSampler
+        self, posterior: EnsemblePosterior, base_sampler: IndexSampler
     ) -> None:
         r"""Null operation just needed for compatibility with
         `CachedCholeskyAcquisitionFunction`."""

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -19,7 +19,7 @@ class IndexSampler(MCSampler):
     r"""A sampler that calls `posterior.rsample_from_base_samples` to
     generate the samples via index base samples."""
 
-    def forward(self, posterior: Posterior) -> Tensor:
+    def forward(self, posterior: EnsemblePosterior) -> Tensor:
         r"""Draws MC samples from the posterior.
 
         Args:

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -44,7 +44,8 @@ class IndexSampler(MCSampler):
                 for.
         """
         if self.base_samples is None or self.base_samples.shape != self.sample_shape:
-            with manual_seed(seed=self.seed):
+            with torch.random.fork_rng():
+                torch.manual_seed(self.seed)
                 base_samples = torch.multinomial(
                     posterior.weights,
                     num_samples=self.sample_shape.numel(),

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -12,7 +12,6 @@ deterministic optimization of acquisition functions with ensemble models.
 import torch
 from botorch.posteriors import Posterior
 from botorch.sampling.base import MCSampler
-from botorch.utils.sampling import manual_seed
 from torch import Tensor
 
 

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -34,7 +34,7 @@ class IndexSampler(MCSampler):
         )
         return samples
 
-    def _construct_base_samples(self, posterior: Posterior) -> None:
+    def _construct_base_samples(self, posterior: EnsemblePosterior) -> None:
         r"""Constructs base samples as indices to sample with them from
         the Posterior.
 

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -40,7 +40,7 @@ class IndexSampler(MCSampler):
         the Posterior
 
         Args:
-            posterior (Posterior): The ensemble posterior to construct the base samples
+            posterior: The ensemble posterior to construct the base samples
                 for.
         """
         if self.base_samples is None or self.base_samples.shape != self.sample_shape:

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -10,7 +10,7 @@ deterministic optimization of acquisition functions with ensemble models.
 """
 
 import torch
-from botorch.posteriors import Posterior
+from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.sampling.base import MCSampler
 from torch import Tensor
 

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -12,9 +12,13 @@ from botorch.utils.sampling import manual_seed
 import torch
 
 
-class BaseSampler(MCSampler):
+class IndexSampler(MCSampler):
     def forward(self, posterior: Posterior) -> Tensor:
-        return super().forward(posterior)
+        self._construct_base_samples(posterior=posterior)
+        samples = posterior.rsample_from_base_samples(
+            sample_shape=self.sample_shape, base_samples=self.base_samples
+        )
+        return samples
 
     def _construct_base_samples(self, posterior: Posterior):
         if self.base_samples is None or self.base_samples.shape != self.sample_shape:

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from botorch.sampling.base import MCSampler
+from botorch.posteriors import Posterior
+from torch import Tensor
+from botorch.utils.sampling import manual_seed
+import torch
+
+
+class BaseSampler(MCSampler):
+    def forward(self, posterior: Posterior) -> Tensor:
+        return super().forward(posterior)
+
+    def _construct_base_samples(self, posterior: Posterior):
+        if self.base_samples is None or self.base_samples.shape != self.sample_shape:
+            with manual_seed(seed=self.seed):
+                base_samples = torch.multinomial(
+                    torch.ones(self.size) / self.size,
+                    num_samples=self.sample_shape.numel(),
+                    replacement=True,
+                ).reshape(self.sample_shape)
+            self.register_buffer("base_samples", base_samples)
+        if self.base_samples.device != posterior.device:
+            self.to(device=posterior.device)  # pragma: nocover
+        if self.base_samples.dtype != posterior.dtype:
+            self.to(dtype=posterior.dtype)

--- a/botorch/sampling/index_sampler.py
+++ b/botorch/sampling/index_sampler.py
@@ -9,11 +9,11 @@ Sampler to be used with `EnsemblePosteriors` to enable
 deterministic optimization of acquisition functions with ensemble models.
 """
 
-from botorch.sampling.base import MCSampler
-from botorch.posteriors import Posterior
-from torch import Tensor
-from botorch.utils.sampling import manual_seed
 import torch
+from botorch.posteriors import Posterior
+from botorch.sampling.base import MCSampler
+from botorch.utils.sampling import manual_seed
+from torch import Tensor
 
 
 class IndexSampler(MCSampler):

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -25,6 +25,11 @@ Deterministic Model API
 .. automodule:: botorch.models.deterministic
     :members:
 
+Ensemble Model API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.ensemble
+    :members:
+
 
 Models
 -------------------------------------------

--- a/sphinx/source/posteriors.rst
+++ b/sphinx/source/posteriors.rst
@@ -39,6 +39,11 @@ Determinstic Posterior
 .. automodule:: botorch.posteriors.deterministic
     :members:
 
+Ensemble Posterior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.posteriors.ensemble
+    :members:
+
 Higher Order GP Posterior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.posteriors.higher_order

--- a/sphinx/source/sampling.rst
+++ b/sphinx/source/sampling.rst
@@ -17,6 +17,11 @@ Deterministic Sampler
 .. automodule:: botorch.sampling.deterministic
     :members:
 
+Index Sampler
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.sampling.index_sampler
+    :members:
+
 Get Sampler Helper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.sampling.get_sampler

--- a/test/models/test_deterministic.py
+++ b/test/models/test_deterministic.py
@@ -62,7 +62,7 @@ class TestDeterministicModels(BotorchTestCase):
         # basic test
         p = model.posterior(X)
         self.assertIsInstance(p, EnsemblePosterior)
-        self.assertEqual(p.size, 1)
+        self.assertEqual(p.ensemble_size, 1)
         self.assertTrue(torch.equal(p.mean, f(X)))
         # check that observation noise doesn't change things
         p_noisy = model.posterior(X, observation_noise=True)

--- a/test/models/test_deterministic.py
+++ b/test/models/test_deterministic.py
@@ -62,6 +62,7 @@ class TestDeterministicModels(BotorchTestCase):
         # basic test
         p = model.posterior(X)
         self.assertIsInstance(p, EnsemblePosterior)
+        self.assertEqual(p.size, 1)
         self.assertTrue(torch.equal(p.mean, f(X)))
         # check that observation noise doesn't change things
         p_noisy = model.posterior(X, observation_noise=True)

--- a/test/models/test_deterministic.py
+++ b/test/models/test_deterministic.py
@@ -19,7 +19,7 @@ from botorch.models.deterministic import (
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.transforms.input import Normalize
 from botorch.models.transforms.outcome import Standardize
-from botorch.posteriors.deterministic import DeterministicPosterior
+from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.utils.testing import BotorchTestCase
 
 
@@ -61,7 +61,7 @@ class TestDeterministicModels(BotorchTestCase):
         X = torch.rand(3, 2)
         # basic test
         p = model.posterior(X)
-        self.assertIsInstance(p, DeterministicPosterior)
+        self.assertIsInstance(p, EnsemblePosterior)
         self.assertTrue(torch.equal(p.mean, f(X)))
         # check that observation noise doesn't change things
         p_noisy = model.posterior(X, observation_noise=True)

--- a/test/models/test_ensemble.py
+++ b/test/models/test_ensemble.py
@@ -13,6 +13,7 @@ class DummyEnsembleModel(EnsembleModel):
     r"""A dummy ensemble model."""
 
     def __init__(self):
+        r"""Init model."""
         super().__init__()
         self._num_outputs = 2
         self.a = torch.rand(16, 3, 2)

--- a/test/models/test_ensemble.py
+++ b/test/models/test_ensemble.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from botorch.models.ensemble import EnsembleModel
+from botorch.utils.testing import BotorchTestCase
+
+
+class DummyEnsembleModel(EnsembleModel):
+    r"""A dummy ensemble model."""
+
+    def __init__(self):
+        super().__init__()
+        self._num_outputs = 2
+        self.a = torch.rand(16, 3, 2)
+
+    def forward(self, X):
+        return torch.stack(
+            [torch.einsum("...d,dm", X, self.a[i]) for i in range(16)], dim=-3
+        )
+
+
+class TestEnsembleModels(BotorchTestCase):
+    def test_abstract_base_model(self):
+        with self.assertRaises(TypeError):
+            EnsembleModel()
+
+    def test_DummyEnsembleModel(self):
+        for shape in [(10, 3), (5, 10, 3)]:
+            e = DummyEnsembleModel()
+            X = torch.randn(*shape)
+            p = e.posterior(X)
+            self.assertEqual(p.size, 16)

--- a/test/models/test_ensemble.py
+++ b/test/models/test_ensemble.py
@@ -16,11 +16,11 @@ class DummyEnsembleModel(EnsembleModel):
         r"""Init model."""
         super().__init__()
         self._num_outputs = 2
-        self.a = torch.rand(16, 3, 2)
+        self.a = torch.rand(4, 3, 2)
 
     def forward(self, X):
         return torch.stack(
-            [torch.einsum("...d,dm", X, self.a[i]) for i in range(16)], dim=-3
+            [torch.einsum("...d,dm", X, self.a[i]) for i in range(4)], dim=-3
         )
 
 
@@ -34,4 +34,4 @@ class TestEnsembleModels(BotorchTestCase):
             e = DummyEnsembleModel()
             X = torch.randn(*shape)
             p = e.posterior(X)
-            self.assertEqual(p.size, 16)
+            self.assertEqual(p.ensemble_size, 4)

--- a/test/posteriors/test_deterministic.py
+++ b/test/posteriors/test_deterministic.py
@@ -6,6 +6,8 @@
 
 import itertools
 
+from warnings import catch_warnings
+
 import torch
 from botorch.posteriors.deterministic import DeterministicPosterior
 from botorch.utils.testing import BotorchTestCase
@@ -18,6 +20,11 @@ class TestDeterministicPosterior(BotorchTestCase):
         ):
             values = torch.randn(*shape, device=self.device, dtype=dtype)
             p = DeterministicPosterior(values)
+            with catch_warnings(record=True) as ws:
+                p = DeterministicPosterior(values)
+                self.assertTrue(
+                    any("marked for deprecation" in str(w.message) for w in ws)
+                )
             self.assertEqual(p.device.type, self.device.type)
             self.assertEqual(p.dtype, dtype)
             self.assertEqual(p._extended_shape(), values.shape)

--- a/test/posteriors/test_ensemble.py
+++ b/test/posteriors/test_ensemble.py
@@ -4,10 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
+
 import torch
 from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.utils.testing import BotorchTestCase
-import itertools
 
 
 class TestEnsemblePosterior(BotorchTestCase):

--- a/test/posteriors/test_ensemble.py
+++ b/test/posteriors/test_ensemble.py
@@ -17,7 +17,10 @@ class TestEnsemblePosterior(BotorchTestCase):
             ((5, 2), (5, 1)), (torch.float, torch.double)
         ):
             values = torch.randn(*shape, device=self.device, dtype=dtype)
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(
+                ValueError,
+                "Values has to be at least three-dimensional",
+            ):
                 EnsemblePosterior(values)
 
     def testEnsemblePosteriorAsDeterministic(self):

--- a/test/posteriors/test_ensemble.py
+++ b/test/posteriors/test_ensemble.py
@@ -23,7 +23,7 @@ class TestEnsemblePosterior(BotorchTestCase):
             ):
                 EnsemblePosterior(values)
 
-    def testEnsemblePosteriorAsDeterministic(self):
+    def test_EnsemblePosterior_as_Deterministic(self):
         for shape, dtype in itertools.product(
             ((1, 3, 2), (2, 1, 3, 2)), (torch.float, torch.double)
         ):

--- a/test/posteriors/test_ensemble.py
+++ b/test/posteriors/test_ensemble.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from botorch.posteriors.ensemble import EnsemblePosterior
+from botorch.utils.testing import BotorchTestCase
+import itertools
+
+
+class TestEnsemblePosterior(BotorchTestCase):
+    def test_EnsemblePosterior_invalid(self):
+        for shape, dtype in itertools.product(
+            ((5, 2), (2, 5, 2, 1), (5, 2, 1)), (torch.float, torch.double)
+        ):
+            values = torch.randn(*shape, device=self.device, dtype=dtype)
+            with self.assertRaises(ValueError):
+                EnsemblePosterior(values)
+
+    def test_EnsemblePosterior(self):
+        for shape, dtype in itertools.product(
+            ((5, 2, 16), (2, 5, 2, 32)), (torch.float, torch.double)
+        ):
+            values = torch.randn(*shape, device=self.device, dtype=dtype)
+            p = EnsemblePosterior(values)
+            self.assertEqual(p.device.type, self.device.type)
+            self.assertEqual(p.dtype, dtype)
+            self.assertEqual(p.size, shape[-1])
+            self.assertTrue(torch.equal(p.mean, values.mean(dim=-1)))
+            self.assertTrue(torch.equal(p.variance, values.var(dim=-1)))
+
+            # tests regarding sampling are commented out as this seems still
+            # to be incorrect
+            # self.assertEqual(p._extended_shape(), values.shape)
+            # with self.assertRaises(NotImplementedError):
+            #    p.base_sample_shape
+            # test sampling
+            # samples = p.rsample()
+            # self.assertTrue(torch.equal(samples, values.unsqueeze(0)))
+            # samples = p.rsample(torch.Size([2]))
+            # self.assertTrue(torch.equal(samples, values.expand(2, *values.shape)))

--- a/test/posteriors/test_ensemble.py
+++ b/test/posteriors/test_ensemble.py
@@ -29,7 +29,7 @@ class TestEnsemblePosterior(BotorchTestCase):
         ):
             values = torch.randn(*shape, device=self.device, dtype=dtype)
             p = EnsemblePosterior(values)
-            self.assertEqual(p.size, 1)
+            self.assertEqual(p.ensemble_size, 1)
             self.assertEqual(p.device.type, self.device.type)
             self.assertEqual(p.dtype, dtype)
             self.assertEqual(
@@ -57,8 +57,10 @@ class TestEnsemblePosterior(BotorchTestCase):
             p = EnsemblePosterior(values)
             self.assertEqual(p.device.type, self.device.type)
             self.assertEqual(p.dtype, dtype)
-            self.assertEqual(p.size, 16)
-            self.assertAllClose(p.weights, torch.tensor([1.0 / p.size] * p.size))
+            self.assertEqual(p.ensemble_size, 16)
+            self.assertAllClose(
+                p.weights, torch.tensor([1.0 / p.ensemble_size] * p.ensemble_size)
+            )
             # test mean and variance
             self.assertTrue(torch.equal(p.mean, values.mean(dim=-3)))
             self.assertTrue(torch.equal(p.variance, values.var(dim=-3)))

--- a/test/sampling/test_index_sampler.py
+++ b/test/sampling/test_index_sampler.py
@@ -29,7 +29,9 @@ class TestIndexSampler(BotorchTestCase):
         self.assertTrue(sampler.base_samples is None)
         sampler._construct_base_samples(posterior=posterior)
         self.assertTrue(sampler.base_samples.shape == torch.Size((4, 128)))
-        self.assertTrue(sampler.base_samples.device == posterior.device == self.device)
+        self.assertTrue(
+            sampler.base_samples.device.type == posterior.device.type == self.device.type
+        )
         base_samples = sampler.base_samples
         sampler = IndexSampler(sample_shape=torch.Size((4, 128)), seed=42)
         sampler._construct_base_samples(posterior=posterior)

--- a/test/sampling/test_index_sampler.py
+++ b/test/sampling/test_index_sampler.py
@@ -11,7 +11,7 @@ from botorch.utils.testing import BotorchTestCase
 
 
 class TestIndexSampler(BotorchTestCase):
-    def test_deterministic_sampler(self):
+    def test_index_sampler(self):
         # Basic usage.
         posterior = EnsemblePosterior(
             values=torch.randn(torch.Size((50, 16, 1, 1))).to(self.device)

--- a/test/sampling/test_index_sampler.py
+++ b/test/sampling/test_index_sampler.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from botorch.sampling.index_sampler import IndexSampler
+from botorch.utils.testing import BotorchTestCase
+from botorch.posteriors.ensemble import EnsemblePosterior
+
+
+class TestIndexSampler(BotorchTestCase):
+    def test_deterministic_sampler(self):
+        # Basic usage.
+        posterior = EnsemblePosterior(
+            values=torch.randn(torch.Size((50, 1, 1, 16))).to(self.device)
+        )
+        sampler = IndexSampler(sample_shape=torch.Size((128,)))
+        samples = sampler(posterior)
+        self.assertTrue(samples.shape == torch.Size((128, 50, 1, 1)))
+        self.assertTrue(sampler.base_samples.max() < 16)
+        self.assertTrue(sampler.base_samples.min() >= 0)
+        # check deterministic nature
+        samples2 = sampler(posterior)
+        self.assertAllClose(samples, samples2)
+        # test construct base samples
+        sampler = IndexSampler(sample_shape=torch.Size((4, 128)), seed=42)
+        self.assertTrue(sampler.base_samples is None)
+        sampler._construct_base_samples(posterior=posterior)
+        self.assertTrue(sampler.base_samples.shape == torch.Size((4, 128)))
+        self.assertTrue(sampler.base_samples.device == posterior.device == self.device)
+        base_samples = sampler.base_samples
+        sampler = IndexSampler(sample_shape=torch.Size((4, 128)), seed=42)
+        sampler._construct_base_samples(posterior=posterior)
+        self.assertAllClose(base_samples, sampler.base_samples)

--- a/test/sampling/test_index_sampler.py
+++ b/test/sampling/test_index_sampler.py
@@ -30,7 +30,9 @@ class TestIndexSampler(BotorchTestCase):
         sampler._construct_base_samples(posterior=posterior)
         self.assertTrue(sampler.base_samples.shape == torch.Size((4, 128)))
         self.assertTrue(
-            sampler.base_samples.device.type == posterior.device.type == self.device.type
+            sampler.base_samples.device.type
+            == posterior.device.type
+            == self.device.type
         )
         base_samples = sampler.base_samples
         sampler = IndexSampler(sample_shape=torch.Size((4, 128)), seed=42)

--- a/test/sampling/test_index_sampler.py
+++ b/test/sampling/test_index_sampler.py
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.sampling.index_sampler import IndexSampler
 from botorch.utils.testing import BotorchTestCase
-from botorch.posteriors.ensemble import EnsemblePosterior
 
 
 class TestIndexSampler(BotorchTestCase):

--- a/test/sampling/test_index_sampler.py
+++ b/test/sampling/test_index_sampler.py
@@ -14,7 +14,7 @@ class TestIndexSampler(BotorchTestCase):
     def test_deterministic_sampler(self):
         # Basic usage.
         posterior = EnsemblePosterior(
-            values=torch.randn(torch.Size((50, 1, 1, 16))).to(self.device)
+            values=torch.randn(torch.Size((50, 16, 1, 1))).to(self.device)
         )
         sampler = IndexSampler(sample_shape=torch.Size((128,)))
         samples = sampler(posterior)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

As discussed in https://github.com/pytorch/botorch/issues/1064, this is an attempt to add a `EnsemblePosterior` to botorch, that could be used for example by NN ensembles.

I have problems with implementing `rsample` properly. I think my current implementation is not correct, it is based on `DeterministicPosterior`, but I think we should sample directly solutions from the individual predictions of the ensemble. But I do not know how to interprete `sample_shape` in this context.

As sampler, I registered the `StochasticSampler` for the new posterior class. But also, there I am not sure if this is correct. Furthermore, I have another question regarding `StochasticSampler`. It is stated in the docstring of `StochasticSampler` that it should not be used in combination with `optimize_acqf`. But `StochasticSampler` is assigned to the `DeterministicPosterior`. Does it mean that one cannot use a `ModelList` consisting of a `DeterministicModel` and GPs in combination with `optimize_acqf`? 

@Balandat: any suggestions on this?


### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests. Not yet implemented/finished as it is still WIP.

