### PR TITLE
Fix pickle error in TorchPosterior

### DIFF
--- a/botorch/posteriors/torch.py
+++ b/botorch/posteriors/torch.py
@@ -84,7 +84,7 @@ class TorchPosterior(Posterior):
         Pickle uses `__get/setstate__` to serialize / deserialize the objects.
         Since we define `__getattr__` above, it takes precedence over these
         methods, and we end up in an infinite loop unless we also define
-        `__getattr__` and `__setattr__`.
+        `__getstate__` and `__setstate__`.
         """
         return self.__dict__
 

--- a/botorch/posteriors/torch.py
+++ b/botorch/posteriors/torch.py
@@ -79,7 +79,13 @@ class TorchPosterior(Posterior):
         return getattr(self.distribution, name)
 
     def __getstate__(self) -> Dict[str, Any]:
-        r"""A minimal utility to support pickle protocol."""
+        r"""A minimal utility to support pickle protocol.
+
+        Pickle uses `__get/setstate__` to serialize / deserialize the objects.
+        Since we define `__getattr__` above, it takes precedence over these
+        methods, and we end up in an infinite loop unless we also define
+        `__getattr__` and `__setattr__`.
+        """
         return self.__dict__
 
     def __setstate__(self, d: Dict[str, Any]) -> None:

--- a/botorch/posteriors/torch.py
+++ b/botorch/posteriors/torch.py
@@ -10,7 +10,7 @@ Posterior module to be used with PyTorch distributions.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import torch
 from botorch.posteriors.posterior import Posterior

--- a/botorch/posteriors/torch.py
+++ b/botorch/posteriors/torch.py
@@ -78,6 +78,14 @@ class TorchPosterior(Posterior):
         """
         return getattr(self.distribution, name)
 
+    def __getstate__(self) -> Dict[str, Any]:
+        r"""A minimal utility to support pickle protocol."""
+        return self.__dict__
+
+    def __setstate__(self, d: Dict[str, Any]) -> None:
+        r"""A minimal utility to support pickle protocol."""
+        self.__dict__ = d
+
     def quantile(self, value: Tensor) -> Tensor:
         r"""Compute quantiles of the distribution.
 

--- a/test/posteriors/test_torch_posterior.py
+++ b/test/posteriors/test_torch_posterior.py
@@ -8,7 +8,6 @@ import os
 import tempfile
 import unittest
 
-
 import torch
 from botorch.posteriors.torch import TorchPosterior
 from botorch.utils.testing import BotorchTestCase

--- a/test/posteriors/test_torch_posterior.py
+++ b/test/posteriors/test_torch_posterior.py
@@ -4,7 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import tempfile
+import unittest
+
 
 import torch
 from botorch.posteriors.torch import TorchPosterior
@@ -57,6 +60,7 @@ class TestTorchPosterior(BotorchTestCase):
             )
             self.assertAllClose(posterior.density(q_value), expected)
 
+    @unittest.skipIf(os.name == "nt", "Pickle test is not supported on Windows.")
     def test_pickle(self) -> None:
         for dtype in (torch.float, torch.double):
             tkwargs = {"dtype": dtype, "device": self.device}


### PR DESCRIPTION
## Motivation

Fixes #1639. The issue was that pickle uses `__getstate__` and `__setstate__` to save / load the objects. In `TorchPosterior`, `__getattr__` was taking precedence, so instead of calling `TorchPosterior.__set/getstate__` it was calling `self.distribution.__set/getstate__`. While loading the posterior, we start with a `TorchPosterior` that does not have any attributes --including `distribution`--, so calling `self.distribution` was leading to an infinite loop of calling `TorchPosterior` with `name=distribution` (since it calls `getattr(self.distribution, name)`).

## Test Plan

Units.
