### PR TITLE
Upload tutorials artifiact

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -125,15 +125,10 @@ jobs:
       publish_versioned_website: false
 
   run_tutorials:
-    steps:
-      - name: Run tutorials without smoke test on latest PyTorch / GPyTorch / Ax
-        uses: ./.github/workflows/reusable_tutorials.yml
-        with:
-          smoke_test: false
-          use_stable_pytorch_gpytorch: false
-          use_stable_ax: false
-      - name: Upload performance info artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: tutorials-report
-          path: tutorials_actions_artifacts/report.csv
+    name: Run tutorials without smoke test on latest PyTorch / GPyTorch / Ax
+    uses: ./.github/workflows/reusable_tutorials.yml
+    with:
+      smoke_test: false
+      use_stable_pytorch_gpytorch: false
+      use_stable_ax: false
+      nightly_cron: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -131,4 +131,4 @@ jobs:
       smoke_test: false
       use_stable_pytorch_gpytorch: false
       use_stable_ax: false
-      nightly_cron: true
+      upload_artifact: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -125,9 +125,15 @@ jobs:
       publish_versioned_website: false
 
   run_tutorials:
-    name: Run tutorials without smoke test on latest PyTorch / GPyTorch / Ax
-    uses: ./.github/workflows/reusable_tutorials.yml
-    with:
-      smoke_test: false
-      use_stable_pytorch_gpytorch: false
-      use_stable_ax: false
+    steps:
+      - name: Run tutorials without smoke test on latest PyTorch / GPyTorch / Ax
+        uses: ./.github/workflows/reusable_tutorials.yml
+        with:
+          smoke_test: false
+          use_stable_pytorch_gpytorch: false
+          use_stable_ax: false
+      - name: Upload performance info artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: tutorials-report
+          path: tutorials_actions_artifacts/report.csv

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -81,3 +81,9 @@ jobs:
       name: Run tutorials without smoke test
       run: |
         python scripts/run_tutorials.py -p "$(pwd)"
+    - if: ${{ nightly_cron }}
+      name: Upload performance info artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: tutorials-report
+        path: tutorials_actions_artifacts/report.csv

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -88,7 +88,7 @@ jobs:
       name: Run tutorials without smoke test
       run: |
         python scripts/run_tutorials.py -p "$(pwd)"
-    - if: ${{ upload_artifact }}
+    - if: ${{ inputs.upload_artifact }}
       name: Upload performance info artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -12,6 +12,9 @@ on:
       use_stable_ax:
         required: true
         type: boolean
+      upload_artifact:
+        required: true
+        type: boolean
   workflow_call:
     inputs:
       smoke_test:
@@ -23,6 +26,10 @@ on:
         type: boolean
         default: false
       use_stable_ax:
+        required: false
+        type: boolean
+        default: false
+      upload_artifact:
         required: false
         type: boolean
         default: false
@@ -81,7 +88,7 @@ jobs:
       name: Run tutorials without smoke test
       run: |
         python scripts/run_tutorials.py -p "$(pwd)"
-    - if: ${{ nightly_cron }}
+    - if: ${{ upload_artifact }}
       name: Upload performance info artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -89,6 +89,7 @@ jobs:
       smoke_test: false
       use_stable_pytorch_gpytorch: true
       use_stable_ax: false
+      nightly_cron: false
 
   run_tutorials_stable_w_stable_ax:
     name: Run tutorials without smoke test on min req. versions of PyTorch & GPyTorch and stable Ax
@@ -97,3 +98,4 @@ jobs:
       smoke_test: false
       use_stable_pytorch_gpytorch: true
       use_stable_ax: true
+      nightly_cron: false

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -89,7 +89,6 @@ jobs:
       smoke_test: false
       use_stable_pytorch_gpytorch: true
       use_stable_ax: false
-      nightly_cron: false
 
   run_tutorials_stable_w_stable_ax:
     name: Run tutorials without smoke test on min req. versions of PyTorch & GPyTorch and stable Ax
@@ -98,4 +97,3 @@ jobs:
       smoke_test: false
       use_stable_pytorch_gpytorch: true
       use_stable_ax: true
-      nightly_cron: false

--- a/.github/workflows/tutorials_smoke_test_on_pr_and_push.yml
+++ b/.github/workflows/tutorials_smoke_test_on_pr_and_push.yml
@@ -16,4 +16,3 @@ jobs:
       smoke_test: true
       use_stable_pytorch_gpytorch: false
       use_stable_ax: false
-      nightly_cron: false

--- a/.github/workflows/tutorials_smoke_test_on_pr_and_push.yml
+++ b/.github/workflows/tutorials_smoke_test_on_pr_and_push.yml
@@ -16,3 +16,4 @@ jobs:
       smoke_test: true
       use_stable_pytorch_gpytorch: false
       use_stable_ax: false
+      nightly_cron: false

--- a/tutorials_actions_artifacts/README.md
+++ b/tutorials_actions_artifacts/README.md
@@ -1,0 +1,1 @@
+Uploaded artifacts from GitHub Actions


### PR DESCRIPTION
# Motivation
We record whether the tutorials failed, how long they took, and how much memory they used in the logs. However, we are not using this data effectively because it's hard to access systematically. With this PR, we will
* write output from each tutorial that runs in the nightly cron to a csv
* upload the csv to a folder in the repo

# Test Plan
[x] Nightly cron run passes https://github.com/pytorch/botorch/actions/runs/4116564694
[ ] Not sure how to test the csv upload