### PR TITLE
[Easy] 5-minute timeout for smoke test tutorials

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -116,7 +116,7 @@ def run_tutorial(
     except subprocess.TimeoutExpired:
         error = (
             f"Tutorial {tutorial.name} exceeded the maximum runtime of "
-            "{timeout_minutes} minutes."
+            f"{timeout_minutes} minutes."
         )
         return error, {}
 

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -74,7 +74,9 @@ def parse_ipynb(file: Path) -> str:
     return script
 
 
-def run_script(script: str, env: Optional[Dict[str, str]] = None) -> None:
+def run_script(
+    script: str, timeout_minutes: int, env: Optional[Dict[str, str]] = None
+) -> None:
     # need to keep the file around & close it so subprocess does not run into I/O issues
     with tempfile.NamedTemporaryFile(delete=False) as tf:
         tf_name = tf.name
@@ -87,7 +89,7 @@ def run_script(script: str, env: Optional[Dict[str, str]] = None) -> None:
         capture_output=True,
         text=True,
         env=env,
-        timeout=1800,  # Count runtime >30 minutes as a failure
+        timeout=timeout_minutes * 60,
     )
     os.remove(tf_name)
     return run_out
@@ -100,16 +102,22 @@ def run_tutorial(
     Runs the tutorial in a subprocess, catches any raised errors and returns
     them as a string, and returns runtime and memory information as a dict.
     """
+    timeout_minutes = 5 if smoke_test else 30
     script = parse_ipynb(tutorial)
     tic = time.monotonic()
     print(f"Running tutorial {tutorial.name}.")
     env = {"SMOKE_TEST": "True"} if smoke_test else None
     try:
         mem_usage, run_out = memory_usage(
-            (run_script, (script,), {"env": env}), retval=True, include_children=True
+            (run_script, (script, timeout_minutes), {"env": env}),
+            retval=True,
+            include_children=True,
         )
     except subprocess.TimeoutExpired:
-        error = f"Tutorial {tutorial.name} exceeded the maximum runtime of 30 minutes."
+        error = (
+            f"Tutorial {tutorial.name} exceeded the maximum runtime of "
+            "{timeout_minutes} minutes."
+        )
         return error, {}
 
     try:
@@ -204,7 +212,6 @@ def run_tutorials(
             df.loc[tutorial.name, "ran_successfully"] = True
             for k in ["runtime", "start_mem", "max_mem"]:
                 df.loc[tutorial.name, k] = performance_info[k]
-        print(df)
 
     if num_errors > 0:
         raise RuntimeError(


### PR DESCRIPTION
## Motivation

Currently, all tutorials time out at 30 minutes. We want smoke test tutorials to take much less time than that, and currently they all run in under 3.5 minutes, and most run much faster than that (see [here](https://github.com/pytorch/botorch/blob/4f80c9b8f97244a01f9b138c2180e41c54ac65f3/notebooks/tutorials_performance_tracking.ipynb)). As we  work to get more tutorials online, it would be good to a have a clear idea of what is fast enough for a smoke-test tutorial run.

## Test Plan

Checked that it ran locally; unit tests