### PR TITLE
[RFC] Use papermill for running tutorials

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -10,16 +10,13 @@ import argparse
 import datetime
 import os
 import subprocess
-import tempfile
 import time
 from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Any, Dict, Optional, Tuple
 
-import nbformat
 import pandas as pd
 from memory_profiler import memory_usage
-from nbconvert import PythonExporter
 
 
 IGNORE = {  # ignored in smoke tests and full runs
@@ -65,31 +62,16 @@ def get_output_file_path(smoke_test: bool) -> str:
     return fname
 
 
-def parse_ipynb(file: Path) -> str:
-    with open(file, "r") as nb_file:
-        nb_str = nb_file.read()
-    nb = nbformat.reads(nb_str, nbformat.NO_CONVERT)
-    exporter = PythonExporter()
-    script, _ = exporter.from_notebook_node(nb)
-    return script
-
-
-def run_script(script: str, env: Optional[Dict[str, str]] = None) -> None:
-    # need to keep the file around & close it so subprocess does not run into I/O issues
-    with tempfile.NamedTemporaryFile(delete=False) as tf:
-        tf_name = tf.name
-        with open(tf_name, "w") as tmp_script:
-            tmp_script.write(script)
+def run_script(tutorial: Path, env: Optional[Dict[str, str]] = None) -> None:
     if env is not None:
         env = {**os.environ, **env}
     run_out = subprocess.run(
-        ["ipython", tf_name],
+        ["papermill", tutorial],
         capture_output=True,
         text=True,
         env=env,
         timeout=1800,  # Count runtime >30 minutes as a failure
     )
-    os.remove(tf_name)
     return run_out
 
 
@@ -100,13 +82,12 @@ def run_tutorial(
     Runs the tutorial in a subprocess, catches any raised errors and returns
     them as a string, and returns runtime and memory information as a dict.
     """
-    script = parse_ipynb(tutorial)
     tic = time.monotonic()
     print(f"Running tutorial {tutorial.name}.")
     env = {"SMOKE_TEST": "True"} if smoke_test else None
     try:
         mem_usage, run_out = memory_usage(
-            (run_script, (script,), {"env": env}), retval=True, include_children=True
+            (run_script, (tutorial,), {"env": env}), retval=True, include_children=True
         )
     except subprocess.TimeoutExpired:
         error = f"Tutorial {tutorial.name} exceeded the maximum runtime of 30 minutes."
@@ -204,7 +185,6 @@ def run_tutorials(
             df.loc[tutorial.name, "ran_successfully"] = True
             for k in ["runtime", "start_mem", "max_mem"]:
                 df.loc[tutorial.name, k] = performance_info[k]
-        print(df)
 
     if num_errors > 0:
         raise RuntimeError(

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ TUTORIALS_REQUIRES = [
     "kaleido",
     "matplotlib",
     "memory_profiler",
+    "papermill",
     "pykeops",
     "torchvision",
 ]


### PR DESCRIPTION
## Motivation

We are using nbconvert to run tutorials. nbconvert is not really made for this use case, but papermill is, so we have some handwritten LOC than can be handled by papermill. With papermill, we can go a bit further and use SMOKE_TEST as a [parameter](https://papermill.readthedocs.io/en/latest/usage-parameterize.html) rather than an environment variable. That would make it easy for people to work with the tutorials as notebooks.

## Test Plan

Ran tutorials locally and made sure smoke-test flag was getting used appropriately.

## Related pull requests

Enabling papermill will make #1703, which automates running a notebook, a bit easier.