### PR TITLE
Warn when optimizer kwargs are being ignored in BoTorch optim utils `_filter_kwargs`

### DIFF
--- a/botorch/optim/utils/common.py
+++ b/botorch/optim/utils/common.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from inspect import signature
 from logging import debug as logging_debug
 from typing import Any, Callable, Optional, Tuple
-from warnings import warn_explicit, WarningMessage
+from warnings import warn, warn_explicit, WarningMessage
 
 import numpy as np
 from linear_operator.utils.errors import NanError, NotPSDError
@@ -29,7 +29,15 @@ DEFAULT = _TDefault()
 def _filter_kwargs(function: Callable, **kwargs: Any) -> Any:
     r"""Filter out kwargs that are not applicable for a given function.
     Return a copy of given kwargs dict with only the required kwargs."""
-    return {k: v for k, v in kwargs.items() if k in signature(function).parameters}
+    allowed_params = signature(function).parameters
+    removed = {k for k in kwargs.keys() if k not in allowed_params}
+    if len(removed) > 0:
+        warn(
+            f"Keyword arguments {list(removed)} will be ignored because they are"
+            f" not allowed parameters for function {function.__name__}. Allowed "
+            f"parameters are {list(allowed_params.keys())}."
+        )
+    return {k: v for k, v in kwargs.items() if k not in removed}
 
 
 def _handle_numerical_errors(

--- a/test/optim/utils/test_common.py
+++ b/test/optim/utils/test_common.py
@@ -10,12 +10,31 @@ from functools import partial
 from warnings import catch_warnings, warn
 
 import numpy as np
-from botorch.optim.utils import _handle_numerical_errors, _warning_handler_template
+from botorch.optim.utils import (
+    _filter_kwargs,
+    _handle_numerical_errors,
+    _warning_handler_template,
+)
 from botorch.utils.testing import BotorchTestCase
 from linear_operator.utils.errors import NanError, NotPSDError
 
 
 class TestUtilsCommon(BotorchTestCase):
+    def test__filter_kwargs(self) -> None:
+        def mock_adam(params, lr: float = 0.001) -> None:
+            return  # pragma: nocover
+
+        kwargs = {"lr": 0.01, "maxiter": 3000}
+        with catch_warnings(record=True) as ws:
+            valid_kwargs = _filter_kwargs(mock_adam, **kwargs)
+        expected_msg = (
+            "Keyword arguments ['maxiter'] will be ignored because they are not"
+            " allowed parameters for function mock_adam. Allowed parameters are "
+            "['params', 'lr']."
+        )
+        self.assertEqual(expected_msg, str(ws[0].message))
+        self.assertEqual(set(valid_kwargs.keys()), {"lr"})
+
     def test_handle_numerical_errors(self):
         x = np.zeros(1, dtype=np.float64)
 


### PR DESCRIPTION
Summary: The HOGP tutorial was using kwargs 'maxiter' and 'disp' that were being silently ignored since the Adam optimizer doesn't take those arguments.

Reviewed By: saitcakmak

Differential Revision: D42729349

