### PR TITLE
Require torch >= 1.12

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - setuptools
     - setuptools_scm
   run:
-    - pytorch >=1.11
+    - pytorch >=1.12
     - gpytorch ==1.9.1
     - linear_operator ==0.3.0
     - scipy

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Optimization simply use Ax.
 
 **Installation Requirements**
 - Python >= 3.8
-- PyTorch >= 1.11
+- PyTorch >= 1.12
 - gpytorch == 1.9.1
 - linear_operator == 0.3.0
 - pyro-ppl >= 1.8.4

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - gpytorch
   - conda-forge
 dependencies:
-  - pytorch>=1.11
+  - pytorch>=1.12
   - gpytorch==1.9.1
   - linear_operator==0.3.0
   - scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 multipledispatch
 scipy
-torch>=1.11
+torch>=1.12
 pyro-ppl>=1.8.4
 gpytorch==1.9.1
 linear_operator==0.3.0


### PR DESCRIPTION
Summary: In `test/utils/probability/test_utils.py`, we compare `log_ndtr` implementation with `torch.special.log_ndtr`, which is was introduced in 1.12.

Reviewed By: esantorella

Differential Revision: D43545624

