### PR TITLE
[RFC] Use papermill for running tutorials

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ TUTORIALS_REQUIRES = [
     "kaleido",
     "matplotlib",
     "memory_profiler",
+    "papermill",
     "pykeops",
     "torchvision",
 ]


### PR DESCRIPTION
## Motivation

We are using nbconvert to run tutorials. nbconvert is not really made for this use case, but papermill is, so we have some handwritten code than can be handled by papermill. With papermill, we can go a bit further and use SMOKE_TEST as a [parameter](https://papermill.readthedocs.io/en/latest/usage-parameterize.html) rather than an environment variable. That would make it easy for people to work with the tutorials as notebooks.

## Test Plan

Ran tutorials locally and made sure smoke-test flag was getting used appropriately.

## Related pull requests

Enabling papermill will make #1703, which automates running a notebook, a bit easier.
