### PR TITLE
Speed up MOMF tutorial by not replicating optimizations and re-enable it in OSS CI

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -30,7 +30,6 @@ IGNORE_ALWAYS = {  # ignored in smoke tests and full runs
 RUN_IF_SMOKE_TEST_IGNORE_IF_STANDARD = {  # only used in smoke tests
     "thompson_sampling.ipynb",  # very slow without KeOps + GPU
     "composite_mtbo.ipynb",  # TODO: very slow, figure out if we can make it faster
-    "Multi_objective_multi_fidelity_BO.ipynb",  # TODO: very slow, speed up
     # Causing the tutorials to crash when run without smoke test. Likely OOM.
     # Fix planned.
     "constraint_active_search.ipynb",

--- a/tutorials/Multi_objective_multi_fidelity_BO.ipynb
+++ b/tutorials/Multi_objective_multi_fidelity_BO.ipynb
@@ -66,10 +66,10 @@
       "window_display": false
     },
     "captumWidgetMessage": {},
-    "last_server_session_id": "848e6d1a-4b12-4dee-a635-3ef845e077e0",
-    "last_kernel_id": "7e8af735-5d56-4716-8549-522bc4c7e2f3",
+    "last_server_session_id": "7d34e865-49dc-488a-a0bc-0b0a171cbf3f",
+    "last_kernel_id": "76f15f75-b06c-41b9-ab13-b7249a2b2e22",
     "last_base_url": "https://bento.edge.x2p.facebook.net/",
-    "last_msg_id": "58b07569-46a5521d982f6e80c023abd6_740",
+    "last_msg_id": "ca397f66-c4b80ded698f4d013e75775e_242",
     "outputWidgetContext": {}
   },
   "nbformat": 4,
@@ -92,11 +92,11 @@
         "showInput": false
       },
       "source": [
-        "In this tutorial notebook we demonstrate how to perform multi-objective multi-fidelity (MOMF) optimization in BoTORCH as described in [1]. The main concept in MOMF is introducing a 'fidelity objective' that is optimized along with the problem objectives. This fidelity objective can be thought of as a trust objective that rewards the optimization when going to higher fidelity. This emulates a real world scenario where high fidelity data may sometime yield similar values for other objectives but is still considered more trustworthy. Thus the MOMF explicitly optimizes for getting more trustworthy data while taking into account the higher computational costs associated with it.\n",
+        "In this tutorial notebook we demonstrate how to perform multi-objective multi-fidelity (MOMF) optimization in BoTorch as described in [1]. The main concept in MOMF is a \"fidelity objective\" that is optimized along with the problem objectives. This fidelity objective can be thought of as a trust objective that rewards the optimization when going to higher fidelity. This emulates a real-world scenario where high fidelity data may sometimes yield similar values for other objectives but is still considered more trustworthy. Thus the MOMF explicitly optimizes for getting more trustworthy data while taking into account the higher computational costs associated with it.\n",
         "\n",
-        "We will optimize a synthetic function that is a modified multi-fidelity Branin-Currin. This is a 3 x 2 dimensional problem with one of the input dimension being the fidelity. For the MOMF this results in a 3 x 3 optimization since it also takes into account the fidelity objective. In this case the fidelity objective is taken to be a linear function of fidelity, $ f(s)=s$, where $s$ is the fidelity. The MOMF algorithm can accept any discrete or continuous cost functions as an input. In this example, we choose an exponential dependency of the form $C(s)=\\exp(s)$. The goal of the optimization is to find the Pareto front, which is a trade-off solution set for Multi-objective problems, at the highest fidelity. \n",
+        "We will optimize a synthetic function that is a modified multi-fidelity Branin-Currin. This is a 3 x 2 dimensional problem with one of the input dimension being the fidelity. For the MOMF, this results in a 3 x 3 optimization since it also takes the fidelity objective into account. In this case the fidelity objective is a linear function of fidelity, $ f(s)=s$, where $s$ is the fidelity. The MOMF algorithm can accept any discrete or continuous cost functions as an input. In this example, we choose an exponential dependency of the form $C(s)=\\exp(s)$. The goal of the optimization is to find the Pareto front, which is a trade-off solution set for Multi-objective problems, at the highest fidelity. \n",
         "\n",
-        "In the second part of this tutorial we compare the method with a multi-objective only optimization using qEHVI [2] with q set to 1 (note that MOMF also supports q>1 if the underlying MO acquisition function supports it). The MO-only optimization runs only at the highest fidelity while MOMF makes use of lower fidelity data to estimate the Pareto front at the highest fidelity.\n",
+        "In the second part of this tutorial, we compare the method with a multi-objective only optimization using qEHVI [2] with q set to 1 (note that MOMF also supports q>1 if the underlying MO acquisition function supports it). The MO-only optimization runs only at the highest fidelity while MOMF makes use of lower fidelity data to estimate the Pareto front at the highest fidelity.\n",
         "\n",
         "[1] [Irshad, Faran, Stefan Karsch, and Andreas Döpp. \"Expected hypervolume improvement for simultaneous multi-objective and multi-fidelity optimization.\" arXiv preprint arXiv:2112.13901 (2021).](https://arxiv.org/abs/2112.13901)\n",
         "\n",
@@ -106,18 +106,18 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "9a7d5d13-9548-4c87-8c85-117e4781337a",
+        "originalKey": "b8c55b46-3934-4389-a48b-9a4a1d0f7008",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "9a7d5d13-9548-4c87-8c85-117e4781337a",
+        "requestMsgId": "d0d48506-6d24-4a4b-a27a-49366b07e0f2",
         "customOutput": null,
-        "executionStartTime": 1677718872876,
-        "executionStopTime": 1677718874462
+        "executionStartTime": 1677807565825,
+        "executionStopTime": 1677807567435
       },
       "source": [
         "import os\n",
-        "from typing import Any, Dict, Optional, Tuple\n",
+        "from typing import Any, Callable, Dict, Optional, Tuple\n",
         "\n",
         "import matplotlib.pyplot as plt\n",
         "import numpy as np\n",
@@ -129,14 +129,14 @@
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "I0301 170113.129 _utils_internal.py:179] NCCL_DEBUG env var is set to None\n"
+            "I0302 173926.276 _utils_internal.py:179] NCCL_DEBUG env var is set to None\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "I0301 170113.131 _utils_internal.py:188] NCCL_DEBUG is INFO from /etc/nccl.conf\n"
+            "I0302 173926.277 _utils_internal.py:197] NCCL_DEBUG is forced to WARN from None\n"
           ]
         }
       ]
@@ -155,14 +155,14 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "ab903ec3-1743-4b98-ab82-c9fc1d7fc66d",
+        "originalKey": "9080711e-1447-4d2a-b2cd-7ebcc65d3821",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "ab903ec3-1743-4b98-ab82-c9fc1d7fc66d",
+        "requestMsgId": "89df896b-bc40-4885-93eb-e1c5a2a8d1a7",
         "customOutput": null,
-        "executionStartTime": 1677718874597,
-        "executionStopTime": 1677718874603
+        "executionStartTime": 1677807567557,
+        "executionStopTime": 1677807567566
       },
       "source": [
         "tkwargs = {  # Tkwargs is a dictionary contaning data about data type and data device\n",
@@ -181,18 +181,18 @@
         "showInput": false
       },
       "source": [
-        "### Here we define different variables that define the problem setting and optimization settings"
+        "### Define the problem and optimization settings"
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "b76711ae-a742-44fa-b8b7-5da3f86db1cd",
+        "originalKey": "eb357e02-e811-425c-a4f9-2c00d15c2b0f",
         "collapsed": false,
-        "requestMsgId": "b76711ae-a742-44fa-b8b7-5da3f86db1cd",
+        "requestMsgId": "cc866d6c-1875-4d42-b4ff-114864b138ff",
         "customOutput": null,
-        "executionStartTime": 1677718874986,
-        "executionStopTime": 1677718880334,
+        "executionStartTime": 1677807567751,
+        "executionStopTime": 1677807568470,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -200,26 +200,26 @@
         "from botorch.test_functions.multi_objective_multi_fidelity import MOMFBraninCurrin\n",
         "\n",
         "BC = MOMFBraninCurrin(negate=True)\n",
-        "dim_x = BC.dim  # Input Dimension for MO only optimization\n",
-        "dim_yMO = BC.num_objectives  # Output Dimension for MO only optimization\n",
+        "dim_x = BC.dim  # Input Dimension for MO-only optimization\n",
+        "dim_yMO = BC.num_objectives  # Output Dimension for MO-only optimization\n",
         "dim_xMO = dim_x - 1  # Input Dimension for MOMF optimization\n",
         "dim_y = dim_yMO + 1  # Output Dimesnion for MOMF optimization\n",
         "\n",
         "ref_pointMO = [0] * dim_xMO  # Reference point for MO only Hypervolume calculation\n",
         "ref_point = [0] * dim_x  # Reference point for MOMF Hypervolume calculation\n",
         "\n",
-        "n_TRIALS = 3\n",
-        "BATCH_SIZE = 2  # For Batch-optimization BATCH_SIZE should be greater than 1\n",
+        "BATCH_SIZE = 2  # For batch optimization, BATCH_SIZE should be greater than 1\n",
         "n_BATCH = 5 if SMOKE_TEST else 30  # Number of iterations within one optimization loop\n",
         "n_INIT = 5  # Number of initial points for MOMF\n",
-        "n_INITMO = 1  # Number of initial points for MO only optimization\n",
-        "MC_SAMPLES = 8 if SMOKE_TEST else 128  # Number of Monte Carlo samples\n",
+        "n_INITMO = 1  # Number of initial points for MO-only optimization\n",
+        "# Number of Monte Carlo samples, used to \n",
+        "MC_SAMPLES = 8 if SMOKE_TEST else 128\n",
         "# Number of restart points for multi-start optimization\n",
         "NUM_RESTARTS = 2 if SMOKE_TEST else 10\n",
         "# Number of raw samples for initial point selection heuristic\n",
         "RAW_SAMPLES = 4 if SMOKE_TEST else 512\n",
         "\n",
-        "# Bounds for MO only optimization\n",
+        "# Bounds for MO-only optimization\n",
         "standard_boundsMO = torch.tensor([[0.0] * dim_xMO, [1.0] * dim_xMO], **tkwargs)\n",
         "# Bounds for MOMF optimization\n",
         "standard_bounds = torch.tensor([[0.0] * dim_x, [1.0] * dim_x], **tkwargs)"
@@ -242,12 +242,12 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "59d94c16-62af-47ce-9c72-e5734d517271",
+        "originalKey": "1287a6f8-a45e-4f29-b879-f6fc96451ae3",
         "collapsed": false,
-        "requestMsgId": "59d94c16-62af-47ce-9c72-e5734d517271",
+        "requestMsgId": "fc4ea43c-236b-442f-94e6-e74b87bb2084",
         "customOutput": null,
-        "executionStartTime": 1677718880658,
-        "executionStopTime": 1677718880672
+        "executionStartTime": 1677807568632,
+        "executionStopTime": 1677807568636
       },
       "source": [
         "def fid_obj(X: torch.Tensor) -> torch.Tensor:\n",
@@ -287,26 +287,24 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "b12679e2-f324-4bde-8698-cf8af5007720",
+        "originalKey": "b4cddf01-d91f-44a9-86be-fbe1a0f5d25d",
         "collapsed": false,
-        "requestMsgId": "b12679e2-f324-4bde-8698-cf8af5007720",
+        "requestMsgId": "7379c6f5-277b-49b1-a009-b39b8c3d8704",
         "customOutput": null,
-        "executionStartTime": 1677718880785,
-        "executionStopTime": 1677718880795
+        "executionStartTime": 1677807568776,
+        "executionStopTime": 1677807568807
       },
       "source": [
-        "exp_arg = torch.tensor(4, **tkwargs)\n",
-        "\n",
-        "\n",
-        "def cost_func(x, A):\n",
+        "def cost_func(x):\n",
         "    \"\"\"A simple exponential cost function.\"\"\"\n",
-        "    val = torch.exp(A * x)\n",
+        "    exp_arg = torch.tensor(4, **tkwargs)\n",
+        "    val = torch.exp(exp_arg * x)\n",
         "    return val\n",
         "\n",
         "\n",
         "# Displaying the min and max costs for this optimization\n",
-        "print(f\"Min Cost: {cost_func(0, exp_arg)}\")\n",
-        "print(f\"Max Cost: {cost_func(1, exp_arg)}\")\n",
+        "print(f\"Min Cost: {cost_func(0)}\")\n",
+        "print(f\"Max Cost: {cost_func(1)}\")\n",
         "\n",
         "\n",
         "def cost_callable(X: torch.Tensor) -> torch.Tensor:\n",
@@ -321,7 +319,7 @@
         "        from fidelity dimension using cost_func.\n",
         "    \"\"\"\n",
         "\n",
-        "    cost = cost_func(torch.flatten(X), exp_arg).reshape(X.shape)\n",
+        "    cost = cost_func(torch.flatten(X)).reshape(X.shape)\n",
         "    cost = cost[..., [-1]]\n",
         "    return cost"
       ],
@@ -351,12 +349,12 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "315ade09-5ecc-4473-9a42-50940dea6d79",
+        "originalKey": "e4c13423-3541-4786-ae34-f7182f739c4b",
         "collapsed": false,
-        "requestMsgId": "315ade09-5ecc-4473-9a42-50940dea6d79",
+        "requestMsgId": "bbf454ec-3c11-4a83-a34e-f0a0dbd740b0",
         "customOutput": null,
-        "executionStartTime": 1677718880908,
-        "executionStopTime": 1677718880914
+        "executionStartTime": 1677807568972,
+        "executionStopTime": 1677807568982
       },
       "source": [
         "from botorch.models.gp_regression import SingleTaskGP\n",
@@ -364,20 +362,20 @@
         "from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood\n",
         "\n",
         "\n",
-        "def gen_init_data(dim_x, points) -> Tuple[torch.Tensor, torch.Tensor]:\n",
+        "def gen_init_data(dim_x: int, n_points: int) -> Tuple[torch.Tensor, torch.Tensor]:\n",
         "    \"\"\"\n",
         "    Generates training data with Fidelity dimension sampled\n",
         "    from a probability distribution that depends on Cost function\n",
         "    \"\"\"\n",
-        "    train_x = torch.rand(points, dim_x, **tkwargs)\n",
+        "    train_x = torch.rand(n_points, dim_x, **tkwargs)\n",
         "    # Array from which fidelity values are sampled\n",
         "    fid_samples = torch.linspace(0, 1, 101, **tkwargs)\n",
         "    # Probability calculated from the Cost function\n",
-        "    prob = 1 / cost_func(fid_samples, exp_arg)\n",
+        "    prob = 1 / cost_func(fid_samples)\n",
         "    # Normalizing\n",
         "    prob = prob / torch.sum(prob)\n",
         "    # Generating indices to choose fidelity samples\n",
-        "    idx = prob.multinomial(num_samples=points, replacement=True)\n",
+        "    idx = prob.multinomial(num_samples=n_points, replacement=True)\n",
         "    train_x[:, -1] = fid_samples[idx]\n",
         "    # Calls the objective wrapper to generate train_obj\n",
         "    train_obj = get_objective(train_x)\n",
@@ -415,18 +413,19 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "ccb1d811-6315-498b-9fa7-1f900941daec",
+        "originalKey": "2ab73c8f-09b9-43f2-9f20-3bf2d914dce7",
         "collapsed": false,
-        "requestMsgId": "ccb1d811-6315-498b-9fa7-1f900941daec",
+        "requestMsgId": "b290d7b7-4b1c-4520-b673-d9429da6adfb",
         "customOutput": null,
-        "executionStartTime": 1677718881300,
-        "executionStopTime": 1677718881312,
+        "executionStartTime": 1677807569140,
+        "executionStopTime": 1677807569178,
         "code_folding": [],
         "hidden_ranges": []
       },
       "source": [
         "from botorch.acquisition.multi_objective.multi_fidelity import MOMF\n",
         "from botorch.optim.optimize import optimize_acqf\n",
+        "from botorch.sampling.normal import SobolQMCNormalSampler\n",
         "from botorch.utils.multi_objective.box_decompositions.non_dominated import (\n",
         "    FastNondominatedPartitioning,\n",
         ")\n",
@@ -434,13 +433,13 @@
         "\n",
         "\n",
         "def optimize_MOMF_and_get_obs(\n",
-        "    model,\n",
-        "    train_obj,\n",
-        "    sampler,\n",
-        "    ref_point,\n",
-        "    standard_bounds,\n",
-        "    BATCH_SIZE,\n",
-        "    cost_call,\n",
+        "    model: SingleTaskGP,\n",
+        "    train_obj: torch.Tensor,\n",
+        "    sampler: SobolQMCNormalSampler,\n",
+        "    ref_point: torch.Tensor,\n",
+        "    standard_bounds: torch.Tensor,\n",
+        "    BATCH_SIZE: int,\n",
+        "    cost_call: Callable[[torch.Tensor], torch.Tensor],\n",
         "):\n",
         "    \"\"\"\n",
         "    Wrapper to call MOMF and optimizes it in a sequential greedy\n",
@@ -483,7 +482,7 @@
       "source": [
         "### Running MOMF optimization \n",
         "\n",
-        "We run a single trial of 30 iterations to optimize the multi-fidelity versions of the Branin-Currin functions. The optimization loop works in the following sequence. \n",
+        "We run 30 iterations to optimize the multi-fidelity versions of the Branin-Currin functions. The optimization loop works in the following sequence. \n",
         "\n",
         "1. At the start an initial data of 5 random points is generated and a model initialized using this data.\n",
         "2. The models are used to generate an acquisition function that is optimized to select new input parameters\n",
@@ -495,22 +494,36 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "8b5af56b-3fc3-4de4-9758-9a52fcafa1f2",
+        "originalKey": "2ab80417-6e93-459f-91cd-846ded130e3f",
+        "showInput": true,
+        "customInput": null,
         "collapsed": false,
-        "requestMsgId": "8b5af56b-3fc3-4de4-9758-9a52fcafa1f2",
+        "requestMsgId": "28cea5de-0493-4b66-8bfe-0d078b2e5fbc",
+        "executionStartTime": 1677807569294,
+        "executionStopTime": 1677807569302,
+        "customOutput": null
+      },
+      "source": [
+        "from botorch import fit_gpytorch_mll\n",
+        "from tqdm import tqdm, trange"
+      ],
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "312928d7-97ec-4aa6-8fad-ab60a4d143db",
+        "collapsed": false,
+        "requestMsgId": "1473f416-f608-4c4e-9b9b-b60fb8ac48f1",
         "customOutput": null,
-        "executionStartTime": 1677770838135,
-        "executionStopTime": 1677770838136,
+        "executionStartTime": 1677807569434,
+        "executionStopTime": 1677807722319,
         "code_folding": [],
         "hidden_ranges": []
       },
       "source": [
         "%%time\n",
-        "# MOMF Opt run\n",
-        "from botorch import fit_gpytorch_mll\n",
-        "from botorch.sampling.normal import SobolQMCNormalSampler\n",
-        "from tqdm import tqdm\n",
-        "\n",
         "\n",
         "# Intializing train_x to zero\n",
         "train_x = torch.zeros(n_INIT + n_BATCH * BATCH_SIZE, dim_x, **tkwargs)\n",
@@ -518,79 +531,81 @@
         "train_obj = torch.zeros(n_INIT + n_BATCH * BATCH_SIZE, dim_y, **tkwargs)\n",
         "torch.manual_seed(0)\n",
         "train_x[:n_INIT, :], train_obj[:n_INIT, :] = gen_init_data(dim_x, n_INIT)\n",
-        "mll, model = initialize_model(train_x[:n_INIT, :], train_obj[:n_INIT, :])\n",
         "\n",
         "# Generate Sampler\n",
         "momf_sampler = SobolQMCNormalSampler(sample_shape=torch.Size([MC_SAMPLES]))\n",
         "\n",
-        "for iteration in tqdm(range(0, n_BATCH)):\n",
-        "    # run N_BATCH rounds of BayesOpt after the initial random batch\n",
-        "    fit_gpytorch_mll(mll)  # Fit the model\n",
+        "# run N_BATCH rounds of BayesOpt after the initial random batch\n",
         "\n",
+        "for iteration in tqdm(range(0, n_BATCH)):\n",
         "    # Updating indices used to store new observations\n",
         "    lower_index = n_INIT + iteration * BATCH_SIZE\n",
         "    upper_index = n_INIT + iteration * BATCH_SIZE + BATCH_SIZE\n",
+        "\n",
+        "    # reinitialize the models so they are ready for fitting on next iteration\n",
+        "    mll, model = initialize_model(train_x[:lower_index, :], train_obj[:lower_index, :])\n",
+        "\n",
+        "    fit_gpytorch_mll(mll=mll)  # Fit the model\n",
+        "    \n",
         "    # optimize acquisition functions and get new observations\n",
         "    new_x, new_obj = optimize_MOMF_and_get_obs(\n",
-        "        model,\n",
-        "        train_obj[:upper_index, :],\n",
-        "        momf_sampler,\n",
-        "        ref_point,\n",
-        "        standard_bounds,\n",
-        "        BATCH_SIZE,\n",
-        "        cost_call=cost_callable,\n",
+        "        model=model,\n",
+        "        train_obj=train_obj[:upper_index, :],\n",
+        "        sampler=momf_sampler,\n",
+        "        ref_point=ref_point,\n",
+        "        standard_bounds=standard_bounds,\n",
+        "        BATCH_SIZE=BATCH_SIZE,\n",
+        "        cost_call=cost_callable\n",
         "    )\n",
         "    # Updating train_x and train_obj\n",
         "    train_x[lower_index:upper_index, :] = new_x\n",
-        "    train_obj[lower_index:upper_index, :] = new_obj\n",
-        "    # reinitialize the models so they are ready for fitting on next iteration\n",
-        "    mll, model = initialize_model(train_x[:upper_index, :], train_obj[:upper_index, :])"
+        "    train_obj[lower_index:upper_index, :] = new_obj"
       ],
-      "execution_count": 8,
+      "execution_count": 9,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
             "\r  0%|          | 0/30 [00:00<?, ?it/s]",
-            "\r  3%|▎         | 1/30 [00:04<02:10,  4.50s/it]",
-            "\r  7%|▋         | 2/30 [00:07<01:46,  3.80s/it]",
-            "\r 10%|█         | 3/30 [00:11<01:45,  3.92s/it]",
-            "\r 13%|█▎        | 4/30 [00:19<02:16,  5.23s/it]",
-            "\r 17%|█▋        | 5/30 [00:24<02:15,  5.43s/it]",
-            "\r 20%|██        | 6/30 [00:30<02:15,  5.64s/it]",
-            "\r 23%|██▎       | 7/30 [00:37<02:14,  5.84s/it]",
-            "\r 27%|██▋       | 8/30 [00:44<02:21,  6.44s/it]",
-            "\r 30%|███       | 9/30 [00:52<02:25,  6.92s/it]",
-            "\r 33%|███▎      | 10/30 [00:59<02:18,  6.91s/it]",
-            "\r 37%|███▋      | 11/30 [01:06<02:07,  6.74s/it]",
-            "\r 40%|████      | 12/30 [01:11<01:54,  6.39s/it]",
-            "\r 43%|████▎     | 13/30 [01:18<01:51,  6.57s/it]",
-            "\r 47%|████▋     | 14/30 [01:26<01:49,  6.83s/it]",
-            "\r 50%|█████     | 15/30 [01:33<01:42,  6.84s/it]",
-            "\r 53%|█████▎    | 16/30 [01:38<01:30,  6.43s/it]",
-            "\r 57%|█████▋    | 17/30 [01:44<01:22,  6.38s/it]",
-            "\r 60%|██████    | 18/30 [01:50<01:12,  6.04s/it]",
-            "\r 63%|██████▎   | 19/30 [01:56<01:06,  6.07s/it]",
-            "\r 67%|██████▋   | 20/30 [02:01<00:59,  5.94s/it]",
-            "\r 70%|███████   | 21/30 [02:07<00:52,  5.84s/it]",
-            "\r 73%|███████▎  | 22/30 [02:12<00:45,  5.67s/it]",
-            "\r 77%|███████▋  | 23/30 [02:17<00:37,  5.42s/it]",
-            "\r 80%|████████  | 24/30 [02:23<00:33,  5.53s/it]",
-            "\r 83%|████████▎ | 25/30 [02:28<00:27,  5.52s/it]",
-            "\r 87%|████████▋ | 26/30 [02:33<00:20,  5.25s/it]",
-            "\r 90%|█████████ | 27/30 [02:38<00:15,  5.32s/it]",
-            "\r 93%|█████████▎| 28/30 [02:46<00:12,  6.05s/it]",
-            "\r 97%|█████████▋| 29/30 [02:51<00:05,  5.81s/it]",
-            "\r100%|██████████| 30/30 [02:57<00:00,  5.74s/it]",
-            "\r100%|██████████| 30/30 [02:57<00:00,  5.92s/it]"
+            "\r  3%|▎         | 1/30 [00:02<01:14,  2.58s/it]",
+            "\r  7%|▋         | 2/30 [00:05<01:11,  2.56s/it]",
+            "\r 10%|█         | 3/30 [00:08<01:14,  2.78s/it]",
+            "\r 13%|█▎        | 4/30 [00:11<01:17,  2.96s/it]",
+            "\r 17%|█▋        | 5/30 [00:17<01:38,  3.95s/it]",
+            "\r 20%|██        | 6/30 [00:21<01:41,  4.24s/it]",
+            "\r 23%|██▎       | 7/30 [00:27<01:47,  4.67s/it]",
+            "\r 27%|██▋       | 8/30 [00:32<01:47,  4.87s/it]",
+            "\r 30%|███       | 9/30 [00:38<01:49,  5.19s/it]",
+            "\r 33%|███▎      | 10/30 [00:44<01:48,  5.42s/it]",
+            "\r 37%|███▋      | 11/30 [00:50<01:47,  5.65s/it]",
+            "\r 40%|████      | 12/30 [00:57<01:49,  6.11s/it]",
+            "\r 43%|████▎     | 13/30 [01:03<01:41,  5.97s/it]",
+            "\r 47%|████▋     | 14/30 [01:08<01:30,  5.64s/it]",
+            "\r 50%|█████     | 15/30 [01:12<01:18,  5.26s/it]",
+            "\r 53%|█████▎    | 16/30 [01:18<01:15,  5.36s/it]",
+            "\r 57%|█████▋    | 17/30 [01:23<01:07,  5.17s/it]",
+            "\r 60%|██████    | 18/30 [01:27<00:59,  4.95s/it]",
+            "\r 63%|██████▎   | 19/30 [01:32<00:55,  5.02s/it]",
+            "\r 67%|██████▋   | 20/30 [01:38<00:51,  5.11s/it]",
+            "\r 70%|███████   | 21/30 [01:43<00:46,  5.20s/it]",
+            "\r 73%|███████▎  | 22/30 [01:49<00:42,  5.37s/it]",
+            "\r 77%|███████▋  | 23/30 [01:54<00:36,  5.22s/it]",
+            "\r 80%|████████  | 24/30 [01:58<00:30,  5.04s/it]",
+            "\r 83%|████████▎ | 25/30 [02:03<00:24,  4.93s/it]",
+            "\r 87%|████████▋ | 26/30 [02:08<00:20,  5.12s/it]",
+            "\r 90%|█████████ | 27/30 [02:15<00:16,  5.54s/it]",
+            "\r 93%|█████████▎| 28/30 [02:21<00:11,  5.53s/it]",
+            "\r 97%|█████████▋| 29/30 [02:26<00:05,  5.45s/it]",
+            "\r100%|██████████| 30/30 [02:32<00:00,  5.78s/it]",
+            "\r100%|██████████| 30/30 [02:32<00:00,  5.09s/it]"
           ]
         },
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "CPU times: user 8min 15s, sys: 22.8 s, total: 8min 38s\nWall time: 2min 57s\n"
+            "CPU times: user 1h 40min 17s, sys: 1min 34s, total: 1h 41min 52s\nWall time: 2min 32s\n"
           ]
         },
         {
@@ -619,12 +634,12 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "394df01c-9f56-4f8d-b7fd-cbdada2d3a17",
+        "originalKey": "c8cf162e-9d0b-4fde-9486-3b949f3296ee",
         "collapsed": false,
-        "requestMsgId": "3f5bec9f-3f1e-4bdc-9a01-1905c4481e63",
+        "requestMsgId": "9976fec7-0b59-41d9-a1b3-eeacdf4978eb",
         "customOutput": null,
-        "executionStartTime": 1677770851719,
-        "executionStopTime": 1677770851761
+        "executionStartTime": 1677807722448,
+        "executionStopTime": 1677807722456
       },
       "source": [
         "from botorch.utils.multi_objective.pareto import is_non_dominated\n",
@@ -643,12 +658,12 @@
         "\n",
         "def get_pareto(\n",
         "    train_x: torch.Tensor, train_obj: torch.Tensor, test_x: torch.Tensor\n",
-        ") -> Tuple:\n",
+        ") -> Tuple[float, torch.Tensor]:\n",
         "    \"\"\"\n",
         "    Function that takes in training and testing data with a reference point.\n",
         "    \n",
-        "    It initializes a model and takes out the Posterior mean at the testing points.\n",
-        "    From these points the non-dominated set is calculated and used to compute\n",
+        "    It computes the posterior mean at the testing points based on the model.\n",
+        "    From these points, the non-dominated set is calculated and used to compute\n",
         "    the hypervolume.\n",
         "    \"\"\"\n",
         "    mll, model = initialize_model(train_x, train_obj)\n",
@@ -656,45 +671,48 @@
         "    with torch.no_grad():\n",
         "        # Compute posterior mean over outputs at testing data\n",
         "        means = model.posterior(test_x).mean\n",
+        "    # Calculating Non-dominated points\n",
         "    pareto_mask = is_non_dominated(means)\n",
-        "    # Saving the Pareto front\n",
-        "    pareto_f = means[pareto_mask]\n",
+        "    pareto_front = means[pareto_mask]\n",
         "    # Computing Hypervolume\n",
-        "    box_decomp = DominatedPartitioning(torch.tensor(ref_pointMO, **tkwargs), pareto_f)\n",
+        "    box_decomp = DominatedPartitioning(\n",
+        "        torch.tensor(ref_pointMO,**tkwargs), pareto_front\n",
+        "    )\n",
         "    hyper_volume = box_decomp.compute_hypervolume().item()\n",
-        "    return hyper_volume, pareto_f"
+        "    return hyper_volume, pareto_front"
       ],
-      "execution_count": 9,
+      "execution_count": 10,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "4f9721ff-f288-4ef8-b006-9f09eda9452a",
+        "originalKey": "b908df5b-4183-4c3f-95c2-bfdf8739ce79",
         "collapsed": false,
-        "requestMsgId": "96d21269-6e95-4c95-b14b-6e0b36e13267",
+        "requestMsgId": "414e876f-4de6-4df2-90fd-29b2d5ee8b65",
         "customOutput": null,
-        "executionStartTime": 1677770868727,
-        "executionStopTime": 1677770871260
+        "executionStartTime": 1677807722727,
+        "executionStopTime": 1677807725035
       },
       "source": [
         "# Using the above two functions to generate the final Pareto front.\n",
         "n_points = 10**4\n",
         "test_x = gen_test_points(n_points, dim_x)\n",
-        "_hv, final_PF = get_pareto(train_x, train_obj[:, :-1], test_x)\n",
-        "_hv"
+        "\n",
+        "hypervolume, final_PF = get_pareto(train_x, train_obj[:, :-1], test_x)\n",
+        "hypervolume"
       ],
-      "execution_count": 10,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "0.4863664818097104"
+            "text/plain": "0.48020996821155426"
           },
           "metadata": {
-            "bento_obj_id": "139791161716528"
+            "bento_obj_id": "140557423574896"
           },
-          "execution_count": 10
+          "execution_count": 11
         }
       ]
     },
@@ -711,12 +729,12 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "8e121c01-9b8f-4102-a8e1-e637afee3842",
+        "originalKey": "db102a2d-5072-4dea-95e3-8b9129095409",
         "collapsed": false,
-        "requestMsgId": "7eba50de-ffea-4e79-b59a-2015db897ec2",
+        "requestMsgId": "725e3ee7-fe6a-49a1-a0c2-5d778b40faef",
         "customOutput": null,
-        "executionStartTime": 1677770889122,
-        "executionStopTime": 1677770889793
+        "executionStartTime": 1677807725344,
+        "executionStopTime": 1677807725900
       },
       "source": [
         "fig, axes = plt.subplots(1, 1, figsize=(4, 4), dpi=200)\n",
@@ -727,7 +745,7 @@
         "    markersize=3.5,\n",
         "    label=\"MOMF\",\n",
         ")\n",
-        "axes.set_title(\"Branin-Currin_Pareto Front\", fontsize=\"12\")\n",
+        "axes.set_title(\"Branin-Currin Pareto Front\", fontsize=\"12\")\n",
         "axes.set_xlabel(\"Branin\", fontsize=\"10\")\n",
         "axes.set_ylabel(\"Currin\", fontsize=\"10\")\n",
         "axes.set_xlim(0, 1)\n",
@@ -736,16 +754,16 @@
         "axes.legend(loc=\"lower right\", fontsize=\"7\", frameon=True, ncol=1)\n",
         "plt.tight_layout()"
       ],
-      "execution_count": 11,
+      "execution_count": 12,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
             "text/plain": "<Figure size 800x800 with 1 Axes>",
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwwAAAMMCAYAAAD+fyB7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAewgAAHsIBbtB1PgAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOzde5xcZWH/8c8mu5DNgkC03CqCFySJSrSpaLXFSzlJPTaxR5TWSrykWq1aS6iX6qvaYtuftlX8WWu1aqM1/LS0waOkOZocrRe0tBq1iTEB8QKigiiEUJJZ2Enm90eexWGzZy67M7Mzez7v12teZy7Pucw+O7vnO+e5DNVqNSRJkiRpOgvm+gAkSZIk9S8DgyRJkqRCBgZJkiRJhQwMkiRJkgoZGCRJkiQVMjBIkiRJKmRgkCRJklTIwCBJkiSpkIFBkiRJUiEDgyRJkqRCBgZJkiRJhQwMkiRJkgoZGCRJkiQVMjBIkiRJKmRgkCRJklTIwCBJkiSpkIFBkiRJUiEDgyRJkqRCBgZJkiRJhYbn+gAkqZkoTp4KfC48/Oc8S180x4ck60WSSsPAIPWRKSdgRSaAu4EfAruBDLgqz9JKjw5TDURxcirwW8DTgccADwJOBMaB24HrgS8BH8+z9FtzfbxlE8XJWcD3WyhaA+4CbgV2AB8Hrs6ztNqDw1QQxcnngafMYhPvyrP0kg4eklRKBgZp8IwAJ4XbY4DnAX8dxcn6PEu3zfXBdcnBcKINcMscH8u0ojg5Cfgz4GXAommKHBduZwKrgLdEcfIp4A/zLP3uHBxyJ/R9vczCEHBCuJ0DPB/YG8XJ8/Ms/cZcH1w3RHEyBuwHFuZZOjTXx6PpRXHycuC9XtVTLxkYpP71HSCZ5vkR4BeAXwbWAw8HTgf+PYqTX8uz9L/m4Fi7Ks/SrwBL5/o4ikRxshz4JPCI8NQhYCvwqVCPtwOLw4lnDDwr/P19BrAzipNn51m6fY7fRtv6vV5aUAHOK3ht8nN2XvicPRRYBnw+ipOnztPQsBJYONcH0cClQN7mOj/r0rHMpaLfWalrDAxS/7onz9LdDV7fHsXJO4A0nHgOA/8nNIVRj0Rx8hDgC6HpEcB/A79X0Nzoy8DGKE4eGeptOTAGfDKKkyfmWbqzx4dfdoebfMYIn7O3A1cAFwIPCHW4Ms/Swz06zl7p9xPRm1uorzLo93rSPOQoSdIAy7P0HuCP6546P4qTY+bwkEolipOFwOa6sPA54OnN+ibkWfpt4EnAV8JTi4APR3FiM5A+lGfpOPCium+rHwv86hwfVjc8fq4PQI2FZmPL5vo4VD5eYZAGXJ6le6M4mQhNKBaGk9cf15eJ4uTPQ/t6gDXAZ4E3hv4PZwB78yx97NRtR3GyGvidcCLxkNCs5gBwc+i4+/48S79edGxRnHwjnFztz7P0xPDcM0MTj5XAqcA9wHeBfwfemWfpvmm203A0nk7tZwZ+u+4k63bgd/MsPdjKinmW7o/i5PeBrwH7gK+Gfil3cHTn3JvyLD2r0faiOKkVlW2n/qM4eRHwoVD2D4F/AC4BXhKa5dxT9zPu13rpuDxL747i5N9DcCB0xP3idGU78Lm5MfR1uT3P0gdFcfIo4C+BXwFOATbkWfp/p1nv8cCLw7GdHvZ7B/BtYDvwj3mWHtVEp+53p+i5p+VZ+vkprw8DFwNrQ10+KPT7uAPYBXwa+Kc8Sw80/eH20Cx+theEz8uTw+/t4vC5/S7wH+Fne3PBPlcA/xMevivP0kuiOHkA8FLgucDDwsAI+4BvABvzLP3XKduo/1xOemEUJy8M95v+jZBmw8AgDbgoTkbqPsu10GmxmX8O/6iKtvkA4F9CU6epHgA8Ktx+P4qTv8qz9E0Fm7rv5DmKkwXhH94LppQ5FnhcuK2L4uRX8yz9UQvvYS72M9Vr6+7/bZ6lt7azcp6lO6M4+SXgW3mWHprlsbSjYf1P8bYp7/OeNvYzV/XSLfWd00+b+mIHPzf123wwcE0Ik0VljgH+sS7M1Ds13M4HXh/FyUvzLL2y2X6bHNOjgE/U9dmp94vh9gzgT6M4uWhq2OgXLf5sTwh1+hvTvHxyuP0K8NooTv4kz9J3TlPufl8iRHHyiNAXY+oJ/snAamB1FCcX5Fn6+zN+c1KH2SRJGny/Fr7ZA9jRwjd6Tw4ni58KHXAfF0b2qbex7qTnx6Gz4fnh2+Knh5PIe8J+/zR8+zWd+pPgy8LJ4rbwzfzKcOyvCd+sEf6BHvXtXgt6tZ/7RHFyevh5TO7/n2aynTxLd/U4LLRS/5POAjYA/wU8O5Rd28a+el4vXVbfIXi64VU79bmp92fh2+zLwonpecDVU8psrgsLN4b9/mr4Gf8W8GHgMHA88LEoTn5ryvqPCbcfT/PcY8LVL/j5la9r6sLC18I35U8Kx/b88I07odP4tihOHtfC+5wLDX+24cuY7XVh4RbgDcBTw892Tajzw8AxwOVRnLximv3Ufw4Wh6tppwBvBy4I24qBj9SVe2m4GjfpE6Eu1tc998m6OlrVuR+LdDSvMEgDLAzleXndU3/ZwmovDf9okjxLp2uK8OjQuRPg3tAm//opxT4XmptMflP5pnBSMtVkp9DjgD8B/nKab1W/FMXJV0PHYYDfiuLkhDxLW7lS0uv91KsfG/5b0zX16FMN63+KF4WmFE/Js/TeGexrLuqlmx5Zd/8H9S90+HMzaTHwu8Dz8ixNpysQmrWtCQ+/CDwzz9K764p8PXSqT0NH+wXA+6M4ySe/XJjsSByaNlL/3DT+se4b+Y8C66Z0/v4q8NEoTv4uNGk7BvhAGNWtnzT92YYwO9nBeA/wa3mW3lH3+tfD6HRZCG0AfxPFyVV5lv6krlz9z2dd+P148jQjbX0qipNDoVkZ4fO3lSP1cSdwZxQnD6orf6edwNUrXmGQ+texUZw8eprb46I4WR3FyVvCP7EVYTK3l+RZOvWbx+k8EHhtg5PFRcB7wknNP0xz0jPp34Dbwv2HRXFyZoN9Lgztmv9suhfzLP1iXXOP4bpv7tvVq/0wpTnG/zQo12+a1f/Usm+YYVio18t66YrQ3Ciue2rqMLjd+NyMAt9oEBaG6pqL3Qs8f0pYuE/42/DP4eEvhD4WbYniZFndN9n7gFc0GCnq9cDkSfPKKE76bWSfZj/bhcCr6p56+ZSwcJ88S68CtoSHY8ALpysXLALe3GBY3o119/stZKnEvMIg9a9HAN9sUuYw8EHgHXmWXtfidnflWXpD0Yt5lu4IM9s2lGdpLYqT74Z2t4ROljc1WOWfmgxDuSfMKUHdNmeiV/t5YN3922exnV5rWP9T3FnXvGS2elUvHRfFyWhoLnJieGpbnqW76st08XNzVYPXfqkuuP5HnqU/bLL7j9R9e/2bM2hGV9+U6RONrgLlWVqJ4uQTdc3dnlE3Kli/aPSzPS/UDcD38yy9psm2Plp3pecZwN8UlDs0Teflenvq7vfV50DlZmCQBtuCMHrNyihO3g98MM/S6dpW12t7rP/Q9OnEcBm/fujPkbr7xzbZTLOTqbvq7i9u9xjnYD/H1d1vaWSkPtFO/X+zg3MN9Kpe2rEgNCWazsIQCp8QPmMPC8//GGipM2qHPjeN6uuJdfe/3cIhfa3u/i+1UH6q+m+8W5kgckddYOhEP4Z/i+Lp5rJs6HF5lhZdAWz0s53Je53U6ArZt/MsvavB63PxOZCaMjBI/etbeZZOezITxuJ+cOjA+orQae69wO9EcbImz9L/bbDdW1rZeRQnTw8nRk8NHfRmq9m38PVBZzbzEcx4Pw1OHiddn2fpZDvvSt3zD2jvEOdUS/U/g7LN9Kr+2zHawlW8ev8dhs79QVGBLnxuGtVBfXOmV0dx8uo2tnvUKE8tOKPu/vcblJtUf+Xk9Abl5kqjn+1s3uuJUZwsLhhiueHnIM/S6gxCkdR1BgZpAIXOitcD10dx8qHQEfGloSPuP4bOfEUqDV6bbBf9D8DLO3zYvRoJaDb7aXby+NAwCg1A/RCqp85in73WsP5nUbaZXo4E1Sl3h5PK/wL+Fdha1Peji5+bRnVwwiy2O9LgpLaV/TX6UmJSfX+KToTqS8NwpO34ToPXWv3ZNn2veZZORHFyb+jkTXi/0/1sB/FzIBkYpEEX2kS/GnhWaPP6vChO/jzMJjwTr55y0vPx0Nb5G2FUjvv+yUZx8vkpowWVyd66+0+Yw+PQzB3Is/S4Fsq1Yi4+N/XNxd4V+jO1Y7zN8vVhqZWrQPVlWulk38zNPRwVqN33OrVcJ96v1DcMDNI8kGfpeDgJuSg89dQW2zTfT/iW9HV1T709z9LXNlhlpMFrAyfP0naawlwTTgqGgIdEcbI8z9I9LazXcWHWXc2ROfzc1Hc6rvTgZLp+f61cMTi+YN1B0NZ7jeLk2Cn1OmjvV2rIYVWl+aP+H9QDG5Rr5BF1bY3vBf6iSfmpM5WWRp6lPw2hYdIfzmQ7UZxcFMXJlihOVk55qf4byoU05mgqc2uuPjf1M08/skG5Trmx7v7DGpSbrkyjkaD60Wze6215lrZ79UbqawYGaf74xbr7Mx3m8xfq7v+w0WgeUZw8uU87MvZS/azEL5nmpL+hMAnTO8MQlzuiOKlvplLfvrpZW3WbRM2tufrc1A9Ten4PrjTV7+/JLZSvH8Xpqw3K9aP69/qkFsoP8nuVmjIwSPNAFCcPnNIm+toZbqq+k96SBvtbCLxtytPzqnlSK8KkT5PzFAwDV0Zx8pBW1o3iZHEYB37y5PFzeZZ+oa7IvrqRg46P4uSMaTYz6Q9m9g7UIXPyucmzdGcY/ADgQcDzGpWP4uTXozj5XhQn747iZEWTstOFj4/XXflaG8VJo/d6ArA2PKwBn2j2fvrM1+tGR3pwFCcXNCn/grr7RTNHd5pNEdUzBgZpwIVJpT4UZhgFuCbP0naGiqx3HXBPuH9iFCerphaI4mRR2N8TgP+se6nRjLXz2cXA5IRZDwe+FMXJ6kYrRHGyPDRnOj889YOpJ3th+Nb6ycFeWbCt1wEXTBmRRr01l5+bt9fdvzzMxnyUKE4eHjphPzTMYDxdu/z6Zo1nT30xz9Lv1534Hw+8N4qTo84jwnPvqZvo7pN5ljYarajvhNGw6q8g/n34YuYoUZxMDqNLmKfjY108tIZ1JHWL6VTqX8c2mBfg2DDG+3nAi+pOOm4Ffm+mOwydpz8WtgnwL1GcvCUMK7k4zPfw8tBe943hOCYv118aZrC9K8/SrzXYzbySZ+ktUZycD3wKOCeM3/7pKE7+M3zTuAv4KbAIWBqaHz2rrl/CbiDOs/Qn02z+iroJtl4fxcmDgSxcfTgthIwLwlC6TwQafmus7pjLz02epR+M4mRtmGX4QcBXozj5e2B7OLk8HXhamHxushPy+wtmLv4OcG64/89RnHwg/J5+J8/Sz4TnXxmaI50cBlk4K4qT94RRwxYCjwrvdXLis58M8BWwvweeHa7engPsjOLk8jAfx3gIX78NPCeUrwIvbHOo2nZ9P4yOtQA4L9T1V8Lfgw/kWXpHF/etEjMwSP3rEW1OKvV54CV5ln63hbKNvDaczDwSOCm0sZ/q7XmWvjW02f+z8Nyy0DznprJ1hs6z9PtRnPxS+Fm8KpwkPqlJ2+e7gXcDb2nQQfLvQ7iYbG72/HCrlwF/FE5i8O/6nJnLz81zQmh8UbjS+Ppwm857wu/LdN4XTpABHh9uAJcBn+HnAflXgatDAD4v3KazC0jyLL214PW+lmfp4ShOngl8NDSv+kXgHQXFfwasqwtW3TqmO6M4+Ze6uXZeWXf18UrAwKCusEmSNJjuDf+gvhpOAM7Ps/RpHQgL5Fn6s3AC8JfAt0Ln2wNhmNZ/Ap44OWRk+Eb0d0O58fBt4vaOvMMBk2fpwTxLXw88BHhZ6J/w7TDp06EQEG4Iz/8+8JA8S9/YaDSV0CxpVRjj/8vAncBEmEwsD82h1uRZek/daot7845Vby4/N3mW3ptn6YvDt/rvCVet7gy/d3eFuSD+DliRZ+mr8iyddvKwPEvzEEh3heO6C9gZtldf7gbgMcCLgU+GJnnjoS/HTcC/hatfj8uz9HszfV/9IM/SA3mWPitcyftw+AzfHf4G3xKC1KXAw/Is/XSPDuvlwHuBm8Nx/CSEzlYm05NmZKhWc24RSZIkSdPzCoMkSZKkQgYGSZIkSYUMDJIkSZIKOZqGJKkvNRhWeCZuy7P0tg5uT5JKw8AgSepXM52AcDqXAX/ewe1JUmnYJEmSJElSIYdVlSRJklSo1E2SojgZBt4MvDFMaX9ZnqWzvmQdxckTgVcA5wOnhAl8bgA2A+9uNFGTJEmS1E9K2yQpipOlwLXAm0JY6NR23xhmZF0HnAr8IMyAeR7wN8A3ojg5rVP7kyRJkrqpdIEhipOhKE5eBXwd+GWgY1O5R3HybOCvws/13cApeZaek2fp6cCTgJuApcDHozgZ6tR+JUmSpG4pXWAAnhlO5hcAG4C4ExuN4mQB8LbwcEuepa/Os3T/5Ot5ll4LXAjUgCeG+5IkSVJfK2NgGAb2AOflWfp/8yztVK/vJwBnh/t/O12BPEu/BnwhPHxhh/YrSZIkdU0ZA8NXgV/Os3RXh7cbheXB0DeiyGfC8oLQ6VqSJEnqW6U7Yc2z9Edd2vSjwvL6PEurDcrtDstFwMOAb3fpeCRJkqRZK+MVhm45MyybBZIf191/aBePR5IkSZo1A0PnHB+WdzcpV//68Q3KSZIkSXOudE2SumhRWN7bpNw906wza7fcfKNTdkuSJA2g0844q6+H2zcwdM7k7M3HNCl3bN39SicP4IEnn8rChVbpfHfoUJXbb7sVrPPSsM7LyXovH+u8fOrrvJ/5m9g5d4XlcU3K1TdDuqtBubYtXDjMwmGrtEys8/KxzsvJei8f61z9xD4MnfO9sDyjSbn617/TxeORJEmSZs3A0DnfDMtzojhp1CzpsWF5F3BjD45LkiRJmjEDQ+d8KiwXAec3KPeMsMw6OMu0JEmS1BUGhg7Js3Qn8PXw8PXTlYni5AJgZXj4wd4dnSRJkjQz9qZpQxQnbwbeHB4+PM/Sm6YUeQ3wGeCCKE7eC7whz9I7w7oRcEUo98k8Sz/b26OXJEmS2le6wBDFSQacXvDyy6M4+a0pz8V5lk7OzrwAWBjuHzVebp6ln4vi5JXAu4GXAy+O4uRG4ETglFDsS8DFnXtHkiRJUveULjAAy4EzC147pe7EflKzeRXuJ8/S90Vx8l/AHwFPB84KsztfE64wfDDP0sMzP3xJkiSpd4ZqNfvdzge33Hxj7eTTHuyYzSVwqFrltlt+CIB1Xg7WeTlZ7+VjnZfPZJ33+0zPdnqWJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqZGCQJEmSVMjAIEmSJKmQgUGSJElSIQODJEmSpEIGBkmSJEmFDAySJEmSChkYJEmSJBUyMEiSJEkqNDzXBzBXojh5IvAK4HzgFKAC3ABsBt6dZ+n4DLe7EFgHPA94LHAScA9wE/B54D15lu7t/DuSJEmSOq+UVxiiOHkj8OVwYn8q8ANgHDgP+BvgG1GcnDaD7T4wbPdDwCrgAcCNwEHgUcArgZ1RnPxBd96ZJEmS1FmlCwxRnDwb+Kvw3t8NnJJn6Tl5lp4OPClcCVgKfDyKk6E2N78JeAJQBV4GHJdn6SPzLD0FOBv4D2AEeE8UJ0/u0luUJEmSOqZUgSGKkwXA28LDLXmWvjrP0v2Tr+dZei1wIVADnhjut7rthwPPCA/flWfp+/MsPVS37e8Avx2uZAyFQCFJkiT1tVIFhvDt/9nh/t9OVyDP0q8BXwgPX9jGts+uu39NwbZ/Blw/TXlJkiSpL5UtMERheRC4tkG5z4TlBVGctNox/Ja6+8c3KLc4LG9tcbuSJEnSnClbYHhUWF6fZ2m1QbndYbkIeFiL2/4W8N1w/7enKxDFyTl129va4nYlSZKkOVO2YVXPDMsfNSn347r7DwW+3WzDeZZWw+hHnwR+M4qTK4C3h3WPCx2q/xpYGIZX/dDs3srRDh1qlIE0X9TXs3VeDtZ5OVnv5WOdl8+g1HPZAsNkU6G7m5Srf71R86L7ybM0j+Lk14A3hHkYnj+lyE3Am4C/qe8Q3Sm332Yrp7KxzsvHOi8n6718rHP1k7I1SVoUlvc2KXfPNOu06onAOeFney/wHeC28Npp4UrDija3KUmSJM2Jsl1hmJy9+Zgm5Y6tu19pdeNRnHwIeBFwB7Ae+MjklYQoTn4R+AvgxcDTojh5dp6ln5rRuyjwwJNPZeHCslVp+Rw6VL3vmyfrvBys83Ky3svHOi+f+jrvZ2X7TbwrLI9rUq6+GdJdDcrdJ4qTtSEsAPxunqXb6l/Ps/RHwPooTk4EEuAfozh5WJPO121ZuHCYhcNlq9Jys87LxzovJ+u9fKxz9ZOyNUn6Xlie0aRc/evfaXHbk5O8/WRqWJjiX+r2YdMkSZIk9bWyBYZvhuU5UZw0apb02LC8C7ixxW2fHpb7m5TbV3f/lBa3LUmSJM2JsgWGyT4Di4DzG5R7RlhmeZbWWtz2ZBA4M4qTRj/X0+vu39HitiVJkqQ5UarAkGfpTuDr4eHrpysTxckFwMrw8INtbP6asDw2DKla5LlheTfwjTa2L0mSJPVcGXvTvAb4DHBBFCfvBd6QZ+mdHAkLEXBFKPfJPEs/W79iFCdvBt4cHj48z9Kb6l7+MPAn4QrCu6M4GQE21Y2SdCLwp8AzQ/l35FlaP3yrJEmS1HdKdYWBI1cZPge8EqgCLwdujeLkuihObgW2AycDXwIunmb1BWGm5oXA0JTt/m9oyvQD4KQwk3MlipMboji5AfgZ8Meh+IeAt/TmHUuSJEkzV7rAwJGT+/cBjw9XBX4CnBWutlwDvAx4Sp6lzWaDnm67u4BHAZcAnwPuDNs+Hfh+uHrx9DxL1+dZerg7706SJEnqnKFardU+vepnt9x8Y+3k0x7smM0lcKha5bZbfgiAdV4O1nk5We/lY52Xz2Sdn3bGWUMtFJ8zpbzCIEmSJKk1BgZJkiRJhQwMkiRJkgoZGCRJkiQVMjBIkiRJKmRgkCRJklTIwCBJkiSpkIFBkiRJUiEDgyRJkqRCBgZJkiRJhQwMkiRJkgoZGCRJkiQVMjBIkiRJKmRgkCRJklTIwCBJkiSpkIFBkiRJUiEDgyRJkqRCBgZJkiRJhQwMkiRJkgoZGCRJkiQVMjBIkiRJKmRgkCRJklTIwCBJkiSpkIFBkiRJUiEDgyRJkqRCBgZJkiRJhQwMkiRJkgoZGCRJkiQVMjBIkiRJKmRgkCRJklTIwCBJkiSpkIFBkiRJUiEDgyRJkqRCBgZJkiRJhYbn+gA02CoTNa7eWSW/rsr+So0TRoeIlg6zdsUwoyNDc314kiRJmiUDg2Zs254qGzaPs+9g7X7Pb91d5bJsiHc+ZxGrl/srJkmSNMhskqQZ2banyvpNlaPCwqR9B2us31Rh255qz49NkiRJnWNgUNsqEzU2bB7n8PRZ4T6Ha3DpVeNUJpoUlCRJUt8yMKhtV++sFl5ZmOqOAzW27PIqgyRJ0qAyMKht+XXtBYDtew0MkiRJg8oeqWrb/kp7TYzaLd8qR2iSJEnqPgOD2nbCaHsn4+2Wb8Ugj9Bk0JEkSYOkP8+o1NeipcNs3d16M6NVyzr7azY5QlNRp+vJEZo2rhvtu9AwyEFHkiSVk30Y1La1K4Y5aXFr34QvGRtizbmdOwEe5BGaHIpWkiQNIgOD2jY6cuSb8AVNMsOCIbj8wkUdbWYzqCM0DXLQkSRJ5WZg0IysXj7MxnWjLBmbPgwsGRvqSpOgQR2haVCDjiRJko2lNWOrlw+z4+wxtuyqsn3vzzvwrlo2zJpzu9OBt19GaGrXTILORStHunY8kiRJrTIwaFZGR4a4aOVIz05u+2GEppkY1KAjSZJkkyQNlGhpexm30yM0zdSgBh1JkqT+OJuSWrR2xTCXZUMt9Qfo9AhNszHXQ9EWcU4ISZLUjFcYNFDmcoSm2ZjLoWiLbNtTZeVbD3DJ5nG27q7ype8eYuvuKpdsHmflWw84vKskSQIDgwbRXI3QNBv9FnScE0KSJLWqf86opDbMxQhNszUZdC69apw7Dhx9or5kbIjLL+z+TM/tzgmx4+yxvvx5SpKk3jAwaGD1eoSmTuiHoDOTOSEG6WcsSZI6y8Ag9dhcB53ZzglhR2lJksrFwCCVzGzmhApTwAwAACAASURBVNi2p8qGzeNHXaHYurvKZdmRfhr91HdEkiTNnp2epZKZ6ZwQdpSWJKmcDAxSycxk8rt2O0pXJpypWpKk+cLAIJXMTOaEmElHaUmSND8YGKSSmcmcEDPpKC1JkuYHA4NUQu1OfjebjtKSJGmwOZyJVFLtzAkx047SkiRp8BkYpBJrdU6IaOkwW3e33sxo1TL/tEiSNF/YJElSUzPpKC1JkuYHA4OkpmbSUVqSJM0PBgZJLWm3o7QkSZof/M8uqWXtdJSWJEnzg4FBUlta7SgtSZLmB5skSZIkSSpkYJAkSZJUyMAgSZIkqZCBQZIkSVIhA4MkSZKkQo6SJGkgVCZqXL2zSn7dz4dzjZYOs3aFw7lKktRNBgZJfW/bniobNo+z72Dtfs9v3V3lsuzILNROGCdJUnfYJElSX9u2p8r6TZWjwsKkfQdrrN9UYdueas+PTZKkMjAwSOpblYkaGzaPc3j6rHCfwzW49KpxKhNNCkqSpLYZGCT1rat3VguvLEx1x4EaW3Z5lUGSpE4zMEjqW/l17QWA7XsNDJIkdZqBQVLf2l9pr4lRu+UlSVJzBgZJfeuE0faGS223vCRJas7AIKlvRUvbGyp11TKHVpUkqdMMDJL61toVw5y0uLWrBkvGhlhzroFBkqROMzBI6lujI0cmZVvQJDMsGILLL1zkjM+SJHWBgUFSX1u9fJiN60ZZMjZ9GFgyNsTGdaPO9CxJUpf4H1ZS31u9fJgdZ4+xZVeV7Xur7K/UOGF0iFXLhllz7rBXFiRJ6iIDg6SBMDoyxEUrR7ho5chcH4okSaViYJA0cCoTNa7eWSW/7udXG6Klw6xd4dUGSZI6zcAgaaBs21Nlw+Zx9h28/yRtW3dXuSw70kna/gySJHWOnZ4lDYxte6qs31Q5KixM2newxvpNFbbtqfb82CRJmq8MDJIGQmWixobN4xyePivc53ANLr1qnMpEk4KSJKklXreXNBCu3lktvLIw1R0HamzZVe15B2n7VkiS5iMDg6SBkF/XXjOj7Xt7GxjsWyFJmq9skiRpIOyvtNfEqN3ys2HfCknSfGZgkDQQThhtr0lPu+Vnyr4VkqT5zsAgaSBES9trzrNqWW+a/8ykb4UkSYPEwCBpIKxdMcxJi1u7arBkbIg15/YmMMykb4UkSYPEwCBpIIyOHOk4vKBJZlgwBJdfuKhnoxL1c98KSZI6wcAgaWCsXj7MxnWjLBmbPgwsGRti47rRno5G1K99KyRJ6hTH+JM0UFYvH2bH2WNs2VVl+96fz3ewatkwa87t/XwH0dJhtu5uvZlRr/pWSJLUKf7nkjRwRkeGuGjlSM8nZpvO2hXDXJYNtdTxuZd9KyRJ6hSbJEnSLPRr3wpJkjrFwCBJs9SPfSskSeqUUv/3iuLkicArgPOBU4AKcAOwGXh3nqXjs9j2MPAy4HeBpcAi4IfAl8O2v9HZdyNpLvVb3wpJkjqltIEhipM3An8RrrLcA9wEHA+cF27rozh5ep6lt8xg20uATwOPD0/9ENgHPBR4JLAuipP1eZZu6vw7kzRX+qlvhSRJnVLKJklRnDwb+Kvw/t8NnJJn6Tl5lp4OPCmEh6XAx6M4aetrwVA+DWFhJ/DYPEvPyLP0EcCDgatCUPunKE7O6t67lDSfVSZqXLljgpdcUeG5HzjIS66ocOWOCSoTzvMgSeqs0l1hiOJkAfC28HBLnqWvrn89z9Jrozi5EPgq8ETgwtBEqVXPD02cfgKsyrP0trpt3xbFycXAA8LrZwE3duzNSSqFbXuqbNg8ftTITFt3V7ksO9IJ2/4SkqROKeN/lCcAZ4f7fztdgTxLvxbFyReApwIvbDMwXBKWb68PC3XbHgdWzejIJZXe9r2HeMlH7+VwwYWEfQdrrN9UsZO1JKljytgkKQrLg8C1Dcp9JiwvCB2Ym284Ts4AVoaH/za7w5Sk+xuvwh+nxWFh0uEaXHrVuM2TJEkdUcavnx4VltfnWdpoetbdYbkIeBjw7Ra2PdnJeV+epTdFcfJgYD3wK8AS4KfA54EP5Fm6f5bvQ1LJbL/hWPYdbK3sHQdqbNlVtQO2JGnWyhgYzgzLHzUp9+O6+w9tMTAsC8ubozhZC2wK/RXqPRN4XRQnz8qztNEVjrYdOtQo/2i+qK9n67wcJuv5mpvaO/nftudeLlzhcK6Dys96+Vjn5TMo9VzGwHB8WN7dpFz968c3KFfvQWG5BPh/wOeAtwDfBI4D1gBvB34B+PcoTs7Ns7RZcGnZ7bfd2qlNaUBY5+Vy13h7rUh/euc93HbLT7t2POodP+vlY52rn5QxMCwKy3ublLtnmnWaGQvLBwNbgGflWTrZiPge4MNRnOwOfSeWAG8AXtXm8UsqqQcsOtzV8pIkTaeMgWFy9uZjmpQ7tu5+pcVt1/cw/Mu6sHCfPEt3RHGyFXgWkHQyMDzw5FNZuLCMVVouhw5V7/vmyTovh8k6/7UzJ/jsd49tYY0jfnPFcZx82oldPTZ1j5/18rHOy6e+zvtZGX8T7wrL45qUq2+GdFeDcvX+t+7+zgbl/jMEhtOjODmhUx2gFy4cZuFwGau0vKzzcll19j2867+Oa6nj85KxIZ71uGNZOGwfhvnAz3r5WOfqJ2UcVvV7YXlGk3L1r3+nxW3fXHe/0X/pO+vujzUoJ0n3WTQM70iOYUGTDLBgCC6/cBGjI4YFSdLslTEwfDMsz4nipFGzpMeG5V1tzMa8q+7+QxuUO73u/p0NyknS/axatpCN60ZZMjZ9GFgyNuSkbZKkjirjf5RPAW8NHZnPr5ugbapnhGU2XV+EAv8ZAsYDwvp7C8qdG5bfy7O0xVHVJemI1cuH2XH2GFt2Vdm+t8r+So0TRodYtWyYNecOe2VBktRRpbvCkGfpTuDr4eHrpysTxckFdTM2f7CNbd8ThlMF+OMoTo7qbRjFyVJgbXj48XaPX5IARkeGuGjlCB+8eJR/e+liPnjxKBetHDEsSJI6rnSBIXgNcBi4IIqT99af2EdxEtWd9H8yz9LP1q8YxcmboziphtuZR20Z/hy4PTQ7yqI4eXjduitCSFgI/Ax4RzffpCRJkjRbpQwMeZZ+DnglUAVeDtwaxcl1UZzcCmwHTga+BFw8zeoLwgn/wuk6NudZehsQh9DwK8C3ozi5IYqTG4H/CbNB7wOSPEv7fxwtSZIklVopAwNHTuzfBzwe+DDwE+Cs0KfjGuBlwFPyLG02G3TRtr8SgsFfh34Mp4UQsjfM9Lw8z9Ivdf5dSVJ3VCZqXLljgpdcUeG5HzjIS66ocOWOCSoTrXbxkiQNqqFazT/288EtN99YO/m0Bztmcwkcqla57ZYfAmCdl8Nc1/m2PVU2bB5n38Gj/1+ctHiIdz5nkaMydcFc17t6zzovn8k6P+2Ms/q6A1pprzBIkprbtqfK+k2VacMCwL6DNdZvqrBtT7XnxyZJ6g0DgyRpWpWJGhs2j3O4yYXowzW49KpxmydJ0jxlYJAkTevqndXCKwtT3XGgxpZdXmWQpPnIwCBJmlZ+XXsBYPteA4MkzUcGBknStPZX2mti1G55SdJgMDBIkqZ1wmh7g3a0W16SNBgMDJKkaUVL2xvScdUyh4CUpPnIwCBJmtbaFcOctLi1qwZLxoZYc66BQZLmIwODJGlaoyNHJmVb0CQzLBiCyy9cxOiITZIkaT4yMEiSCq1ePszGdaMsGZs+DCwZG2LjulFnepakecy/8JKkhlYvH2bH2WNs2VVl+94q+ys1ThgdYtWyYdacO+yVBUma5wwMkqSmRkeGuGjlCBetHJnrQ5Ek9ZhNkiRJkiQVMjBIkiRJKmRgkCRJklTIwCBJkiSpkIFBkiRJUiEDgyRJkqRCPRtWNYqThcCFwNOAM4BRoNng3bU8S3+9R4coSZIkaYqeBIYoTo4HPgusrHu6UViohddrPTg8SZIkSQV6dYXhT4FfDvfvAa4H9gOHe7R/SZIkSTPQq8DwrHC14H3Aa/IsrfRov5IkSZJmoVeB4UzgbmBDnqX39mifkiRJkmapV4FhHPixYUGSJEkaLL0aVvXbwIk92pckSZKkDulVYPhn4NQoTn61R/uTJEmS1AG9apL0XiACPhbFycV5ln6hR/uVJPW5ykSNq3dWya+rsr9S44TRIaKlw6xdMczoSLPpeiRJ3darwJAA/w84BfiPKE52AN8EfthsaNU8S9/So2OUJPXYtj1VNmweZ9/B+0+7s3V3lcuyId75nEWsXt6zOUYlSdPo1V/hzVMmYfvlunkZmjEwSNI8tG1PlfWbKhwumKJz38Ea6zdV2Lhu1NAgSXOoV30YCDM3z+QmSZpnKhM1NmweLwwLkw7X4NKrxqlMNCkoSeqaXn1lczwwnmfpoR7tT5LUx67eWT2qGVKROw7U2LKrykUrR7p+XJKko/UkMORZeqAX+5EkDYb8umpb5d+SjbN9b9XO0JI0B3rZJEmSJAD2V9prYnT7gSMdoS/ZPM7Ktx5g2572AockaeY6foUhipPzgbvzLP36lOdmJM/SL3bs4CRJfeGE0ZlfIbAztCT1Vjf+0n4e+AawcspzM+mxVuthPwtJUo9ES4fZunvmVwkmO0PvOHvM5kmS1GXdapI03V9vR0mSJAGwdsUwJy2e3Z/4yc7QkqTu6sa3908D7p7mOUmSABgdOTIpW6N5GFqxfa+jJ0lSt3U8MORZ+oVWnpMkldvq5cNsXDfKpVeNc8eBmaWGos7TlYkaV++skl9XZX+lxgmjQy2NsDTT9SRpPutJ/4AoTl4Q5mH4117sT5I0GFYvH2bH2WNs2VVl+94q//X9Q9zeRniYrvP0tj1VNmweP2qeh627q1yWHbmyMV1n6ZmuJ0nzXa+GVd0IvKlH+5IkDZDRkSEuWjnCBy8e5U3POLatdVctu/8J/LY9VdZvqhROCjc5wtLUYVlnup4klUGvAsOPgZN6tC9J0oBqpzP0krEh1pz788BQmaixYfN40z4RkyMsVSZqs1pPksqiV4HhQ8DpoWmSJEnTmuwMvaBJZlgwBJdfuOh+/Qqu3lktvEIwVf0ISzNdT5LKoleNMf8cqABvj+LkacDHgJ3Az/IsPdSjY5AkDYBmnaGXjA1x+YVH9yfIr2vvRH5yhKWZridJZdGrwPCtsDwAvCDc4EiH6Ebr1fIstYeZJJXM1M7QkyMWrVo2zJpzpx+xqGjEpCKT5We6niSVRa9Oxpf2aD+SpHlisjN0q9/mTzdiUivlZ7qeJJVFrwLDZT3ajySppKKlw2zd3XrzoskRlma6niSVRU/+6uVZamCQJHXV2hXDXJYNtdSBuX6EpZmuJ0ll0ZNRkqI4eUgUJw/uxb4kSeU00xGWZjMykySVQa+GVb0R+EyP9iVJKqnJEZaWjE1/Ur9kbIiN60aPGmGp2Xpjx8D7nudMz5LKqVd/+X4G+JWMJKnrZjLC0uR6b6sey4bN4xy49/6vHbgXXv+JezhmeMjQIKl0evVXbzvwvChOfinP0q/3aJ+SpJJqd4QlgG17qrz8Y8UzPu87WGP9psq0VygkaT7rVZOkS4Ac+FQUJy+M4mSsR/uVJKmpykSNDZuLw8KkwzW49KpxKhPOxSCpPHr1FclbgO8BvwBsBN4fxcn3QlOliQbr1fIs/fUeHaMkqaSu3lltaZQkgDsO1Niyy9meJZVHrwLDy4HJv8RDwAhwTrhNpxbK+RWOJKnr8utan4cBYPteA4Ok8uhVYPiiJ/+SpH61v9Lev6h2y0vSIOvVxG1P7cV+JEmaiRNG2xvIr93ykjTIetXpWZKkvhUtbe/7s1XLHCVJUnkYGCRJpbd2xTAnLW7tqsGSsSHWnGtgkFQePfmLF8XJm2ew2kJgUZ6lr+/CIUmSdJ/RkSHe+ZxFrN9UaTi06oIhuPzCRYWTv0nSfNSrr0j+fBadng0MkqSuW718mI3rRrn0qnHuOHD0v6wlY0NcfuEiJ22TVDq9/KvXztcx3wcOdvFYJEk6yurlw+w4e4wtu6ps31tlf6XGCaNDrFo2zJpzh72yIKmUejVKUtO+ElGcLAGeALwOOAP4vTxLv9KL45MkadLoyBAXrRxxngVJCvqm03OepXfkWfqpPEufBuwAtkVx8oi5Pi5JkiSpzPomMEzxx8ADgDfO9YFIkiRJZdaXPbfyLP1RFCe3A78+18ciSdKkykSNq3dWya/7ef+GaOkwa1fYv0HS/NWXgSEYDVcZJEmac9v2VNmweZx9B+8/gtLW3VUuy44My+oISpLmo75skhTFyVOBMeDuuT4WSZK27amyflPlqLAwad/BGus3Vdi2p9rzY5OkbuvVxG3nt1BsAXAi8HjgD8K8DTt6cHiSJBWqTNTYsHm84YRuAIdrcOlV4+w4e8zmSZLmlV5dO/18mxO3DQGHgbd38ZgkSWrq6p3VwisLU91xoMaWXVWHZJU0r/SySdJQG7frgd/Os/QzPTw+SZKOkl/XXjOj7XttliRpfunVFYantVCmBowDN+dZeksPjkmSpKb2V9q5QN5+eUnqd72a6fkLvdiPJEmddsJoe/0R2i0vSf2u64EhipOVwJl5ln68SbkR4J+Av8iz9IZuH5ckSa2Ilg6zdXfrzYxWLevuv1bngpDUa13twxDFyR8B1wJvaqH4euBi4KtRnKzq5nFJktSqtSuGOWlxayfiS8aGWHNu9wLDtj1VVr71AJdsHmfr7ipf+u4htu6ucsnmcVa+9YDDukrqiq4FhihOnge8M1zFeHQUJ6c0WeVgmHfhAcDHozhZ0a1jkySpVaMjRyZlW9AkMywYgssvXNS1b/mdC0LSXOlKYIjiZDHwd+HhbuCX8yz9SaN18izdBDwa+DawODRPkiRpzq1ePszGdaMsGZs+DCwZG2LjutGuzfTc7lwQlQk7XkvqnG5dYXg+8EDgx8Bv5Fm6s5WV8iz9AfAbwE+Bx0Vx8owuHZ8kSW1ZvXyYHX8yxrueu4hnPnqYX334Qp756GHe9dxF7PiTsa6FBYAt3zzU9lwQktQp3frr9owwTOpf51n643ZWzLP0xihO3g78NfBc4FNdOkZJktoyOjLERStHej4x22euP9RW+e17nTxOUud06wrDuWH5kRmu/4GwPK9DxyNJ0sDaX2m3vE2SJHVOtwLDqcBP8yzdP5OV8yy9E7gNOLPzhyZJ0mA5YbTd8g6vKqlzuhUYRoCfzXIbtwPHduh4JEkaWBecs7Ct8t2eC0JSuXQrMOwLnZ5n45QwzKokSaW25jEL+2YuCEnl063A8EPg5ChOzpjJylGcLAeWAN/t/KFJkjRYRkeGeMETWuvEvO68EWd8ltRR3QoMXwzLF8xw/VeGUZa+3MFjkiRpIFUmanzkvydaKrvpKxPOwyCpo7oVGK4ChoDXRXGytJ0VozhZBfx+ePjR7hyeJEmDY67mYahM1LhyxwQvuaLCcz9wkJdcUeHKHQYSqWy6EhjyLP0y8DngeCCP4uTJrawXxcm6EDYWAFvyLP1KN45PkqRBMpN5GGZr254qK996gEs2j7N1d5UvffcQW3dXuWTzOCvfeoBte5wcTiqLbvaKehHwVeAXgc9HcbIF2ARcm2fprRwJCEPAw4CnAC8N8y4MATeF9SVJKr1ez8OwbU+V9ZsqHC7YzL6DNdZvqrBx3WhXZ7iW1B+69inPs/TmKE5+A0jDfArPCjeiODkMVIDFISBMGgJ2Ar8T5mKQJKn0ejkPQ2WixobN44VhYdLhGlx61Tg7zh6zk7U0z3WrDwMcCQ3/AzwOeHsYInUo3BYCx4X9Tz53J/CXwBPyLL2+m8clSdIg6eU8DFfvrM5JfwlJ/avr1xHDlYLXRXHyZuDJwOOBk0P/hgpwM7AD+HKepfd2+3gkSRo0ax6zkL/4dGsn8rOdhyG/rr0AsH1vlYtWtjbkq6TB1LOGh3mWjgOfDTdJktSi0ZEh3vmcRQ37FQAsGILLL1w0qyZC7fZ/mG1/CUn9r6tNkiRJUmesXj7MxnWjLBmbPgwsGRvqSCfkdvs/zKa/hKTB4NAGkiQNiNXLh9lx9hhbdlXZvrfK/kqNE0aHWLVsmDXnDnek83G0dJitu1tvljSb/hKSBoOfckmSBsjoyBAXrRzpWr+BtSuGuSwb6kl/CUmDwSZJkiTpPpP9JRY0uVjRif4SkgaDgUGSJN1Pr/pLSBoMftIlSdJRetFfQtJgMDBIkqRpdbu/hKTBYJMkSZIkSYW8wiBJkrqiMlHj6p1V8ut+3qQpWjrM2hU2aZIGiYFBkiR13LY9VTZsHj9qeNatu6tclh0ZiclO09JgsEmSJEnqqG17qqzfVCmcy2HfwRrrN1XYtqf1CeIkzR0DgyRJ6pjKRI0Nm8c53GTet8M1uPSqcSoTzSeIkzS3DAySJKljrt5ZbWmWaIA7DtTYssurDFK/K23jwShOngi8AjgfOAWoADcAm4F351k63sF9nQh8CzgduCnP0rM6tW1JkvpJfl17AWD73qrDtkp9rpRXGKI4eSPwZWAdcCrwA2AcOA/4G+AbUZyc1sFd/l0IC5IkzWv7K+01MWq3vKTeK11giOLk2cBfhff+buCUPEvPybP0dOBJwE3AUuDjUZzMesy3KE7WhGByqDPvQJKk/nXCaHv/OtstL6n3ShUYojhZALwtPNySZ+mr8yzdP/l6nqXXAhcCNeCJ4f5s9rcEeH94+JFZHbwkSQMgWtpea+dVy0rbOloaGKUKDMATgLPD/b+drkCepV8DvhAevnCW+/v70OTpSuCLs9yWJEl9b+2KYU5a3NpVgyVjQ6w5d5jKRI0rd0zw4o8c5Px3HOBx/+duzn/H3bz4Iwe5cseEIylJc6xsgSEKy4PAtQ3KfSYsL4jiZEZffURxkgDPA24DXjWTbUiSNGhGR45MyragSWZYMASXX7iIL95wiJVvPcAlm8f59J5D3PDTw9x6V40bflrj03sOccnmcVa+9YBzNkhzqGyB4VFheX2epY3+8uwOy0XAw9rdSRQnDwLeFx7+QZ6lP2v/UCVJGkyrlw+zcd0oS8amTw1LxobYuG4UoOEEb5Oc6E2aW2VrOHhmWP6oSbkf191/KPDtNvfzD8DJwMfyLP14m+vO2KFD/iEtg/p6ts7LwTovp0Gv9wseCf/9mmP5928eIr/+EPsrcMIoROcs5DcfsxCocd7fNp/gbdLhGly6ucJ/v3YRoyPzs6P0oNe52jco9Vy2wHB8WN7dpFz968c3KHeUKE6eCzwXuLXXTZFuv+3WXu5OfcA6Lx/rvJwGud6fctqRW73//RlcvfdY9h08rq1t3XEQXvuvd/K68w+waJ6fwQxynWv+mecft6MsCst7m5S7Z5p1mori5BfC1QWAl+VZekf7hyhJ0vx3zU0zm6ztE3sX8e/XH8vyk6s8e/k9rDr7nnkfHqS5VraP2OTszcc0KXds3f1KG9t/L/AgYFOepVfP4Phm5YEnn8rChWWr0vI5dKh63zdP1nk5WOflNN/rfbx2D3B4RutWDw+x69YRdt06wv+99jguf/YxrFq2sOPH2Gvzvc51tPo672dl+028KyybXQOtb4Z0V4Ny94ni5Hlh3oYfA38080OcuYULh1k4XLYqLTfrvHys83Kaj/V+4uKJGQeGendW4Pf+37186AWjrF4+f35G87HONbjKNkrS98LyjCbl6l//TrONRnFySpg1+jDwgjxL983uMCVJmt/aneCtkRrwqisrztcgdUnZous3w/KcKE6OybO0qC/DY8PyLuDGFrb7G8ADw/3PRHHSqOyZUZxM/kX75zxLX9TaoUuSNH+sXTHMZdlQ0yFVW3X3PXDVNya4+LxmrY4ltatsVxg+FZaLgPMblHtGWGZ5lrbyl2wC2N/kNtkXolb33MFZvh9JkgZSqxO8teOK/57o3MYk3adUVxjyLN0ZxcnXgV8CXl83o/N9oji5AFgZHn6wxe1+FPhoozJRnLwI+BDwgzxLz5rpe5Akab6YnODt0qvGuePA7K80/PDO2feJkHS0UgWG4DUhKFwQxcl7gTfkWXonR07qI+CKUO6TeZZ+tn7FKE7eDLw5PHx4nqU39fzoJUmaR1YvH2bH2WNs2VXlU9+a4Bs3H+Yn/zvT8DA/J3ST5lrZmiSRZ+nngFcCVeDlwK1RnFwXxcmtwPYwQ/OXgIunWX0BsDDc/KskSVIHjI4McdHKET70gsVc+7oxTlo8s3+xDz7Rf81SN5QuMHAkNLwPeDzwYeAnwFnhass1wMuAp+RZ2mw2aEmS1GGz6dvw7Mct5ModE7zkigrP/cBBXnJFhSt3TDh6kjRLQ7WaH6L54Jabb6ydfNqDHbO5BA5Vq9x2yw8BsM7LwTovp7LX+7Y9VV7xsQoH2+jHvPgYODjN+IcnLT4SQvp9noay13kZTdb5aWec1deXx0p5hUGSJPW31cuHOf/s9mZvni4sAOw7WGP9pgrb9lQ7c3BSyRgYJElSX7r7ns5t63ANLr1q3OZJ0gwYGCRJUl86YbSzrTTuOFBjyy6vMkjtMjBIkqS+FC3tfBv+7XsNDFK7DAySJKkvrV0xPOMhVovsr9gkSWqXgUGSJPWl2QyxWmTvrYccblVqk4FBkiT1rdXLh9m4bpQlY9OnhrFj2tve7Qdg6+4ql2weZ+VbDzhyktQCB/iVJEl9bfXyYXacPcaWXVW2762yv1LjhNEhVi0bJlq2kCe//SD7DrZ/tWByuNWN60b7fo4GaS756ZAkSX1vdGSIi1aOcNHKkaNee+dzFrF+U4XDM2hhNDnc6o6zxxgd6eu5s6Q5Y5MkSZI00Jo1W2rG4ValxgwMkiRp4K1ePsyOPxnjXc9dxDMfPcwD2wwPDrcqFTMwSJKkeWGy2dIHLx5l2antneI43KpUzMAgSZLmnXZnie70rNLSfGJgkCRJ8067s0SvWuY4MFIRA4MkSZp32pklesnYEGvONTBIRQwMkiRp3ml1lugFQ3D5hYscUlVqwMAg6hVoywAAIABJREFUSZLmpWbDrS4ZG3LSNqkFfkIkSdK81WiW6DXnDntlQWqBgUGSJM1rjWaJbqYyUePqnVXy634eNqKlw6xdYdhQeRgYJEmSprFtT5UNm8fZd/D+czRs3V3lsuxIHwmbM6kM7MMgSZI0xbY9VdZvqhwVFibtO1hj/aYK2/Y4Q7TmPwODJElSncpEjQ2bxzncZPLnwzW49KpxKhPOEq35zcAgSdL/b+/ew6SoDryP/3pmmplmgAHkIooXNCigApEEb0GjUqDlwm7FSzYqiRJXE9fEqEm8vIlZN5uYq4kxeeOqUSMm2eyr1iqxFAqveBc1IALeRSVegsAgMDNMz/T7B2fYZqar79WX6e/neXiqq+vUmeo53UP9uk6dAyS5Z3k88MpCbxu2JrRwBVcZ0L8RGAAAAJL4a3ILAItXExjQvxEYAAAAkrS25dbF6JUPuumWhH6NwAAAAJCkJZbbcKmv/r1b067eyg3Q6LcIDAAAAEmsCbkPlcqoSejPCAwAAABJ5k5p0LCBuU/K1p2Q/uUPbVrw9Ha6KKFfITAAAAAkiUV3TMpWl8dEzp1d0rfdDroooV8hMAAAAPQye1KDbp4X0/DmPFIDXZTQzxAYAAAAUpg9qUHLLmvW+JH5hQYmdkN/QWAAAAAIEItGdMDo+rz3Z2I39AcEBgAAgDTyGTUp2c1PcBM0qhuBAQAAII18R03qsXwd8zSguhEYAAAA0ihk1KQe3ASNakZgAAAAyKDQUZPETdCoYgQGAACALPSMmvTTzzUqmud90NwEjWpEYAAAAMhSLBrRmdMH6MYzYnl3UVq8msCA6kJgAAAAyFEhXZRa2+iShOpCYAAAAMhDTxelKXvmdjrVEivg7mmgDAgMAAAAeYpFIzr7iAE57TNrYmHzOgClxjsWAACgAHOnNOgqL6KN2zJ3NRreHNGcyQ1q60zonuVx+Wviam1LqCUW0fEHRHT4SKmJszNUGN6SAAAABeiZp2H+gjZ1p8kMdRHpmpOb9OirXbrojvY+AePeldLQpmH63nFbdOqY8I8byBZdkgAAAAqU6Sbo4c0R3TwvJkmav6At8GrEpvY6XXLfYC1e3RXq8QK54AoDAABAEcye1KBl45u1cEVci1f/b1ejWRMbNGfyjlOuaVdvTXsVQpK6ExF9092uz04YoFiUG6RRfgQGAACAIolFIzptWlSnTYv22fbnZZ1Z3ecgSRu2SQtXxFPWA5QaXZIAAABKwF+T24RtTPCGSkFgAAAAKIFcJ2xjgjdUCgIDAABACeQ6YRsTvKFSEBgAAABKwJqQ262jTPCGSkFgAAAAKIG5Uxo0bGB2Vw2GD9TOkZWAciMwAAAAlEDPBG91GTJDXSShnzkMqYrKQWAAAAAokUwTvA1t6tbPT/xYsybWl/zYgCBc6wIAACihoAneZh4Q0WEj31cTZ2eoMLwlAQAASizVBG9d8bjefke6Z3Wjnnm4Q5vbt6slFtEx43dcbXjk1a6d4cKa0KC5UxrotoSSIDAAAABUgMWru3TxncO0qb1OUvfO5+9d2XcCt3tXxnWVt+OeiNmTOJ1DuLiHAQAAoMwWrYrrnD9uN2EhOxu3JTR/QZsWrWJGaISLwAAAAFBGbZ0JXXRHu7rzmNi5OyFdfGe72jqZFRrhITAAAACU0T3L49q4Lf8T/g1bE1q4gqsMCA+BAQAAoIz8NYWf7C9eTWBAeAgMAAAAZdTaVnh3omLUAQQhMAAAAJRRS6zwoVGLUQcQhMAAAABQRtaEwodFnTWRoVURHgIDAABAGc2d0qBhAwu7QhCLZlEIyBOBAQAAoIxi0R0TsNUVkBkuu7uDoVURGgIDAABAmc2e1KCbTh+goU3dWZTui6FVESYCAwAAQAWYNbFe3pc26qrjt8g+qE67Ned2yYGhVREWAgMAAECFaGqQ5kzo0A1faNTE3XM7TWNoVYSFwAAAAFCBch0qlaFVERYCAwAAQAXKdbhVhlZFWAgMAAAAFSiX4VaHN0c0ZzKBAeEgMAAAAFSgWDSiLx6W3QQL86ZHFYvSJQnhIIoCAABUoLbOhG57ujOrsr9+eLsWPL1dkYi059A6nTk9qlMOzS5EtHUmdM/yuPw1cbW2JdQSi8ia0KBZk+q1eFVXn+fnTmkgnNQYAgMAAEAFumd5XBu3ZTfyUVdC2rBtx+OPtnbr226Hrrq3Q7/555hmTwo+3Vu0Kq6L7mjv83PuXRlXRFLvn37vyriu8nZMNNe73t7BY1CjNGxgRBu3JbSlQzsDx9Hj6/SjRdu1aFVcW7dLiYQ0oF4aM1Q6YFS9TpgUJZRUGAIDAABABfLXFDavwtbt0tm3temWL6YODYtWxTV/QZu6AzJJUFTZuC2h+QvadPO8/603KHj0du/K1K+pLS69sV56Y32X7l/VtTOUHD2+Xvcsj+v+VZ167e/d+vDjhNo7d4SMxqi017CIBjVG9PaGbrWZizEtsYj2aIloxKA6rogUCYEBAACgAhVjXoWEpIvuaNNzlw/a5aS5rTOhi+5oDwwLmXQnpIvvbNey8c169NWutMEjHxu3JXT2bW1qbpS2dKQu09khrX4/0SfabG5P6J2NCUnd5oqI9ItT0l9pQXrc9AwAAFCBijWvwsZt0sIVu36zn0t3pyAbtiZ05wudBQWPdBIKDgu52LhNOntBmxatYibsfBEYAAAAKlCu8zCks3j1rifLhXZ36rHg6c6Cg0cpJBLS1/7cprbOyj/WSkRgAAAAqEC5zMOQSe/uTcXo7iRJ6zZ1F6WeUvi4Q7rzhexGncKuCAwAAAAVKBbdceNvXREyQ+/uTcXq7iRV183Et2c5TC12RWAAAACoULMnNejmeTENby7sxHzWxF27NxWru9PYodUVGN7dRJekfBAYAAAAKtjsSQ1adlmzrj21SScd3KAjxtUpWp/9/sMGSnMm7xoQitHdaXhzRGdMz24m6spBYMgHgQEAAKDCxaIRnTYtqpvOjOmu85p14xkxRbI4349ox5CivechKLS7U11EuubkJp1yaLRo91mUwtihnPrmg98aAABAlZk9qUG3zItpcGNwmUGNCpy0TVl0dwqKAcObIzsnbSvmfRalcOZh1XZFpDIwgwUAAEAVmj2pQcu/M0h3vtCp25/uNP3zExo7tE5nHhbVyZ+MZpzhePakBi0b36yFK+JavDqu1raEWmIRzZrYIGtivfzVXX2enzN515mTe4LHxXe2a8PW4nT5GdS4Y6bqRBF7EA1qlE7+JIEhHwQGAACAKhWLRnTm9AE6c/qAguo4bVpUp03rezJ92rS6lM/3lip4DGqUdmuu00dbu7WlQzsDx4xP1OnHi7fr/pfiO0PBgAZpTIt0wKh6nXhQVHMmN+jRV7uKFkIikn79+b5ds5AdAgMAAAAKli549PbLU2PSqenLJIeQ+17q1Gt/79aHHyfU3rkjZDRGpb2HRTSoKaJX3u/WpvbU9QwbuOM+jqCuWciM3xwAAAAqUi4hpK0zkbJrVe8uVMgdgQEAAABVL5dwgdwwShIAAACAQAQGAAAAAIEIDAAAAAACERgAAAAABCIwAAAAAAhEYAAAAAAQiMAAAAAAIBCBAQAAAEAgAgMAAACAQAQGAAAAAIEIDAAAAAACERgAAAAABCIwAAAAAAhEYAAAAAAQiMAAAAAAIFBDuQ+gnCzbOVzS+ZKOljRaUpukVyXdIek633PbC6jbkXSWpE9LGiGpQ9JaSQ9I+pXvua8X99UAAAAAxVezVxgs27lC0uOS5knaXdLbktolTZf0E0kvWLYzJo96my3buVfSXZLmmrCwVlKnpIMkfV3SiyZQAAAAABWtJgODZTufk/QD8/qvkzTa99wDfc/dQ9KR5gR/gqS7LNuJ5Fj97yTZkrol/R9JQ3zPHe977nBJMyS9ISkm6Y+W7ewd0ksEAAAAiqLmAoNlO3WSfmRWF/qe+3Xfc1t7tvue+6SkkyUlJB1uHmdb98GSPm9Wr/Y994fJ3Zp8z31M0hfMapOk+cV6XQAAAEAYai4wSDpM0njz+KepCvie+5ykR8zql3Ko+1BJ683VhRsC6n7GlJGkqTkdOQAAAFBitRgYLLPcJunJNOWWmOVMy3ayujnc99zbfM8dKWmA77lvpynac0Ujmt0hAwAAAOVRi4HhILN82ffceJpyK82ySdJ+ufwA33O7grZZtjNC0j69fgYAAABQkWpxWNWek/V1Gcr9LenxOEmvFOnnX2p+792Sfl+kOiVJXV3p8g/6i+R2ps1rA21em2j32kOb155qaedaDAyDzXJLhnLJ2wenKZc1M5TqxWb1Ot9zVxWj3h4fffh+MatDFaDNaw9tXpto99pDm6OS1GKXpCaz3J6hXEeKffJm2c48SX82v/OHJH2r0DoBAACAsNXiFYaeYU4HZCjXmPS4rZAfaNnOdyX9u1ldJOlk33M7C6kzld1G7a76+lps0trS1RXf+c0TbV4baPPaRLvXHtq89iS3eSWrxXfiZrMclKFccjekzWnKBbJsp9FM5HaGeepGSednuNk6b/X1DapvqMUmrV20ee2hzWsT7V57aHNUklp8J75hJmTbK0O55O2v5fpDLNtpkeSZmaPjki7xPfdXuR8uAAAAUD61eA/Di2Z5oGU76bol9UyqtlnSW7n8AMt2Bkq614SFzZJOIiwAAACgGtViYLjPLJskHZ2m3Ilm6fmem8i2cjPJ292SjpL0kaRjfM9dXNghAwAAAOVRc4HB99zlkp43q5emKmPZzkxJ08zqTTn+iO9Jmmlurj7B99y/FnbEAAAAQPnU4j0MkvRNSUskzbRs57eSLvc9d5N2hAVL0u2m3N2+5z6QvKNlO1dKutKs7u977tqkbftJusysXuZ77rJSvSAAAAAgDDUZGHzPfciynX+VdJ2kr0g627KdtyQNlTTaFHtM0pkpdq+TVG8eR3pt+1rS7/RfLNs5O4tjmZqpDAAAAFAuNRkYtONE/XrLdp6SdKGk4yTta2Z3XmquMNzke253jtUOS3p8UJEPGQAAACi5SCKR9f28qGDvvfNWYtSYsYzZXAO64nF9+N67kiTavDbQ5rWJdq89tHlh2joTumd5XP6auFrbEmqJRWRNaNDcKQ2KRXt3CqkMPW0+Zq99K/MADd6JAAAAqGqLVsV10R3t2rht1y/C710Z1xX3SL88pUlzJkfLdnzVruZGSQIAAED/sWhVXPMXtPUJCz22bZfO/WO7frSoo+TH1l8QGAAAAFCV2joTuuiOdnVn0cP+2oe26/L/aVNbJ93xc0VgAAAAQFW6Z3k88MpCKrc+Fde0q7do0ap4qMfV3xAYAAAAUJX8Nbmf+G/cJs1f0EZoyAGBAQAAAFWptS2/7kXdCeniO9vpnpQlAgMAAACqUkss/9FIN2xNaOEKrjJkg8AAAACAqmRNKGyGgMWrCQzZIDAAAACgKs2d0qCBA/LfP98uTbWGwAAAAICqFItG9MtTmvLev5AuTbWEwAAAAICqNWdyVBcem99lhlkTC+vSVCsIDAAAAKhql81u1A2nN2lgNPt9hjdHNGcygSEbBAYAAABUvTmTo1p55SCdc1Tm1FAXka45uUmxKF2SskFgAAAAQL8Qi0b0/TlNuvWLMQ1vTh0GhjdHdPO8mGZP4upCtvhNAQAAoF+ZPalBy8Y3a+GKuBavjqu1LaGWWESzJjZozuQGrizkiMAAAACAficWjei0aVGdNi2HGxuQEl2SAAAAAAQiMAAAAAAIRGAAAAAAEIjAAAAAACAQgQEAAABAIAIDAAAAgEAEBgAAAACBCAwAAAAAAhEYAAAAAAQiMAAAAAAIRGAAAAAAEIjAAAAAACAQgQEAAABAIAIDAAAAgEAEBgAAAACBCAwAAAAAAhEYAAAAAAQiMAAAAAAIRGAAAAAAEIjAAAAAACAQgQEAAABAIAIDAAAAgEAEBgAAAACBCAwAAAAAAhEYAAAAAAQiMAAAAAAIRGAAAAAAEIjAAAAAACAQgQEAAABAIAIDAAAAgEAEBgAAAACBCAwAAAAAAhEYAAAAAAQiMAAAAAAIRGAAAAAAEIjAAAAAACAQgQEAAABAIAIDAAAAgEAEBgAAAACBCAwAAAAAAhEYAAAAAAQiMAAAAAAIRGAAAAAAEIjAAAAAACAQgQEAAABAIAIDAAAAgEAEBgAAAACBCAwAAAAAAhEYAAAAAAQiMAAAAAAIRGAAAAAAEIjAAAAAACAQgQEAAABAoIZyHwAAAEB/19nZqa6urrRluuJxdcZ3lGlvb1d9A6dp1aq+vl7RaLTch1E0vBMBAABCsnnzZq1fv14dHR0ZyyYSCXWbULGl7W1FIpESHCHC0tjYqBEjRmjIkCHlPpSCERgAAABCsHnzZq1bt06DBg3SiBEjFI1G04aARCKhzs5OScpYFpWrpx1bW1u1bt06Sar60EBgAAAACMH69es1aNAgjR07NquT/0Qiofr6HbeXRqMDCAxVLBaLafDgwXr33Xe1fv36qg8M3PQMAABQZJ2dnero6FBLSwsn/jUqEomopaVFHR0dO68cVSsCAwAAQJH13ODcn258Re562j/TDe+VjsAAAAAQEq4u1Lb+0v4EBgAAAACBCAwAAAAAAhEYAAAAAARiWFUAAIAq1NaZ0D3L4/LXxNXallBLLCJrQoPmTmlQLFr+vvOL/Af1s19cJ0m65ic/0CEHT0pZrqurS2ecda4++miDrJnH6tsXf32XbY8+9oQefHipXn3tdW1u3aymWJNGjhyh6Z+aJnv2TI0Zs3ufOi3bkSSdMOt4XfKNCwKP8cbf/V7/fef/SJJ8z935/CWXfkcrXnwp7es7aNIE/fJnV2f8PfQHBAYAAIAqs2hVXBfd0a6N2xK7PH/vyriu8iL6xSlNmj2pMk7zotGovPv9wMDw7LLntXnzx32eb23drKv+48dauWq1PnPk4Tr3y2dp9KiR6ti+Xa+8+pr+cu/9+p+7/6ILzj9Xs63jUv7chx99XF8998saODDWZ3tXV5eWPPiIotFo4LCn1/zkBxowYEDKbanq7K8q450EAACArCxaFdf8BW3qTqTevnFbQvMXtOnmebGKCA2fnDpZSx9/Qhd89Rw1Nzf32X6//4AmH3KQnnv+rzufSyQS+vcf/kQvrV6j717+Lc34zBG77HPo1Mn6xzm2rrzqh7rm2t9o1MgR+uTUybuUmTr5YD33wnI99MhSnXTirD4/9+lnn9OGjRt16Cen6PkXlqc89k/sP06xWO0EgyDcwwAAAFAl2joTuuiO9sCw0KM7IV18Z7vaOjMULIEZRx2ujo7teuChR/ts27hpk55+5jkddcRhuzz/5FPPaMWLL2nOSSf0CQs9Yk1NuuLSizVgwAD950239tk+dNhQHTRxgu5b5Kfc//7FSzThwAO0227D835ttYLAAAAAUCXuWR7v0w0pyIatCS1cEQ/9mDIZs/vumnDgAfLu73vivuTBRxSRdMyMI3d5funjT0mS7BOstHUPGzpURx0xXa+/8abWvv1On+3HfnaGXn7lNb3x5lu7PL9x4yY98+zzOv64Y/J8VbWFwAAAAFAl/DW5BYDFq8sfGCTpxNnH6/U33tQrr76+y/OLFj+gIw6friFDhuzy/Nq331Z9fb3G7btPxro/sf9+kqR33l3XZ9txn52hpsbGPmFl8ZKHVFdXp+M+OyPPV1Rbyt+xDQAAAFlpbcuti1Gu5cNy7DEzdP2Nt+i+Rb4OGL+/JGnVmpe19u13dN45Z/Upv21bm5qaGrOaKXngwIGSlPLG6ebmZs34zBF68KFHde6Xv7TzBuZFSx7QUUccpiGDB6ete+7Jpwdu+/ypjs45+4sZj68/IDAAAABUiZZYbsOl5lo+LLFYTMfMOEoPPrxU551ztpqaGnX/oiUaOWI3TTt0ap/yQ4e26L33P1BXV5fq6+vT1r1169ad+6Ry4mxL/gMPa+njT+r4Y4/RypdW65131un8887JeNzX/vxqDRjQmHLbsGGpf15/RJckAACAKmFNyO273lkTK+e74RNnz9S2bdv0yNLH1dberkcefVzW8ceqrq7v6ei+++yt7u7uPl2YUnnltR1lxu2zd8rthxw8SXuN3XNnt6RF/gMaOXKEDu01qlIq4/bdR5/Yf1zKf7sNr52bpQkMAAAAVWLulAYNG5jdVYPhzRHNmVw5gWHSxAnaZ++99NAjS/XEk0+rrb1ds2f1nT9B5mZlSbrnL/elrXPjxk166qlndfBBE1NO4NZjtnW8Xly5Sn977z09uvQJzZqZOqggNX5TAAAAVSIW3TEpW12GzFAXka45uakiZnxOdsKs47VixUo98OAjOuTgSdpjzJiU5aYccrCO/syRWvLgw7pv0ZKUZdra2/XDn1yjrq4unX/el9P+3FnWsaqvr9f1N96yI6jMTB1UkFrlxE4AAABkNHtSg26eF9PFd7Zrw9a+NzUPb47ompMrZ6bnZNbxx+rmW2/Xs8+9oG9f8vW0ZS/5xgWKx+O65trf6ImnntGxR39Go0eP0vbt2/XKq6/rL9792rJ1q75z+Tc1/hP7p61r2NChOmz6ND3+xNOaOvngtFcj0FflvZMAAACQ1uxJDVo2vlkLV8S1eHVcrW0JtcQimjWxQXMmN1TclYUeLS1DdMTh07XsuRc046gj05YdODCmq668XE889YyWPPCwbrntD9qwcZMaGwdo9KhRso4/VieeMFMjR4zI6mefONvS4088rdmzji/Sq6kdkUSiMobbQmHee+etxKgxY1XfQAbs77ricX343ruSJNq8NtDmtYl2r27t7e168803NW7cODU1NWW1TyKRUGfndklSNDogqyFFUdkyvQ96Pudj9tq3ohubexgAAAAABCIwAAAAAAhEYAAAAAAQiMAAAAAAIBCBAQAAAEAgAgMAAACAQAQGAAAAAIEIDAAAACFhvqva1l/an8AAAABQZPX19ZKkzs7Och8Kyqin/XveD9WKwAAAAFBk0WhUjY2Nam1t7TffMiM3iURCra2tamxsVDQaLffhFIR55gEAAEIwYsQIrVu3Tu+++65aWloUjUYViUQCyycSiZ3fSHd1dacti8rV046tra3asmWL9txzz3IfUsFqNjBYtnO4pPMlHS1ptKQ2Sa9KukPSdb7ntldi3QAAoDoMGTJEkrR+/XqtW7cuY/lEIqHuri5JUl19PYGhyjU2NmrPPffc+T6oZjUZGCzbuULS902XrA5JayUNljTd/Jtv2c5xvue+V0l1AwCA6jJkyBANGTJEnZ2d6jJhIEhXPK6P/v6BJGm3kaNV31CTp2n9Qn19fdV3Q0pWc+9Ey3Y+J+kHZvU6Sd/1PbfVbDtC0p8kTZB0l2U7R/qem3XHwzDrBgAA1SsajWY8geyKxxVt2HFzbFNTE4EBFaOmbnq2bKdO0o/M6kLfc7/ec0IvSb7nPinpZEkJSYebx2WvGwAAACiXmgoMkg6TNN48/mmqAr7nPifpEbP6pQqpGwAAACiLWgsMllluk/RkmnJLzHKmZTvZXg8Ms24AAACgLGotMBxkli/7nhtPU26lWTZJ2q8C6gYAAADKota+4d7HLDONbfa3pMfjJL1S5rqz0tWVLqegv0huZ9q8NtDmtYl2rz20ee2plnautcAw2Cy3ZCiXvH1wmnKlqjsrH334fjGrQxWgzWsPbV6baPfaQ5ujktRaYGgyy+0ZynWk2KecdWc0Zq99md0FAAAARVdr9zD0zLA8IEO5xqTHbRVQNwAAAFAWtRYYNpvloAzlkrsKbU5TrlR1AwAAAGVRa4HhDbPcK0O55O2vVUDdAAAAQFnUWmB40SwPtGwnXdehqWa5WdJbFVA3AAAAUBa1FhjuM8smSUenKXeiWXq+5yYqoG4AAACgLGoqMPieu1zS82b10lRlLNuZKWmaWb2pEuoGAAAAyiWSSNTWl9yW7RwraYkJS9dLutz33E1mmyXpdkmjJN3te+4/9dr3SklXmtX9fc9dW6y6AQAAgEpUc4FBO07evyLpOjMPRYe5l2CopNGmyGOSTvQ9d0uv/f5N0vfM6jjfc/vcg5Bv3QAAAEAlqqkuST18z71e0qcl3SrpA0n7mhP8pZLOk3RMvif0YdYNAAAAlFpNXmEAAAAAkJ2avMIAAAAAIDsEBgAAAACBCAwAAAAAAhEYAAAAAAQiMAAAAAAIRGAAAAAAEIjAAAAAACBQQ7kPAP/Lsp3DJZ0v6WgzM3SbpFcl3SHpOt9z2yuxbuQv5DZ3JJ1lJhIcYWYeXyvpAUm/8j339eK+GmSjlJ9Fy3aGSnpJ0h6S1vqeu2+x6kZuQv6sN5iJQU+XNEFSk6R3JT1u6n6huK8G2QirzS3bqZc0T9IXJE2VNCzp7/vDkn7je+7q4r8iZMN8Hq+UdIWkeklX+Z77b0Wot6zncUzcViEs27lC0vfNVZ+eD/5gSWNMkTWSjvM9971Kqhv5C6tdLNtplvTfkmzzVKepezfzH4vMH5ozfM91i/uqkE6pP4uW7dxmTixEYCifkP++D5d0v/liQCYodEjaW1JUUlzSfN9zFxT3VSGdEP++7ybpXkmHmafaJb0jqUXSKPNcp6QLfc/9bXFfFTKxbGeCpAWSPpX0dMGBoRLO4+iSVAEs2/mcpB+Y9rhO0mjfcw/0PXcPSUeaN8YESXdZthOplLqRv5Db5XcmLHRL+j+ShvieO9733OGSZkh6Q1JM0h8t29k7pJeIXkr9WbRsZ44JC13FeQXIR8h/3yOSXBMWlkua6nvuXr7nfkLSWEl3mp4Ev7Nsh7BYIiF/1heYsBA3V5UG+Z57gO+5oyWNl/SgCYq/sWznqJBeInqxbCdi2c4Fkp43YeH+ItZdEedxBIYys2ynTtKPzOpC33O/7ntua89233OflHSypISkw83jsteN/IXc5gdL+rxZvdr33B8mX6b0PfcxcxlbptvC/GK9LgQr9WfRfOt8g1m9raCDR95K0O5nmO4JH0iPD9KbAAANk0lEQVSa5Xvu8qS6P5R0piRf0p8lERhKIOS/7/tLOtGsXut77g2+5+78QsD33NfM3/92SRETKFAaJ5mT+TpJFyVd4S9IJZ3HERjK7zDzrYAk/TRVAd9zn5P0iFn9UoXUjfyF2S6HSlpvri7ckKqA77nPmDIy/V8RvlJ/Fn8taXdzovhogXUhf2G3+zfM8mcmIPSuu9333Fm+587zPffhHOtGfsJs8/FJj5cG1L1e0sspyiNcDZJWSZrue+4vfc8tVn//ijmPIzCUn2WW2yQ9mabcErOcaW6oKXfdyF9o7eJ77m2+546UNMD33LfTFO35hiKa3SGjQCX7LJqb3b8g6UNJF+RTB4omtHa3bGcvSdPM6v8r7DBRRGF+1pP7pw9OU26gWb6fZb0o3LOSPuV77ooi11sx53GcHJbfQWb5su+58TTlVpplk6T9JL1S5rqRv9DbJfkydW+W7YyQtE+vn4FwleSzaNr2erP6Vd9z11u2k98RoxjCbPeem5w3+p671rKdsaaL4RGShkv6uxkx58bkLgwIXZht/pKk1yXtb7oe3d67gGU7B5r6ZG6ORgn4nrsupKor5jyOwFB+PSdumd5sf0t6PC7LN0OYdSN/5W6XS81nv1vS74tUJ9IrVZv/XzNSyp98z70rx31RfGG2+0SzfMeynbnmZtghvcqcJOnblu38o+nrjPCF1ua+58Yt2/mqpLsl/YNlO7dL+pnZd5C5AfbHZijPhyXdUthLQQUo9/nCTnRJKr+ey4pbMpRL3p7uUmSp6kb+ytYuprvKxWb1Ot9zVxWjXmQUeptbtnOqpFNNNwS6IlWGMNt9hFkOl/QH04f50+YbxhGSzpb0kaSRkv5i2c6eeRw/chfqZ933XN+Mdnen6Xr4gqSt5sZ3V1KjpO9Kmp3uSjOqRsWcx3GFofyazHJ7hnIdKfYpZ93IX1naxbKdeWbI1TpJD0n6VqF1ImuhtrllOyPN1QVJOs/33A25HyJCEGa7N5vlWEkLJf1j0o2WHZJutWxnpen3PFzS5QTJkijF3/fDJR1o/pZvl/S2ubo0yozLf6SkKaZfPapbxZzHcYWh/HqGvByQoVxj0uO2Cqgb+St5u1i2810zvGZU0iJJc3zP7SykTuQk7Db/rflWeYHvuffkcXwIR5jtnjwKy3+kGpXF99xlSf3YuZmlNEL9rFu2c4sZBW0Pc8/KQDPPzmgTHv9ghl591LKdE7OoEpWtYs7jCAzlt9ksB2Uol3yJaXOacqWqG/krWbtYttNo+rn+u3nqRkn/4Hvu1nzqQ95Ca3PLdr5gxt7+m6QL8z9EhCDMz/rHSY+Xpyn3hFnuYdlOS5Z1I39hftbnSjrLrJ7ue+4tveZhWOd77nzTNalJ0n8y8mHVq5jzOAJD+b1hlntlKJe8/bUKqBv5K0m7mJODB83kTnFJF/qee26GkRYQjlDa3LKd0WayoG5JX/Q9d2Nhh4kiC/Oz/k7S43Szu25KetycphyKI8w275mU6wPfcxelKfdfST9jSpZ1ozJVzHkcgaH8XjTLAy3bSXfJqWeCrc2S3qqAupG/0NvFsp2BpivCkWb/k3zP/VX+h4wChdXmJ0jazfwtX2LZTqL3v6SRUvZJev7WAl8PshPmZz15vPdxacrtkfR4U5pyKI4w27ynLTMNk5v8xcHoLOtGZaqY8zgCQ/ndZ5ZNko5OU66nL6KXwwyCYdaN/IXaLuYS9N2SjjKjpBzje+7iwg4ZBQqrzTvNyUO6fz39WRNJz20r8PUgO2F+1p9I6nqQrq/6ZLN8w/dc2j18YbZ5TxDYx7KddOdvySGRARCqW8WcxxEYysz33OWSnjerl6YqY9nOzKQZPW+qhLqRvxK0y/ckzTQ3S53ge+5fCztiFCqsNvc994++5w5N90/S+ab420nPn5+hahRByH/fO8wNrpJ0iWU7Q1PUPUHSXLPKvBwlEPLf96Vm2WiGVA1yqlluMcOuokpV0nkcN8NUhm+aab1nWrbzW0mX+567STveCFbSbI53+577QPKOlu1cKelKs7q/77lri1U3QhVKm1u2s5+ky8zqZWaUFFSGMD/nqFxhtvu/STrNfKPsWbYzz/fc182+UyT9yUzitV7Sz0vxYiGF2Oa3mr/ve0i6zrKdqBkZrcvsO1TSd8yEfZL0cxMsUcGq5TyOwFABfM99yLKdfzU3L35F0tmW7bwlaWhS/8PHJJ2ZYvc68x+CUt34VmDdCEmIbf61pM/1v1i2c3YWxzI1UxkULszPOSpXyH/fP7Rsx5bkSTpC0iuW7bxhhk/umSF2oyTH99z3w3uVSBZWm/ue+7EZKnWhpL3N/Uk3WLbTc4I5LmnfW5JGx0PILNvxenUFS/YVy3b+qddztu+5PbMzV8V5HF2SKoTvudebWTpvNTM27mtO/JZKOs/0Q88001/J60b+QmqXYUmPDzIjZGT6hxLhs1ibQv77/oykiZJ+LGm1mbhrlHn8M0mTfM99rPivCumE1ea+564wf9u/YSbg3GTq3kPSm+bb5uN8z53ve253OK8OKUxK83/r6BTbMs2rsItK+L8jkkhwjysAAACA1LjCAAAAACAQgQEAAABAIAIDAAAAgEAEBgAAAACBCAwAAAAAAhEYAAAAAAQiMAAAAAAIRGAAAAAAEIjAAAAAACAQgQEAAABAIAIDAAAAgEAEBgAAAACBCAwAAAAAAhEYAAAAAAQiMAAAAAAIRGAAAAAAEKih3AcAAEApWbZzq6QvSVrre+6+5T4eAKh0BAYAwE6W7Tws6ZiAzXFJH0t6S9LTkhb4nvtEiQ+xGN6WtFzS38p9IABQDSKJRKLcxwAAqBBJgaFd0su9NjdJGiNpSNJzN0j6iu+5/GcCAP0UVxgAAKm87Hvu1FQbLNv5lKTvSzpB0rmSnpH0u9IfIgCgFLjpGQCQE99zl0n6nKQPzVNnlvmQAAAh4goDACBnvue2WbbzvLnKsHvytqSbihdJciT9VNLJkkZLOs733IeTyu4n6WuSjpO0n6SYpM2SVkr6s6T/9D033qv+QeZeCkk6VdJdkr4i6SxJB5iuU2sl3S3pP3zP3RxwfLvc9GzZzgWSrpO01ffcQZbt7Cnpckm2pD1MN60XJf3a99w/h/fbBYDKwhUGAEC+WsxybZoyv5T0r5I6JL0iqbNng2U7tgkG35B0iKQtkl43J/wzJP1a0oOW7cR61dme9LhO0p2SfiNpL0nvmZ9xgKRvmf2jWb6enfVatjNR0nMmiHRKWmfu3fiMpP+ybOeiLOsEgKpHYAAA5MyynQmSPm1Wg75t30PS6ZJs33P39T13gu+5j5v9h0i63VxRWCPpIN9zx/iee6A5Mb/M1DFD0rd71duV9PgiSdMlfdbsP1HSSEnXm+3TzNWNbPTUWy/pT5Iel7Sn77kH+p67v6TxJtBI0pWW7TRlWS8AVDUCAwAgK5btNFi2M9aynfmSHjTdWv9L0u8DdjlE0i98z70vxbbjk0Zb+rbvuat7NvieG/c998eSHjVPfT55x14jMh0uaZ7vuY8kbW+XdIm5qiFJx2b5EnvqbZI0WNI/+577QVK9r0v6oVkdKumTWdYLAFWNexgAAKlMsWwn3VCpr0o6w/fcP2aoJ+V233Ndy3YGSBohaWPAvs9KOtrc2xBkme+5D6aof5tlOy9Lmmy6KuXqGt9zO1M8/0LS470kPZlH3QBQVQgMAIBUUs3DIEmDzInyeEnXWrYzVdL3fc/9OIc6pB0n9d1JIy2lssUsG9OUeTHNtlaz7H0PRDaC6m1NepxPvQBQdQgMAIBU0s3DMEDSP0j6ubmxeJZlOzNShIYN6SZ0M/WcLemfJB0sabc8TsLfTbOt2ywjOdaZrt7upMf51AsAVYfAAADIie+52yXdZdnOc5JWSZoi6UoTHpKl6tIj7QgLIyQ9YLoM9VhnvsHv2W93MxRrOt0ZtucrrHoBoOpw0zMAIC++566VtNisnpLj7tckhYVfSRrle+5Y33MP8j13qrm6cX2GOgAAJcAVBgBAIf5mlntmu4OZF6EnYCzyPffCgKIjCj88AEChuMIAACjEWLNcn8M+I5PuVXg0VQHLdurMLNIAgDIjMAAA8mLZzl6SLLP6UA67bk16HHQV4bLk4VSZJA0AyofAAADIiWU7dZbtzJTkmysF7ZK+n+3+vue2SlpuVudbtnNoUt17WLZznbmJ+qqk3WYU9UUAALLGPQwAgFQOtGznrymebzLdkJrN+geSTvc9d02O9V8haaGkFknLLNtZa77EGispLukcSUslfVdSvaSFpszxvuemG0oVAFBkXGEAAKTSZIZL7f1vnKSPzdWFb0g6MNVMy5n4nutJ6rlKsVnSHmbTHyQd4XvuAt9z35J0oaR3zLZ2SR3FfZkAgEwiiUTgnDoAAAAAahxXGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAE+v/lS1XWnn9M1wAAAABJRU5ErkJggg==\n"
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwwAAAMMCAYAAAD+fyB7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAewgAAHsIBbtB1PgAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOzde5xcdWH38c8mu7DLAoHQcisIqClJrIkaRWpbUMtJymkTPUZprcZLaqvVVgWtPvpUK9Y+Wi/Qlrb6eImXWFueJp6ayKHJ0aqI0taIJsYkiBcQBURJCCWZhZ1knj/yWzxs9sxld3b2Mp/367WvMzvzm3N+M2cv5zu/W0+tVkOSJEmSxjJnqisgSZIkafoyMEiSJEkqZWCQJEmSVMrAIEmSJKmUgUGSJElSKQODJEmSpFIGBkmSJEmlDAySJEmSShkYJEmSJJUyMEiSJEkqZWCQJEmSVMrAIEmSJKmUgUGSJElSKQODJEmSpFIGBkmSJEmlDAySJEmSShkYJEmSJJUyMEiSJEkqZWCQJEmSVKp3qisgSa2K4uTpwBfCtx/Ps/QlU1wleV4kadYyMEjT2KgLsDLDwAPAj4CdQAZszLO00qFqqo4oTk4Hng08E3g88AvAScAQcC9wC3Aj8Ok8S7891fWdTaI4eRvwF00UHQbuA74LfAX4mOeis6I4ORf4wQR388Q8S7/ZpipJKjAwSDNfH3By+Ho88Hzgr6M4WZtn6ZaprtwkORgutAHumuK6jCmKk5PDxerLgf4xihwfvs4BlgNvj+LkeuBP8yz93hRUuR2m/Xkp0Qf8Yvj6VeD1UZx8BHhNnqUHprpykyGKk1cA77claHqL4uQ/gacCz8iz9ItTXR91LwODNHN8F0jGuH/kYufJwFrgMcCZwGejOPmNPEv/cwrqOqnyLP1vYOFU16NMFCeLgc8Ajw13HQKuA64P5/Fe4DjgfCAGnhX+Hl8KbI/i5Dl5lm6d4pfRsml+Xv4Z+D8ljw0WgtsLgWOBPwDOjeLk0jxLhztc1064YKorUEdlnPX77iTUZcpEcdIHLJ3qekgYGKQZ5cE8S3fWeXxrFCfvA9Jw4dkbLpCe2cE6dr0oTh4FfCl0PQL4L+APSrq4fAVYF8XJL4fztjhcvH4mipML8yzd3uHqz2Z7G/z+/Bfw/6I4uRr4D+BU4DeBPwWu6mA9O2U6B4bDDc5Vt1ha0jopdZyzJEmzSJ6lDwKvK9x1URQnx0xhlbpKFCdzgQ2FsPAF4JmN+sPnWfod4GnAf4e7+oGPRXHSM/m1VlE4V68u3PUnU1idSRHFySCwaKrroYaeMtUVkEbYwiDNMnmW7o7iZDh0VZobLl7vLJYZNRh0JfB54M1h/MPZwO48S58wet9RnKwAfi/8I3tU6FZzALgjDNz9YJ6lN5fVLYqTbwBPAPbnWXpSuO+3Q1eqZcDpwIPA94DPAlfnWbpvjP3UnY2nXccZh98t/JO/F/j9PEsPNvPEPEv3R3HyR8DXgX3A18K4lL0cPSj09jxLz623vyhOamVlWzn/UZy8BPhoKPunwD8CrwVeBpwXWr5G3uPpel5a9W9hUHo/cF4UJ2fnWXrH6EJRnJwAvAT4beBx4XdtbhhAvSt0QftQnqV7xzrIqPfrfXmWvj6KkxcDrwF+ObQ2nZxn6X2jntcbuk49G3hS6JJ4CLgnhM5PAxvyLD086nnFcznixeGYlP1cRXFyVhiL85uhy+PJYbzK3cBXgX+Zbl3oJvDeHhe6o10KLAFOCe/tveF387PA+rJuaqGF6rXh2yfmWfrNKE6WAq8I79+Z4cPaH4f6vS/P0ltG7eOLwMWjdv2FKH64R+qVeZa+rU1vldQUWxikWSb0ex35MKAG7G/iaR8H/jxcDBzVIhHFyYlRnGTAv4cLpMcBJ4SLoxPD9y8HtkVx8pd1jnOwsM85UZx8PPwDfk7oQ35s2N8TgbcAN0dx8kvjeBs6dZzR/qxw+z15lt7dypNDF6QnAafnWfpHZReak6Du+R/lXcD7wifUrXaXmKrz0pLQUvfjwl1njC4TxcmvA7cCfwesAM4K78fImKKLw3u1K4qTX23muFGcvBL4WHj9gyVlHhfCyEfD2Jezw3EHQ4D7XeBa4GvhQn9Cojh5dXidfx4GhJ8aXuO8MAbnpcCWKE62RHFy0kSPN1mafG8vCmH170Jg+KXCe/uoMIbsI8CeKE5+peRQB0ft8+UhaLwCWBD2NRDGN/1h+Bm/ZFJetNRGBgZp9vkNYKQry7YmZnn5NeB54dPQOPxDffmoMuvCP1BCa8UVwEXh0+JnhgujB8Nx/zx8kjmWQ4XbVwIvAraEi5xloe6vD5+wA5wL/M043oNOHedhUZycGd6PkeN/ZDz7ybN0R56lh5oo2i7NnP8R5wKXA/8ZLvKfCKxq4VgdPy8TMLdwu1p8IFyIbwZOC3flhZa3ZcBzw32EMp+N4uSUBsc7HngHsAd4QQiOTw8teCPHfWxoyVsQ7toc3rsnh4v5lwPfCI89CfhyFCfzCsf4tzCT2trCfZ8J9z0+DPouvs7XAH8bLpoPh78Dzwqv8WLgf4VWBsJzrw/d8qabZt7bC4CtoZWL0Oq2JsxQ9LTQovb18NijgRtKAlnxZzwKLXK3hsBwYfh6CTDSTfE44OPhg54RLw3n4zOF+9YWztM/tu+tkZpjlyRpFglTeRYHaL6jiaf9YfjHlORZWhv9YPgkbXX49qHQJ/+WUcW+ELqbXBu+f0v4NG+0kS4Sx4eLjXfkWfqWUWVujOLka2HgMMCzoziZl2dpMy0lnT5OUbELwbfzLP3ZOPfTaXXP/ygvAb4JXJxn6UPjONZUnJeWhW4pxZaN0d2RXhvW0iB0K7l0VMi7GdgYxcl1IYTNB14J1Gt9ey5wP/C0Ot2wPlE47qvzLL1m1OP/GcXJOmB9CDDnhokPXsWRMHofcF8UJ79QeM59Yw0wjuLkvPBBAOEi+Fl5ll43qtgN4Xg3hdapC4E/Bv6+zuucCnXf2yhO5oRWtmPDXe/Ks/RNo4rdFMXJx8IYpWeHbll/E/ZdVOwG9vYwgH5lnqVDhfv/K4qTTWFWp/mhm9LyMJMaeZb+INSr2F3qBw4E11SyhUGaOY6N4uRXxvh6YhQnK6I4eXvoqrA0LET1sjxLNzWx31OAP6tzsdgP/EMIA/84RlgY8a+hDzXAo6M4OafOMecCO8oW1cqz9IbQNYDwwcZR4yma1KnjUJhClXBRPVM0Ov+jy75pnGGhqJPnZTyeG7rdAHwjz9Kfjnr8e6EF6TPAe+u0CP1D4Xaj2cpOCQFqzLAQxclvhFYEgGyMsABH3rtq+DR75GLzxVGcnNjg2GP540KXs4+PERZGjvdT4A2Fu145jmNNtrrvLfBbhemAR7pfHSWc51eG1lRCmD2zwbHXjAoLI/vaF2ZGG/Hkpl6JNEVsYZBmjscC32pQ5jDw4TCQbk+T+92RZ+mtZQ/mWboN2NZoJ3mW1qI4+V7o40z41Oz2Ok/5yOhBmaPsCp9aUtjneHTqOMUuJ/dOYD+dVvf8j3Jf+MS0HTp1XloSxcnjR7XSvXt0mTxL39/k7orrAjS6sKyNuoAc7bLC7U/U21EYQP8Z4MWhz/wzRnVvacazCrc/3qDsZuB/wrimRVGcnJNnab3f/U5r9N4WX+sn63UJzLP0rjAoeUUIvlGd92dzg3FMuwq3O/YzLo2HgUGaXeaEvrbLojj5IPDh8IljPS3P9R+6Pp0U+t8Wp/4s9sM9doynFjUKIfcXbh/Xah2n4DjHF243NTPSNNHK+f9Wg4v8VnTqvIyYX2egan8Y1LoijKsY+WR9faGbXanQpeXUcMFc/LkvhoRGvw8/yrO0XtC8sHD7O43qFN7fkdmPntRKYAgtEiPjJA4XpvsdU56lw1Gc7AjjYQhjWyYSGAYLs3w1a/tYM7sFjd7b4qf7zSx0uS38rBBea1lg6PTPuDRpDAzSzPHtPEvHvOAJ86qfFf5hvzIMSnw/8HtRnKzMs/R/6uz3rmYOHsXJM4E/CoMFT2viKY00+hS+GHQmsh7BuI9T5wJzxC2F6RUrhfvH0wVkqjR1/sdRtpFOnf8Rzw9fzTgMvBf432VdtaI46Q+/D78XukwNTLB+jd7bYhe/mwtTbDajUevGaGcV3vO7x+pSM4bbC4Gh1eNNtkbv7dmF2z+oU25EMQzVe62d/hmXJo2BQZoFwkxItwC3RHHyUeD/hsGsF4fbv1/n6ZU6jxEWD/vH0C+6nTo1E9BEjtOoC9h5wG3hdrHrwekl5aejuud/AmUb6eRMUI0cCt2tvgt8Mayd8L2ywmE17zzM598ujd7beQ0eb+dzi+XrfdhQ9EDh9kQDc2UcK1HXe/9aeW+beb3Nvtbp9DMuTYiBQZplwliCV4d+uacCz4/i5G1hNeHxePWosPDpMODzG2GGlYf/GZcsONQtdhduP3UK66Gx/UOepRNetTl0P0oLYeH+MObhs+HT6f0jfeBHLbY3UcWuYM8ERg/Eruf+JsoUFVtVmv3ku1iu1e5Eox3u8IxArb7edr5WaUYwMEizUJ6lQ+HifWSg5NOb7Pf8CKF1oTgDynvzLP2zOk/pq/PYjJNnaSvdBL4cLh56gEdFcbI4z9JdTTyv7cJKwJocURgTQJhm+Bl1Vjdv5+/D/sLYijvrzFbWrmONaLa14ISS588E+wuDjk9sogvTTH6t0rg4rao0exX/kTVaNKrMYwt9dB9qMI88Yd73rhSml/xy4a4/Hc9+oji5LIqTzVGcLBv1UPGTzEaLYznjyuS5qHA7rRMWCF3W2qXYRaqdXaHG8sNCi8ZpYV2KRh5duD2dZkhqxm2F24+uU26sMjPttUrjYmCQZq/iwlPjnebzFwu3f5RnaWnXhihOfm0aDnbstOKqxC8b46K/rrCg1tXA7wDbojgpdu8q9sNu1CfdLlGTp/g78e065QgraLdLcaai32zjfo8SxkSNtI71hJWOS4VA8fjCXQ2nYZ5miu/tr9UpN6I4Y9XXJqE+0rRjYJBmoShOThk1luCmce6qOD3o/DrHm1tYFXbErOqe1Iw8S9PCOgW9wLVhgGxD4aJrYyF0fSHP0i8ViuwrzKpyQhQnZ4+xmxF/PL5XoCY0+zuxFFhTuGuivw//Wrj9wihOTqpTlihOPhbFyQ1RnLwhipPj6xQt6762sXD7JQ3q9rzCLFE3jrHQ3XRXfK0viOKk9FxFcfKYQqg4AGyd/OqBXcg11QwM0iwTxckA8NGwYBPAl/MsbTTbT5k9hVVNT4riZPkYx+sPx3sq8NXCQ/VWep7NXgj8KNx+DHBjFCcr6j0hipPFoTvTSHeXH46eAjRM37qjcNerSvb1BuCSUTO5qH2Kq3g/K/z8P0KYjjcFbg5d+QB+MfxujkuepV8FvhK+PQX4WNmFbRQnfxjWk/iNsC7L6HVBit0VFzC2DxZ+hp4fxcmqkmOdC7yzcNf7mn5R00SepV8M54rQrfL/jFUuipNjgQ8VugR+qF6raxs0c56kjjCxSjPHsXXWBTg2rI1wQfg0cORi/W7gD8Z7wDB4+p8LnzD+SxQnbw+LGx0X1nt4RejT++ZQj5HuC1eElZ/vz7P06+Otw0wTVoK9CLgeOD/M8f7vUZx8NVxE7ggz3PQDC0P3o2cVLkJ2AnGepT8ZY/efLAy4fWMUJ2cBWWh9OCOEjEvCVLoXAks7+NK7RRq6ns0LYxT+I4qT9wB3hG6AvwO8ILQGXQpsCb+PfcB7ozj5GPDTPEtva+JYo70kdIE5KfzMfCOKk2vC4ntzQn1eBIwE+2HgD8dYbO8HYYzCHOCCKE7+PnTLOSNcBO/Ns/TOKE5eG1aOnwN8OoqTj4TX/xPg5DCZwp+G+gB8PM/Sf5vg+ztVXho+8BgEXh/FyZIwG9z3wu/qE8NrHRk/shv435Ncp+JK4X8RAst+jvyd+egkH1t6BFsYpJnjsWFdgLG+tgHXAX9RCAtfBH49z9JbJ3jcPyvMsHRy6GN/E/B54N0hLLw3z9J3ApsLz1sUuudsLNnvrJVn6Q/Chf27C5/uPg14T7iAvDlcnKwDnhPCwgPhk9qn5Fl6R8mu/x4odlN6AfBPITR8JISFDHhNoYwfDLVRnqX7gbXhYhzgV8NUw18D/q3wif7vhJmMNhWe/spwYd6oi0/Zsb8L/Hrh9/FxwAfC7+NXQqAcCQv3As8e1a1tZD/3Af9SuOtVYbXidxVnRcqz9CPAy8P4mblhobrrw8/v54G3hLBwGLhmIh9OTLU8S3eE358fh7uWh1W+twE3htc3Eha+CFyUZ+lkr+j+qcKUuKeFv73rCit4Sx1jYJBmh4eAn4WLln8I/8yeUW/xqWblWfqz0HLxjjDIsxL67n4nXKReODLVamhJ+P1Qbih8EtmpPr7TSp6lB/MsfSPwqHDRtTG8Z/8TFnR6ALg13P9HwKPyLH1zvVV1Q7ek5WFtjK+ExcaGwzSQeegOtTLP0gcLT2tmhhu1IM/ST4egcC1wZzgHPw2/f28CFuVZekMo/uZwUX9n+J3YHVoExnvsb4eg8OLwaf8d4XdyOLQofh64AnhMnqVZnV29IqwGf0f4+/GTEPAfsXBZnqUfDB9WvCOEnZ+F1pN9obXsb4GleZa+emT9iZkqz9L/DF1//jT83borvDcPhE/714fWv2eEv4uTXZ97w5obXwrB4WCox42TfWxptJ5azTVHJEmSJI3NFgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUqmuXgE0ipNe4K1hYZ25wJV5lr6tDfu9MKzoeVFYnbESFmjaAFxTb2EmSZIkaTrp2haGKE4WAjeFpe3ntnG/bw4rsK4BTgd+GFb3vAB4N/CNKE7OaNfxJEmSpMnUdYEhipOeKE7+BLgZeDLw723c93OAvwrv6zXAaXmWnp9n6ZnA04DbgYXAp6M46WnXcSVJkqTJ0nWBAfjtcDE/B7gciNux0yhO5gDvCt9uzrP01XmW7h95PM/Sm4DVQA24MNyWJEmSprVuDAy9wC7ggjxL/ybP0lqb9vtUYEG4/Z6xCuRZ+nXgS+HbF7fpuJIkSdKk6cbA8DXgyXmW7mjzfqOwPRjGRpT5XNheEgZdS5IkSdNW112w5ln640na9ePC9pY8S6t1yu0M237g0cB3Jqk+kiRJ0oR1YwvDZDknbBsFkjsLt8+bxPpIkiRJE2ZgaJ8TwvaBBuWKj59Qp5wkSZI05bquS9Ik6g/bhxqUe3CM50zYXXfc1q7B25IkSeqgM84+d1pPt29gaJ+R1ZuPaVDu2MLtSjsrcMqppzN3rqd0tjt0qMq999wNnvOu4TnvTp737uM57z7Fcz6d+ZPYPveH7fENyhW7Id1fp1zL5s7tZW6vp7SbeM67j+e8O3neu4/nXNOJYxja5/the3aDcsXHvzuJ9ZEkSZImzMDQPt8K2/OjOKnXLekJYXs/cFsH6iVJkiSNm4Ghfa4P237gojrlLg3brI2rTEuSJEmTwsDQJnmWbgduDt++cawyUZxcAiwL3364c7WTJEmSxsfRNC2I4uStwFvDt4/Js/T2UUVeD3wOuCSKk/cDb8qz9L7w3Aj4ZCj3mTxLP9/Z2kuSJEmt67rAEMVJBpxZ8vArojh59qj74jxLR1ZnngPMDbePmi83z9IvRHHyKuAa4BXAS6M4uQ04CTgtFLsReGH7XpEkSZI0ebouMACLgXNKHjutcGE/otG6Co+QZ+kHojj5T+A1wDOBc8Pqzl8OLQwfzrP08PirL0mSJHVOT63muNvZ4K47bqudesZZztncBQ5Vq9xz148A8Jx3B895d/K8dx/PefcZOefTfaVnBz1LkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSV6p3qCkyVKE4uBF4JXAScBlSAW4ENwDV5lg6Nc79zgTXA84EnACcDDwK3A18E/iHP0t3tf0WSJElS+3VlC0MUJ28GvhIu7E8HfggMARcA7wa+EcXJGePY7ylhvx8FlgMnArcBB4HHAa8Ctkdx8seT88okSZKk9uq6wBDFyXOAvwqv/RrgtDxLz8+z9EzgaaElYCHw6ShOelrc/XrgqUAVeDlwfJ6lv5xn6WnAAuA/gD7gH6I4+bVJeomSJElS23RVYIjiZA7wrvDt5jxLX51n6f6Rx/MsvQlYDdSAC8PtZvf9GODS8O3f5ln6wTxLDxX2/V3gd0NLRk8IFJIkSdK01lWBIXz6vyDcfs9YBfIs/TrwpfDti1vY94LC7S+X7PtnwC1jlJckSZKmpW4LDFHYHgRuqlPuc2F7SRQnzQ4Mv6tw+4Q65Y4L27ub3K8kSZI0ZbotMDwubG/Js7Rap9zOsO0HHt3kvr8NfC/c/t2xCkRxcn5hf9c1uV9JkiRpynTbtKrnhO2PG5S7s3D7POA7jXacZ2k1zH70GeB3ojj5JPDe8Nzjw4DqvwbmhulVPzqxl3K0Q4fqZSDNFsXz7DnvDp7z7uR57z6e8+4zU85ztwWGka5CDzQoV3y8XveiR8izNI/i5DeAN4V1GF4wqsjtwFuAdxcHRLfLvffYy6nbeM67j+e8O3neu4/nXNNJt3VJ6g/bhxqUe3CM5zTrQuD88N4+BHwXuCc8dkZoaVja4j4lSZKkKdFtLQwjqzcf06DcsYXblWZ3HsXJR4GXAHuBtcAnRloSojj5JeAvgZcCz4ji5Dl5ll4/rldR4pRTT2fu3G47pd3n0KHqw588ec67g+e8O3neu4/nvPsUz/l01m0/ifeH7fENyhW7Id1fp9zDojhZFcICwO/nWbql+HiepT8G1kZxchKQAP83ipNHNxh83ZK5c3uZ29ttp7S7ec67j+e8O3neu4/nXNNJt3VJ+n7Ynt2gXPHx7za575FF3n4yOiyM8i+FY9g1SZIkSdNatwWGb4Xt+VGc1OuW9ISwvR+4rcl9nxm2+xuU21e4fVqT+5YkSZKmRLcFhpExA/3ARXXKXRq2WZ6ltSb3PRIEzonipN77embh9t4m9y1JkiRNia4KDHmWbgduDt++cawyUZxcAiwL3364hd1/OWyPDVOqlnle2D4AfKOF/UuSJEkd142jaV4PfA64JIqT9wNvyrP0Po6EhQj4ZCj3mTxLP198YhQnbwXeGr59TJ6ltxce/hjwv0ILwjVRnPQB6wuzJJ0E/Dnw26H8+/IsLU7fKkmSJE07XdXCwJFWhi8ArwKqwCuAu6M42RPFyd3AVuBU4EbghWM8fU5YqXku0DNqv/8TujL9EDg5rORcieLk1ihObgV+BrwuFP8o8PbOvGJJkiRp/LouMHDk4v4DwFNCq8BPgHNDa8uXgZcDF+dZ2mg16LH2uwN4HPBa4AvAfWHfZwI/CK0Xz8yzdG2epYcn59VJkiRJ7dNTqzU7plfT2V133FY79YyznLO5CxyqVrnnrh8B4DnvDp7z7uR57z6e8+4zcs7POPvcniaKT5mubGGQJEmS1BwDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSV6p3qCkjjVRmusWl7lXxPlf2VGvMGeogW9rJqaS8DfT1TXT1JkqRZwcCgGWnLriqXbxhi38HaI+6/bmeVK7Mern5uPysW++MtSZI0UXZJ0oyzZVeVtesrR4WFEfsO1li7vsKWXdWO102SJGm2MTBoRqkM17h8wxCHx84KDztcgys2DlEZblBQkiRJdRkYNKNs2l4tbVkYbe+BGpt32MogSZI0EQYGzSj5ntYCwNbdBgZJkqSJMDBoRtlfaa2LUavlJUmS9EgGBs0o8wZamy611fKSJEl6JOed1IwSLezlup3NdzNavqjzP+KuDyFJkmYTA4NmlFVLe7ky62lq4PP8wR5WLunsj7jrQ0iSpNnGLkmaUQb6jlx0z2nwQf2cHrhqdX9HP9GfqvUhKsM1rt02zMs+WeF5HzrIyz5Z4VzchCAAACAASURBVNptw04pK0mS2sKPOjXjrFjcy7o1A1yxcYi9B46+KJ4/2MNVqzv7SX6r60NsWzDYljCzdfchXpfaoiFJkiaPVxKakVYs7mXbgkE276iydffPxwosX9TLyiWdHyswnvUhLlvWN6FjfukHfbzu+odKQ8pIi8a6NQOGBkmSNG5eRWjGGujr4bJlfRO+8G6H8awPMZF6D1Xhyv84vuMtGpIkqfs4hkFqg06vD7H11mO5b6i5X19XvJYkSRNhYJDaoNPrQ3z59tZaJ1zxWpIkjZeBQWqDaGFrvfsmuj7E/U22LoxwxWtJkjReBgapDVYt7eXk45prNWjH+hAn9h9uqbwrXkuSpPEyMEht0On1IX7jnOGWyk/FiteSJGl2MDBIbTKyPsT8wbHDwPzBnrZNcbp8wYOc1GQrw1SseC1JkmYPryKkNurU+hD9vfAXz3yA111/Yt2pVadixWtJkjS7GBikNuvU+hAXnzfMh3//GF7/b8PTZsVrSZI0+3glIc1gyxfNZdvCY6bNiteSJGn2MTBIM9x0WvFakiTNPg56liRJklTKwCBJkiSplF2SpC5QGa6xaXuVfM/PxzlEC3tZtdRxDpIkqT4DgzTLbdlV5fINQ+w7+MiZlK7bWeXK7MiCc86kJEmSytglSZrFtuyqsnZ95aiwMGLfwRpr11fYsqva8bpJkqSZwcAgzVKV4RqXbxiqu7AbwOEaXLFxiMpwg4KSJKkrGRikWWrT9mppy8Joew/U2LzDVgZJknQ0A4M0S+V7WgsAW3cbGCRJ0tEMDNIstb/SWhejVstLkqTuYGCQZql5A61Nl9pqeUmS1B0MDNIsFS1sbarU5YucWlWSJB3NwCDNUquW9nLycc21Gswf7GHlEgODJEk6moFBmqUG+o4syjanQWaY0wNXre53xWdJkjQmA4M0i61Y3Mu6NQPMHxw7DMwf7GHdmgFXepYkSaW8SpBmuRWLe9m2YJDNO6ps3V1lf6XGvIEeli/qZeWSXlsWJElSXQYGqQsM9PVw2bI+LlvWN9VVkSRJM4xdkiRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKmVgkCRJklTKwCBJkiSplIFBkiRJUikDgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSVMjBIkiRJKtU71RWQpMlWGa6xaXuVfE+V/ZUa8wZ6iBb2smppLwN9PVNdPUmSpjUDg6RZbcuuKpdvGGLfwdoj7r9uZ5Ursx6ufm4/Kxb7p1CSpDJ2SZI0a23ZVWXt+spRYWHEvoM11q6vsGVXteN1kyRppjAwSJqVKsM1Lt8wxOGxs8LDDtfgio1DVIYbFJQkqUsZGCTNSpu2V0tbFkbbe6DG5h22MkiSNBYDg6RZKd/TWgDYutvAIEnSWAwMkmal/ZXWuhi1Wl6SpG5hYJA0K80baG261FbLS5LULQwMkmalaGFrU6UuX+TUqpIkjcXAIGlWWrW0l5OPa67VYP5gDyuXGBgkSRqLgUHSrDTQd2RRtjkNMsOcHrhqdb8rPkuSVMLAIGnWWrG4l3VrBpg/OHYYmD/Yw7o1A670LElSHf6XlDSrrVjcy7YFg2zeUWXr7ir7KzXmDfSwfFEvK5f02rIgSVIDBgZJs95AXw+XLevjsmV9U10VSZJmHLskSZIkSSplYJAkSZJUqqu7JEVxciHwSuAi4DSgAtwKbACuybN0aAL77gVeDvw+sBDoB34EfCXs+xvtfTWS2qUyXGPT9ir5np+PeYgW9rJqqWMeJEndp2tbGKI4eXO4eF8DnA78EBgCLgDeDXwjipMzxrnv+cBXgb8HngYcBO4CzgNeCvx3FCdr2v+qJE3Ull1Vlr3zAK/dMMR1O6vc+L1DXLezyms3DLHsnQfYsqs61VWUJKmjujIwRHHyHOCvwuu/Bjgtz9Lz8yw9M1zg3x5aBT4dxUlLHyeG8inwFGA78IQ8S8/Os/SxwFnAxtCy85EoTs6dvFcpqVVbdlVZu77CvoO1MR/fd7DG2vUVQ4Mkqat0XWCI4mQO8K7w7eY8S1+dZ+n+kcfzLL0JWA3UgAvD7Va8IHRx+gmwPM/S7YV93wO8EMiBawEDgzRNVIZrXL5hiMNjZ4WHHa7BFRuHqAw3KChJ0izRjWMYngosCLffM1aBPEu/HsXJl4CnAy8OYxqa9dqwfW8ICKP3PQQsH1fNJU2aTdurpS0Lo+09UGPzjqrTtEqSukLXtTAAUdgeBG6qU+5zYXtJGMDceMdxcjawLHz7rxOrpqROyve01s1o6267JUmSukM3tjA8LmxvybO03n/8nWHbDzwa+E4T+35K2O7Ls/T2KE7OAtYCvwrMB34KfBH4ULEblKSpt7/SWhejVstLkjRTdWNgOCdsf9yg3J2F2+c1GRgWhe0dUZysAtYDJ44q89vAG6I4eVYYL9E2hw75iWc3KJ5nz3n7nNjfWgA4sb/GoWpn3n/PeXfyvHcfz3n3mSnnuRsDwwlh+0CDcsXHT6hTrugXwnY+8E/AF4C3A98CjgdWAu8FfhH4bBQnS/IsbRRcmnbvPXe3a1eaITzn7XPBaceSffv4pss/9fT7ueeuBye1TmPxnHcnz3v38ZxrOunGwNAftg81KFe8EuivU65oMGzPAjYDz8qzdORjyweBj0VxsjOMnZgPvAn4kxbrL2kSLF/wIH/z1eO4b6jx0K6T+g8TPbbzYUGSpKnQjYFhZPXmYxqUO7Zwu9Lkvot9Gt5RCAsPy7N0WxQn1wHPApJ2BoZTTj2duXO78ZR2l0OHqg9/8uQ5b6+rVh/iZZ96qO7UqnN64KrV/Tzq7LM6Vi/PeXfyvHcfz3n3KZ7z6awbfxLvD9tGfQ+K3ZDur1Ou6H8Kt7fXKffVEBjOjOJkXrsGQM+d28vc3m48pd3Lc95elz6+l3Vr5nLFxiH2Hjg6Ncwf7OGq1f2sWDx177nnvDt53ruP51zTSTf+JH4/LMh2doNyxce/2+S+7yjcrrdC9H2F24OAMyZJ08SKxb1sWzDI5h1Vtu6usr9SY95AD8sX9bJySS8DfS0t/i5J0ozXjYHhW2F7fhQnx+RZWjaW4Qlhez9wW5P73lG4fR6wu6TcmYXb95WUkTRFBvp6uGxZnwuzSZLUpQu3XR+2/cBFdcpdGrbZWGMRSny10H3p0jrlloTt9/MsPdjkviVJkqSO67rAkGfpduDm8O0bxyoTxcklhRWbP9zCvh8M06kCvC6Kk5PG2PdCYFX49tOt1l+SJEnqpK4LDMHrgcPAJVGcvL94YR/FSVS46P9MnqWfLz4xipO3RnFSDV/nHLVneBtwb+h2lEVx8pjCc5eGkDAX+Bnwvsl8kZIkSdJEdWVgyLP0C8CrgCrwCuDuKE72RHFyN7AVOBW4EXjhGE+fEy745441sDnP0nuAOISGXwW+E8XJrVGc3AZ8M6wGvQ9I8iyd/vNoSZIkqat1ZWDgyIX9B4CnAB8DfgKcGwaBfxl4OXBxnqWNVoMu2/d/h2Dw12Hg8xkhhOwOKz0vzrP0xva/KkmSJKm9emq1Zsfzajq7647baqeecZZzNneBQ9Uq99z1IwA855OvMlxj0/Yq+Z6fT7EaLexl1dLOTbHqOe9Onvfu4znvPiPn/Iyzz53Wc3b7kyhJJbbsqnL5hiH2HXzkByvX7axyZdbD1c+d2kXcOm06hCdJUud1z386SWrBll1V1q6vcLikEXbfwRpr11dYt2agK0KD4UmSulfXjmGQpDKV4RqXbxgqDQsjDtfgio1DVIZnd9fOkfA0OiyMGAlPW3ZVO143SdLkMzBI0iibtldLL45H23ugxuYds/dC2fAkSTIwSNIo+Z7WAsDW3bM3MBieJEkGBkkaZX+ltU/JWy0/kxieJEkGBkkaZd5AazP+tFp+JjE8SZIMDJI0SrSwtdl+li+avbMDGZ4kSQYGSRpl1dJeTj6uuQvf+YM9rFwyewOD4UmSZGCQpFEG+o6sKzCnQWaY0wNXre6f1YuWGZ4kSQYGSRrDisW9rFszwPzBsS+W5w/2dMWibYYnSdLs/k8nSROwYnEv2xYMsnlHla27q+yv1Jg30MPyRb2sXNLbNRfHI+Hpio1D7D1w9KDm+YM9XLXalZ4labbyr7sk1THQ18Nly/q4bFnfVFdlShmeJKl7GRgkSU0xPElSd3IMgyRJkqRSBgZJkiRJpQwMkiRJkkoZGCRJkiSV6tig5yhO5gKrgWcAZwMDQKNpNWp5lv5mh6ooSWqzynCNTdur5Ht+PrNStLCXVUudWUmSZoqOBIYoTk4APg8sK9xd7z9FLTx+9ITfkqQZYcuuKpdvGGLfwUf+Kb9uZ5UrsyMLwrl2gyRNf536S/3nwJPD7QeBW4D9wOEOHV+S1EFbdlVZu77C4ZKPffYdrLF2faUrVsuWpJmuU3+lnxVaCz4AvD7P0kqHjitJ6rDKcI3LNwyVhoURh2twxcYhti0YtHuSJE1jnRr0fA7wAHC5YUGSZrdN26tHdUMqs/dAjc07qpNeJ0nS+HUqMAwBP8qz9KEOHU+SNEXyPa0FgK27DQySNJ11KjB8BzipQ8eSJE2h/ZXW5qtotbwkqbM6FRg+Dpwexcmvd+h4kqQpMm+gtfEIrZaXJHVWpwLD+4FNwD9HcXJxh44pSZoC0cLW5tNYvshZkiRpOuvUX+kE+CfgNOA/ojjZBnwL+FGjqVXzLH17h+ooSWqDVUt7uTLraWrg8/zBHlYuMTBI0nTWqb/SG0YtwvbkwroMjRgYJGkGGeg7sihbvXUYAOb0wFWr+51SVZKmuU51SSKs3DyeL0nSDLNicS/r1gwwf3DsP+PzB3tctE2SZohO/aU+ARjKs/RQh44nSZpiKxb3sm3BIJt3VNm6u8r+So15Az0sX9TLyiW9tixI0gzRkcCQZ+mBThxHkjS9DPT1cNmyPi5b1jfVVZEkjVMnuyRJkiRJmmHa3sIQxclFwAN5lt486r5xybP0hrZVTpIkSVJLJqNL0heBbwDLRt03nqU8ax0cZyFJkiRplMm6GB9rJJuj2yRJkqQZZjICwzOAB8a4T5IkSdIM0/bAkGfpl5q5T5IkSdL015FZkqI4eVEUJ5d14liSJEmS2qdT06quA97SoWNJkiRJapNOBYY7gZM7dCxJkiRJbdKpwPBR4MwoTl7UoeNJktSSynCNa7cN87JPVnjehw7ysk9WuHbbMJXh8cwKLkmzR6fWOHgbUAHeG8XJM4B/BrYDP8uz9FCH6iBJ0pi27Kpy+YYh9h18ZDi4bmeVK7Mern5uPysWuyyQpO7Uqb9+3w7bA8CLwhccGRBd73m1PEv9Cy1JmjRbdlVZu77C4ZKGhH0Ha6xdX2HdmgFDg6Su1KkuSQvD1zlhAbdWviRJmhSV4RqXbxgqDQsjDtfgio1Ddk+S1JU69VHJlR06jiRJTdu0vXpUN6Qyew/U2LyjymXL+ia9XpI0nXQkMORZamCQJE07+Z5qS+W37jYwSOo+nVq47VFRnJzViWNJktSs/ZXWuhi1Wl6SZoNOjWG4Dfhch44lSVJT5g20NlSu1fKSNBt0KjD8zAHMkqTpJlrYWs/c5YucJUlS9+lUYNgKPDaKkyd16HiSJDW0amkvJx/X3OdZ8wd7WLnEwCCp+3QqMLwWyIHrozh5cRQngx06riRJpQb6jizKNqdBZpjTA1et7megz8ZySd2nUx+VvB34PvCLwDrgg1GcfD90VRqu87xanqW/2aE6SpK60IrFvaxbM8AVG4fYe+DoQc3zB3u4arUrPUvqXp366/cKYOSvcA/QB5wfvsZSC+WcjkKSNOlWLO5l24JBNu+osnV3lf2VGvMGeli+qJeVS3ptWZDU1ToVGG7w4l+SNJ0N9PVw2bI+11mQpFE6tXDb0ztxHEmSJEntZYdMSZImUWW4xqbtVfI9P+/qFC3sZdVSuzpJmhkMDJIkTZItu6pcvmGIfQcf2Sv3up1Vrsx6+OtnH8vBhxgzTBxjlpA0TXQkMERx8tZxPG0u0J9n6RsnoUqSJE2qLbuqrF1f4XDJCL59B2v80aeGjrp/JEy8L+njCSdNfj0lqZFOtTC8bQKDng0MkqQZpTJc4/INQ6VhoZF9B2u87FMP8b5L+7j4vHqzj0vS5OvUwm2EaVKb/boN2BW+JEmaUTZtrx7VDalVh2tw5X8cz1C1bdWSpHHp1CxJDYNJFCfzgacCbwDOBv4gz9L/7kT9JElqp3xPe67y7xuaQ/7dY/mDs9uyO0kal062MNSVZ+nePEuvz7P0GcA2YEsUJ4+d6npJktSq/ZX2LT10w22uCyFpak2bwDDK64ATgTdPdUUkSWrVvIH2TXF0/9B0/VctqVtMy79CeZb+GLgX+M2proskSa2KFravx++J/Yfbti9JGo9pGRiCAeC0qa6EJEmtWrW0l5OPa08rw0XnOkuSpKk1LQNDFCdPBwaBB6a6LpIktWqgr4ern9vPnAlmhpP6DxM99sF2VUuSxqVTC7dd1ESxOcBJwFOAPw7rNmzrQPUkSWq7FYt7WbdmgCs2DrH3QOuDoOf0wF8888jnZv/v5iqf/87wUatBD/S5HLSkydephdu+2OLCbT3AYeC9k1gnSZIm1YrFvWxbMMjmHVW27q4+fMG/fFEvA33wvz7z4JhhYv5gD+99dh/790H88ZO5b+iR3ZJGVoO++rn9rFjcqX/lkrpVJ//KtPIxyC3An+dZ+rlJrI8kSZNuoK+Hy5b1cdmyo6dHvWRR75hhYuWSXr645yFed/0JHK6N/e9z38Eaa9dXWLdmgIsWzGXT9ir5nqqtEJLarlOB4RlNlKkBQ8AdeZbe1YE6SZI0pcrCRGW4xuvSh0rDwojDNfiTayv0zYV9Bx/5mK0QktqlUys9f6kTx5EkaTbYtL16VAAo80CdMdHFVghDg6TxmvRZkqI4WRbFyXOaKNcXxcknojhZMNl1kiRpOsv3VNu2r8M1uGLjEJXh9q0+Lam7TGpgiOLkNcBNwFuaKL4WeCHwtShOlk9mvSRJms72V9p7cb/3QI3NO9oXQiR1l0kLDFGcPB+4OnR7+pUoThotwnYwrLtwIvDpKE6WTlbdJEmazuYNtH+g8tbdBgZJ4zMpgSGKk+OAvwvf7gSenGfpT+o9J8/S9cCvAN8BjgM+Mhl1kyRpuosWtn+8QbtbLSR1j8lqYXgBcApwJ/BbeZZub+ZJeZb+EPgt4KfAE6M4uXSS6idJ0rS1amkvJx/X3n1ORquFpO4wWYHh0jBN6l/nWXpnK0/Ms/S2sGBbD/C8SaqfJEnT1kBfD+9LjmFOT/taBZYvcpYkSeMzWYFhSdh+YpzP/1DYXtCm+kiSNKMsXzSX9136P5zUf3jMx08+Do4/trl9zR/sYeUSA4Ok8Zmsvx6nAz/Ns3T/eJ6cZ+l9UZzcA5zT/qpJkjQzXHzeMNmL9/FfPz2dz32ndtRq0Dfceoi16yscrtMQMacHrlrd74rPksZtsgJDH/CzCe7jXmB+m+ojSdKM1N8Lz3tSL793wdH/slcs7mXdmgGu2DjE3gNHp4b5gz1ctdqVniVNzGT9BdkXBj1PxGlhmlVJklRixeJeti0YZPOOKlt3V49qhbBlQdJETVZg+FGY5ejsPEvvaPXJUZwsDq0LX5+c6kmSNHsM9PVw2bI+LlvWN9VVkTQLTdag5xvC9kXjfP6rwixLX2ljnSRJkiS1aLICw8YwLeobojhZ2MoTozhZDvxR+PZTk1M9SZIkSc2YlMCQZ+lXgC8AJwB5FCe/1szzojhZE8LGHGBznqX/PRn1kyRJktScyZw24SXA14BfAr4YxclmYD1wU56ld3MkIPQAjwYuBv4wrLvQA9weni9JkiRpCk1aYMiz9I4oTn4LSMN6Cs8KX0RxchioAMeFgDCiB9gO/F6epfdNVt0kSZIkNWeyxjDAkdDwTeCJwHvDFKk94WsucHw4/sh99wHvAJ6aZ+ktk1kvSZIkSc2Z9JVcQkvBG6I4eSvwa8BTgFPD+IYKcAewDfhKnqUPTXZ9JEmSJDWvY0s/5lk6BHw+fEmSJEmaASa1S5IkSZKkmc3AIEmSJKmUgUGSJElSKQODJEmSpFIGBkmSJEmlDAySJEmSShkYJEmSJJUyMEiSJEkqZWCQJEmSVMrAIEmSJKmUgUGSJElSKQODJEmSpFIGBkmSJEmleqe6AlMlipMLgVcCFwGnARXgVmADcE2epUNtPNZJwLeBM4Hb8yw9t137liRpOqkM19i0vUq+p8r+So15Az1EC3tZtbSXgb6eqa6epHHoysAQxcmbgb8MLSwPArcDJwAXhK+1UZw8M8/Su9p0yL8LYUGSpFlry64ql28YYt/B2iPuv25nlSuzHq5+bj8rFnflpYc0o3Vdl6QoTp4D/FV47dcAp+VZen6epWcCTwvhYSHw6ShOJvxRSBQnK4E1wKH2vAJJkqafLbuqrF1fOSosjNh3sMba9RW27Kp2vG6SJqarAkMUJ3OAd4VvN+dZ+uo8S/ePPJ5n6U3AaqAGXBhuT+R484EPhm8/MaHKS5I0TVWGa1y+YYjDY2eFhx2uwRUbh6gMNygoaVrpqsAAPBVYEG6/Z6wCeZZ+HfhS+PbFEzze3wOnA9cCN0xwX5IkTUubtldLWxZG23ugxuYdP29lqAzXuHbbMC/7ZIXnfeggL/tkhWu3DRsqpGmk2wJDFLYHgZvqlPtc2F4Sxcm4OltGcZIAzwfuAf5kPPuQJGkmyPe01s1o6+4j5bfsqrLsnQd47YYhrttZ5cbvHeK6nVVeu2GIZe88YPclaZrotsDwuLC9Jc/Sen+FdoZtP/DoVg8SxckvAB8I3/5xnqU/a72qkiTNDPsrrbUG7K/UHPMgzSDdNlXBOWH74wbl7izcPg/4TovH+UfgVOCf8yz9dIvPHbdDh/yj2g2K59lz3h08591pJp33E/tbCwyDx9S4fEOluTEPGyr815/1d8WUrDPpnKs9Zsp57rbAcELYPtCgXPHxE+qUO0oUJ88Dngfc3emuSPfec3cnD6dpwHPefTzn3Wm6n/cLTjuW7NvHN11+gIPsO9jfVNm9B+FTN/6MlQsfnEANZ57pfs7VXbqtS9LIX6eHGpQr/lVq7i/akbDwi6F1AeDleZbubb2KkiTNLMsXPMhJ/YebKntS/2HuG2qtteCG2/rGWTNJ7dBtLQwjqzcf06DcsYXblRb2/37gF4D1eZZuGkf9JuSUU09n7txuO6Xd59Ch6sOfPHnOu4PnvDvNtPN+1epDvOxTD9XtZjSnB65a3c9HbuoFmgsYAEO1AU4946T2VHQam2nnXBNXPOfTWbf9JN4fto3aTYvdkO6vU+5hUZw8P6zbcCfwmvFXcfzmzu1lbm+3ndLu5jnvPp7z7jQTzvulj+9l3Zq5XLFxiL0Hjk4N8wd7uGr1kZWeN24/3FJgOOm4OdP+9bfbTDjn6h7d9pP4/bAg29kNyhUf/26jnUZxclpYNfow8KI8S/dNvKqSJM0sKxb3sm3BIJt3VNm6u8r+So15Az0sX9TLyiW9Dw9cjhb2ct3O5gd7Ll/UbZcr0vTSbb+B3wrb86M4OSbP0rKxDE8I2/uB25rY728Bp4Tbn4vipF7Zc6I4Gfno5eN5lr6kuapLkjT9DfT1cNmyPi5bVj7uYNXSXq7Meppa7G3+YA8rl3Tb5Yo0vXTboOfrw7YfuKhOuUvDNsuztJm54oaB/Q2+RsZC1Ar3HZzg65EkacYZ6Ovh6uf2M6fB2OeRMQ/dMKWqNJ11VWTPs3R7FCc3A08C3lhY0flhUZxcAiwL3364yf1+CvhUvTJRnLwE+CjwwzxLzx3va5AkaTZYsbiXdWsGmhrzMJbKcI1N26vke37e9Sla2Muqpb0GDKnNuiowBK8PQeGSKE7eD7wpz9L7OHJRHwGfDOU+k2fp54tPjOLkrcBbw7ePybP09o7XXpKkWaLZMQ+jbdlV5fINQ0d1abpuZ5UrsyOtF2VBQ1Lruu63Kc/SL0Rx8qowSPkVwEujOLkNOAk4LRS7EXjhGE+fA8wNt/34QpKkCWpmzEPRll1V1q4vXyV638Eaa9dXWLdmwNAgtUm3jWGAI6HhA8BTgI8BPwHODeHpy8DLgYvzLG20GrQkSeqgynCNyzcM1V3rAeBwDa7YOERluJlhiJIa6dronWfpN4GXtvictwFvG+fxPhYCiiRJGodN26tNzawEsPdAjc07qk23XEgq15UtDJIkaebJ9zS/dgPA1t2tlZc0NgODJEmaEfZXWuti1Gp5SWMzMEiSpBlh3kBr8420Wl7S2AwMkiRpRogWtjb0cvmirh2qKbWVgUGSJM0Iq5b2cvJxzbUazB/sYeUSA4PUDgYGSZI0Iwz0HVmUbU6DzDCnB65a3e+Kz1KbGL0lSdKMsWJxL+vWDHDFxiH2Hjh6UPP8wR6uWt3PRQvmcu22YfI9P19BOlrYy6ql5StISxqbgUGSJM0oKxb3sm3BIJt3VNm6++eBYPmiXlYu6eWGWw+x7J0Hjlqz4bqdVa7MjrRSuAq01Dx/WyRJ0owz0NfDZcv6jlqYbcuuKmvXV0pXg953sMba9RXWrRkwNEhNcgyDJEmaFSrDNS7fMFQaFkYcrsEVG4eoDLtOg9QMA4MkSZoVNm2vHtUNqczeAzU273AlaKkZBgZJkjQr5HtaCwDr/+uhSauLNJsYGCRJ0qywv9JaF6Nv/uiw3ZKkJhgYJEnSrDBvoLXpUquHsVuS1AQDgyRJmhWiha3PerR1t4FBasTAIEmSZoVVS3vpbfHKptVuTFI3MjBIkqRZYaCvhyec1dqlTavdmKRuZGCQJEmzxgsvOKal8ssXuXib1IiBQZIkzRqrlvZy8nHNtRrMH+xh5RIDg9SIgUGSJM0aA309XP3cfuY0yAxzeuCq1f0M9NklSWrEwCBJYNvf8wAAIABJREFUkmaVFYt7WbdmgPmDY4eB+YM9rFszwIrFti5IzfA3RZIkzTorFveybcEgm3dU2bq7yv5KjXkDPSxf1MvKJb22LPz/9u48TorywP/4t2emmRkGGUAOQVBQkUMFIoln0CgUSLmyWyExh7JR4k8TY4zHJmqycdckmttswvqLG42akMv9qbWKlmIBHnjFMyjh8AQVjS4CgzAH3TP9+4OnSTPT1dd0TXfTn/frNa/q6nr66Wqe7qa+/TxVD5AHAgMAANgnNUYjOnN6VGdOj5Z6V4CKRmAAAAAI0BZL6J5Vcfnr/t5LYU2s07yp9FKgehAYAAAA0li6Jq5L72jX1ta9J3e7b3Vc13i7T67mPAhUA056BgAA6GbpmrgWLm7rERaStrYmtHBxm5auiff5vgF9jcAAAACQoi2W0KV3tKsrfVbYoyshXXZnu9piWQoCFY7AAAAAkOKeVfHAnoXutuxMaMmL9DJg30ZgAAAASOGvyy8APLiWwIB9G4EBAAAgRUtbfkOM8i0PVBoCAwAAQIrmxvwul5pveaDSEBgAAABSWBPzu1Tq7ElcWhX7NgIDAABAinlT6zS4f269BkOaIjpjCoEB+zYCAwAAQIrG6O5J2WqyZIaaiHT9/AZmfMY+j8AAAADQzZzJdbplQaOGNKUPA0OaIrplQSMzPaMq8C4HAABIY87kOj07vklLXozrwbVxtbQl1NwY0exJdTpjSh09C6gaBAYAAIAAjdGIzpwe1ZnTo6XeFaBkGJIEAAAAIBCBAQAAAEAgAgMAAACAQAQGAAAAAIE46RkAACBEbbGE7lkVl7/u71dasibWad5UrrSEykBgAAAACMnSNXFdeke7trYm9rr/vtVxXePtniCOuRxQ7hiSBAAAEIKla+JauLitR1hI2tqa0MLFbVq6Jt7n+wbkg8AAAABQZG2xhC69o11d6bPCHl0J6au3t6ktlqUgUEIEBgAAgCK7Z1U8sGehuw87pOse6Ah9n4BCERgAAACKzF+X3zCj3zwVo5cBZYvAAAAAUGQtbfkd/Mc6pXtf6gxtf4DeIDAAAAAUWXNj/pdL9dcTGFCeCAwAAABFZk3M/1KpW3YyJAnlicAAAABQZPOm1qk2z6Os1lhYewP0DoEBAACgyBqjEY0ZlOewJDoYUKYIDAAAACEYOSi/w6ym+vzPewD6AoEBAAAgBEP65xcABvcPbVeAXiEwAAAAhCDfE5+tCbWh7QvQGwQGAACAEMybWqfBOfYyRCQ19gt9l4CCEBgAAABC0BiN6GefalBNDpkhIenC22N65I1oX+wakBcCAwAAQEjmTK7TjZ9rUC79DF0J6ZoVA9Qe74MdA/JAYAAAAAhR667cr5i6rb1G/qv1Ie8RkB8CAwAAQIj8dfl1GTy6gWFJKC8EBgAAgBC1tOU3I9ub27haEsoLgQEAACBEzY35zcewYWut2mJM+4zyQWAAAAAIUb7zMcS6Irr3pc7Q9gfIV37vYAAAAORl3tQ6fd2VYnlkAH99pz57jNQWS+ieVXH56+JqaUuouTEia2Kd5k2tU2M0v54LoFAEBgAAgBA1RiM6bFiN1v6tK+fHtLRJS9fEdekd7drauvfwpPtWx3WNt3uOhzmTOZRD+BiSBAAAELJDhuZ3yNUeS2jh4rYeYSFpa+vu7UvXMGkDwkcsBQAACJk1sU73rc794H7tewl1ZTnvuSshnf/7Nk0/qEZDmmoYqoTQ0MMAAAAQsnlT6zS4f24H8v2jCbXuyq3eXZ3Sk2906b7VcV1yR7umf38nvQ4oOgIDAABAyBqju885qMmSGWoiCR22f+EH/AxVQhgIDAAAAH1gzuQ63bKgUUOa0qeGIf2ln879UPW9nLetKyF95U9t2tqa+0nWQCacwwAAANBH5kyu07Pjm7TkxbgeXPv3S6XOnlQne7L04eYPdO/6+l4/z85d0sd+sFM3fLaRKymh13gHAQAA9KHGaERnTo/qzOnRve7vjMf1oaQZB8e0/LXihIaFi9t0ywJCA3qHdw8AAEAZmT2+Qz9/aoC2tva+rq6EdNmd7Xp2fNNeV08q9oRwqfVtaU1oR3uXtrZKrbsSikQiGj0oorOOiepTR0e5ilMFIjAAAACUkYY66adOP533h11ZL62aiy07E1ryYnxPj0axJ4QLqu/vEvpgZ0Kr3A59x+vQ9fMb1LpLe4WVk8fXKtaZ0J+ejeuND7rUEZMSCSkhKVor9auTmhsjGtUc0dABXEK2r0USiSK8E1Fy7761ITF85GjV1pEB93Wd8bjef/dtSRJtXh1o8+pEu1ef7m2+7OXdvQNbdvb+WO30I+t089mNWromroWL2zIGkZqIch7GlEt9YamNSIcOi6gxGlFCUkNdQu3xiCKS+tdHNKR/73pN+kKyzUeOGVueO2jw7QMAAFCGup8gvaU1oWc3dirWmX9dLW0JtcUSuvSO9pwmhEs3jKm7XOsLS2dCevn9hHb3QyT17DX5xv9I18+v1/yP9OvzfdxXcFlVAACAMpU8Qfrmsxt11/n9ddNZjVnnckinuTGie1bFMwwb2ltyGFMm+dRXSrvi0kW3d+j837eVelcqFoEBAACgQiTncmjK88fy2ZPq5K/LbzK3B9dmLp9vfaW25KW4vue1l3o3KhKBAQAAoILMmVynZ65syjk0DGmK6IwpdWppy683IFv5fOsrBzc8GmNCuwIQGAAAACrM4P41uuGz2Ycn1USk6+c3qDEaUXNjfmOZspXPt75yce39u0q9CxWHwAAAAFCBksOThjSlP3Af0hTZ62pH1sT8rnUze1Lm8vnWVy6Wr6+soVTloDJbGgAAAD2upJSc12D2pDqdMWXvy4nOm1qna7xITicqJ4cxZZJPfeWkLVZZ+1sOCAwAAAAVLHklpeTEbJnK/exTDTnNw5AcxlSM+spNuc7JUM4YkgQAAFAl8h3G1Nv6ytHMCfxeni/+xQAAAKpIPsOYCqlvS2tCO9q7tK1V2rkroUgkotGDIjr72KiaGyK68u6OosxeXYiIpG/NZQK3fBEYAAAAqkyuw5jCqG/WpLoeYeUTh9cq1pnQH5+J640PutQRkxKJ3fM210SkeFf3OZwLc/Ep/TS4PwNs8kVgAAAAQJ/JFC7OPb4+7WPaYom/92Ds7FKruTJqQ1Rqj+2+/b8fdumd7emfM2LCwpVz0tePzAgMAAAAKGu59mBsbe3Stffv0vL1cbXFEmqMRjRzQp2+NZeehd4gMAAAAGCfMLh/jX4yv6HUu7HPIWoBAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAALVlXoHSsmyneMkXSjpJEkjJLVJekXSHZIW+Z7b3ou6HUnnSPqYpKGSOiRtlLRc0i98z32tuK8GAAAAKL6q7WGwbOebkh6XtEDSAZLelNQu6RhJP5L0gmU7Iwuot8mynfsk3SVpngkLGyXFJB0h6WJJL5lAAQAAAJS1qgwMlu18UtK15vUvkjTC99wJvueOknSCOcCfKOkuy3YieVb/a0m2pC5J35I00Pfc8b7nDpE0Q9Lrkhol/cGynYNCeokAAABAUVRdYLBsp0bSD8zqEt9zL/Y9tyW53ffcJyXNl5SQdJy5nWvdR0r6jFn9vu+516UOa/I99zFJnzOrDZIWFut1AQAAAGGousAg6VhJ483tH6cr4Hvuc5IeMatfyKPuoyVtNr0Lvwqo+2lTRpKm5bXnAAAAQB+rxsBgmWWrpCczlFtmlrMs28np5HDfc3/re+4wSf18z30zQ9Fkj0Y0t10GAAAASqMaA8MRZrne99x4hnKrzbJB0iH5PIHvuZ1B2yzbGSrp4G7PAQAAAJSlarysavJgfVOWcu+k3B4n6eUiPf8V5t+9S9JvilSnJKmzM1P+wb4itZ1p8+pAm1cn2r360ObVp1LauRoDw35muSNLudTt+2UolzNzKdXLzOoi33PXFKPepA/e/1sxq0MFoM2rD21enWj36kObo5xU45CkBrPclaVcR5rHFMyynQWSbjf/5g9J+npv6wQAAADCVo09DMnLnPbLUq4+5XZbb57Qsp1vS/qOWV0qab7vubHe1JnO/sMPUG1tNTZpdensjO/55Yk2rw60eXWi3asPbV59Utu8nFXjO3G7WQ7IUi51GNL2DOUCWbZTbyZyO8vcdZOkC7OcbF2w2to61dZVY5NWL9q8+tDm1Yl2rz60OcpJNb4TXzcTso3JUi51+6v5PollO82SPDNzdFzS5b7n/iL/3QUAAABKpxrPYXjJLCdYtpNpWFJyUrXtkjbk8wSW7fSXdJ8JC9slnU5YAAAAQCWqxsBwv1k2SDopQ7m5Zun5npvItXIzydvdkk6U9IGkk33PfbB3uwwAAACURtUFBt9zV0l63qxeka6MZTuzJE03qzfn+RT/JmmWObn6NN9z/9K7PQYAAABKpxrPYZCkf5G0TNIsy3Z+Kekq33O3aXdYsCT9zpS72/fc5akPtGznaklXm9VDfc/dmLLtEElXmtUrfc99tq9eEAAAABCGqgwMvuc+ZNnOVyQtkvQlSedatrNB0iBJI0yxxySdnebhNZJqze1It21fTfk3/T+W7Zybw75My1YGAAAAKJWqDAzafaB+o2U7T0n6mqRTJY01szuvND0MN/ue25VntYNTbh9R5F0GAAAA+lwkkcj5fF6UsXff2pAYPnI012yuAp3xuN5/921JEm1eHWjz6kS7Vx/avPok23zkmLHdR62Ulao76RkAAABA7ggMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCortQ7AAAAsK+LxWLq7OzMWKYzHlcsvrtMe3u7aus4TKtUtbW1ikajpd6NouGdCAAAEJLt27dr8+bN6ujoyFo2kUioy4SKHW1vKhKJ9MEeIiz19fUaOnSoBg4cWOpd6TUCAwAAQAi2b9+uTZs2acCAARo6dKii0WjGEJBIJBSLxSQpa1mUr2Q7trS0aNOmTZJU8aGBwAAAABCCzZs3a8CAARo9enROB/+JREK1tbtPL41G+xEYKlhjY6P2228/vf3229q8eXPFBwZOegYAACiyWCymjo4ONTc3c+BfpSKRiJqbm9XR0bGn56hSERgAAACKLHmC87504ivyl2z/bCe8lzsCAwAAQEjoXahu+0r7ExgAAAAABCIwAAAAAAhEYAAAAAAQiMuqAgAAVKC2WEL3rIrLXxdXS1tCzY0RWRPrNG9qnRqjpR87v9RfoZ/8bJEk6fofXaujjpyctlxnZ6fOOud8ffDBFlmzTtE3Lrt4r22PPvaEVjy8Uq+8+pq2t2xXQ2ODhg0bqmM+Ol32nFkaOfKAHnVatiNJOm32TF1+yUWB+3jTr3+j/77zfyRJvufuuf/yK/5VL77014yv74jJE/UfP/l+1n+HfQGBAQAAoMIsXRPXpXe0a2trYq/771sd1zVeRD/7VIPmTC6Pw7xoNCrvAT8wMDzz7PPavv3DHve3tGzXNd/7oVavWauPn3Cczv/iORoxfJg6du3Sy6+8qnvve0D/c/e9uujC8zXHOjXt8z786OP68vlfVP/+jT22d3Z2atmKRxSNRgMve3r9j65Vv3790m5LV+e+qjzeSQAAAMjJ0jVxLVzcpq5E+u1bWxNauLhNtyxoLIvQ8JFpU7Ty8Sd00ZfPU1NTU4/tD/jLNeWoI/Tc83/Zc18ikdB3rvuR/rp2nb591dc14+PH7/WYo6dN0T+eYevqa67T9T+/QcOHDdVHpk3Zq8y0KUfquRdW6aFHVur0ubN7PO+fn3lOW7Zu1dEfmarnX1iVdt8PO3ScGhurJxgE4RwGAACACtEWS+jSO9oDw0JSV0K67M52tcWyFOwDM048Th0du7T8oUd7bNu6bZv+/PRzOvH4Y/e6/8mnntaLL/1VZ5x+Wo+wkNTY0KBvXnGZ+vXrp/+6+bYe2wcNHqQjJk3U/Uv9tI9/4MFlmjjhcO2//5CCX1u1IDAAAABUiHtWxXsMQwqyZWdCS16Mh75P2Yw84ABNnHC4vAd6HrgvW/GIIpJOnnHCXvevfPwpSZJ9mpWx7sGDBunE44/Ra6+/oY1vvtVj+ymfmKH1L7+q19/YsNf9W7du09PPPK+Zp55c4KuqLgQGAACACuGvyy8APLi29IFBkubOmanXXn9DL7/y2l73L31wuY4/7hgNHDhwr/s3vvmmamtrNW7swVnrPuzQQyRJb729qce2Uz8xQw319T3CyoPLHlJNTY1O/cSMAl9RdSn9wDYAAADkpKUtvyFG+ZYPyyknz9CNN92q+5f6Onz8oZKkNevWa+Obb+mC887pUb61tU0NDfU5zZTcv39/SUp74nRTU5NmfPx4rXjoUZ3/xS/sOYF56bLlOvH4YzVwv/0y1j1v/ucDt33m047OO/efs+7fvoDAAAAAUCGaG/O7XGq+5cPS2Niok2ecqBUPr9QF552rhoZ6PbB0mYYN3V/Tj57Wo/ygQc1692/vqbOzU7W1tRnr3rlz557HpDN3jiV/+cNa+fiTmnnKyVr917V6661NuvCC87Lu989/+n3161efdtvgwemfb1/EkCQAAIAKYU3M77fe2ZPK57fhuXNmqbW1VY+sfFxt7e165NHHZc08RTU1PQ9Hxx58kLq6unoMYUrn5Vd3lxl38EFptx915GSNGX3gnmFJS/3lGjZsqI7udlWldMaNPViHHTou7d/+Q6rnZGkCAwAAQIWYN7VOg/vn1mswpCmiM6aUT2CYPGmiDj5ojB56ZKWeePLPamtv15zZPedPkDlZWZLuuff+jHVu3bpNTz31jI48YlLaCdyS5lgz9dLqNXrn3Xf16MonNHtW+qCC9PiXAgAAqBCN0d2TstVkyQw1Een6+Q1lMeNzqtNmz9SLL67W8hWP6KgjJ2vUyJFpy0096kid9PETtGzFw7p/6bK0Zdra23Xdj65XZ2enLrzgixmfd7Z1impra3XjTbfuDiqz0gcVpFc+sRMAAABZzZlcp1sWNOqyO9u1ZWfPk5qHNEV0/fzymek5lTXzFN1y2+/0zHMv6BuXX5yx7OWXXKR4PK7rf36DnnjqaZ1y0sc1YsRw7dq1Sy+/8pru9R7Qjp079a9X/YvGH3ZoxroGDxqkY4+Zrsef+LOmTTkyY28Eeiq/dxIAAAAymjO5Ts+Ob9KSF+N6cG1cLW0JNTdGNHtSnc6YUld2PQtJzc0Ddfxxx+jZ517QjBNPyFi2f/9GXXP1VXriqae1bPnDuvW3v9eWrdtUX99PI4YPlzXzFM09bZaGDR2a03PPnWPp8Sf+rDmzZxbp1VSPSCJRHpfbQu+8+9aGxPCRo1VbRwbc13XG43r/3bclSbR5daDNqxPtXtna29v1xhtvaNy4cWpoaMjpMYlEQrHYLklSNNovp0uKorxlex8kP+cjx4wt68bmHAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAQEiY76q67SvtT2AAAAAostraWklSLBYr9a6ghJLtn3w/VCoCAwAAQJFFo1HV19erpaVln/mVGflJJBJqaWlRfX29otFoqXenV5hnHgAAIARDhw7Vpk2b9Pbbb6u5uVnRaFSRSCSwfCKR2POLdGdnV8ayKF/JdmxpadGOHTt04IEHlnqXeq1qA4NlO8dJulDSSZJGSGqT9IqkOyQt8j23vRzrBgAAlWHgwIGSpM2bN2vTpk1ZyycSCXV1dkqSamprCQwVrr6+XgceeOCe90Elq8rAYNnONyV91wzJ6pC0UdJ+ko4xfwst2znV99x3y6luAABQWQYOHKiBAwcqFoup04SBIJ3xuD743/ckSfsPG6Hauqo8TNsn1NbWVvwwpFRV9060bOeTkq41q4skfdv33Baz7XhJf5Q0UdJdlu2c4HtuzgMPw6wbAABUrmg0mvUAsjMeV7Ru98mxDQ0NBAaUjao66dmynRpJPzCrS3zPvTh5QC9Jvuc+KWm+pISk48ztktcNAAAAlEpVBQZJx0oab27/OF0B33Ofk/SIWf1CmdQNAAAAlES1BQbLLFslPZmh3DKznGXZTq79gWHWDQAAAJREtQWGI8xyve+58QzlVptlg6RDyqBuAAAAoCSq7Rfug80y27XN3km5PU7SyyWuOyednZlyCvYVqe1Mm1cH2rw60e7VhzavPpXSztUWGPYzyx1ZyqVu3y9Dub6qOycfvP+3YlaHCkCbVx/avDrR7tWHNkc5qbbA0GCWu7KU60jzmFLWndXIMWOZ3QUAAABFV23nMCRnWO6XpVx9yu22MqgbAAAAKIlqCwzbzXJAlnKpQ4W2ZyjXV3UDAAAAJVFtgeF1sxyTpVzq9lfLoG4AAACgJKotMLxklhMs28k0dGiaWW6XtKEM6gYAAABKotoCw/1m2SDppAzl5pql53tuogzqBgAAAEqiqgKD77mrJD1vVq9IV8aynVmSppvVm8uhbgAAAKBUIolEdf3IbdnOKZKWmbB0o6SrfM/dZrZZkn4nabiku33P/aduj71a0tVm9VDfczcWq24AAACgHFVdYNDug/cvSVpk5qHoMOcSDJI0whR5TNJc33N3dHvcv0v6N7M6zvfcHucgFFo3AAAAUI6qakhSku+5N0r6mKTbJL0naaw5wF8p6QJJJxd6QB9m3QAAAEBfq8oeBgAAAAC5qcoeBgAAAAC5ITAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgepKvQP4O8t2jpN0oaSTzMzQbZJekXSHpEW+57aXY90oXMht7kg6x0wkONTMPL5R0nJJv/A997Xivhrkoi8/i5btDJL0V0mjJG30PXdssepGfkL+rNeZiUE/L2mipAZJb0t63NT9QnFfDXIRVptbtlMraYGkz0maJmlwyvf7w5Ju8D13bfFfEXJhPo9XS/qmpFpJ1/ie++9FqLekx3FM3FYmLNv5pqTvml6f5Ad/P0kjTZF1kk71PffdcqobhQurXSzbaZL035Jsc1fM1L2/+Y9F5ovmLN9z3eK+KmTS159Fy3Z+aw4sRGAonZC/34dIesD8MCATFDokHSQpKikuaaHvuYuL+6qQSYjf7/tLuk/SseaudklvSWqWNNzcF5P0Nd9zf1ncV4VsLNuZKGmxpI+m3N3rwFAOx3EMSSoDlu18UtK1pj0WSRrhe+4E33NHSTrBvDEmSrrLsp1IudSNwoXcLr82YaFL0rckDfQ9d7zvuUMkzZD0uqRGSX+wbOegkF4iuunrz6JlO2eYsNBZnFeAQoT8/R6R5JqwsErSNN9zx/iee5ik0ZLuNCMJfm3ZDmGxj4T8WV9swkLc9CoN8D33cN9zR0gaL2mFCYo3WLZzYkgvEd1YthOxbOciSc+bsPBAEesui+M4AkOJWbZTI+kHZnWJ77kX+57bktzue+6TkuZLSkg6ztwued0oXMhtfqSkz5jV7/uee11qN6XvuY+ZbmyZYQsLi/W6EKyvP4vmV+dfmdXf9mrnUbA+aPezzPCE9yTN9j13VUrd70s6W5Iv6XZJBIY+EPL3+6GS5prVn/ue+yvfc/f8IOB77qvm+79dUsQECvSN083BfI2kS1N6+HulnI7jCAyld6z5VUCSfpyugO+5z0l6xKx+oUzqRuHCbJejJW02vQu/SlfA99ynTRmZ8a8IX19/Fv9T0gHmQPHRXtaFwoXd7peY5U9MQOhed7vvubN9z13ge+7DedaNwoTZ5uNTbq8MqHuzpPVpyiNcdZLWSDrG99z/8D23WOP9y+Y4jsBQepZZtkp6MkO5ZWY5y5xQU+q6UbjQ2sX33N/6njtMUj/fc9/MUDT5C0U0t11GL/XZZ9Gc7P45Se9LuqiQOlA0obW7ZTtjJE03q/+vd7uJIgrzs546Pn2/DOX6m+XfcqwXvfeMpI/6nvtikestm+M4Dg5L7wizXO97bjxDudVm2SDpEEkvl7huFC70dkntpu7Osp2hkg7u9hwIV598Fk3b3mhWv+x77mbLdgrbYxRDmO2ePMl5q++5Gy3bGW2GGB4vaYik/zVXzLkpdQgDQhdmm/9V0muSDjVDj37XvYBlOxNMfTInR6MP+J67KaSqy+Y4jsBQeskDt2xvtndSbo/L8c0QZt0oXKnb5Qrz2e+S9Jsi1YnM+qrN/6+5Usoffc+9K8/HovjCbPdJZvmWZTvzzMmwA7uVOV3SNyzb+Ucz1hnhC63Nfc+NW7bzZUl3S/oHy3Z+J+kn5rEDzAmwPzSX8nxY0q09VeJHAAALbUlEQVS9eykoA6U+XtiDIUmll+xW3JGlXOr2TF2RfVU3CleydjHDVS4zq4t8z11TjHqRVehtbtnOpyV92gxDYChSeQiz3Yea5RBJvzdjmD9mfmEcKulcSR9IGibpXst2Dixg/5G/UD/rvuf65mp3d5qhhy9I2mlOfHcl1Uv6tqQ5mXqaUTHK5jiOHobSazDLXVnKdaR5TCnrRuFK0i6W7Swwl1ytkfSQpK/3tk7kLNQ2t2xnmOldkKQLfM/dkv8uIgRhtnuTWY6WtETSP6acaNkh6TbLdlabcc9DJF1FkOwTffH9fpykCea7fJekN03v0nBzXf4TJE014+pR2crmOI4ehtJLXvKyX5Zy9Sm328qgbhSuz9vFsp1vm8trRiUtlXSG77mx3tSJvITd5r80vyov9j33ngL2D+EIs91Tr8LyvXRXZfE999mUceyczNI3Qv2sW7Zzq7kK2ihzzkp/M8/OCBMef28uvfqoZTtzc6gS5a1sjuMIDKW33SwHZCmX2sW0PUO5vqobheuzdrFsp96Mc/2OuesmSf/ge+7OQupDwUJrc8t2Pmeuvf2OpK8VvosIQZif9Q9Tbq/KUO4Jsxxl2U5zjnWjcGF+1udJOsesft733Fu7zcOwyffchWZoUoOk/+LKhxWvbI7jCAyl97pZjslSLnX7q2VQNwrXJ+1iDg5WmMmd4pK+5nvu+VmutIBwhNLmlu2MMJMFdUn6Z99zt/ZuN1FkYX7W30q5nWl2120pt5sylENxhNnmyUm53vM9d2mGcn9KeY6pOdaN8lQ2x3EEhtJ7ySwnWLaTqcspOcHWdkkbyqBuFC70drFsp78ZinCCefzpvuf+ovBdRi+F1eanSdrffJcvs2wn0f0v5UopB6fcf1svXw9yE+ZnPfV67+MylBuVcntbhnIojjDbPNmW2S6Tm/rDwYgc60Z5KpvjOAJD6d1vlg2STspQLjkW0ctjBsEw60bhQm0X0wV9t6QTzVVSTvY998He7TJ6Kaw2j5mDh0x/yfGsiZT7Wnv5epCbMD/rT6QMPcg0Vn2KWb7uey7tHr4w2zwZBA62bCfT8VtqSOQCCJWtbI7jCAwl5nvuKknPm9Ur0pWxbGdWyoyeN5dD3ShcH7TLv0maZU6WOs333L/0bo/RW2G1ue+5f/A9d1CmP0kXmuJvptx/YZaqUQQhf793mBNcJelyy3YGpal7oqR5ZpV5OfpAyN/vK82y3lxSNcinzXKHuewqKlQ5HcdxMkx5+Bczrfcsy3Z+Kekq33O3afcbwUqZzfFu33OXpz7Qsp2rJV1tVg/1PXdjsepGqEJpc8t2DpF0pVm90lwlBeUhzM85yleY7f7vks40vyh7lu0s8D33NfPYqZL+aCbx2izpp33xYiGF2Oa3me/3UZIWWbYTNVdG6zSPHSTpX82EfZL0UxMsUcYq5TiOwFAGfM99yLKdr5iTF78k6VzLdjZIGpQy/vAxSWeneXiN+Q9B6U5862XdCEmIbf7VlM/1/7Fs59wc9mVatjLovTA/5yhfIX+/v2/Zji3Jk3S8pJct23ndXD45OUPsVkmO77l/C+9VIlVYbe577ofmUqlLJB1kzk/6lWU7yQPMcSmPvTXl6ngImWU7XrehYKm+ZNnOP3W7z/Y9Nzk7c0UcxzEkqUz4nnujmaXzNjNj41hz4LdS0gVmHHq2mf76vG4ULqR2GZxy+whzhYxsf+gjfBarU8jf709LmiTph5LWmom7hpvbP5E02ffcx4r/qpBJWG3ue+6L5rv9EjMB5zZT9yhJb5hfm0/1PXeh77ld4bw6pDE5w/+tI9Jsyzavwl7K4f+OSCLBOa4AAAAA0qOHAQAAAEAgAgMAAACAQAQGAAAAAIEIDAAAAAACERgAAAAABCIwAAAAAAhEYAAAAAAQiMAAAAAAIBCBAQAAAEAgAgMAAACAQAQGAAAAAIEIDAAAAAACERgAAAAABCIwAAAAAAhEYAAAAAAQiMAAAAAAIFBdqXcAAIC+ZNnObZK+IGmj77ljS70/AFDuCAwAgD0s23lY0skBm+OSPpS0QdKfJS32PfeJPt7FYnhT0ipJ75R6RwCgEkQSiUSp9wEAUCZSAkO7pPXdNjdIGilpYMp9v5L0Jd9z+c8EAPZR9DAAANJZ73vutHQbLNv5qKTvSjpN0vmSnpb0677fRQBAX+CkZwBAXnzPfVbSJyW9b+46u8S7BAAIET0MAIC8+Z7bZtnO86aX4YDUbSknFS+V5Ej6saT5kkZIOtX33IdTyh4i6auSTpV0iKRGSdslrZZ0u6T/8j033q3+AeZcCkn6tKS7JH1J0jmSDjdDpzZKulvS93zP3R6wf3ud9GzZzkWSFkna6XvuAMt2DpR0lSRb0igzTOslSf/pe+7t4f3rAkB5oYcBAFCoZrPcmKHMf0j6iqQOSS9LiiU3WLZjm2BwiaSjJO2Q9Jo54J8h6T8lrbBsp7Fbne0pt2sk3SnpBkljJL1rnuNwSV83j4/m+Hr21GvZziRJz5kgEpO0yZy78XFJf7Js59Ic6wSAikdgAADkzbKdiZI+ZlaDfm0fJenzkmzfc8f6njvR99zHzeMHSvqd6VFYJ+kI33NH+p47wRyYX2nqmCHpG93q7Uy5famkYyR9wjx+kqRhkm4026eb3o1cJOutlfRHSY9LOtD33Am+5x4qabwJNJJ0tWU7DTnWCwAVjcAAAMiJZTt1lu2MtmxnoaQVZljrnyT9JuAhR0n6me+596fZNjPlakvf8D13bXKD77lx33N/KOlRc9dnUh/Y7YpMx0la4HvuIynb2yVdbno1JOmUHF9ist4GSftJ+qzvue+l1PuapOvM6iBJH8mxXgCoaJzDAABIZ6plO5kulfqKpLN8z/1DlnrSbvc917Vsp5+koZK2Bjz2GUknmXMbgjzre+6KNPW3WrazXtIUM1QpX9f7nhtLc/8LKbfHSHqygLoBoKIQGAAA6aSbh0GSBpgD5fGSfm7ZzjRJ3/U998M86pB2H9R3pVxpKZ0dZlmfocxLGba1mGX3cyByEVRvS8rtQuoFgIpDYAAApJNpHoZ+kv5B0k/NicWzLduZkSY0bMk0oZup51xJ/yTpSEn7F3AQ/naGbV1mGcmzzkz1dqXcLqReAKg4BAYAQF58z90l6S7Ldp6TtEbSVElXm/CQKt2QHml3WBgqabkZMpS0yfyCn3zcAeZSrJl0ZdleqLDqBYCKw0nPAICC+J67UdKDZvVTeT78+pSw8AtJw33PHe177hG+504zvRs3ZqkDANAH6GEAAPTGO2Z5YK4PMPMiJAPGUt9zvxZQdGjvdw8A0Fv0MAAAemO0WW7O4zHDUs5VeDRdAct2asws0gCAEiMwAAAKYtnOGEmWWX0oj4fuTLkd1ItwZerlVJkkDQBKh8AAAMiLZTs1lu3MkuSbnoJ2Sd/N9fG+57ZIWmVWF1q2c3RK3aMs21lkTqK+JuVhM4r6IgAAOeMcBgBAOhMs2/lLmvsbzDCkJrP+nqTP+567Ls/6vylpiaRmSc9atrPR/Ig1WlJc0nmSVkr6tqRaSUtMmZm+52a6lCoAoMjoYQAApNNgLpfa/W+cpA9N78Ilkiakm2k5G99zPUnJXortkkaZTb+XdLzvuYt9z90g6WuS3jLb2iV1FPdlAgCyiSQSgXPqAAAAAKhy9DAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACERgAAAAABCIwAAAAAAgEIEBAAAAQCACAwAAAIBABAYAAAAAgQgMAAAAAAIRGAAAAAAEIjAAAAAACPT/ARLSw2AzsLVLAAAAAElFTkSuQmCC\n"
           },
           "metadata": {
-            "bento_obj_id": "139790888033632",
+            "bento_obj_id": "140557428341344",
             "needs_background": "light"
           }
         }
@@ -760,7 +778,7 @@
       "source": [
         "# Comparison of MOMF with single-fidelity multi-objective optimization using qEHVI \n",
         "\n",
-        "In this section we draw a comparison of the MOMF with qEHVI. For this purpose we will now run 3 trials of the MOMF and qEHVI with 80 iterations for both. For this we define some helper functions for qEHVI similar to what was done for MOMF. \n",
+        "In this section, we draw a comparison of the MOMF with qEHVI. This section parallels the last, again running 30 iterations and defining helper functions for qEHVI similar to those used for MOMF. \n",
         "\n",
         "**Note: Most of the material for qEHVI example has been taken from [3]**\n",
         "\n",
@@ -780,23 +798,28 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "796d8e48-41e0-4983-8af8-343ce131745a",
+        "originalKey": "1a8503dd-3376-4141-9615-a8c7d4b19267",
         "collapsed": false,
-        "requestMsgId": "4c9f8112-a4f0-4701-ad3e-646118fc6eff",
+        "requestMsgId": "81ea55da-f905-4996-91e3-79bb910058de",
         "customOutput": null,
-        "executionStartTime": 1677770893360,
-        "executionStopTime": 1677770893366
+        "executionStartTime": 1677807726181,
+        "executionStopTime": 1677807726184
       },
       "source": [
         "def get_obj_MO(X: torch.Tensor) -> torch.Tensor:\n",
-        "    # Since MO-only optimization only evaluates at highest fidelity so a column of ones is added to the input to be consistent\n",
-        "    # with the same objective function definition.\n",
+        "    \"\"\"\n",
+        "    Get the Branin-Currin objective at X.\n",
+        "\n",
+        "    Since MO-only optimization only evaluates at the highest fidelity,\n",
+        "    a column of ones is added to the input to be consistent with the\n",
+        "    objective function definition.\n",
+        "    \"\"\"\n",
         "    h_fid = torch.ones(*X.shape[:-1], 1, **tkwargs)\n",
         "    X = torch.cat([X, h_fid], dim=-1)\n",
         "    y = BC(X)\n",
         "    return y"
       ],
-      "execution_count": 12,
+      "execution_count": 13,
       "outputs": []
     },
     {
@@ -808,27 +831,27 @@
       "source": [
         "### Data Initialization qEHVI \n",
         "\n",
-        "For qEHVI we initialize with 1 point to keep the initial cost low. We do not aim to make the initial costs the same but for all cases the initial costs of the MOMF are lower when the fidelity is drawn in a probabilistic fashion."
+        "For qEHVI, we initialize with one point to keep the initial cost low. We do not aim to make the initial costs the same, but for all cases the initial costs of the MOMF are lower when the fidelity is drawn in a probabilistic fashion."
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "e8375e2a-d3db-4c83-8bae-fd08896f10a4",
+        "originalKey": "adafd8d7-29fd-4cca-b71a-4ade50983f5c",
         "collapsed": false,
-        "requestMsgId": "2d3daa89-a57a-4abf-9512-87df85c390fc",
+        "requestMsgId": "5d2462fe-1ba1-4d92-8a92-59e2e59681e2",
         "customOutput": null,
-        "executionStartTime": 1677770897003,
-        "executionStopTime": 1677770897015
+        "executionStartTime": 1677807726289,
+        "executionStopTime": 1677807726297
       },
       "source": [
         "def gen_init_data_MO(dim_x: int, points: int) -> Tuple[torch.Tensor, torch.Tensor]:\n",
-        "    # generates random training data.\n",
+        "    \"\"\"Generate random training data.\"\"\"\n",
         "    train_x = torch.rand(size=(points, dim_x), **tkwargs)\n",
         "    train_obj = get_obj_MO(train_x)\n",
         "    return train_x, train_obj"
       ],
-      "execution_count": 13,
+      "execution_count": 14,
       "outputs": []
     },
     {
@@ -847,14 +870,14 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "3eb0c088-2b64-4c5b-bfb5-efaad71876cc",
+        "originalKey": "f3d43939-a492-46d2-9d11-58f27f7dc86c",
         "collapsed": false,
-        "requestMsgId": "40671711-282c-425e-8ffe-ef8ca25e2cc7",
+        "requestMsgId": "056dfc13-9587-432e-9007-150dd5fe23a1",
         "code_folding": [],
         "hidden_ranges": [],
         "customOutput": null,
-        "executionStartTime": 1677770899537,
-        "executionStopTime": 1677770899544
+        "executionStartTime": 1677807726461,
+        "executionStopTime": 1677807726477
       },
       "source": [
         "from botorch.acquisition.multi_objective.monte_carlo import (\n",
@@ -863,9 +886,16 @@
         "\n",
         "\n",
         "def optimize_MO_and_get_obs(\n",
-        "    model, train_obj, sampler, ref_point, standard_bounds, BATCH_SIZE_MO\n",
-        "):\n",
-        "    \"\"\"Optimizes the qEHVI acquisition function, and returns a new candidate and observation.\"\"\"\n",
+        "    model: SingleTaskGP,\n",
+        "    train_obj: torch.Tensor,\n",
+        "    sampler: SobolQMCNormalSampler,\n",
+        "    ref_point: torch.Tensor,\n",
+        "    standard_bounds: torch.Tensor,\n",
+        "    BATCH_SIZE_MO: int\n",
+        ") -> Tuple[torch.Tensor, torch.Tensor]:\n",
+        "    \"\"\"\n",
+        "    Optimize the qEHVI acquisition function and return a new candidate and observation.\n",
+        "    \"\"\"\n",
         "    # partition non-dominated space into disjoint rectangles\n",
         "    partitioning = FastNondominatedPartitioning(\n",
         "        ref_point=torch.tensor(ref_point, **tkwargs), Y=train_obj\n",
@@ -891,7 +921,7 @@
         "    new_obj = get_obj_MO(new_x)\n",
         "    return new_x, new_obj"
       ],
-      "execution_count": 14,
+      "execution_count": 15,
       "outputs": []
     },
     {
@@ -901,270 +931,108 @@
         "showInput": false
       },
       "source": [
-        "### Running MOMF and qEHVI optimization for multiple Trials\n",
+        "### Running qEHVI optimization for multiple Trials\n",
         "\n",
-        "We run 5 trials of 30 iterations each to optimize the multi-fidelity versions of the Brannin-Currin functions using MOMF and qEHVI. The Bayesian loop works in the following sequence. \n",
+        "We run 30 iterations to optimize the Branin-Currin functions using qEHVI. The Bayesian loop works almost the same as the one we ran early with MOMF:\n",
         "\n",
-        "1. At the start of each trial an initial data is generated and a model initialized using this data.\n",
+        "1. An initial data is generated and a model initialized using this data.\n",
         "2. The models are used to generated an acquisition function that gives us a suggestion for new input parameters\n",
         "3. The objective function is evaluated at the suggested new_x and returns a new_obj.\n",
-        "4. The models are updated with the new points and then are used again to make the next prediction.\n",
-        "\n",
-        "**Note: The following code cell would take some time to run**"
+        "4. The models are updated with the new points and then are used again to make the next prediction."
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "f7b1789d-fd1d-4aac-bc65-a36a10fe827a",
+        "originalKey": "a164ba4e-94f4-45ac-aece-433790bd1429",
+        "showInput": true,
+        "customInput": null,
         "collapsed": false,
-        "requestMsgId": "d8bf707c-53bb-4e83-815b-b4cd914e4d8b",
-        "customOutput": null,
-        "executionStartTime": 1677770909837,
-        "executionStopTime": 1677771898078,
-        "code_folding": [],
-        "hidden_ranges": []
+        "requestMsgId": "2f6b294a-808f-4d30-95ac-0f0d9ec2787e",
+        "executionStartTime": 1677807726594,
+        "executionStopTime": 1677807837327,
+        "customOutput": null
       },
       "source": [
-        "%%time\n",
-        "# MOMF and qEHVI\n",
-        "\n",
         "# Intializing train_x to zero\n",
-        "train_x = torch.zeros( n_INIT + n_BATCH * BATCH_SIZE, dim_x, n_TRIALS, **tkwargs)\n",
-        "# Intializing train_obj to zero\n",
-        "train_obj = torch.zeros(n_INIT + n_BATCH * BATCH_SIZE, dim_y, n_TRIALS, **tkwargs)  \n",
-        "\n",
-        "# Intializing train_xMO to zero\n",
         "train_xMO = torch.zeros(\n",
-        "    n_INITMO + n_BATCH * BATCH_SIZE, dim_xMO, n_TRIALS, **tkwargs\n",
+        "    n_INITMO + n_BATCH * BATCH_SIZE, dim_xMO, **tkwargs\n",
         ")\n",
-        "# Intializing train_objMO to zero\n",
-        "train_objMO = torch.zeros(\n",
-        "    n_INITMO + n_BATCH * BATCH_SIZE, dim_yMO, n_TRIALS, **tkwargs\n",
+        "# Intializing train_obj to zero\n",
+        "train_objMO = (\n",
+        "    torch.zeros(n_INITMO + n_BATCH * BATCH_SIZE, dim_yMO, **tkwargs)\n",
         ")\n",
+        "torch.manual_seed(0)\n",
+        "train_xMO[:n_INITMO, :], train_objMO[:n_INITMO, :] = gen_init_data_MO(\n",
+        "    dim_xMO, n_INITMO\n",
+        ")\n",
+        "mll_MO, model_MO = initialize_model(\n",
+        "    train_xMO[:n_INITMO, :], train_objMO[:n_INITMO, :]\n",
+        ")\n",
+        "\n",
+        "# Generate Sampler\n",
         "sampler = SobolQMCNormalSampler(sample_shape=torch.Size([MC_SAMPLES]))\n",
         "\n",
-        "for trial in range(n_TRIALS):\n",
-        "    print(f\"Trial {trial}\")\n",
-        "    # Generate Data and initialize model\n",
-        "    train_x[:n_INIT, :, trial], train_obj[:n_INIT, :, trial] = gen_init_data(\n",
-        "        dim_x, n_INIT\n",
+        "for iteration in tqdm(range(0, n_BATCH)):\n",
+        "    # run N_BATCH rounds of BayesOpt after the initial random batch\n",
+        "    fit_gpytorch_mll(mll=mll_MO)  # Fit the model\n",
+        "\n",
+        "    # Updating indices used to store new observations\n",
+        "    lower_index = n_INITMO + iteration * BATCH_SIZE\n",
+        "    upper_index = n_INITMO + iteration * BATCH_SIZE + BATCH_SIZE\n",
+        "    # optimize acquisition functions and get new observations\n",
+        "    new_x, new_obj = optimize_MO_and_get_obs(\n",
+        "        model=model_MO,\n",
+        "        train_obj=train_objMO[:upper_index, :],\n",
+        "        sampler=sampler,\n",
+        "        ref_point=ref_pointMO,\n",
+        "        standard_bounds=standard_boundsMO,\n",
+        "        BATCH_SIZE_MO=BATCH_SIZE,\n",
         "    )\n",
-        "    mll, model = initialize_model(\n",
-        "        train_x[:n_INIT, :, trial], train_obj[:n_INIT, :, trial]\n",
-        "    )\n",
-        "\n",
-        "    train_xMO[:n_INITMO, :, trial], train_objMO[:n_INITMO, :, trial] = gen_init_data_MO(\n",
-        "        dim_xMO, n_INITMO\n",
-        "    )\n",
-        "    mll_MO, model_MO = initialize_model(\n",
-        "        train_xMO[:n_INITMO, :, trial], train_objMO[:n_INITMO, :, trial]\n",
-        "    )\n",
-        "    for _iter in tqdm(range(n_BATCH), desc=\"batch\"):\n",
-        "        # run N_BATCH rounds of BayesOpt after the initial random batch\n",
-        "        # fit the models\n",
-        "        fit_gpytorch_mll(mll)\n",
-        "        fit_gpytorch_mll(mll_MO)\n",
-        "\n",
-        "        # Updating indices used to store new observations\n",
-        "        lower_index = n_INIT + _iter * BATCH_SIZE\n",
-        "        upper_index = n_INIT + _iter * BATCH_SIZE + BATCH_SIZE\n",
-        "\n",
-        "        lower_indexMO = n_INITMO + _iter * BATCH_SIZE\n",
-        "        upper_indexMO = n_INITMO + _iter * BATCH_SIZE + BATCH_SIZE\n",
-        "        # optimize acquisition function and get new observations\n",
-        "        new_x, new_obj = optimize_MOMF_and_get_obs(\n",
-        "            model,\n",
-        "            train_obj[:upper_index, :, trial],\n",
-        "            sampler,\n",
-        "            ref_point,\n",
-        "            standard_bounds,\n",
-        "            BATCH_SIZE,\n",
-        "            cost_call=cost_callable,\n",
-        "        )\n",
-        "\n",
-        "        new_x_MO, new_obj_MO = optimize_MO_and_get_obs(\n",
-        "            model_MO,\n",
-        "            train_objMO[:upper_indexMO, :, trial],\n",
-        "            sampler,\n",
-        "            ref_pointMO,\n",
-        "            standard_boundsMO,\n",
-        "            BATCH_SIZE,\n",
-        "        )\n",
-        "        # Updating train_x and train_obj\n",
-        "        train_x[lower_index:upper_index, :, trial] = new_x\n",
-        "        train_obj[lower_index:upper_index, :, trial] = new_obj\n",
-        "\n",
-        "        train_xMO[lower_indexMO:upper_indexMO, :, trial] = new_x_MO\n",
-        "        train_objMO[lower_indexMO:upper_indexMO, :, trial] = new_obj_MO\n",
-        "        # reinitialize the models so they are ready for fitting on next _iter\n",
-        "        mll, model = initialize_model(\n",
-        "            train_x[:upper_index, :, trial],\n",
-        "            train_obj[:upper_index, :, trial],\n",
-        "        )\n",
-        "\n",
-        "        mll_MO, model_MO = initialize_model(\n",
-        "            train_xMO[:upper_indexMO, :, trial],\n",
-        "            train_objMO[:upper_indexMO, :, trial],\n",
-        "        )"
+        "    # Updating train_x and train_obj\n",
+        "    train_xMO[lower_index:upper_index, :] = new_x\n",
+        "    train_objMO[lower_index:upper_index, :] = new_obj\n",
+        "    # reinitialize the models so they are ready for fitting on next iteration\n",
+        "    mll_MO, model_MO = initialize_model(train_xMO[:upper_index, :], train_objMO[:upper_index, :])"
       ],
-      "execution_count": 15,
+      "execution_count": 16,
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Trial 0\n"
-          ]
-        },
-        {
-          "output_type": "stream",
           "name": "stderr",
           "text": [
-            "\rbatch:   0%|          | 0/30 [00:00<?, ?it/s]",
-            "\rbatch:   3%|▎         | 1/30 [00:05<02:50,  5.89s/it]",
-            "/mnt/xarfuse/uid-22473/0b567aa0-seed-nspid4026534046_cgpid16409003-ns-4026534043/botorch/optim/initializers.py:224: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-22473/0b567aa0-seed-nspid4026534046_cgpid16409003-ns-4026534043/botorch/optim/initializers.py:224: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n  warnings.warn(\n\rbatch:   7%|▋         | 2/30 [00:21<05:24, 11.57s/it]",
-            "\rbatch:  10%|█         | 3/30 [00:27<04:04,  9.06s/it]",
-            "\rbatch:  13%|█▎        | 4/30 [00:36<03:52,  8.93s/it]",
-            "\rbatch:  17%|█▋        | 5/30 [00:44<03:35,  8.63s/it]",
-            "\rbatch:  20%|██        | 6/30 [01:07<05:28, 13.69s/it]",
-            "\rbatch:  23%|██▎       | 7/30 [01:18<04:48, 12.56s/it]",
-            "\rbatch:  27%|██▋       | 8/30 [01:29<04:29, 12.23s/it]",
-            "\rbatch:  30%|███       | 9/30 [01:43<04:27, 12.75s/it]",
-            "\rbatch:  33%|███▎      | 10/30 [01:52<03:48, 11.44s/it]",
-            "\rbatch:  37%|███▋      | 11/30 [02:01<03:23, 10.70s/it]",
-            "\rbatch:  40%|████      | 12/30 [02:14<03:27, 11.55s/it]",
-            "\rbatch:  43%|████▎     | 13/30 [02:26<03:17, 11.63s/it]",
-            "\rbatch:  47%|████▋     | 14/30 [02:36<02:58, 11.16s/it]",
-            "\rbatch:  50%|█████     | 15/30 [02:47<02:46, 11.12s/it]",
-            "\rbatch:  53%|█████▎    | 16/30 [02:58<02:36, 11.16s/it]",
-            "\rbatch:  57%|█████▋    | 17/30 [03:10<02:28, 11.41s/it]",
-            "\rbatch:  60%|██████    | 18/30 [03:21<02:13, 11.13s/it]",
-            "\rbatch:  63%|██████▎   | 19/30 [03:33<02:05, 11.44s/it]",
-            "\rbatch:  67%|██████▋   | 20/30 [03:44<01:54, 11.40s/it]",
-            "\rbatch:  70%|███████   | 21/30 [03:55<01:41, 11.27s/it]",
-            "\rbatch:  73%|███████▎  | 22/30 [04:06<01:28, 11.04s/it]",
-            "\rbatch:  77%|███████▋  | 23/30 [04:17<01:17, 11.03s/it]",
-            "\rbatch:  80%|████████  | 24/30 [04:28<01:05, 10.99s/it]",
-            "\rbatch:  83%|████████▎ | 25/30 [04:39<00:55, 11.12s/it]",
-            "\rbatch:  87%|████████▋ | 26/30 [04:50<00:44, 11.11s/it]",
-            "\rbatch:  90%|█████████ | 27/30 [04:59<00:31, 10.57s/it]",
-            "\rbatch:  93%|█████████▎| 28/30 [05:11<00:21, 10.79s/it]",
-            "\rbatch:  97%|█████████▋| 29/30 [05:22<00:11, 11.04s/it]",
-            "\rbatch: 100%|██████████| 30/30 [05:34<00:00, 11.21s/it]",
-            "\rbatch: 100%|██████████| 30/30 [05:34<00:00, 11.15s/it]",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Trial 1\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\rbatch:   0%|          | 0/30 [00:00<?, ?it/s]",
-            "\rbatch:   3%|▎         | 1/30 [00:06<02:54,  6.00s/it]",
-            "\rbatch:   7%|▋         | 2/30 [00:13<03:18,  7.10s/it]",
-            "\rbatch:  10%|█         | 3/30 [00:20<03:08,  6.99s/it]",
-            "\rbatch:  13%|█▎        | 4/30 [00:29<03:19,  7.68s/it]",
-            "\rbatch:  17%|█▋        | 5/30 [00:39<03:37,  8.69s/it]",
-            "\rbatch:  20%|██        | 6/30 [00:51<03:54,  9.75s/it]",
-            "\rbatch:  23%|██▎       | 7/30 [01:07<04:32, 11.83s/it]",
-            "\rbatch:  27%|██▋       | 8/30 [01:22<04:36, 12.57s/it]",
-            "\rbatch:  30%|███       | 9/30 [01:36<04:34, 13.08s/it]",
-            "\rbatch:  33%|███▎      | 10/30 [01:50<04:26, 13.32s/it]",
-            "\rbatch:  37%|███▋      | 11/30 [02:00<03:56, 12.46s/it]",
-            "\rbatch:  40%|████      | 12/30 [02:12<03:40, 12.23s/it]",
-            "\rbatch:  43%|████▎     | 13/30 [02:26<03:37, 12.77s/it]",
-            "\rbatch:  47%|████▋     | 14/30 [02:39<03:26, 12.91s/it]",
-            "\rbatch:  50%|█████     | 15/30 [02:50<03:04, 12.32s/it]",
-            "\rbatch:  53%|█████▎    | 16/30 [03:02<02:50, 12.21s/it]",
-            "\rbatch:  57%|█████▋    | 17/30 [03:13<02:33, 11.84s/it]",
-            "\rbatch:  60%|██████    | 18/30 [03:25<02:23, 11.93s/it]",
-            "\rbatch:  63%|██████▎   | 19/30 [03:37<02:12, 12.02s/it]",
-            "\rbatch:  67%|██████▋   | 20/30 [03:49<02:00, 12.07s/it]",
-            "\rbatch:  70%|███████   | 21/30 [03:59<01:42, 11.43s/it]",
-            "\rbatch:  73%|███████▎  | 22/30 [04:10<01:29, 11.24s/it]",
-            "\rbatch:  77%|███████▋  | 23/30 [04:20<01:16, 10.94s/it]",
-            "\rbatch:  80%|████████  | 24/30 [04:31<01:04, 10.80s/it]",
-            "\rbatch:  83%|████████▎ | 25/30 [04:42<00:55, 11.01s/it]",
-            "\rbatch:  87%|████████▋ | 26/30 [04:53<00:43, 10.79s/it]",
-            "\rbatch:  90%|█████████ | 27/30 [05:04<00:32, 10.93s/it]",
-            "\rbatch:  93%|█████████▎| 28/30 [05:16<00:22, 11.25s/it]",
-            "\rbatch:  97%|█████████▋| 29/30 [05:26<00:10, 10.87s/it]",
-            "\rbatch: 100%|██████████| 30/30 [05:38<00:00, 11.17s/it]",
-            "\rbatch: 100%|██████████| 30/30 [05:38<00:00, 11.28s/it]",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Trial 2\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\rbatch:   0%|          | 0/30 [00:00<?, ?it/s]",
-            "\rbatch:   3%|▎         | 1/30 [00:05<02:47,  5.77s/it]",
-            "\rbatch:   7%|▋         | 2/30 [00:11<02:39,  5.68s/it]",
-            "\rbatch:  10%|█         | 3/30 [00:17<02:44,  6.09s/it]",
-            "\rbatch:  13%|█▎        | 4/30 [00:25<02:53,  6.66s/it]",
-            "\rbatch:  17%|█▋        | 5/30 [00:34<03:04,  7.38s/it]",
-            "\rbatch:  20%|██        | 6/30 [00:43<03:15,  8.15s/it]",
-            "\rbatch:  23%|██▎       | 7/30 [00:55<03:35,  9.35s/it]",
-            "\rbatch:  27%|██▋       | 8/30 [01:06<03:37,  9.87s/it]",
-            "\rbatch:  30%|███       | 9/30 [01:18<03:39, 10.44s/it]",
-            "\rbatch:  33%|███▎      | 10/30 [01:32<03:51, 11.59s/it]",
-            "\rbatch:  37%|███▋      | 11/30 [01:46<03:56, 12.45s/it]",
-            "\rbatch:  40%|████      | 12/30 [01:57<03:35, 11.99s/it]",
-            "\rbatch:  43%|████▎     | 13/30 [02:09<03:22, 11.92s/it]",
-            "\rbatch:  47%|████▋     | 14/30 [02:21<03:11, 11.95s/it]",
-            "\rbatch:  50%|█████     | 15/30 [02:34<03:02, 12.15s/it]",
-            "\rbatch:  53%|█████▎    | 16/30 [02:43<02:37, 11.28s/it]",
-            "\rbatch:  57%|█████▋    | 17/30 [02:52<02:19, 10.72s/it]",
-            "\rbatch:  60%|██████    | 18/30 [03:02<02:06, 10.51s/it]",
-            "\rbatch:  63%|██████▎   | 19/30 [03:13<01:57, 10.66s/it]",
-            "\rbatch:  67%|██████▋   | 20/30 [03:23<01:44, 10.48s/it]",
-            "\rbatch:  70%|███████   | 21/30 [03:36<01:40, 11.18s/it]",
-            "\rbatch:  73%|███████▎  | 22/30 [03:48<01:30, 11.36s/it]",
-            "\rbatch:  77%|███████▋  | 23/30 [04:00<01:21, 11.69s/it]",
-            "\rbatch:  80%|████████  | 24/30 [04:12<01:08, 11.49s/it]",
-            "\rbatch:  83%|████████▎ | 25/30 [04:22<00:55, 11.10s/it]",
-            "\rbatch:  87%|████████▋ | 26/30 [04:34<00:45, 11.42s/it]",
-            "\rbatch:  90%|█████████ | 27/30 [04:45<00:33, 11.24s/it]",
-            "\rbatch:  93%|█████████▎| 28/30 [04:54<00:21, 10.79s/it]",
-            "\rbatch:  97%|█████████▋| 29/30 [05:04<00:10, 10.43s/it]",
-            "\rbatch: 100%|██████████| 30/30 [05:15<00:00, 10.59s/it]",
-            "\rbatch: 100%|██████████| 30/30 [05:15<00:00, 10.52s/it]"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "CPU times: user 48min 32s, sys: 2min 4s, total: 50min 37s\nWall time: 16min 28s\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
+            "\r  0%|          | 0/30 [00:00<?, ?it/s]",
+            "\r  3%|▎         | 1/30 [00:01<00:42,  1.46s/it]",
+            "\r  7%|▋         | 2/30 [00:03<00:43,  1.55s/it]",
+            "\r 10%|█         | 3/30 [00:04<00:45,  1.70s/it]",
+            "\r 13%|█▎        | 4/30 [00:07<00:50,  1.96s/it]",
+            "\r 17%|█▋        | 5/30 [00:09<00:54,  2.20s/it]",
+            "\r 20%|██        | 6/30 [00:13<01:03,  2.65s/it]",
+            "\r 23%|██▎       | 7/30 [00:17<01:12,  3.15s/it]",
+            "\r 27%|██▋       | 8/30 [00:20<01:04,  2.91s/it]",
+            "\r 30%|███       | 9/30 [00:23<01:05,  3.13s/it]",
+            "\r 33%|███▎      | 10/30 [00:28<01:10,  3.52s/it]",
+            "\r 37%|███▋      | 11/30 [00:33<01:16,  4.01s/it]",
+            "\r 40%|████      | 12/30 [00:37<01:12,  4.00s/it]",
+            "\r 43%|████▎     | 13/30 [00:41<01:10,  4.14s/it]",
+            "\r 47%|████▋     | 14/30 [00:45<01:03,  3.94s/it]",
+            "\r 50%|█████     | 15/30 [00:48<00:54,  3.66s/it]",
+            "\r 53%|█████▎    | 16/30 [00:53<00:57,  4.13s/it]",
+            "\r 57%|█████▋    | 17/30 [00:58<00:57,  4.44s/it]",
+            "\r 60%|██████    | 18/30 [01:02<00:51,  4.26s/it]",
+            "\r 63%|██████▎   | 19/30 [01:07<00:49,  4.52s/it]",
+            "\r 67%|██████▋   | 20/30 [01:11<00:44,  4.43s/it]",
+            "\r 70%|███████   | 21/30 [01:16<00:40,  4.47s/it]",
+            "\r 73%|███████▎  | 22/30 [01:21<00:37,  4.63s/it]",
+            "\r 77%|███████▋  | 23/30 [01:25<00:32,  4.58s/it]",
+            "\r 80%|████████  | 24/30 [01:29<00:25,  4.27s/it]",
+            "\r 83%|████████▎ | 25/30 [01:32<00:20,  4.01s/it]",
+            "\r 87%|████████▋ | 26/30 [01:36<00:16,  4.02s/it]",
+            "\r 90%|█████████ | 27/30 [01:39<00:11,  3.74s/it]",
+            "\r 93%|█████████▎| 28/30 [01:43<00:07,  3.65s/it]",
+            "\r 97%|█████████▋| 29/30 [01:46<00:03,  3.65s/it]",
+            "\r100%|██████████| 30/30 [01:50<00:00,  3.71s/it]",
+            "\r100%|██████████| 30/30 [01:50<00:00,  3.69s/it]",
             "\n"
           ]
         }
@@ -1177,9 +1045,9 @@
         "showInput": false
       },
       "source": [
-        "### Evaluating the hypervolume for each iteration for MOMF\n",
+        "### Evaluating the hypervolume for each iteration\n",
         "\n",
-        "As before we are interested in the Pareto front at the highest fidelity after the MOMF. In this section we only show the evolution of the mean hypervolume for both MOMF and qEHVI. The calculation for the MOMF is done in a similar fashion as before but now for each trial and iteration to get the evolution of hypervolume."
+        "As before, we are interested in the Pareto front at the highest fidelity after the MOMF. In this section we only show the evolution of the mean hypervolume for both MOMF and qEHVI. The calculation for the MOMF is done in a similar fashion as before, but now for each iteration."
       ]
     },
     {
@@ -1194,20 +1062,19 @@
         "2. We generate a posterior mean from the model and calculated the dominated set from these 10000 points.\n",
         "3. This dominated set is used to estimate the hypervolume and then the next iteration is started where the model now takes n+1 data points\n",
         "\n",
-        "**The test points used here are already generated before for evaluation of the single trial of MOMF**\n",
-        "\n",
-        "**Note: The following cell would take some time**"
+        "**The test points used here are already generated before for evaluation of MOMF**\n",
+        ""
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "9b016ea0-d3bb-4e91-a156-40fa3d8f24e7",
+        "originalKey": "920723cf-8abf-4d22-a404-0db53ee1ccf6",
         "collapsed": false,
-        "requestMsgId": "3fd21b5e-68de-40f7-b81f-59f8e98e3094",
-        "executionStopTime": 1677772442963,
+        "requestMsgId": "fe41acaa-141f-457b-8183-4c01e3fd4c4b",
+        "executionStopTime": 1677807921495,
         "customOutput": null,
-        "executionStartTime": 1677772016559,
+        "executionStartTime": 1677807837917,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -1217,250 +1084,86 @@
         "# GP posterior at the highest fidelity with 10000 random points\n",
         "\n",
         "# Array that contains hypervolume for n_TRIALS\n",
-        "hv_MOMF = np.zeros((train_obj.shape[0], n_TRIALS))  \n",
-        "for trial in range(n_TRIALS):\n",
-        "    # Loop to run over all trials\n",
-        "    print(f\"Trial {trial}\")\n",
-        "    for num, i in enumerate(tqdm(range(n_INIT, train_obj.shape[0], 1))):\n",
-        "        # Loop to get evolution of hypervolume during a single trial of MOMF optimization.\n",
-        "        hv_MOMF[num, trial], _ = get_pareto(\n",
-        "            train_x[:i, :, trial], train_obj[:i, :-1, trial], test_x\n",
-        "        )"
+        "hv_MOMF = np.zeros(train_obj.shape[0])\n",
+        "# Loop to get evolution of hypervolume during MOMF optimization.\n",
+        "for i in trange(n_INIT, train_obj.shape[0]):\n",
+        "    hv_MOMF[i], _ = get_pareto(train_x[:i, :], train_obj[:i, :-1], test_x)"
       ],
-      "execution_count": 16,
+      "execution_count": 17,
       "outputs": [
         {
           "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Trial 0\n"
-          ]
-        },
-        {
-          "output_type": "stream",
           "name": "stderr",
           "text": [
             "\r  0%|          | 0/60 [00:00<?, ?it/s]",
-            "\r  2%|▏         | 1/60 [00:00<00:40,  1.46it/s]",
-            "\r  3%|▎         | 2/60 [00:01<00:43,  1.32it/s]",
-            "\r  5%|▌         | 3/60 [00:02<00:47,  1.20it/s]",
-            "\r  7%|▋         | 4/60 [00:03<00:53,  1.04it/s]",
-            "\r  8%|▊         | 5/60 [00:04<01:01,  1.11s/it]",
-            "\r 10%|█         | 6/60 [00:06<01:08,  1.27s/it]",
-            "\r 12%|█▏        | 7/60 [00:08<01:11,  1.36s/it]",
-            "\r 13%|█▎        | 8/60 [00:09<01:11,  1.37s/it]",
-            "\r 15%|█▌        | 9/60 [00:11<01:13,  1.44s/it]",
-            "\r 17%|█▋        | 10/60 [00:13<01:31,  1.84s/it]",
-            "\r 18%|█▊        | 11/60 [00:14<01:17,  1.58s/it]",
-            "\r 20%|██        | 12/60 [00:17<01:28,  1.85s/it]",
-            "\r 22%|██▏       | 13/60 [00:19<01:34,  2.01s/it]",
-            "\r 23%|██▎       | 14/60 [00:21<01:28,  1.91s/it]",
-            "\r 25%|██▌       | 15/60 [00:23<01:29,  2.00s/it]",
-            "\r 27%|██▋       | 16/60 [00:25<01:32,  2.11s/it]",
-            "\r 28%|██▊       | 17/60 [00:28<01:35,  2.21s/it]",
-            "\r 30%|███       | 18/60 [00:30<01:31,  2.18s/it]",
-            "\r 32%|███▏      | 19/60 [00:33<01:34,  2.31s/it]",
-            "\r 33%|███▎      | 20/60 [00:35<01:33,  2.35s/it]",
-            "\r 35%|███▌      | 21/60 [00:38<01:45,  2.70s/it]",
-            "\r 37%|███▋      | 22/60 [00:42<01:47,  2.83s/it]",
-            "\r 38%|███▊      | 23/60 [00:45<01:50,  2.98s/it]",
-            "\r 40%|████      | 24/60 [00:48<01:50,  3.06s/it]",
-            "\r 42%|████▏     | 25/60 [00:53<02:05,  3.59s/it]",
-            "\r 43%|████▎     | 26/60 [00:56<01:54,  3.37s/it]",
-            "\r 45%|████▌     | 27/60 [00:59<01:44,  3.16s/it]",
-            "\r 47%|████▋     | 28/60 [01:02<01:44,  3.26s/it]",
-            "\r 48%|████▊     | 29/60 [01:05<01:39,  3.22s/it]",
-            "\r 50%|█████     | 30/60 [01:08<01:29,  3.00s/it]",
-            "\r 52%|█████▏    | 31/60 [01:11<01:28,  3.05s/it]",
-            "\r 53%|█████▎    | 32/60 [01:14<01:23,  3.00s/it]",
-            "\r 55%|█████▌    | 33/60 [01:17<01:19,  2.95s/it]",
-            "\r 57%|█████▋    | 34/60 [01:20<01:19,  3.06s/it]",
-            "\r 58%|█████▊    | 35/60 [01:23<01:15,  3.03s/it]",
-            "\r 60%|██████    | 36/60 [01:26<01:12,  3.02s/it]",
-            "\r 62%|██████▏   | 37/60 [01:30<01:14,  3.23s/it]",
-            "\r 63%|██████▎   | 38/60 [01:32<01:06,  3.04s/it]",
-            "\r 65%|██████▌   | 39/60 [01:37<01:15,  3.59s/it]",
-            "\r 67%|██████▋   | 40/60 [01:41<01:15,  3.76s/it]",
-            "\r 68%|██████▊   | 41/60 [01:45<01:09,  3.64s/it]",
-            "\r 70%|███████   | 42/60 [01:48<01:04,  3.61s/it]",
-            "\r 72%|███████▏  | 43/60 [01:52<01:01,  3.62s/it]",
-            "\r 73%|███████▎  | 44/60 [01:57<01:04,  4.04s/it]",
-            "\r 75%|███████▌  | 45/60 [02:01<01:00,  4.02s/it]",
-            "\r 77%|███████▋  | 46/60 [02:06<01:02,  4.44s/it]",
-            "\r 78%|███████▊  | 47/60 [02:10<00:56,  4.33s/it]",
-            "\r 80%|████████  | 48/60 [02:13<00:44,  3.73s/it]",
-            "\r 82%|████████▏ | 49/60 [02:15<00:36,  3.34s/it]",
-            "\r 83%|████████▎ | 50/60 [02:20<00:38,  3.82s/it]",
-            "\r 85%|████████▌ | 51/60 [02:22<00:29,  3.31s/it]",
-            "\r 87%|████████▋ | 52/60 [02:24<00:24,  3.03s/it]",
-            "\r 88%|████████▊ | 53/60 [02:27<00:19,  2.79s/it]",
-            "\r 90%|█████████ | 54/60 [02:29<00:15,  2.64s/it]",
-            "\r 92%|█████████▏| 55/60 [02:32<00:14,  2.85s/it]",
-            "\r 93%|█████████▎| 56/60 [02:36<00:12,  3.10s/it]",
-            "\r 95%|█████████▌| 57/60 [02:39<00:09,  3.19s/it]",
-            "\r 97%|█████████▋| 58/60 [02:44<00:06,  3.49s/it]",
-            "\r 98%|█████████▊| 59/60 [02:48<00:03,  3.67s/it]",
-            "\r100%|██████████| 60/60 [02:52<00:00,  4.01s/it]",
-            "\r100%|██████████| 60/60 [02:52<00:00,  2.88s/it]",
-            "\n"
+            "\r  2%|▏         | 1/60 [00:00<00:45,  1.29it/s]",
+            "\r  3%|▎         | 2/60 [00:01<00:41,  1.40it/s]",
+            "\r  5%|▌         | 3/60 [00:01<00:35,  1.60it/s]",
+            "\r  7%|▋         | 4/60 [00:02<00:30,  1.84it/s]",
+            "\r  8%|▊         | 5/60 [00:03<00:31,  1.75it/s]",
+            "\r 10%|█         | 6/60 [00:03<00:31,  1.73it/s]",
+            "\r 12%|█▏        | 7/60 [00:04<00:31,  1.66it/s]",
+            "\r 13%|█▎        | 8/60 [00:04<00:24,  2.11it/s]",
+            "\r 15%|█▌        | 9/60 [00:05<00:36,  1.41it/s]",
+            "\r 17%|█▋        | 10/60 [00:06<00:39,  1.25it/s]",
+            "\r 18%|█▊        | 11/60 [00:07<00:40,  1.20it/s]",
+            "\r 20%|██        | 12/60 [00:08<00:48,  1.01s/it]",
+            "\r 22%|██▏       | 13/60 [00:09<00:36,  1.27it/s]",
+            "\r 23%|██▎       | 14/60 [00:10<00:45,  1.02it/s]",
+            "\r 25%|██▌       | 15/60 [00:12<00:51,  1.14s/it]",
+            "/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n  warnings.warn(\n/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-07 to the diagonal\n  warnings.warn(\n/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-06 to the diagonal\n  warnings.warn(\n/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-05 to the diagonal\n  warnings.warn(\n/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-04 to the diagonal\n  warnings.warn(\n/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-03 to the diagonal\n  warnings.warn(\n\r 27%|██▋       | 16/60 [00:13<00:51,  1.18s/it]",
+            "\r 28%|██▊       | 17/60 [00:15<00:56,  1.32s/it]",
+            "\r 30%|███       | 18/60 [00:16<00:56,  1.36s/it]",
+            "\r 32%|███▏      | 19/60 [00:18<00:59,  1.44s/it]",
+            "\r 33%|███▎      | 20/60 [00:20<01:05,  1.63s/it]",
+            "\r 35%|███▌      | 21/60 [00:21<01:02,  1.59s/it]",
+            "/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n  warnings.warn(\n/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-07 to the diagonal\n  warnings.warn(\n/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-06 to the diagonal\n  warnings.warn(\n/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-05 to the diagonal\n  warnings.warn(\n/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-04 to the diagonal\n  warnings.warn(\n/mnt/xarfuse/uid-28646/3942ec4c-seed-nspid4026533215_cgpid2605254-ns-4026533212/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-03 to the diagonal\n  warnings.warn(\n\r 37%|███▋      | 22/60 [00:23<01:06,  1.75s/it]",
+            "\r 38%|███▊      | 23/60 [00:25<01:07,  1.81s/it]",
+            "\r 40%|████      | 24/60 [00:26<00:57,  1.60s/it]",
+            "\r 42%|████▏     | 25/60 [00:28<00:55,  1.58s/it]",
+            "\r 43%|████▎     | 26/60 [00:30<00:56,  1.66s/it]",
+            "\r 45%|████▌     | 27/60 [00:31<00:51,  1.57s/it]",
+            "\r 47%|████▋     | 28/60 [00:33<00:49,  1.53s/it]",
+            "\r 48%|████▊     | 29/60 [00:34<00:47,  1.52s/it]",
+            "\r 50%|█████     | 30/60 [00:36<00:45,  1.50s/it]",
+            "\r 52%|█████▏    | 31/60 [00:37<00:41,  1.44s/it]",
+            "\r 53%|█████▎    | 32/60 [00:39<00:41,  1.49s/it]",
+            "\r 55%|█████▌    | 33/60 [00:40<00:39,  1.48s/it]",
+            "\r 57%|█████▋    | 34/60 [00:41<00:37,  1.44s/it]",
+            "\r 58%|█████▊    | 35/60 [00:42<00:27,  1.08s/it]",
+            "\r 60%|██████    | 36/60 [00:42<00:20,  1.20it/s]",
+            "\r 62%|██████▏   | 37/60 [00:44<00:27,  1.18s/it]",
+            "\r 63%|██████▎   | 38/60 [00:46<00:30,  1.39s/it]",
+            "\r 65%|██████▌   | 39/60 [00:47<00:30,  1.47s/it]",
+            "\r 67%|██████▋   | 40/60 [00:48<00:26,  1.34s/it]",
+            "\r 68%|██████▊   | 41/60 [00:50<00:27,  1.46s/it]",
+            "\r 70%|███████   | 42/60 [00:52<00:25,  1.44s/it]",
+            "\r 72%|███████▏  | 43/60 [00:53<00:23,  1.39s/it]",
+            "\r 73%|███████▎  | 44/60 [00:55<00:26,  1.66s/it]",
+            "\r 75%|███████▌  | 45/60 [00:59<00:35,  2.36s/it]",
+            "\r 77%|███████▋  | 46/60 [01:00<00:28,  2.06s/it]",
+            "\r 78%|███████▊  | 47/60 [01:02<00:26,  2.02s/it]",
+            "\r 80%|████████  | 48/60 [01:04<00:23,  1.95s/it]",
+            "\r 82%|████████▏ | 49/60 [01:05<00:18,  1.67s/it]",
+            "\r 83%|████████▎ | 50/60 [01:07<00:16,  1.63s/it]",
+            "\r 85%|████████▌ | 51/60 [01:08<00:14,  1.66s/it]",
+            "\r 87%|████████▋ | 52/60 [01:10<00:13,  1.65s/it]",
+            "\r 88%|████████▊ | 53/60 [01:12<00:11,  1.61s/it]",
+            "\r 90%|█████████ | 54/60 [01:14<00:10,  1.71s/it]",
+            "\r 92%|█████████▏| 55/60 [01:16<00:09,  1.80s/it]",
+            "\r 93%|█████████▎| 56/60 [01:17<00:06,  1.75s/it]",
+            "\r 95%|█████████▌| 57/60 [01:19<00:05,  1.68s/it]",
+            "\r 97%|█████████▋| 58/60 [01:20<00:03,  1.64s/it]",
+            "\r 98%|█████████▊| 59/60 [01:22<00:01,  1.58s/it]",
+            "\r100%|██████████| 60/60 [01:23<00:00,  1.52s/it]",
+            "\r100%|██████████| 60/60 [01:23<00:00,  1.39s/it]"
           ]
         },
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Trial 1\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\r  0%|          | 0/60 [00:00<?, ?it/s]",
-            "\r  2%|▏         | 1/60 [00:01<01:04,  1.09s/it]",
-            "\r  3%|▎         | 2/60 [00:02<01:16,  1.33s/it]",
-            "\r  5%|▌         | 3/60 [00:03<01:15,  1.33s/it]",
-            "\r  7%|▋         | 4/60 [00:05<01:24,  1.52s/it]",
-            "\r  8%|▊         | 5/60 [00:06<01:13,  1.33s/it]",
-            "\r 10%|█         | 6/60 [00:07<01:08,  1.28s/it]",
-            "\r 12%|█▏        | 7/60 [00:08<01:03,  1.21s/it]",
-            "\r 13%|█▎        | 8/60 [00:10<01:12,  1.39s/it]",
-            "\r 15%|█▌        | 9/60 [00:13<01:29,  1.75s/it]",
-            "\r 17%|█▋        | 10/60 [00:16<01:42,  2.06s/it]",
-            "\r 18%|█▊        | 11/60 [00:19<02:04,  2.55s/it]",
-            "\r 20%|██        | 12/60 [00:23<02:24,  3.02s/it]",
-            "\r 22%|██▏       | 13/60 [00:26<02:18,  2.95s/it]",
-            "\r 23%|██▎       | 14/60 [00:28<02:00,  2.62s/it]",
-            "\r 25%|██▌       | 15/60 [00:29<01:32,  2.06s/it]",
-            "\r 27%|██▋       | 16/60 [00:32<01:51,  2.53s/it]",
-            "\r 28%|██▊       | 17/60 [00:35<01:55,  2.69s/it]",
-            "\r 30%|███       | 18/60 [00:37<01:40,  2.40s/it]",
-            "\r 32%|███▏      | 19/60 [00:39<01:34,  2.31s/it]",
-            "\r 33%|███▎      | 20/60 [00:41<01:25,  2.13s/it]",
-            "\r 35%|███▌      | 21/60 [00:44<01:35,  2.44s/it]",
-            "\r 37%|███▋      | 22/60 [00:46<01:32,  2.43s/it]",
-            "\r 38%|███▊      | 23/60 [00:47<01:11,  1.94s/it]",
-            "\r 40%|████      | 24/60 [00:50<01:21,  2.26s/it]",
-            "\r 42%|████▏     | 25/60 [00:54<01:36,  2.75s/it]",
-            "\r 43%|████▎     | 26/60 [00:57<01:39,  2.92s/it]",
-            "\r 45%|████▌     | 27/60 [01:00<01:33,  2.83s/it]",
-            "\r 47%|████▋     | 28/60 [01:02<01:22,  2.57s/it]",
-            "\r 48%|████▊     | 29/60 [01:04<01:17,  2.49s/it]",
-            "\r 50%|█████     | 30/60 [01:07<01:13,  2.46s/it]",
-            "\r 52%|█████▏    | 31/60 [01:09<01:07,  2.33s/it]",
-            "\r 53%|█████▎    | 32/60 [01:11<01:06,  2.37s/it]",
-            "\r 55%|█████▌    | 33/60 [01:14<01:06,  2.48s/it]",
-            "\r 57%|█████▋    | 34/60 [01:17<01:06,  2.56s/it]",
-            "\r 58%|█████▊    | 35/60 [01:19<01:04,  2.57s/it]",
-            "\r 60%|██████    | 36/60 [01:22<01:03,  2.63s/it]",
-            "\r 62%|██████▏   | 37/60 [01:24<00:57,  2.48s/it]",
-            "\r 63%|██████▎   | 38/60 [01:26<00:53,  2.41s/it]",
-            "\r 65%|██████▌   | 39/60 [01:28<00:47,  2.24s/it]",
-            "\r 67%|██████▋   | 40/60 [01:31<00:44,  2.23s/it]",
-            "\r 68%|██████▊   | 41/60 [01:33<00:43,  2.27s/it]",
-            "\r 70%|███████   | 42/60 [01:35<00:39,  2.21s/it]",
-            "\r 72%|███████▏  | 43/60 [01:37<00:38,  2.26s/it]",
-            "\r 73%|███████▎  | 44/60 [01:39<00:35,  2.22s/it]",
-            "\r 75%|███████▌  | 45/60 [01:42<00:33,  2.24s/it]",
-            "\r 77%|███████▋  | 46/60 [01:44<00:31,  2.26s/it]",
-            "\r 78%|███████▊  | 47/60 [01:47<00:31,  2.43s/it]",
-            "\r 80%|████████  | 48/60 [01:50<00:30,  2.56s/it]",
-            "\r 82%|████████▏ | 49/60 [01:53<00:29,  2.68s/it]",
-            "\r 83%|████████▎ | 50/60 [01:55<00:25,  2.54s/it]",
-            "\r 85%|████████▌ | 51/60 [01:58<00:22,  2.55s/it]",
-            "\r 87%|████████▋ | 52/60 [01:59<00:18,  2.34s/it]",
-            "\r 88%|████████▊ | 53/60 [02:02<00:16,  2.41s/it]",
-            "\r 90%|█████████ | 54/60 [02:04<00:14,  2.39s/it]",
-            "\r 92%|█████████▏| 55/60 [02:06<00:11,  2.32s/it]",
-            "\r 93%|█████████▎| 56/60 [02:09<00:09,  2.32s/it]",
-            "\r 95%|█████████▌| 57/60 [02:11<00:06,  2.31s/it]",
-            "\r 97%|█████████▋| 58/60 [02:13<00:04,  2.28s/it]",
-            "\r 98%|█████████▊| 59/60 [02:15<00:02,  2.22s/it]",
-            "\r100%|██████████| 60/60 [02:18<00:00,  2.24s/it]",
-            "\r100%|██████████| 60/60 [02:18<00:00,  2.30s/it]",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Trial 2\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\r  0%|          | 0/60 [00:00<?, ?it/s]",
-            "\r  2%|▏         | 1/60 [00:00<00:48,  1.21it/s]",
-            "\r  3%|▎         | 2/60 [00:01<00:45,  1.29it/s]",
-            "\r  5%|▌         | 3/60 [00:02<00:43,  1.31it/s]",
-            "\r  7%|▋         | 4/60 [00:03<00:41,  1.35it/s]",
-            "\r  8%|▊         | 5/60 [00:03<00:40,  1.36it/s]",
-            "\r 10%|█         | 6/60 [00:04<00:39,  1.36it/s]",
-            "\r 12%|█▏        | 7/60 [00:05<00:42,  1.26it/s]",
-            "\r 13%|█▎        | 8/60 [00:06<00:42,  1.22it/s]",
-            "\r 15%|█▌        | 9/60 [00:07<00:44,  1.14it/s]",
-            "\r 17%|█▋        | 10/60 [00:08<00:50,  1.02s/it]",
-            "\r 18%|█▊        | 11/60 [00:10<01:00,  1.23s/it]",
-            "\r 20%|██        | 12/60 [00:12<01:07,  1.40s/it]",
-            "\r 22%|██▏       | 13/60 [00:13<01:12,  1.54s/it]",
-            "\r 23%|██▎       | 14/60 [00:15<01:16,  1.66s/it]",
-            "\r 25%|██▌       | 15/60 [00:18<01:24,  1.88s/it]",
-            "\r 27%|██▋       | 16/60 [00:19<01:14,  1.70s/it]",
-            "\r 28%|██▊       | 17/60 [00:21<01:21,  1.91s/it]",
-            "\r 30%|███       | 18/60 [00:24<01:22,  1.96s/it]",
-            "\r 32%|███▏      | 19/60 [00:26<01:25,  2.08s/it]",
-            "\r 33%|███▎      | 20/60 [00:28<01:23,  2.09s/it]",
-            "\r 35%|███▌      | 21/60 [00:30<01:21,  2.10s/it]",
-            "\r 37%|███▋      | 22/60 [00:32<01:17,  2.05s/it]",
-            "\r 38%|███▊      | 23/60 [00:35<01:23,  2.25s/it]",
-            "\r 40%|████      | 24/60 [00:37<01:17,  2.15s/it]",
-            "\r 42%|████▏     | 25/60 [00:39<01:12,  2.07s/it]",
-            "\r 43%|████▎     | 26/60 [00:41<01:10,  2.09s/it]",
-            "\r 45%|████▌     | 27/60 [00:43<01:08,  2.08s/it]",
-            "\r 47%|████▋     | 28/60 [00:45<01:03,  1.99s/it]",
-            "\r 48%|████▊     | 29/60 [00:47<01:04,  2.07s/it]",
-            "\r 50%|█████     | 30/60 [00:49<01:03,  2.11s/it]",
-            "\r 52%|█████▏    | 31/60 [00:51<00:59,  2.04s/it]",
-            "\r 53%|█████▎    | 32/60 [00:53<00:57,  2.05s/it]",
-            "\r 55%|█████▌    | 33/60 [00:55<00:53,  1.97s/it]",
-            "\r 57%|█████▋    | 34/60 [00:57<00:57,  2.20s/it]",
-            "\r 58%|█████▊    | 35/60 [00:59<00:53,  2.13s/it]",
-            "\r 60%|██████    | 36/60 [01:01<00:49,  2.06s/it]",
-            "\r 62%|██████▏   | 37/60 [01:03<00:47,  2.06s/it]",
-            "\r 63%|██████▎   | 38/60 [01:05<00:45,  2.06s/it]",
-            "\r 65%|██████▌   | 39/60 [01:08<00:46,  2.20s/it]",
-            "\r 67%|██████▋   | 40/60 [01:10<00:43,  2.16s/it]",
-            "\r 68%|██████▊   | 41/60 [01:12<00:41,  2.19s/it]",
-            "\r 70%|███████   | 42/60 [01:15<00:43,  2.44s/it]",
-            "\r 72%|███████▏  | 43/60 [01:18<00:43,  2.55s/it]",
-            "\r 73%|███████▎  | 44/60 [01:21<00:40,  2.52s/it]",
-            "\r 75%|███████▌  | 45/60 [01:24<00:39,  2.65s/it]",
-            "\r 77%|███████▋  | 46/60 [01:26<00:36,  2.60s/it]",
-            "\r 78%|███████▊  | 47/60 [01:29<00:33,  2.58s/it]",
-            "\r 80%|████████  | 48/60 [01:30<00:27,  2.29s/it]",
-            "\r 82%|████████▏ | 49/60 [01:33<00:25,  2.31s/it]",
-            "\r 83%|████████▎ | 50/60 [01:35<00:23,  2.38s/it]",
-            "\r 85%|████████▌ | 51/60 [01:38<00:22,  2.49s/it]",
-            "\r 87%|████████▋ | 52/60 [01:40<00:18,  2.33s/it]",
-            "\r 88%|████████▊ | 53/60 [01:42<00:16,  2.38s/it]",
-            "\r 90%|█████████ | 54/60 [01:44<00:12,  2.11s/it]",
-            "\r 92%|█████████▏| 55/60 [01:45<00:09,  1.93s/it]",
-            "\r 93%|█████████▎| 56/60 [01:47<00:07,  1.93s/it]",
-            "\r 95%|█████████▌| 57/60 [01:49<00:05,  1.87s/it]",
-            "\r 97%|█████████▋| 58/60 [01:51<00:03,  1.90s/it]",
-            "\r 98%|█████████▊| 59/60 [01:52<00:01,  1.80s/it]",
-            "\r100%|██████████| 60/60 [01:55<00:00,  1.96s/it]",
-            "\r100%|██████████| 60/60 [01:55<00:00,  1.92s/it]"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "CPU times: user 7min 4s, sys: 7.78 s, total: 7min 12s\nWall time: 7min 6s\n"
+            "CPU times: user 54min 36s, sys: 59.1 s, total: 55min 35s\nWall time: 1min 23s\n"
           ]
         },
         {
@@ -1485,64 +1188,63 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "85178f61-ceae-435d-8170-788e07f78e5a",
+        "originalKey": "44b79dfa-0f7b-47a9-bf4a-ad79de86581d",
         "collapsed": false,
-        "requestMsgId": "55a0b5d2-8e7c-4e93-9aad-0b26e16960bd",
-        "executionStopTime": 1677773475882,
+        "requestMsgId": "bd220648-baad-4ce6-a362-b1f18f2dc41a",
+        "executionStopTime": 1677807921819,
         "customOutput": null,
-        "executionStartTime": 1677773475626
+        "executionStartTime": 1677807921806
       },
       "source": [
-        "# Since the MO data is already at highest fidelity we can calculate the evolution of hypervolume directly from data\n",
+        "# Since the MO data is already at highest fidelity,\n",
+        "# we can calculate the evolution of hypervolume directly from data\n",
         "\n",
-        "hv_MO = np.zeros((train_objMO.shape[0], n_TRIALS))\n",
-        "# Loop to run over all the trials\n",
-        "for trial in range(0, n_TRIALS):\n",
-        "    # Loop to get evolution of hypervolume within a single trial\n",
-        "    for num, i in enumerate(range(0, train_objMO.shape[0], 1)):\n",
-        "        # Calculating Non-dominated points\n",
-        "        pareto_maskMO = is_non_dominated(train_objMO[:i, :, trial])\n",
-        "        # Used to calculate hypervolume\n",
-        "        box_decomp = DominatedPartitioning(\n",
-        "            torch.tensor(ref_pointMO, **tkwargs),\n",
-        "            train_objMO[:i, :, trial][pareto_maskMO],\n",
-        "        )\n",
-        "        hv_MO[num, trial] = box_decomp.compute_hypervolume().item()"
+        "hv_MO = np.zeros(train_objMO.shape[0])\n",
+        "# Loop to get evolution of hypervolume per iteration\n",
+        "for i in range(train_objMO.shape[0]):\n",
+        "    # Calculating Non-dominated points\n",
+        "    pareto_maskMO = is_non_dominated(train_objMO[:i, :])\n",
+        "    # Used to calculate hypervolume\n",
+        "    box_decomp = DominatedPartitioning(\n",
+        "        torch.tensor(ref_pointMO, **tkwargs),\n",
+        "        train_objMO[:i, :][pareto_maskMO],\n",
+        "    )\n",
+        "    hv_MO[i] = box_decomp.compute_hypervolume().item()"
       ],
-      "execution_count": 35,
+      "execution_count": 18,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "5711e66e-5d6a-463d-a97b-0ce52d198394",
+        "originalKey": "a0e48588-bd5a-47d6-a882-1ab2c78214ce",
         "collapsed": false,
-        "requestMsgId": "08fc75e2-b0e9-4383-814d-55f98679a87a",
-        "executionStopTime": 1677773487251,
+        "requestMsgId": "a45e5ea4-a81f-42b9-89b7-5270f5a0fa44",
+        "executionStopTime": 1677807921995,
         "customOutput": null,
-        "executionStartTime": 1677773487243
+        "executionStartTime": 1677807921978
       },
       "source": [
-        "# Cost calculation MOMF and MO\n",
-        "cost_single = cost_func(train_x[:, -1], exp_arg)\n",
+        "# Cost calculation for both MOMF and MO\n",
+        "cost_single = cost_func(train_x[:, -1])\n",
         "cost_MOMF = torch.cumsum(cost_single, axis=0)\n",
         "# Generating ones equal to number of iterations for MO only-optimization\n",
         "ones = torch.ones(train_objMO.shape[0], **tkwargs)\n",
-        "cost_singleMO = cost_func(ones, exp_arg)\n",
+        "cost_singleMO = cost_func(ones)\n",
         "cost_MO = torch.cumsum(cost_singleMO, axis=0)"
       ],
-      "execution_count": 36,
+      "execution_count": 19,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "6e6c0332-98a4-41d6-a303-727dc4eeff53",
+        "originalKey": "92bd7261-4af0-446d-9860-66da9b65ec5c",
         "collapsed": false,
-        "requestMsgId": "7c1f48b0-9eac-42e1-8067-a5ef84a90ceb",
-        "executionStopTime": 1677773488223,
+        "requestMsgId": "02e08476-08cd-484a-8e20-32b7e67a6435",
+        "executionStopTime": 1677807922126,
         "customOutput": null,
-        "executionStartTime": 1677773488216
+        "executionStartTime": 1677807922120
       },
       "source": [
         "# Converting to Numpy arrays for plotting\n",
@@ -1551,7 +1253,7 @@
         "# The approximate max hypervolume taken by evaluating the BC function offline with random 50000 points\n",
         "true_hv = 0.5235514158034145"
       ],
-      "execution_count": 37,
+      "execution_count": 20,
       "outputs": []
     },
     {
@@ -1573,71 +1275,57 @@
       "source": [
         "### Results\n",
         "\n",
-        "The following plot shows the hypervolume as a percetage of the true hypervolume for both MOMF and qEHVI. The hypervolume is plotted at each iteration on a log scale. We also plot the confidence intervals derived from running multiple trials for the MOMF and MO.\n",
-        ""
+        "The following plot shows, for each iteration and for both MOMF and qEHVI, the hypervolume (as a percentage of the true hypervolume) and the cost (shown on a log scale)."
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "0f398395-874d-4112-a22d-68ac3e784003",
-        "collapsed": false,
-        "requestMsgId": "e820a6ac-b793-472e-ba26-47507d1fa6ef",
-        "executionStopTime": 1677773491191,
+        "originalKey": "4586e4ae-80d1-407f-bdd4-e7fef2749b84",
+        "showInput": true,
+        "customInput": null,
         "customOutput": null,
-        "executionStartTime": 1677773490693
+        "collapsed": false,
+        "requestMsgId": "c0311205-50c7-4b31-a580-fa8f7840e72b",
+        "executionStopTime": 1677807922713,
+        "executionStartTime": 1677807922247
       },
       "source": [
-        "MOMF_mean = np.mean(hv_MOMF[n_INIT : n_BATCH * BATCH_SIZE, :] / true_hv * 100, axis=1)\n",
-        "MOMF_CI = (\n",
-        "    1.96\n",
-        "    * np.std(hv_MOMF[n_INIT : n_BATCH * BATCH_SIZE, :] / true_hv * 100, axis=1)\n",
-        "    / np.sqrt(n_TRIALS)\n",
+        "fig, ax = plt.subplots(1, 1, figsize=(4, 4), dpi=200)\n",
+        "ax.plot(\n",
+        "    cost_MOMF[n_INIT :],\n",
+        "    hv_MOMF[n_INIT : ] / true_hv * 100,\n",
+        "    label=\"MOMF\"\n",
         ")\n",
-        "mean_costMOMF = np.mean(cost_MOMF[n_INIT : n_BATCH * BATCH_SIZE], axis=1)\n",
-        "MO_mean = np.mean(hv_MO[n_INITMO:, :] / true_hv * 100, axis=1)\n",
-        "MO_CI = 1.96 * np.std(hv_MO[n_INITMO:, :] / true_hv * 100, axis=1) / np.sqrt(n_TRIALS)\n",
+        "ax.plot(\n",
+        "    cost_MO[n_INITMO:],\n",
+        "    hv_MO[n_INITMO:] / true_hv * 100,\n",
+        "    label=\"EHVI\"\n",
+        ")\n",
         "\n",
-        "fig, axes = plt.subplots(1, 1, figsize=(4, 4), dpi=200)\n",
-        "axes.errorbar(mean_costMOMF, MOMF_mean, yerr=MOMF_CI, markersize=3.5, label=\"MOMF\")\n",
-        "axes.errorbar(cost_MO[n_INITMO:], MO_mean, yerr=MO_CI, markersize=3.5, label=\"EHVI\")\n",
-        "axes.set_title(\"Branin-Currin\", fontsize=\"12\")\n",
-        "axes.set_xlabel(\"Total Cost Log Scale\", fontsize=\"10\")\n",
-        "axes.set_ylabel(\"Hypervolume (%)\", fontsize=\"10\")\n",
-        "axes.set_ylim(0, 100)\n",
-        "axes.tick_params(labelsize=10)\n",
-        "axes.legend(loc=\"lower right\", fontsize=\"7\", frameon=True, ncol=1)\n",
+        "ax.set_title(\"Branin-Currin\", fontsize=\"12\")\n",
+        "ax.set_xlabel(\"Total Cost Log Scale\", fontsize=\"10\")\n",
+        "ax.set_ylabel(\"Hypervolume (%)\", fontsize=\"10\")\n",
+        "ax.set_ylim(0, 100)\n",
+        "ax.tick_params(labelsize=10)\n",
+        "ax.legend(loc=\"lower right\", fontsize=\"7\", frameon=True, ncol=1)\n",
         "plt.xscale(\"log\")\n",
         "plt.tight_layout()"
       ],
-      "execution_count": 38,
+      "execution_count": 21,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
             "text/plain": "<Figure size 800x800 with 1 Axes>",
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwwAAAMMCAYAAAD+fyB7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAewgAAHsIBbtB1PgAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOzdeZhkZWHv8W919TYbMCyzAbKIgOKGCxIVEeSY61HUo1GjiIoxwQ1jFLN4r8YYTdwwUTDJ5WJwiVtUjutBPcJI3EVAFEQWEZBlZmAYZu+luur+MW9j0Ux1d01Xnerq+n6ep55TVWd7q2um6vzq3Uq1Wg1JkiRJ2p2+ThdAkiRJ0vxlYJAkSZLUkIFBkiRJUkMGBkmSJEkNGRgkSZIkNWRgkCRJktSQgUGSJElSQwYGSZIkSQ0ZGCRJkiQ1ZGCQJEmS1JCBQZIkSVJDBgZJkiRJDRkYJEmSJDVkYJAkSZLUkIFBkiRJUkMGBkmSJEkNGRgkSZIkNWRgkCRJktSQgUGSJElSQ/2dLoAkqXdEcfJ0YG14+Mk8S1/V4SLJ90XSDAwMktQmUy7CGhkHtgG3A9cAGfDlPEt3FlRMNRDFySrg+cDJwKOA/YF9gBFgI3A98APgojxLr+10eSWpXQwMktRZA8DycHsU8FLg/VGcvDrP0m93unBtsCNcaAPc1eGy7FYUJ8uBvwfOBIZ3s8nScDsEeCbw7ihOLgbOyrP0tx0ocivM+/dFUueUarVap8sgSQvSlBqGm4BkN5sNAAcATwBeDTw0PF8BTsiz9CcFFrnnRXHyCOCrwBHhqQngm8DF4T3cCCwGjgJi4Hl1P75tB16QZ+l3OvgSJKnlDAyS1CZTAsO1eZY+cobth4AUeFZ4am2epSe3v6Ri19//IcAVoekRwE+BP5uuuVEUJ0eG9+wR4akR4Pg8S68uptSS1H6OkiRJ80SepaPAW+ueeloUJ4MdLFLPiOKkDHypLiysBU6eqW9CnqU3AE8GfhaeGgY+EcVJqf2llqRi2IdBkuaRPEuvi+JkPDRVKocL2Dsn10dx8q7Qvh7gVOAS4O2h78PBwHV5lj526nGjOPlj4E+BJwIPCc1qtgO/Dx13z8+z9MpG5Yri5CrgscDmPEv3Cc89OzSjejywChgFfgt8A/iXPEs37eY4047G06rz7IGXhL8NodnRy/Is3TGbHfMs3RzFyV+E2olNwOWhT8q9ofyHAr8Lm9+aZ+mh0x0vipNao22bef+jOHkVcGHY9izg34A3A68BDgNG6/7G8/V9kTQPGBgkaR6J4mSg7rO5BmyeYZdPAi+a5nh7AZ+va+ZUby/gmHD7iyhO3ptn6TsaHOr+i+coTvrChegrpmwzBBwbbqdHcfLUPEvvmKH8nTrPVG+ru//BPEvXNbNznqVXR3HyuND0bGKOZWnGtO//FO+b8jpHmzhPp94XSfOATZIkaX45AZhszvLzPEu3T7PtU8LF4sWhA+6xYWSfev9ZFxbuBN4CPC38WnxyuIgcDef8P+FX6d2pvwj+h3Cx+O3wy/zjQ7nPDr+wAxwK/OsevP6iznO/KE7WhL/H5Pk/vifHybP0lwWHhdm8/5MOBf4K+AnwgrDtc5s4V+Hvi6T5wxoGSZonwnCeH6576j0z7PLnYUSfJM/SB41gEcXJI4EXhodjoU3+9VM2Wxuam3whPH4H8IndnKsalkuBvwXes5vaiB9EcXI5cFl4/PwoTvbOs3SmWpJOnKfeiXX3r82z9J49PE7Rpn3/p3gV8AvgxDxLx/bgXJ14XyTNEwYGSSrGULiAn2oAWBF+Lf7z0BZ8HHhdnqVfm+GY+wFvm+ZicRj4WOgHcdduwsKkLwLnhnIcHsXJIXmW3tpg2zJwZV07+gfIs/R/ojj5bRgetj/8cn/Z7radQVHnoW4IVcJFdbeY6f2fuu2f7mFYqFfk+yJpnjAwSFIxjgB+NcM2VeAC4Jw8S38zi2P+Ms/SGxutzLP058DPZzpInqW1cJG3Ijy1BmgUGAA+nmdpdZr1v66bT2LFNNvNpKjz7Fd3f+McjlO0ad//Ke4DLm3ReYt6XyTNEwYGSZo/+sIINo+P4uR84II8SyvTbN/0WP+h2dM+YZSk+qE/B+ruD81wmJlCyJa6+4ubLWMHzrO07v6sRkaaJ5p5/381w0V+M4p6XyTNEwYGSSpGw4nbojhZAhwUmiW9PnQi/XfgT6M4OTXP0q0NjnnXbE4cxcnJwF8ATwdWzulV7DLTr/D1IWcu8xHs8XkaNP+qd32epePh/s665/dqrogdNav3fw+2nUlR77+kecLAIEkdFkZCuh64PoqTC4H/G/oznBjuv6zBrjsbPA+7LppLYez917a4yEWNBDSX88zU/Osw4JZwv34I1VVzOGfRpn3/57DtTIocCUrSPOCwqpI0j4QOrG8CNoSnXhrFyZF7eLg3TQkLFwHPDn0UFudZWpq89XjH1Ovq7j+pg+WQpHnJGgZJmmfyLB2J4uR7wIvDU08HbmjmGKF24a/rnvpQnqVvm2aXgWnWdZ0Qgmbr+2GSvBLwkChOHpFn6a/bWLyGojjxe1nSvGMNgyTNT/Vj1+83zXaNHBFqEghzMPzjDNsfugfnWBDyLL07hIZJZ+3JcaI4eXEUJ1+P4uTxU1bVD3tanuEwjiokad4xMEjS/HRg3f09GerzgLr7t+dZuqXRhlGcPKUuXPSq+lmJX7Obi/5pRXGyP/AvwHOAn0dxUj8ZXH3/gb1nOJRNoiTNOwYGSZpnojjZb8rswz/eg8PUDw+67zTnKgPvm/L0gmqeNBt5lqZ18xT0A1+I4uQhs9k3ipPFwJfrQtfaPEvr+4Rsqhs5aFkUJwdPc7jX7dkrkKT2MTBI0jwSxcki4EJgSXjq+3mWzjTiz+78BhgN9/eJ4uSZuznXcDjXk4Af1a06ZM9K3/VeDtwe7j8U+EEUJ3883Q5RnDwiNGd6WnjqNuCl9duE4Vt/WffUGxoc66+BU4Btc30hktRKdq6SpGIMTTM3wFCYH+E44FV1F+zrgD/bk5OFjtOfC8cD+HwUJ+8GfhIm03p8GEHpcODtoQxPDtu+Jcz8vCXP0iv25PzdKM/Su6I4eRpwMXAUcDDwrShOfgSk4aL/bmAYODo0P3peXb+Ea4A4z9L1uzn8fwGPC/f/JoqTg4As1D6sDiHjlDCM7vHAYwp86ZI0LQODJBXjiFnMDVDve8Br8iz97RzO+bYQAo4Eloc29lN9KM/Sfw5t9v8+PPfw0Dzn1l7rDJ1n6e+iOHlc+Fu8MYSrJ9eFqd3ZBpwLvDvP0pEG25wXwsVkU7PTwq1eBvwl8NPw2O9oSfOCTZIkqfPGgHuAy4GPAU/Ls/SkOYYF8iy9J9RavAe4NnS+3R6GaP04cPzkUKuhJuFlYbsRYD3wnZa9wi6SZ+mOPEv/BngIcGbon3ADsDVMWrYNuDE8/xfAQ/Isffs0YWGyWdIzw9wYPwTuA8bDDMx5aA51ap6lo3W7LS7mFUvS9Eq1Wm0Wm0mSJEnqRdYwSJIkSWrIwCBJkiSpIQODJEmSpIYMDJIkSZIaMjBIkiRJasjAIEmSJKkhA4MkSZKkhnp6FskoTvqBdwJvB8rAP+RZ+q5Z7Hc88HrgacDKMBnSjcCXgHOnm7xnLvtKkiRJRevZGoYoTo4Gfgy8I4SF2e739jBL5+nAKuC2MCvqccAHgKuiOFnd6n0lSZKkTui5wBDFSSmKkzcCVwJPAL7VxL4vAN4b/m7nAivzLD0qz9I1wJOBW4GjgYuiOCm1al9JkiSpU3ouMADPDhfsfcBfAfFsdoripA94X3j49TxL35Rn6ebJ9XmW/hh4IVADjg/357yvJEmS1Em9GBj6gV8Dx+VZ+q95ltZmud+TgIeF+x/c3QZ5ll4BXBYevrJF+0qSJEkd04uB4XLgCXmW/rLJ/aKw3BH6PjTy3bA8JXSqnuu+kiRJUsf03EVpnqV37OGux4Tl9XmWVqbZ7pqwHAYOB26Y476SJElSx/RiDcOeOiQsZwocd9bdP6wF+0qSJEkdY2CYvWVhuW2G7erXL5uy3JN9JUmSpI7puSZJczAclmMzbDe6m33msu+c3fX7W2bbsVuSJEldbvXBh7Z0iH4Dw+xNzsA8OMN2Q3X3d7Zg3zlbsfqgVh1KWhAmJips3LAOgP1WrKJc9qNQ0vT83FAv81/77G0Jy6UzbFfflGjLlOWe7Dtn5X7fZqmRcrnf/yOSmuLnhnqNfRhm7+awPHiG7erX39SCfSVJkqSOMTDM3q/C8qgoTqZrWvTYsNwC3NKCfSVJkqSOMTDM3sVhOQw8bZrtnhWWWd0s0nPZV5IkSeoYA8Ms5Vl6NXBlePg3u9smipNTgMeHhxe0Yl9JkiSpkwwMzTkbqAKnRHHy71Gc7DO5IoqTCPhMePjVPEsvaeG+kiRJUkeUarXeavkSxUkGrJny9GPCcj2wbsq6OM/S+2dgjuLktcC5YYSp0dDXYB9gZdjkB8Cz8ix90CRtc9l3jnrrTZZmMFGpsOGu2yEMO+xoJ5Jm4ueGukxL52HoxRqGR4SAUH+btHI36x7QSTnP0v8Angh8IgSMQ0MA+D5wJnBiowv+uewrSZIkdULP1TD0KN9kqY6/FEpqlp8b6jLWMEiSJEkqhoFBkiRJUkMGBkmSJEkNGRgkSZIkNWRgkCRJktSQgUGSJElSQwYGSZIkSQ0ZGCRJkiQ1ZGCQJEmS1JCBQZIkSVJDBgZJkiRJDRkYJEmSJDVkYJAkSZLUkIFBkiRJUkMGBkmSJEkNGRgkSZIkNWRgkCRJktSQgUGSJElSQwYGSZIkSQ0ZGCRJkiQ11N/pAkiSJEkL0baJCe4cHeWOsbH7l/2lEm856KBOF60pBgZJkiSpSdVajS0TE4xWq1SBjePj/HbnTq7evp0bd+7kjtFRNk9MPGi/ffv7DQySJEnSQrFtYoLvbNrEz7du5YadO9k2MUG1VmPzxASVWq3p491bqbBzYoJF5XJbytsOBgZJkiT1tEqtxoaxMbZXq7ueqNW4budOfrZlC2s3b2Zk8vkWuXNsjIcuWtTSY7aTgUGSJEk9pVarccPOnVy2eTNXbN3Kr7ZvZ3QPagv21B0GBkmSJKk9RqpVarUaE8CWSoWNlQpbKhUmQhCo3+7mkRF+NzLCfZXKA56/aefOQgPCVF/csIHjly1jsK87Biw1MEiSJGneGq9W+c6mTXxv82Z+tX07d4+Pd7pIc/ajrVsZq9UY7HRBZsnAIEmSpI4bq1a5ZWSE8VqNGrBhbIxf79jBN+69d0GEhG5mYJAkSVJH7JiY4Jv33svXN27k+p0792jUoW60b38/g6VSp4sxawYGSZIktd0do6N8+Z57uHLbNu4eH2dzpcLOFo8+1C1Gq1UGDAySJKmb7Byvce/2GoNlOGBZd3TEVHfYXKlwwbp1/Pfdd/dMDcJMtler3DcxwfL+7rgU745SSpLUg2q1GmMTsGMMto3U+O71FbaM1LhvR41qDWo1qO0aMp7Bfli1Vx/7LCqxaACG+kuUSrvWVao1Nu2oce+OGhu3heX2Xbd7w3LH2K5znvnUAd71nOFOv3QtAFsnJvjihg1csG5dR0ckmg8OGBhgzeAgBw4N3b+0SZIkSXqAWq3G1XdU+e51Fa5bV+XeHTUmqjXGJ6BShcoEjFehWq0xMg7bx3ZdxFcKbrGxcXtvX9hpbjaOj/Pr7dv5+Lp1/GbnTsZ7KCgMlEqsHBxk9eAgD1u0iEcvWcLDFi1i9eAgQ10yfGojBgZJktpo4/YqX76qwucuH+c36+d/e+17d/TOBZ723K0jI/xg82Yu37qVe8I8CFsmJtg6MdHporXV45Yu5bhlyzh26VL2LpfZb2CAvfv76QNKXVRj0CwDgyRJLTZRrfE/N03wucvH+favK4x10TWUNQyaTq1W4wt3382Hb7+dLvpnPWuDpdIDagMGSiUeumgRj1y8mOfstx+HDvdmcz0DgyRJLfL7TVW+8PNxPn/FOHfc150X3r+7p8popcZQ/8L9tVR77qN33MGnNmzodDFaav+BAZ61fDnPWL6chy9eTP8CrinYUwYGSZKAsUqN71xX4dd37epfMF6BsYldfQzGJnatn7w/PrGrM/LkNmOVXc9v2NqdIaHelhEYq8CQVwiaIr377nkZFpb09bF8YIBFfX2UgPrL/aXlMgcPDXHEokXsVS4/YL9F5TJHDA9z4NAQZUPCtPw4kCT1tFqtxhevrPDP3x5l3Zbuv+BvhZHxGsuGvYDSH/xq+3bef/vtnS4GKwYGOHW//Th1v/3Yu1xmsK+P4S7vUNwNDAySpJ511e8r/OnHd7JlpNMlmV+2jdY4YFmnS6H54u6xMc6++eZCRzzqL5VY3t/PAQMDPGzRIo5atIhjlizhEYsX02dtQOEMDJKknnPHfVX+8r9H+OHNC7Hb5txtHe10CTRfjFarnH3zzdwzPt7W8/SXShy1aBHP339/nrV8OYumNB9SZxkYJEkL3milxr9cMsr3b6xw66YaG7d3ukTz272OlNSzxqpVLly3DoBKtcpX7r2XeyuVtp7zgiOP5JjFixm0adG8ZWCQJHW90UqNc9eOTbv+vMva+wvpQrF4EHaMGRh61VitxvkhMLRDf6nEiv5+Tlm+/P6+B4aF+c/AIEnqKltGqrzqkzsBqNZq3HFfjWoN7tzc6ZK133A/LB4qMVSGvj44/rAy+y8pUWPXCE337dw1S/TIeI3R8KNwCSiVYMlQif2W7Lrtu6Tx/UUDtg9X6x0+PMxpK1bwrH337fpZj3uRgUGS1FW2j8CPfzf/Z0yezn5LSvzJsf08+qAyg2Xo74P+con+PugrwfAALB4ssXiwxJLByftQ7vNiXnNT3+SI0EfhJ1u2MBFGDBupzv3/Vgl4yNAQRy5axJGLF3P8smU8fPHiBT0T8kJnYJAkFWampkNTnXXS4IKZQKyvBCcdWealTxwgOrqfwQXyutRd2tnk6OR99uGsNWs4YHCQRdYiLCgGBknSnM02CDTbl+DMEwYXzARi33zdIh77kAXyYqTdeOdDHsKyfv+NL0S+q5KkORurwDmXzL7mYKEr98HyRbBiWYm9hqFUKnH4Cn9xVWfVajU+tX59245vk6OFy8AgSWpafcdjgEp14Y2qUy7Bnz1lgJXL+hgow2A/DJRhoFxiKNwfLJfCczDUX6K/DHsPlzh4eYk++xuozab2R5io1bhq2zYI4WDLxARbJybYMjFBDRhtw8Rrw319vGC//VhaLjNoYFiwDAySpKYV1fH4pg1Vto3VWL+1xoYtNdZvrXLrxmI6PF/390tZNuwFkOaHqeFg8rlPbNjQsTIBfOjww/mjvfbqaBnUfgYGSdK8Ff/bjk4XQZoX2j0/wp561JIlnS6CCmBgkCT1vMWD8IhVJQbKu2oUjju0zKDfkJIEBgZJUi9bs3eJ/zx9EY85qNzpokjSvGVgkCQ1bXyi+zs5P/GQMh9/+TAHLHP0IkmajoFBktS0C388+7kU5qOXPL6fDyTDTp4mSbPgzyqSpKZcv36CC37U3YHhH081LEjSbBkYJEmzNlGt8dYvj1ApZmRTSdI8YJMkSdKsXfjjca64zbQgtdvUeRe2VCqFnPdRixdz9/gfahBXDw5SXxd37NKllOsmaHOytt5gYJAkzcrv763yT98a7XQxpJ7QqXkXznvYw1hadtQwPZBNkiRJM6rVapydjrCzu7suSJL2gDUMkqQZffHKCv9z40Th5y0B+y8tsXJZiRV7lVi5rI/Fg/DxLu90LXXCY5Ysob7uYGrzImxipAYMDJKkad29tcrff2OkI+e+9h1LWL7kgZXhd91XNTBIe+CjRxxhcyPtEZskSZKm9b+/Nsp9Oztz7v6yv3ZKUqcZGCRJDV187Thf/1Uxo7NIkuYnmyRJknZr884af/eV1oyK9MYTBxjqLzFaqXHeZcU2J3rcwX0MhW+74w4t099XYtBvP81zt4x0phmgtDt+ZEqSduvd2Sjrt9aa2ucRq/p41jEP/mo566RBhvpLbB0pPjBccNoiVu9jhbq6y6fXr+90EaT7GRgkSQ/yg5sqfPby5i7s919a4ot/vph9l7S338GSYfijw2YfAJYMt7U4UsvdPTbG2vvum9MxXrVy5YNGPHIEJO0pA4Mk6QF2jNU4+6Lmm0O897lDM4aFwX546zMGZ33M3TUd2mu4j4vOXNJ0+aRu8cV77mGugxifsWqVIyKpZQwMkqQH+GA+yq33NtcU6Y8f0c+pj5r5K2Wov8TZ0dAcSictbKPVKhfdc0+niyE9gI06JUn3+8XvJzj/B801RVo2BP/8vCFKNneQ5uzbmzaxqeLIZJpfrGGQJAEwVqnxli+PUG2ucoF3PnuI1Xv7+5O0p8aqVS5ct45arcZFGzfu0TGm9lmwv4JaycAgSQLgvMvGuG5dtal9nnJ4mdOeONC2Mkm9YKxW4/x16+Z0DPssqJ38SUiSxPXrJ/jIpWNN7TPcDx98wbBNkSRpgbOGQZJ61Gilxrlrx6jWanz+igpjTQ7L8tfPHOKw/f3dSZIWOgODJPWosQqcc0lztQqTHn1gH3/+FJsiSVIvMDBILTb5q+1sTc6AK3WL/j748AuH6S/771ZqhZ0Tc511QWovA4PUYs3+anvmCYMM+T+xK3R7GJxa/pHx5jo4T3rDiYMcs8bOlRJ1IxzN1hmrVjHY98CmfPkcZ3WW2s3LFEmapW4Pg3NpgjTpiAP6ePPJs5+pWVromh3h6LSVK5n6P+hSA4PmuXn0VSZJms9KwDkvHGJ4YP7UmkjdrlKrce327U3t88oVKxiaUkvhvAtqJwODJGlWTjtugOMO9WtDaqXbRkYYqzU3W+KrV692zgUVyvHwJEmz8pZn2BRJarUbd+7sdBGkGRkYJEmzsnTIJg9Sq91gYFAXMDBIkiR1iDUM6gY2RpWkBe6GDRNk11T4xq8qnS6KpCluMjCoCxgYJGmBqdVqXH1HleyaCtm1FX57957NtyCpvTZXKqwfH+90MaQZGRgkaQGYqNb46S27ahIuvrbCnZubG3VFUjHedNNNTI5vtNUZntUlDAySFMw0k/NopbmL8I+uHd3tTM+tmgF6rFLj+7/dFRK+/esKG7cbEqT57uom51yQ5gMDgyQFrZgJud55l+2+qcFcZ4CuVmt86aoK7//OaFtrEl53Qj+LB/8wNsag3xjqYWPVKp/ZvgOAJevW0RcmThur2uRPC58f/5LUBUYrNf7lklF+dssEv9tYZd2W9p/zr54xzLJhh1KVAMZqNT63Y2TXg8llgR63ZAlPWLYMnNVZHWBgkKQuMFaBj6y1c6TUq166YgUnL1/e6WKoRzkPgyRJ0jz3sMWLO10E9TADgyR1gatvdzQVqVct6uvjwMHBThdDPcwmSZJUsMnRk2YzWtL4RI2PXDrGv17aus7YkrrLEYsW0We/BXWQgUGSCjY5etJMoyXddHeVN35hJ1ff7igsUi87ctGiThdBPc7AIEnzTK1W48Ifj/OPF48y0sJ+zgftU+L2+5yrQeo2RxgY1GEGBkmaR+7aXOWvvjTCZTe2ps/C0Sv7iB/ZT3xMPwcvL3HUPzhplNRtHmZgUIcZGCRpnvjq1eP87VdGuG/n3I/1R4f18d7nDfPwVeX7n9s6Yu2C1I2sYVCnGRgkqcPu21Hj7V8bIf1FpWXH/OQrFzvpmrQArBkcZFm5PIstpfYxMEhSB/3PjRXe/MUR7trir/+SHszmSJoPDAyS1CHvvXiUT/60uNmbB/vhrc+Y/Vjug35DSB1nYNB84NeBJHVIkWEBYKi/xNnRUKHnlDQ3BgbNBwYGSepS+y0p8axjyqxc1vegddYOSAuDczBoPvArRZK60F88dYC/++Mhhgfs2CwtVMN9fRw4ZK2gOs/AIEldZM3eJT7yomGeeoQf39JCd9jwMOWSPwqo8/zG2QNRnJSB04GXAo8FlgOjwK3A94CP5Vl63TT7Hw+8HngasBLYCdwIfAk4N8/SkWJfkaRu8MJj+3nvc4fZe5EXEFIveOjwcKeLIAHw4IavmlYUJ/sBPwQuBJ4J7AXcAuwAjgHeAFwdxcnrGuz/9rD/6cAq4DZgBDgO+ABwVRQnq4t/ZZLmq+WL4fyXDXPeSxYZFqQe8lD7L2ieMDA079PAk4AKcCawNM/SI/MsXQk8DLgUGAA+FsXJU+p3jOLkBcB7w9/9XGBlnqVH5Vm6BnhyqKE4GrgoihOvCiTx9CPLXPrmJZz66IFOF0VSwaxh0HxhYGhCFCcPBZ4VHn4kz9Lz8yydmFyfZ+lNwEtCjUEpBIrJffuA94WHX8+z9E15lm6u2/fHwAuBGnB8uC+pRw0PwPueP8Rnz1jEqr38qJZ60eHWMGie8FuoOQ+ru//93W2QZ+k9wPW72f5JdY8/2GDfK4DLwsNXtqTEkrrOsQf38d03LeGVxw9SssOj1LOWlcudLoIEBoam3VV3f9k02y0Oy3V1z0VhuQP48TT7fjcsT4nixE7pUg8p98HbThnka69dzEMP8ONZkjQ/+I3UnGuB34b7L9ndBlGcHAUcHh5+s27VMWF5fZ6llWnOcU1YDtcdR9IC99AD+vjG6xfzllOG6C9bqyBJmj/8BbsJeZZWwuhHXwWeE8XJfwEfAm4AloaOy+8HymF41Qvrdj8kLO+Y4TR31t0/LBx7TiYq0+UTtdpEpdbk9hUmKl4gFmliorL7+02+d61yxvFl3v7MARYN1vz/Ks1T1Yni/29OVCpM1DrzuaTuVu5v7SW+gaFJeZbmUZycAPxdmIfhtCmb3Aq8A/hAfYfouiZM22Y4Rf366Zo9zdqGu25vxWE0S9vGSsC+s97+7vV3snPQL4RO2bjhDy0Hm33v5mr/xVXefco2jj94nK0bYWthZ5bUrB3V4j+n71l3Jzv6/EFJzVt98KEtPZ5NkvbM8cBR4e83BtwEbAjrVoeahsdM2WdybLSxGY49upt9JC1An3jhZo4/eLzTxZAkaVrWMDQpipMLgVcB9wKvBj41WZMQxcmBwD8CZwAnRXHygjxLLw67Ts7ePDjDKYbq7u9sRZlXrD6oFYfRLC0aqdW93TM7YOUalg37C1KRJiYq99cs7LdiFeXyro/CZt+7uXroIW6fgpsAACAASURBVKt976UusWVsFDZuKvSc+69aw1JHStI8YGBoQhQnzw1hAeBleZZ+u359nqV3AK+O4mQfIAH+bxQnh4dOzlvCZktnOE19M6Qt02w3a61ux6bplfubq7Yu9/dT7veisVPK5f77/480+97N+dy+99K8M1atcuG6dQ96fqQD/YvK/f2UDQyaB7ySbM7kZGrrp4aFKT4fAsPBoWnSFcDNoSnTwTOco379TS0osyRJmqWxWo3zdxMYpF5mH4bmrAnLzTNsV19nuTIsfxWWR0VxMl2zpMeG5Rbglj0spyRJktQSBobmTAaBQ6I4me5vt6bu/r1hOdmXYRh42jT7PissszxLHTpHkiRJHWVgaM73w3IoDKnayIvCchtwFbv6N1wNXBme/5vd7RTFySnA48PDC1pWakmSJGkPGRia84m6idXOjeLkVVGc3N8bKYqTfaI4+RDw7PDUOXmW1g+TejZQBU6J4uTfQ+foyX0j4DPh4VfzLL2kkFckSZIkTcPA0IQ8S7eGJkO3AcvDTM47ozi5MYqTG4F7gLeGzS8E3j1l/7XAG4AK8FpgXRQnv4niZB3wHWAF8APg5Z15hZIkSdIDGRialGfpL4FjgDcDa4H7gENDv4XfAf8FnJxn6avzLK3uZv//AJ4YaivWh337Q3OnM4ET8yydaTZoSZIkqRAOq7oHwgX9R8JtT/b/RZjcTZIkSZrXrGGQJEmS1JCBQZIkSVJDBgZJkiRJDRkYJEmSJDVkYJCk4I77HjSwmSRJPc9RkiQp+MFvJwo5zxtPHGCov8Sgn8CSpC7g15UkBbdsLKaG4U0nDbFsuFTIuSTNT4cNDbG8/w+XYccuXUq59MDPhcGSnxOaHwwMkhTceV+t00WQ1CP+8bDDePjixZ0uhjQr9mGQpODOzfZhkFSMg4aGOl0EadYMDJIU3LnZGgZJ7be8v59l5XKniyHNmoFBkoCR8Rp3bzMwSGo/axfUbQwMkmTtgqQCHWxgUJcxMEgScPsm+y9IKoaBQd3GwCBJwO1O2iapIDZJUrdxWFVJAm7fZJMkqVeMVatcuG5dw3XtZg2Duo2BQZKAO6xhkHrGWK3G+Q0CQxEMDOo2NkmSJOB2J22TVIClfX3s7ZCq6jIGBkmyD4Okghw4NESpVOp0MaSmGBgk9byJao07rWGQVIADbY6kLmRgkNTz1m+tUbGCQVIBDhwc7HQRpKYZGCT1POdgkFQUaxjUjQwMknqeHZ4lFWWNNQzqQg6rKqmnjFZqfOSScbZvWwTAkqXjXH6bgUFSMZy0Td3IwCCpp4xV4F/WVoDF4ZlKh0skqZfs2++ll7qPTZIkSZIK4pCq6kYGBkmSJEkNWS8maUEbrdQ4d+3YAx5LkqTZMzBIWtDGKnDOJWOz2FKSJO2OTZIkSZIkNWQNg6R5aWpTopmcddIgQ/12JpQkqdUMDJLmpWabEp15wiBDfqJJktRyNkmSJEmS1JCBQZIkSVJDBgZJkiRJDRkYJEmSJDVkF0FJklS4sWqVC9eta7h+olbjqm3b7n987NKllEullqwfq1Zb+lqkhc7AIEmSCjdWq3H+NIFhqiu3b2/rekmN2SRJkiRJUkPWMEhSm7zxxIHdTiY36CevJKmL+LUlSW3yppOGWDbs7NOSpO5mkyRJkiRJDRkYJEmSJDVkYJAkSZLUkIFBkiRJUkMGBkmSJEkNOUqSpDkbrdQ4d+3YrLc/66RBhvpL0+43Wqm1sITt0WjY1EkOnypJWgj8OpM0Z2MVOOeS2QeGM08YZKi/+f3mG4dNlR5srFrlwlnM4DxWrRZSHklzZ2CQJEktM1arcf4sAoOk7mEfBkmSJEkNGRgkSZIkNWRgkCRJktSQfRgkaQZ/+vh+Dtznwb+vOAqSJKkX+HUnSTN42zOHWLO3FbKSpN7kN6AkTaO/D1Yuc+hUSVLvMjBI0jRW7VWi3GdgkCT1LpskSSrcR9eO3j/T83y3u74LkiT1EgODpMKdd9l4p4swa2v2tnZBktTb/OlMkqaxZh8DgySptxkYJGkajo4kSep1fhNK0jRskiRJ6nUGBkmahp2eJUm9zm9CSZrG6r2sYZAk9TYDgyRNY2jAwCBJ6m0GBkmSJEkNGRgkSZIkNWRgkCRJktSQgUGSJElSQwYGSZIkSQ0ZGCRJkiQ1ZGCQJEmS1FB/USeK4mQJcDzweOAwYCWwOKzeAawHfgdcCfwkz9JtRZVN0sI1Vql1ugiSJHW1tgeGKE6eD7waiIDBWe42HsXJd4ELgYvyLPUbX9IeuegXlU4XQZKkrta2wBDFyXOBDwAPC09NTpdaAzYAd4WahRKwCFgNrAiPB4FnhdtNUZz8dZ6lX21XWSUtTJWJGhf8cKzTxZAkqau1PDBEcbIcuAB4fl1I+BnwFeD7wJV5lu5ssO8i4HHACWH/40LguCiKk68Cr8mz9N5Wl1nSwvTNayrctskKSkmS5qKlgSGKk0cC3wAeAkwAnwT+Jc/Sa2ezfwgSPwy390Vx8gjgr4BXAs8DHhfFyXPyLL2mleWWtPDUajXO/Z61C5IkzVWraxh+CCwDvge8Ps/S38zlYHmW/hr48yhOzgH+DXh6qKVY3roiS1qI1t4wwbV3VTtdDEmSul6rA8Ni4Ow8Sz/cyoOG4HFyFCdvAd7XymNLWpisXZAkqTVaPQ/DH7c6LNQLx/5f7Tq+pIXh8lsn+MnvJjpdDEmSFoSW1jDkWXppM9tHcTJY17xoU56lM/4k2Ow5JPWe87432ukiSJK0YBQ2cdukKE5WA2cDzw0TuE2OpFSN4uRG4L+BD+dZuqXosknqfr9ZN8F3rrN2QZKkVml1k6RpRXFyFPCLMPLRQ4HtwB3AujCq0tHAO4Arozg5sMiySVoYzrvMvguSJLVS0TUM7wP2Bf4O+GSepesmV0RxUgKeCLwbeGbY9vSCyyepi912b5WvXO3MzpIktVLRgeFpwOfyLH3/1BV5ltaAn0Vx8rxQ62DnZklN+Y/vjzHhSKqSJLVUy5skRXGyNoqTwxqsXgRsnG7/PEtHgU3AklaXTdLCdc+2Kp+7fLzTxZAkacFpRx+GE4FfRnFy1m7WXQ+8OIqThzTaOYqTF4X+Dde1oWySFqhP/XScEVsjSZLUcu1okvRK4F+Bfw0X/6/Os/SmsO6jwMeB66M4WQv8BtgSgssBwHHAY4Ea8ME2lE3SAvWZn1m7IElSO7S8hiHP0k8DDwe+AjwVuDqKk7dEcVLKs/RC4E3AztBH4c3AO4H/A5wJHAvcHULG51tdNkkL11anXpAkqS3aMqxqnqUb8ix9IfDSMHTqB4EfRnFyVJ6l5wErgZOA1wP/O9xeFzpFH5hn6SfbUS5JkiRJzWnrKEl5ln4hipNLgI8BLwJ+EcXJu4AP5ll6GXBZO88vSZIkaW7aPnFbnqX35Fn6EuCFwH3APwE/ieLkmHafW5IkSdLcFDbTc56lKfAI4LPAE4Arojj5P1GclIsqgyRJkqTmFBYY2BUaNuVZejrw3DAfwz8Al0dx8pgiyyFJkiRpdgoNDJPyLP1GqG34ZBhG9WdRnPxDFCdFzzwtSZIkaRptuUCP4mRxGPXoVOBoYDlQATYAVwL/FZoovTqKk88D/y8Mrfr8KE5enWfpFe0olyRJkqTmtLyGIYqTA4FfAh8Iw6SuAAaARcAhQAJ8KYqTr0Zx0pdn6XeAY0JoeCTw4yhO/imKk8FWl02SJElSc9rRJOn9wOHAj4BnhhmcB4DBEBheAdwKPAd4LbuaKG3Ls/S1QATcDvwtcFUbyiZJkiSpCe1okvTHYSbnKM/SkSnrfg/8VxQnVwNXh87P/za5Ms/SS6M4eWQIHa9vQ9kk9ZhyCSZqnS6FJEndqx2BYSmwfjdhod5tYbn31BV5lu4Azori5AttKJukHvPsR/bztV9VOl0MSQvU6StWcO327Q96/tilSymXSg96fnA3z0nzXTsCw83A0VGcPC3P0v9psM2fheVNjQ6SZ+kP2lA2ST3mz586YGCQ1DavWb2apWWnlNLC1o7AcGHo8PytKE6+HPoibAJKwCrghNC3oVrfHEmSWi06usxRK/0ilyRpLtoRGM4B1gBnAacBL5uyvhQmbXtDnqU/bsP5JQmAs04a6nQRJEnqei0PDHmW1oC3RHHyIeB/AQ8PfRUm6uZh+E6epTtbfW5JmvSkQ8s88ZAyW0fs8SxJ0ly0NDBEcVIKgYE8S+8E/rOVx596Dklq5KyTnMpFUmu8auVK+ms1tm/bAsCSpXvR17drZHo7MasXtLqG4eIoTl6cZ+mWFh8XdoWFvYEvhJoLSdqtY1b3cfKR9l2Q1BpnrFrFolqNDXftGkBhxapVlPvb0apbmp9a/a/9mcBVUZycMc0ISXskipMTgE8Ah7byuHsqipN+4MzQR+NoYDhMOvdD4Nw8SxtOPBfFyfFhnomnASvDvBU3Al8K+043JK2kGbzx6YOU/NVPkqSWaPVMz58CDgMujeLkE1GcHDzXA0ZxcmAUJxcCa8OxP92aos6pTPuGmazPA54M7ADuCuU7A/hZFCenN9j37SFUnB5GjboNGAGOC6NLXRXFyeriX5W0MByyb4nnPNJf/iRJapWWfqvmWfqqKE6uBd4TLohfGsXJRaFm4JI8S2c1GHoUJ2Xg6eHi+0+AgdBp+u15ln6glWVuVhQnJSAFnhhmq35lnqVXh3UrwlCxLwQ+HsXJ9/MsvaVu3xcA7w0PzwXekWfp5rDuj4DPhdqKi6I4ebJ9NaTmvf7EQfrL1i6oN41Vq1y4bt2stz9txQo+s2HDrLc/Y9UqBvta/VujpPmuHaMkfTCKk0uB84FjgReH27YoTn4KXBEmd1sXfpmvAYvDr+2HA48DngTsFQ5ZCnM5nJln6c9bXd49cFpoSrQeeGaepfd/0uZZuiGKk5eHsq8PzaduYVcg6APeFzb9ep6lb6o/aJ6lP47i5IXA5cDxIXR8qegXJ3WzFctKvPhxA50uhtQxY7Ua5zcRGJ6///5NbT9Wq83YyXesWp318SR1h7bU2+dZekUUJ08AXg68DXgksAx4RrjNZPLT6Frgg8Cn59Gv7W8Oyw/Vh4VJof/BM3ez35OAh4X7H9zdgcPf7bJQu/JKA4PUnL946gDDA9YuSO3yifXrO10ESR3Qtoa+4QL/08Cnozg5DnhB+GX+saGD8O6MhNqE7wMX5Vn6s3aVb0+EPhmPDw+/2OzuYbkDmG7Cuu+GwHBKFCf9s23GJfW6ZUPwiic5lKokSa1WSM/AcOF//8V/FCdrgBWhKRLhInp9nqV3FVGeOXhiWG7Ks/TWKE4OAl4N/BGwL3A38D3g/032TahzTFheP0MIuCYsh0MTrRva8DqkBee04wZYNmztgiRJrdaRoUTCpG53duLcc/TwsPx9FCfPDTUoe03Z5tnAX0dx8rw8S+trEg4JyztmOEf93+WwVgSGiYqVFEWaqDTXem6iUmGi0t0Xus2+5nZ4+RP6dvtvvdmyveGEMoP9f3g/ynT/+6PeMTEx0dz2fj/MykSlwgR/+CyZmPDvpvmt1fOEOPZgc/YPy32Bz4ShXt8N/ApYCpwKfAg4APhGFCePzrN0MiAsC8ttM5yjfv2yababtQ133d6Kw2iWto2Vwj+R2bl7/Z3sHOz8BfdcNPua26G67S42jD3479hs2V5y9N0srXs/Nt/dsiJKbbej2txnycb1s+/w3MvuWXcni/v+8MPBxg3+3TS/rT64tdOWGRiasyQsDwK+DjyvrjP2KPCJKE6uCX0U9gX+DnhjWD/Zb2NshnOM1t1v1NdDkiRJKoSBoTn1P928Z3cjN+VZ+vMoTr4JPA9I6gLD5OzNM/XKHKq7v3PuRYYVqw9qxWE0S4tGanVv98wOWLmm69veN/ua26HR37EX3w/1rm0TE7Bx06y332/lKth0X1vLtBDsv2oNi6jdX7Ow34pVlMteQql3+K+9OVvr7l89zXY/CoFhTRQne4cO0FvCuqUznKO+GdKWababtVa3Y9P0yv3NNQko9/dT7u/uC9RmX3N7yrD7v2Mvvh/qXeUZ5kh40PZ+P8xKub+fcu0PnyXlcr9/O/UUp2tszu/r7k/3qVz/c81kM6abw/LgGc5Rv/6mJssnSZIktZSBoTm/rLt/2DTbram7PxkefhWWR0VxMl2zpMeG5ZbJWaIlSZKkTjEwNOdHdc2EnjXNdo8Oy5vzLN0R7l8clsNhArtGJo+bzaPZrSVJktSjDAxNyLN0NAynCvDWKE72mbpNFCdHA88NDy+q2/dq4Mrw8G92d/woTk6pm0n6glaXX5IkSWqWgaF57wI2hmZHWRQnD51cEcXJY0JIKAP3AOdM2fdsoAqcEsXJv9cHjihOorow8tU8Sy8p7BVJkiRJDRTWxT+Kk1KY2OxPwq/oq4Gb8iw9rm6bZwJX51m6vqhyNSvP0g1RnMRABvwRcEMUJzcDA3WzOW8CkjxL103Zd20UJ28AzgVeC5wRxcktwD7AyrDZD4CXF//KpIVpsB/e+owHdhuqVqts37ardeGSpXvR19f3gO0lSdIfFPLVGMXJQcAXgclwMDnC0NTz/zNwRBQnz8+zdG0RZdsTeZb+LIqThwNvBZ4DHBpqa64DvgmcMzUs1O37H1Gc/AT4S+DksO824PvAfwEX5FlaLf5VSQvTUH+Js6OhBzw3Uamw4a5d05ysWL2fwyNKkjSNtn9LRnEyDOTAkSEoXAX8NPzCXr/dALAozEPwpShOHpVn6Z3tLt+eyrP0buBvw63ZfX8BnNGekkntMVqpce7a3U9UPlqxf74kSQtVET+rvRY4CrgLeFGepT9iV0B4QGDIs3Q89AH4JvAM4M+AfyygfJJmYawC51yy+8AgSZIWriI6Pb8AqAGvmwwLjeRZOh6a6pTqRhqSJEmS1CFFBIaHAzvzLP3abDbOs/Q6YP0sZkSWJEmS1GZFBIa9gNua3OfeMHKQJEmSpA4qIjBsAg6Y7cZRnPQDB4X9JEmSJHVQEYHhamDfKE6eM8vtXx1GSrqqzeWSJEmSNIMiAsNnQyfmC6M4OanRRlGc9IdJzT4aOkl/roCySZIkSZpGEcOqfhp4DfAU4LtRnFwLXBPWHRjFyb+FDs5PDv0WSsCPwiRmkiRJkjqo7TUMYdbiU4FvhTDwSOAloRZhf+BMIAaWh/XfAp6bZ6kzQUmSJEkdVkQNA3mW3gfEUZycApwGPAk4EFgMbAVuB34GfDbP0kuLKJMkSZKkmRUSGCblWfpd4LtFnlOSJEnSniui07MkSZKkLmVgkCRJktRQIU2Sojg5BjgbeCqwGlg0i91qeZYW2mRKkiRJ0gO1/YI8ipMnAWuBoTAKkiRJkqQuUcQv+O8ChoHtwOeBX4WRkaoFnFuSJEnSHBQRGI4Pcy48O8/S/yngfJIkSZJapIhOz0PAesOCJEmS1H2KqGG41dGYJEmSpO5UxIX8fwMPjeLk8ALOJUmSJKmFiggM7wOuAr4UxckhBZxPkiRJUou0vUlSnqU7ozh5GvA54IYoTr5XN1JSbYZ9393u8kmSJElqrIh5GPqB84HnhHkYTgm32TAwSJIkSR1URKfntwOn1T2+z3kYJEmSpO5QRGB4WWh69GXgr/IsvaOAc0qSJElqgSICw8HAGHB6nqWjBZxPkiRJUosUERi2AxsNC5IkSVL3KWJY1Z8DK6M4cfI2SZIkqcsUUcPwXuBS4G3A+ws4nyRJUlNetXIlg6XSbtcNlkpQm3YkeGlBK2Iehh9GcfI84IIoTo4DzgN+k2fpXe0+tyRJ0mycsWoVS8vlhusnqg7uqN5VxDwMN4S7ZeD54UYUJzPtWsuztIgaEEmSJEkNFHFBfkQB55AkSZLUBkUEhrOAEWAizMcgSZIkqUsU0YfhY+0+hyRJkqT2cKhTSZIkSQ0ZGCRJkiQ1VMQoSTfvwW5lYCjP0lVtKJIkSZKkWSqi0/OhTWxbA0p19yVJkiR1UBGB4ZMzrC8B+wJPAFaFWaEvLqBckiRJkmZQxChJZ8xmuyhO+oBXhpmgf5Zn6dvbXTZJkiRJ05s3nZ7zLK3mWXoh8JfA30Rx8qJOl0mSJEnqdfMmMNT5FDAOvL7TBZEkSZJ63bwLDHmWjgH3AY/qdFkkSZKkXldEp+emRHGyKHSCrna6LJIkSVKvm3c1DMA7Q5C5q9MFkSRJknpdERO3/ecsNusD9gEeBxwY5mBwaFVJkiSpw4pokvSqJiZhm5y07Tbg3W0skyRJkqRZKCIw3DaLwFADRoDfh4nb/m+epfcVUDZJkiRJ0yhi4rZD230OSZIkSe0xHzs9S5IkSZonDAySJEmSGmppk6QoTt7ZyuPlWWrHZ0mSJKmDWt2H4V1NjIg0GwYGSZIkqYPa0em5NIttJEmSJHWBlgaGPEvtEyFJkiQtIF7gS5IkSWrIwCBJkiSpoSJmeoZdIyj1Ay8AEuBYYCWwBNgG3AlcDnwuz9LvFFUmSZIkSdMrJDBEcXIE8GXgkeGp+o7R+4Tbw4FXRHFyKfDSPEvvKaJskiRJkhpre2CI4mQJ8B3gkBAU1gNXhFqFEWARcDDwRGA5cDLw9ShOnpJnabXd5ZMkSZLUWBE1DK8HDgXuBl6TZ+nXd7dRFCdl4DTgPOA44BXAJwoonyRJkqQGiuj0fGqYzO30RmGBXUOyTuRZ+ingz0JNxJ8WUDZJkiRJ0ygiMBwNbGyiM/OXgc3AY9tcLkmSJEkzKCIw7A1smO3God/CHaE/gyRJkqQOKiIwbAVWNLnPfmG4VUmSJEkdVERg+A2wXxQnJ81m4yhOnh7maPhN+4smSZIkaTpFBIavh07Mn4ri5PjpNozi5ATgM6GT9FcKKJskSZKkaRQxrOrHgDcABwE/jOLkF8BPgN9PmYfhKWFitxLwu7CfJElqk1OvuabTRZDUBdoeGPIs3RbFyf8CvgYcDhzbYASkydmffwM8N8/SHe0umyRJvWyi0wWQ1BWKqGEgz9JfR3HyaOA1wItCaFhct8l24OfA54FP5Fk6WkS5pG4zWqlx7tqxWW9/1kmDDPWXZrFld3jjiQMNX89gIZ9m0vy2tVLpdBEkLUCFfcWGGoOPAh+N4qQUhltdEsLC5jxLa0WVRepWYxU455LZB4YzTxhkaAFdSL/ppCGWDS+cACS12lc2bux0ESQtQG2/lIji5K+Bz+RZesfkcyEc3BdukiSpBb67aVOniyBpASrit8f3Af8Uxcn3gE8BX86zdHsB55UkqWdsrVS4ZdQWvZJar6jGCn3ASeH2b1GcpMCngdymSJIkzd1NIyOdLoKkBaqIeRgeApwdOjWXQmfnlwEXA3dEcfLB0CFakiTtoRt37ux0ESQtUEUMq3o78GHgw1GcHAq8JNweC6wC3gK8JYqTa0KTpc/mWXpXu8slSdJCYmCQ1C5F1DDcL8/SW/IsfX+epY8DjgLeCfw61Dw8CvgAcFsUJ9+O4uS0IssmSVI3MzBIapeODbiYZ+mNwHuA90Rx8gjgxcDzgUcDEXAK8JlOlU+SpG5RrdX4rYFBUpsUWsPQSJ6lvw6jKf1v4KudLo8kSd3kzrExdlSrTe/3n0ce2ZbySFpYOjqlUxQne4dahT8BngEM1a2+tYNFkySpa+xpc6RVg4MtL4ukhafwwBDFyfIQEl4EnAwMhD4MABuBL4aJ3n5YdNkkSepG9l+Q1E6FBIYoTvYDkhASnh7OOxkSdgJfC/0VvpVnaaWIMknz3Wilxrlrxx70nCRNdZOBQVIbtT0wRHGSAycC5fBUCZgALgkhIc2zdFu7yyF1m7EKnHPJ2Cy2lNTrrGGQ1E5F1DA8o+7+5SEkfD7P0g0FnFuSpAVtZ7XK70dHO12Mee9VK1cyWCo1XD/dOqnXFREYbgwh4bN5lt5UwPkkSeoZN+/ciY0VZ3bGqlUsLZdnsaWkqYoIDP8E7DQsSJLUet3eHKnRL/8TtRpXbftDi+Vjly6lXLfdTOunsgZB2nNFBIaPA9cB/13AuSRJ6indHhj85V+a/4qYuO1OYHkB55Ekqed0e2CQNP8VERguBNZEcfKKAs4lSVLPqNVqDqkqqe2KaJL0rjDXwoeiODkJ+BxwNXBPnqUTBZxfkqQF6Z7xcTZP+FUqqb2KCAzXhuV24BXhBrvmaJhuv1qepYXPRC1JUrewOZKkIhRxQX50AeeQJKnnGBgkFaGIwPAPBZxDkqSeY2CQVIS2B4Y8Sw0MkiS1wU0jI50ugqQeUMQoSZIkqcXGq1V+Z2CQVIDCOxVHcTIEPBpYDVTyLM2KLoMkSd3ultFRKrVap4shqQcUFhiiOHkM8PfAs+vOezWQ1W3zAeB3eZb+e1HlkiSpG9l/QVJRCmmSFMXJacDPgOcBA0Ap3KY6HTgvipMPF1EuSZK6lRO2SSpK2wNDFCf/n737jpOrqv8//p6dbeltk2waSUghSBWUTmi5QC4CXrGjFFGQIhYQFHtBEUXFoCCgqD+sX+WKwKVcAoReBEQQIYUkpBI2ZZNNsm12fn9wBifJ7tQ7c+/svJ6Pxz7ulHPPfO7s7Oz93NOmS/q1SRT+K+mzkg7tpVxc0i8kJSV91rKd2aWODQCASkXCAKBcytEl6fMmWbhH0im+53arl0XbzKrP37Fsp1vSlZLOkfRwGeIDAKDi0CUJQLmUo0vSsabV4PxUspDFzyR1Sjq4DLEBAFBxNnV3a11XV9hhAKgS5UgYJkpa53vu8lwK+567VdJKM4sSAADYCd2RAJRTORKGGkkb89wnKSleongAAKhodEcCUE7lGMOwRtLulu0M9j23LVthy3aaJU2V9FoZYguMZTvDJf1H0nhJy33PnZKh7CGSLpA0W9JYSdslLZL0V0nzfM9lJR4AQJ9IGACUUzlaGB42g56/ka2gZTsxSdeZKVcXlCG2IP3MJAsZWbZzhaTHzBSyzZJel9Qu6SBJV0t63rIdumNVsI4uFlICUFp0SQJQTuVoYbhW0pmSvmDZzhhJ+I5QdwAAIABJREFUPzVX4t9m2c4oSUdLutQMdu6RNK8MsQXCsp2TTQKQyNSVyrKd95kZoGSO72u+57aa5w6V9EdJsyTdZtnOYb7ncuZZgVZsyu/XtnFbUkMae1uWBAB2lUgmtaSdhmgA5VPyhMH33BfMVfXvS/qY+ZEZp7CPZTvbJDWYx1JnTV/zPfffpY4tCJbtjJR0o7n7O0ln91GuRtJV5u4dvudenP6877lPWLZzmqRnJB0i6TTTRQkVpj3PFoaFbyS028iyrKEIoEw6e3p0y9q1OZc/u7lZ9TX/+x7ItH9rd7fae3oCiRMAclGOFgb5nvsDy3aWmS43k9Keiu90RX65pC/5nvvncsQVkOtM16I/m+5XvSYMpuVkhrn9w94K+J77rGU7C0xry5kkDJWpPc+ZDl9d16M5e5YqGgBh6EwmdWMeCcPpY8eqvoj9AaCUypIw6K2T4T9btvN/ko40J88TJA2UtMVMo/q0pMcqqRuOZTuOpI9IWifpIknvyVTcbLdJeiJDuftNwjDHsp3aHNeuQIR0dOfbwsCVQqAQxV7FL1edAFDpypYw6K2koccMZq60Ac27sGynSdIN5u75vue27Lx69U72MttXsyQBL5lto6TdJS0MJmKUS74tDAvXkTAAhSj2Kn656gSASlfWhCHFsp24pGHmpHibpNZKalkwfiFpjKQ/+p57Ww7lJ5vtqizlVqfdnhpEwpDoppGinLZ1JPIqv3Bdj7o6u1RTs+PA50SeLRW9SXR3K9EdzIDqIOLJxZkHxzVyYO8xxxXM8SQS3b3eRmVJJPL7W0t0dyuRzPw5DqrOYuvJd/9CReH/Qy6/lyjgewOVJF4b7Cl+2RIGy3b2lXSepOPMlfP0sQudlu28IuluSb/MdVXosFi28wFJH5C01nRFysUQs822FkX680MylMvZujUrg6gGOWrZ0CBpcM7lt3VKLyxaowlDd2xpaOuMSRpZVCxvvrFa2+uD+UccRDy5OGOvNzViQO8xt74Z/OutX0c/8Uq1rSe/z3bL2tXaVpM54QyqzmLryXf/Qq1/I/zPfy6/l6jhewNRN25Sn8uBFaQsHS/NLEnPSvq0pJkmUYml/TRI2k/S5ZJesWznk+WIqxCW7Yw2rQuSdJ7vuRty3LXRbDuzlOvoZR9UkM4CroAvXs/C5ilDGqJ/pREAgGpS8hYGy3beI+m75m6npEdMP/03zMlxo5llaD9Jh5nk4ZeW7SzyPTeKYx2ul9Qk6f/5nvuPPPZLTZqdrbtrQ9rtQFbmGTNuYhDVIEe1C7sk5ddcvaZzpMaMq9vhsQHtybSPTWFGjx0f2BoPQcSTzZAGafyE0n9eE4nut68QjhrTrHg8lN6ZKFJbIiGt35hz+abm8Rocz5ycB1VnsfXku3+hRo1tljZuKvnrZJLL7yUK+N5ANSvHpz213sBjkj7ke+7qvgpatjNZ0l8kvVvSF6M2ONqynY+Y9RFWS/psnrtvNttsfVXSuyFtzlAuZ0H3Y0NmnQX0PX513a6/p3ht8Vfa47W1itf2njB0dCc178FsDV7/c9ahdTmUKs7wgbGyf17j8Vr+RipUPJZfMhyvrVU8y4lpUHUWW0+++xcqCp/9XH4vUcP3BqpNOT7tB5gVkDMmC3prFqXllu18UNISM/VqZFi2M9asztwj6Qzfc/O99POaWZBtUpZy6c8vLiBUhCzfaVUl6b9ryz9TUme3dM383BOG099dnoQBAABESzkShkGSlmRLFlJM0rAkhxPrcjtR0ihz+/4sU6hOtmwnddb4W99zz5L0orm/h2U79b7n9nWmtr/Zbpa0LJjQUU75TqsqSUtaetTRnVRDH60B1WLEgOo+fgAAoqgcg57fkDQgz31qzH5R0iWpNctPasxBMu2xbeaxu822UdLsDK8z12y9CpxqFpLaC5htL9EjLWY9Bg0jYQAAIHLK0cIwX9IZlu1M8j13RbbClu2MM+sP/KoMseXM99w/SPpDpjKW7Zwl6RZJr/ueu8N8Vr7nvmDZznOmi9blZkXnnfefI+lAc/fmoI8B5dFZ4HoF/32jR3uNr6x+vEGjSxIAANFTjhaG75nuNTdbtjMwU0HLdurM6slbJP2gDLGV26VmDMQcy3aut2xneOoJy3YsSb83d2/3PXd+eGGiGIV0SZKkV0IYxxA1w2lhAAAgcsrRwrBa0qnmivlSy3Z+I+kJ8/gWSXWSxks6SNKZpsvOJyR1W7azW28V+p77ehniDpzvuQ9atnOhGTz9aUlnW7azTNJwSWNNsUclfSzkUFGE9kJbGNaWZ2XXKBtBCwMAAJFTjoQhfeXimLnKns1fMzyXLOcK1UHzPfcGy3aeNNOyHitpinmPHpF0q6Sbfc/lUnMF66CFoWC0MAAAED3lOPHe+Qyg354R+J77G0m/yaHcvySdXZ6oUG6FtjCsbk1q07ZkVffjH56x0yIAAAhDORKGk83ysAnTOgD0a4WOYZCkV95I6JCpFduAVjRaGAAAiJ6Sn5n4nntXqV8DiJKOAqZVTXllbY8OmRpkNG/pbVXnQhaYKzXGMAAAED0lTxgs2/m5pN/4nvtMqV8LiIJiTsRLteJzvqs6h6Wau2MBABBV5ej7cL6kT1u286rp339rrqs+A5WomC5JpUoYKgULtwEAED3lSBg2mWlDZ0n6vqQrLdu53yQPf/c9t6MMMQBlU0wLw6tvJJRMJhWLVd+Jc0OtNKCu+o4bAICoK8fCbWPMwOffm+lD45JOMKsmr7Vs5wbLdg4rQxxAWRTTwrC5XVrVGr2xBeVA6wIAANFUjkHP3ZLuknSXZTsNkk6S9GGzHSbpU5I+ZdnOEtPq8P98z11R6riAUkgmk2ovYtCzzMDnicPLkcvnZ92W0naXYoYkoHgxpiMEUAJlnb/RdD+6TdJtlu0MknSKpI9IOl7SdEnfkfRty3YeknSLpNt8z91ezhiBYhQzQ1LKf9cmNGdW9KZWvfvlAA4ug2EDSlo9UBUmNjRoRQc9fQEEK7TLmL7nbvU994++554iaaykc81qxzWSjpH0O0mrLdu51rKdKWHFCeSjmO5IKVEd+Pyf1aWNiy5JQPF2b2wMOwQA/VBU+j3sbloYJpnW1Jj5GSbpIkmvWrZzlWU78bADBTIJYm2DVyKaMPxrFV2SgKgjYQBQCqH1e7BsZ5ykMySdJWmmeTh1xvCUpF9LWivpEkmzJX1R0oGW7cw14yKAyAmihWHxmz3qSkSvF3JLW2ljooUBKN60AfTtAxC8siYMlu3USXqvSRKONy0cqbOEdZJulfQr33P/m7bbHZbtvNeMaThW0pfNWAcgctoDaGHoSkhL3uzRhAgOfC4lEgageNNoYQBQAmVJGCzbOUDS2WaA8wjzcExSQtI9pjXhjr5aDnzP/btlOwlJt0s6k4QBUbU9gBYGmXEMVZcwNJIwAMUYWFOj5vr6sMMA0A+VPGGwbOcFSXubu6kzgkWmxeC3vueuyaUe33PvsGznDTPOAYik9q5guu38d22P5swKpKqKwSxJQHGmDxigmhIv+njW2LGqz/IanT09+s26dSWNA0B5laOFYR+z3Srpr5J+7XvuIwXW1SqpIcDYgEAFMYZBkl5ZmwimogpClySgODPKMH7h7OZmDY5nnn+kLZEgYQD6mXIkDE+aLkd/8j23rci6jmNNGkRZkC0M1YZZkoDiTI/IgOf6WEznNjfnVR5AtJVjpefDAqxrVVB1AaUQxMJtkrRyU1Jt7dWVG9PCABSnHC0MuaivqdF548eHHQaAAFXXqEqgxILqkiRJC9dVVysDLQxAcaYzQxKAEgm8hcGynQcCqirpe+5xAdUFlEUQ06qmVFvCMIjRSUDBxtbVaUhtrdoS1Tf+CUDplaJL0tEBjDOIMVYBlSioaVUl6dU3qithiNGPGSjY7hHpjgSgfypFwvDvLCf7e5iZjv5dgtcGQhXUoGdJWriOK4UAcrM73ZEAlFDgCYPvuftnet6ynecl7et77juDfm0gbIGOYaiyFgagmn112bId/iHnO38CKzwDKKWyrPQMVIsgWxha2wOrCkDEPdLaWtT+0+iSBKCEmCUJCFBQ06oCQD4mNjBrAIDSIWEAAhRkCwOAytXRU94uhbVMGgCghEgYgAC108IAQNL9GzeGHQIABIaEAQhQkNOqAqhMyWRS/9fSEnYYABAYEgYgQHRJAvDUli1a2s6sBQD6DxIGIEBBTqsKoDL9Yd26sEMAgECRMAABau+mhQGoZku3b9djmzeHHQYABIqEAQgQLQxAdfvjm2+GHQIABC7whdss23kuS5GZOZZL+p57YHCRAaXXQQsDULU2dXfrzvXrww4DAAJXipWe95eUlJRtUuj9szzPmRcqDi0MQPW6raVFHcnC/nV9Zvx4NdT8r9G/o6dH81avDjA6AChcKRKGhznZR7ViliSgOnX19OjPRXRHev/o0Rocj799vy2RIGEAEBmBJwy+5x4ddJ1ApaCFAahO/saNauniCwBA/8SgZyAgyWSSlZ6BKpRMJvV7plIF0I+RMAABIVkAqtPzbW16Zfv2sMMAgJIhYQACQnckoDrRugCgvyNhAALClKpA9VnV0aEFra1hhwEAJUXCAASEFgag+vytpYVpAQH0e6WYVhWoSkypClQfb8OGsEPYQX0spnObm3MuP6imJq/y9bFsSywB6I9IGICA0MIAVJ/tPT1hh7CD+poanTd+fF775FseQPWhSxIQkO20MAAAgH6IhAEICNOqAgCA/oiEAQgIYxgAAEB/RMIABKSDFgYAANAPkTAAASl00PPAuqAjAQAACA4JAxCQQrskTR/DnyEAAIguzlSAgBTawjCThAEAAEQYZypAQAqdVnWPsfwZAgCA6OJMBQhIodOq0sIAAACijDMVICCFjmHYY2w88FgAAACCQsIABKTQaVVHDopp9OBY0OEACNFuDQ1hhwAAgakNOwCgvyhm4bY9m2v05uJEoPEAYejs6dEta9fmXP7s5mbV1/S/a1cfGD1a16xcGXYYABAIEgYgIIXOkiRJs5pr9DAJA/qBzmRSN+aRMJw+dqzqSxpR+Q2Lx3X8iBEkDAD6jf53WQcISTEJw57NjGMA+ovTmprU2A9bTQBUL77RgIBs7y68S9KsZv4Ugf6gNhbTB0ePDjsMAAgUXZKAInR0JzXvwU5J0pJ1PQXXM3NMjWIxKVl4zgEgAo4fMUKj6+vVlqCLIYD+g4QBKEJnt3TN/M6i6xlYH9PUUTG91kLGAFSyj44ZE3YIABA4+kEAETGL9RiAinbA4MHac+DAsMMAgMCRMAARsSfjGICKRusCgP6KMxQgIhj4DFSuCfX1mj1sWNhhAEBJMIYBiAimVgVK69IlSxSPZV5VPVHgzAMfGTMma90AUKlIGICImDIqpsa64tZzANC3Z9raSlLvoJoanTJqVEnqBoAooA8EEBHxmphmjuFPEshVMiLzEDtNTRoUp4UQQP/F2QkQIQx8BnL3wKZNYYegGkkfZqE2AP0cZydAhMxiHAOQk2QyqVvXrQs7DM0eNkzjGhrCDgMASoqEAYgQWhiA3Ly8bZtea28POwx9gNYFAFWAsxMgQqKcMAzmIioi5Pb168MOQZK096BBYYcAACUX3bMToAqNHhzTyEHRnJpx+mi+LhAN23t6dM+GDWGHAQBVg2lVgQiJxWLac2yNHnstEXYou5gxukb/WtkTdhiA5m/cqK090f4s1sdiOre5Oa/yQe4PAEEiYQAiZlZzRBMGpnxFRPw9It2RMqmvqdF548eHtj8ABIkzACBiojqOYQZdkhABy9vb9XyJFmADAPSOFgYgYvaM6NSq00gYEAHFDHa+bOJENdRk/hx39PTo6pUrC34NAOiPSBiAiNljbDRPzAc30Eca4epOJnVnEQnDSaNGaXCWFZnbEgkSBgDYSTTPTIAqNqghpskjOTkHdvZYa6vWd3eHHQYAVB0SBiCCWPEZ2FVU1l4AgGpDwgBEUFADnzu7k4HUA4Ttza4uPdraGnYYAFCVSBiACAoqYbjrJbpvoH+4c/16RW+yYQCoDiQMQATNCihh+O2TXUomaWVAZUsmk/oH3ZEAIDQkDEAE7T6qRvUBDGN4eW2PnlrGdVlUtufb2vR6R0fYYQBA1SJhACKoNh4LbN2Dmx7tCqQeICyVsLIzAPRnJAxARM0cE8yf5z0vd2vFxp5A6gLKbUsiofs3bgw7DACoaiQMQEQFtYBbT1K69WlaGVCZ7tuwQR2MwwGAUJEwABEVVAuDJP31ORIGVCbWXgCA8JEwABE1M6AWBknawnhRVKBF27bpP9u2hR0GAFQ9EgYgosYOiYUdAhAqBjsDQDSQMAARFYuRMKB6dfb06O4NG8IOAwBAwgAAiKKHNm1Sa4I1RAAgCkgYAACRQ3ckAIgOEgYAQKSs6ejQ01u2hB0GAMAgYQAARMo/1q8XKy8AQHSQMAAAIiORTOofDHYGgEghYQAARMZTW7ZobWdn2GEAANKQMAAAIuP2lpawQwAA7ISEAQAQCRu7u/VQa2vO5cfX15c0HgDAW0gYAACRcPeGDepO5j7c2R45sqTxAADeQsIAAAhdMpnU3/PojlQj6UQSBgAoCxIGAEDo/rNtm5a0t+dc/tChQzW6rq6kMQEA3kLCAAAI3e15ruz83lGjShYLAGBHJAwAgFBtTyR0bx5rL4ysrdWRw4aVNCYAwP+QMAAAQuVv2qStPT05lz9p5EjV1fDvCwDKhW9cAECo8l174dSmppLFAgDYFQkDACA0r7e3619bt+Zcfr9BgzS1sbGkMQEAdlQbdgCVyrIdR9JZkt4tqUlSh6TlkuZL+pnvuUsy7HuIpAskzZY0VtJ2SYsk/VXSPN9zc58qBAAqmJfH2AVJOpXBzgBQdrQw5MmynUGW7dwl6TZJp5hkYbmkLkl7SbpY0osmoeht/yskPSbp45KaJb0uqV3SQZKulvS8ZTvjyn9k6I+GciEWEXfvxo05lx1YUyNrxIiSxgMA2BUJQ/5+JcmW1CPpK5KG+p47w/fckZKOlPSapAGS/mDZzm7pO1q28z5JV5r3fZ6ksb7n7uF77nhJh5nEY5ak2yzbiYV3iOgvPngA89Qj2jZ0d+dc1hoxQgPj8ZLGAwDYFQlDHizb2VvSh8zd7/ue+7307kO+5z4q6SPmbqOkT6TtWyPpKnP3Dt9zL/Y9tzVt3ycknSYpKekQcxsoyscOqlOcv3L0E6y9AADh4FQiPwdIajGtCzf2VsD33KdNGUnaP+2pgyXNMLd/2Me+z0paYO6eGWjkqErjh9fI3ouhSqh8Uxsbtc+gQWGHAQBViTOJPPie+ztJv7NsJ+57biJD0VYztiG9P4hlttskPZFh3/slHS1pjmU7tb7n5t5eD/TiU0fU644X+RhVg86eHt2ydm3O5c9ublZ9haxn8N5RoxSL0VMTAMJAwlCATMmCZTtNkiabuy+lPbWX2b6aJQlI7dMoaXdJC4uPGNXsXbvVaO/xNXppde4LY6EydSaTujGPhOH0sWNVX9KIglEbi+mkkSPDDgMAqhYJQ/AuN+9rj6Tfpj2eSiJWZdl/ddrtqUEkDIk8BhUiP4nuZAB1dCvRveuV06Dq7qmN6Yx3x3XZ7cUlDIlEaT9Hfb0PJXmttGMp9XGVUyKRqeGzl/Ld3Uoki/+cFRNDLmYPHaqhsdgu32WlON4ovIeIpv76vYH+KV4b7Ck+CUOAzFSqXzB35/me+3La00PMti1LNenPD8lQLmfr1qwMohr0oq0zJqm4K59vvrFa2+t3PeEIsu4DRxVfV8u6NUXXkUlf70OprV+X+xX5qNvWk9/717J2tbbVBJuk5RtDLmYnE71+j5XieKPwHiL6+tP3BvqncZOmBFpfZXRerQCW7Xxc0p/Ne/qgpC/uVCQ1I35nlqo6etkHKEodM1GiQjXV1Oid9UwPDABhooUhAJbtfE3St83deyWd5ntu107FUtOvZusy3JB2e3sQ8Y0ZNzGIatCLAe3JtF9tYUaPHa8hjbteoQyy7iDqahozbqd8Nlh9vQ+lkEh0v32FcNSYZsXj/eOrsC2RkNbnvhBaU/N4DQ54XYN8Y8jmlKYmjWtuDuS1cjneKLyHiKb++r0B5IJPexEs22kwC7mdbh66SdIFfQxq3my2g7NUm94NaXOGcjkLuh8b/ideW3z3i3htreK1u54oB1l3IHXFa0uaMPT1PpRaPF7bb/5G4nnOIhSvrVU84JPdfGPI5tTRo/v8/ZTieKPwHiL6+tP3BpALPu0FsmxnmCTPrNDcLekS33N/lmGX18yCbJOyVJ3+/OKAwgWAivPuIUM0saEhh5IAgFJiDEMBLNsZKOkukyxslnRSlmRBkl402z0s28nULSm12NtmScsCChkAKg4rOwNANJAw5MmynVpJt0s6XNJ6SUf5nntfDrvebbaNkmZnKDfXbD3fc5mrD0BVGhqP65jhw8MOAwBAwlCQb0iaY0aQnuh77r9y2cn33BckPWfuXt5bGct25kg60Ny9ObCIAaDCzB05Ug0Vsgo1APR3fBvnwbKd3SV9ydz9ku+5/8yzikvNgm5zLNu53rKdty+fWbZjSfq9uXu777nzg4scACrLqXRHAoDIYNBzfj6T9p59yrKds7Pt4Hvu/mm3H7Rs50JJ8yR9WtLZlu0skzRc0lhT7FFJHyvZEQBAxM0aMEB7DBwYdhgAAIOEIT8j0m7vVUgFvufeYNnOk5I+K+lYSVPM6s6PSLpV0s2+5/YEFzJKKVGCVW2BandqU1PYIQAA0pAw5MH33LMknRVAPf+SlLV1AtHXvvPyfACK0hCLae6IETmUBACUC2MYgCJ09LZEH4CCHTt8uIawIBYARAoJA1CEjm66JAFBei/dkQAgckgYgCLQJQkIzsSGBh04eHDYYQAAdkLCABShnRYGIDCnjhqlWCwWdhgAgJ2QMABF6KCFAQhEjaT3jBwZdhgAgF6QMABFoIUBCMZhQ4dqTH192GEAAHpBwgAUgTEMQDBYewEAoouEASgC06oCxRtZW6sjhw0LOwwAQB9IGIAiMK0qULyTRo5UHYOdASCySBiAItAlCdjRw62tee9DdyQAiDYSBqAIDHoG/uf5tjZ9Z/nyvPbZZ+BATW1sLFlMAIDikTAARWBaVeAtS7Zv1+eXLFFnMr8k2h41qmQxAQCCQcIAFKGdQc+A1nZ26jOLF2tLIpH3vkcz2BkAIo+EASjCm1t6wg4BCFVrd7cuWrxYb3QV1tw2MB4PPCYAQLBIGIAiLN/AGAZUr/aeHn1+yRItbW8POxQAQAmRMABFWLGRFgZUp+5kUlcsXaoXtm4NOxQAQImRMAAF6uxOanUrLQyoPslkUj9YsUILCphCFQBQeUgYgAKt2JhUTxXlC/W10iXH1euio+rCDgUhu2ntWt3W0hJ2GACAMiFhAAq0bEN1dUeqr43pUqtBFx/TEHYoCNFtLS365Zo1YYcBACgjEgagQMtaqithABZs2qTvv/562GEAAMqMhAEoULW1MKC6vdDWpi8vXSo+9QBQfUgYgAItW8+pE6rD0u3b9bklS9SR5yrOAID+gYQBKNCy9Zw8of9b19mpCxcv1uYCVnEGAPQPJAxAARI9Sb1OlyT0c5uLXMUZANA/kDAABVizOalOLriiH+vo6dEXXntNS1jFGQCqHgkDUIDljF9AP5ZIJvXVZcv0fFtb3vvGSxIRACBMJAxAAZaSMKCfSiaT+uGKFXpg06aC9r980qTAYwIAhKs27ACASrS8igc8p1Z8zqajO6nrFtD3vdL8eu1a/V+BqzhfPH68Thg5Ut9bsSLwuHpTH4vp3ObmvMqHUScAVDoSBqAA1dzC0GBWfM5mSzsJQ6W5vaVFvyhwFeePjhmjM8aO1dae8v1t1NfU6Lzx4yNfJwBUOrokAQVgDAP6m4dbW3Vlgas4Hz9ihD4/YYJiXG0HgH6JhAHIUzKZrOoWBvQ/L27dqi+99poKmfjr3UOG6FuTJ6uGZAEA+i0SBiBP67cmtbUz7CiAYCxtb9dnFy8uaBXnmQMG6Ee77676Gv6VAEB/xrc8kCdWeEZ/0dLVpc8sXqzWAlZxHl9fr59Nn67BcSZSBYD+joQByBPdkdBfXPbaa1rTmX9z2fDaWl03fbpG19WVJC4AQLSQMAB5YsAz+otCVnFurKnRT6dN0+TGxpLEBACIHhIGIE+0MKBaxSX9YOpU7TNoUNihAADKiIQByNPyDSQMqE5fnTxZRwwbFnYYAIAyI2EA8rSUQc+oQheOH69TRo0KOwwAQAhY6RnIw5b2pDZs7f8Jw0VH1amhdsd59ev5tqhaHxo9WmePHRt2GACAkHAKAORhWZWMX7j4mAYNaWQhLkjHDR+uSyZOZBVnAKhidEkC8lAtCQMgSQcOHqzvTJmiOMkCAFQ1WhiAPCxjwDOqxIwBA3TNtGlqYBVnIJK6urqUKGDRRVSeeDyuupDXvSFhAPKwrKX/j18AmuvrNW/aNA1hFWcgcjZv3qyWlhZ1dHSEHQrKqKGhQU1NTRo6dGgor0/CAOSBFgb0d8Pi8bdWca6vDzsUADvZvHmzVq1apcGDB6upqUl1dXWML+rnksmkurq61NraqlWrVklSKEkDCQOQB8YwoD9riMX002nTNJVVnIFIamlp0eDBgzWRiQiqyoABAzRkyBCtXLlSLS0toSQMdE4FctTeldSazXRJQnR19BSe0MYlXbX77tp38OBAYwIQjK6uLnV0dGjYsGEkC1UoFotp2LBh6ujoUFdXV9lfn4QByNHrG3uUJF9ARG3v6dFXli4teP8rdttNs1nFGYis1ADnsAe/Ijyp330Yg93pkgTkiAHPiKqtiYQ+t2SJnmtrK2j/88eN03ubmgKPC0Dwgm5d6OhOat6DnTmX/8wx9bss7InyCLNliYQByBEDnhFFW7q7ddHixXpp27aC9n9/U5POaW4OPC4AlaGzW7pmfu4Jw3lH1qtjlPpsAAAgAElEQVSBs8eqw68cyBEDnhE1G7u7deGiRXp1+/aC9p89bJgumzSJ/tAAgIxIGIAckTAgSlq6unTBokVa0t5ecB1f3W03VnEGAGRFwgDkaDldkhARazs7df6iRXq9yIWbWMUZqEzJZFJtAa3b1tae3/i8fMtnMrghv3759/oP6Ec/mSdJ+vHVV2qfvd/Ra7lEIqHTzzpX69dvkDXnGF32hYt3eO7hRx/XAw89okWLl2hz62Y1DmjU6NFNOuhdB8o+YY7Gjdu1m6ZlO5KkE48/Tpd87qI+Y7zpV7/VX/72d0mS77lvP37J5V/Vv1/8T8bj2+sds/TTH30/6/sQBhIGIAfdiaRe38CgZ4RvZUeHzl+0SKs7c+9zDKB/aeuQZn6zsEkOinXAVVsDq2vhNwdrSAHLvtTV1cm7x+8zYXjmn89p8+Ytuzze2rpZ3/ruD/TSy//VEYcdonPPOUtjx4xWR2enFi5arDvvukd/v/1OXXTBuTrBOrbX133o4cd0/rnnaODAAbs8n0gkdP8DC1RXV9fn1Kc/vvpK1fexMGZvdUYFCQOQg9WtSXXTwICQLWtv1/mLFmldCHNwA0BUvHP/ffXIY4/rovM/qUGDBu3y/D3+fO27z1569rl/vf1YMpnUt793tf7z31f0tS9/UUcecegO+xyw/7469WRbX//W9/Tja3+uMaOb9M79992hzP777q1nn39BDy54RCfNPX6X133qmWe1YeNGHfDO/fTc8y/0Gvv0aVM1YEB0E4O+0B4N5GAp4xcQskXbt+tTCxeSLACoekcefog6Ojo1/8GHd3lu46ZNeurpZ3X4oQfv8PgTTz6tf7/4H5180om7JAspAxobdcXlX1B9fb1+efNvdnl++Ijh2mvPWbr7Xr/X/e+5737N2mOmRo0aWfCxRRUJA5ADBjwjTP/dtk3nLVyoDd3dYYcCAKEb19ysWXvMlHfPrifu9z+wQDFJRx152A6PP/LYk5Ik+0QrY90jhg/X4YcepCWvLdXy11fs8vwxRx+pVxcu1mtLl+3w+MaNm/T0M8/puGOPKvCooo2EAcgBCQPC8kJbm85buFCtIazsCQBRNfeE47TktaVauGjJDo/fe998HXrIQRo6dOgOjy9//XXF43FNnTI5a93Tp+0uSVqxctUuzx179JFqbGjYJVm57/4HVVNTo2OPPrLAI4o2xjAAOVi2ngHPKL9/btmizy1Zou09JKwAkO6Yo47UDTfdorvv9TVzxjRJ0suvvKrlr6/QeZ88a5fy27ZtV2NjQ06zMg0cOFCSeh04PWjQIB15xKF64MGHde45Z749gPne++fr8EMP1tAhQzLWfcppH+3zuQ99wNEnzz4ja3xhIGEAcsCUqii3xzdv1qVLlqgjSbIKADsbMGCAjjrycD3w0CM675Nnq7GxQffce79GN43SgQfsv0v54cOHac3aN5RIJBSPxzPWvXXr1rf36c3cEyz58x/SI489oeOOOUov/ee/WrFilS4475NZ4772mu+rvr6h1+dGjOj99aKALklAFslkki5JKKuHNm3SF0gWACCjuSfM0bZt27Tgkce0vb1dCx5+TNZxx6imlzVmpkzeTT09Pbt0YerNwsVvlZk6ebden99n73do0sQJb3dLutefr9Gjm3TATrMq9WbqlMmaPm1qrz+jRkZ3sDQJA5DFui1JbWdiGpTJfRs26LLXXlMXyQIAZPSOPWdp8m6T9OCCR/T4E09pe3u7Tjh+1/UTZAYrS9I/7rw7Y50bN27Sk08+o7332rPXBdxSTrCO04svvazVa9bo4Uce1/Fzek9U+ov+e2RAQJhSFeXyj/Xr9ZVly1To8OZjhw8POCIAiLYTjz9O//73S5r/wALts/c7NH7cuF7L7bfP3pp9xGG6/4GHdPe99/daZnt7u7539Y+VSCR0wXnnZHzd461jFI/HdcNNt7yVqMzpPVHpLxjDAGSxnAHPKIP/e/NNXbVi1yn8cnXyyJH6/MSJemDTpkDjAoAos447Rr/+za165tnnddklF2cse8nnLlJ3d7d+fO3P9fiTT+uY2Udo7Ngx6uzs1MJFS3Snd4/atm7VV798qWZMn5axrhHDh+vggw7UY48/pf333Ttja0R/QMIAZEELA0rt1jfe0E9W7Tp9X67e39SkyydN0jZmUwKqwuAGaeE3BwdSV1t7UgdctTXn8s99aZAGN2afaSgXg3sf+5uXYcOG6tBDDtI/n31eRx5+WMayAwcO0Le+/mU9/uTTun/+Q7rld7/Xho2b1NBQr7Fjxsg67hjNPXGORjc15fTac0+w9NjjT+mE448r/kAijoQByIIZklBKN69Zo+vXrCl4/9PHjNHnJ0zIaapAAP1DLBbTkMZwXntwY0xDAkoY8nWCdaxOsHbt+vO1K77Ya3nfc3t9/LBDDtJhhxyU12v3VtfB7z6w18cv+8LFuuwLO7Z2XPOD7+b1elFDwgBkwQxJKIVkMqlfrF6tX7/xRsF1nNPcrPPHjSNZAACUFAkDkAUJQ/Xo7OnRLWvX5lz+7OZm1RcwK0YymdSPV63SH9aty3vflAvHj9cnmvt3n1kAQDSQMAAZbNyW1KbtYUeBculMJnVjHgnD6WPHqj7P1+hJJnXVihX6W0tL3vGlXDJxoj46ZkzB+wNASn2tdMlxuX+T1XPmWJX4tQMZLKd1AQHqTib17eXLddeGDQXtH5P05UmTdNro0YHHBqA6NdTGdKkVwOhj9GskDEAGyxjwjIB0JZP66tKlur/AaU9rJH1j8mS9Z9SowGMDACATEgYgg6UtJAwoXkdPj760dKkebm0taP+4pCunTpU1YkTgsQEAkA0JA5ABU6qiWNt7enTJkiV6asuWgvavi8X0g6lTdRSrOAMAQkLCAGSwjFWeUYStiYQ+t2SJnmtrK2j/hlhM10ybpkOHDg08NgAAckXCAGTAlKoo1Jbubl20eLFe2ratoP0H1tTop9Om6cAhQwKPDQCAfJAwAGk6upOa92CnJKkrkdQbW2hhQP42dnfrwkWL9Or2wubkHRyP67rp07XPoEGBxwYA6cq1/gwqGwkDkKazW7pmfmfYYaCCvdnVpQsXLdKS9vaC9h8Wj+vnM2Zoz4EDA48NAHZWjvVnUPlIGAAgIGs7O3X+okV6vaOjoP1H1dbq+hkzNG3AgMBjAwCgUCQMABCAlR0dOn/RIq3uLKyFamxdna6fMUOTGxsDjw0AgGKQMABAkZa2t+uCRYu0rquroP0n1Nfr+hkzNKGB1VYBZJdMJrW1J5hJObYmEiUtn8mgmhrFYrGcy9/rP6Af/WRe1nKz9pipeT/5wdvlLzz/U3rvyXavZZ986hl97Vvf08c/+iGd8bEP67rrb9Ltd3j6+hWX6cgjDu3zNTZu2qTTz/iUxo8fp5tv+JnWvrFOHz/7PB15+KH6+lcuy/mYKgUJAwAUYdH27bpg0SJt6O4uaP/JDQ26fsYMja2nVzCA3Gzt6dFRL7wQymvbL70UWF0L9ttPg+PxvPf74Gnv1ewjD+/z+QEDCm+pPfVkW/+4827d6d2bMWG4139AXd3dOuU9cwt+rUpCwgAABXp12zZ98bXX1FrgFbfpjY36xYwZGlVXF3hsANBfjR4zWnvMnF6SuidNnKB37revnn/h31q1eo0mjB+3S5lkMqm77/E1cOBAWccdXZI4ooZ5sQCgQJ9fsqTgZGHWgAH65cyZJAsAEDGnnjxXyWRSd919b6/PP/v8C1q9Zq2On3OMBlTJJBUkDABQoEL7EO87aJBumDFDw2tp5AWAqDn4oHdp7JjRus9/UJ29jE27y3srkTj5pBNDiC4cJAwAUEYHDh6sn0+friEkCwAQSfF4XO+xT1Dr5s169NEndnhu/YYNeuKpZ3TA/vtpt0kTQ4ux3PiPBQBlctjQofrh7rurkVVSAaBgP7/+Jv38+pv6fP7aH1+ld8zaI+fyvZl7gqXf/f7PutO7V8ceM/vtx++5d74SiYROPbk6BjunkDAA/cRFR9WpoXbH6enq+QuPjKOGDdNVU6eqnmQBAIry4Q+8T0fNPqLP5ydOGJ9z+Zf+87J+fsPNuzw+bNhQHT37cPnzH9Ly11do8m6T1NPTo7vv9TVm9GgdfNC7AjiSysHpBNBPXHxMg4Y05j6fNcrn+BEj9O0pU1SXx3zjAIDejWoapenTpgZSvqWlpc/9Tj3Zlj//Id3p3asLP/1JPfPP5/TGujd1zlkfU7yA6WArGZe6AKCETh45Ut8lWQCAirPHzBmaNXOG5j+wQF1dXbrnvvmqq6vT3BOssEMrO1oYgIiqr5UuOS73xbzofhQ9729q0uWTJqmGZAEAKtIpJ8/V1df8TA89/JieeuZZHT37cA0bNjTssMqOUwwgohpqY7rUagg7DBTo9DFj9PkJExQjWQCAQL257k29unBxxjJTp+wWyGsdNfsI3Xjzb3T9jb9SV1eXTj3ZDqTeSkPCABShsVZq7w47CkTNOc3NOn/cOJIFACUxqKZGC/bbL5C6tiYSsl96Kefy3t57a1BA/fcHFTgJxF/+9nf95W9/z1jmxl/8tMCodlRfV6cTT7D0p7/8TbNmztAeM2cEUm+lIWEAijBheExLWpJhh4GAJJPF/y4vHD9en2huDiQeAOhNLBbT4JAG3Q6Kx0N77ROsY3WCdWzO5adOmZy1/CEHv1u+52Ysc85ZH9M5Z30sY5nmsWOy1lPJGPQMFGHicP6E+oueZFLXrFxZVB2XTJxIsgAA6HdoYQCKMGVUTO+avOPA5I7upK5bsOtS8oiu7mRS316+XHdt2FDQ/jFJV+y2m97X1BR4bJWmPhbTuXkkTfV02wKAyCNhAIowZVRcn569Y8KwpZ2EodL835tvFpws1Ej6xuTJes+oUYHHVYnqa2p03vjxOZQEEAUk+cgFCQOQJt8+7JNH8sXZH7y/qUlPbd6sRzZvzmu/uKQrp06VNWJEyWIDgFIiyUcuSBiANP9d25NX+d1GVsYYBtZ0yKyupkY/2H13fWbxYj3b1pbzft+ZMoVkAQDQ71XZaQGQ2a8fz68r0fhhldHCwJoO2TXU1OjKKVN0Yh7TCx4+bFhJYwIAIAoq4/IoUAYrNvborpfyW1ShNl4ZCQNyMyCkqQIBAIgyEgbAuPHRTiVYUgEAEGFBrBeDyhTm756EAZC0YWtSv3+amY0AANEUNy2gXV38r6pWqd99PITWcBIGQNJvn+zUdr6DAQARVVdXp4aGBrW2ttLKUIWSyaRaW1vV0NCgurq6sr8+g55R9bZ3JfWrPAc7AwBQbk1NTVq1apVWrlypYcOGqa6uTjHWRejXksmkurq61Nraqra2Nk2YMCGUOEgYQmDZziGSLpA0W9JYSdslLZL0V0nzfM9tDzvGavKXZ7u0fitXawAA0TZ06FBJUktLi1atWhV2OCijhoYGTZgw4e3PQLmRMJSZZTtXSPqO6Q7WIWm5pCGSDjI/n7Bs51jfc9eEHWs1SPQkdf3DnWGHAQBAToYOHaqhQ4eqq6tLiUQi7HBQBvF4PJRuSOlIGMrIsp33SbrS3J0n6Wu+57aa5w6V9EdJsyTdZtnOYb7nctm7xLyXurV8A29zKbBYHACUTl1dXegnkage/IsuE8t2aiRdZe7e4XvuxenP+577hGU7p0l6RtIhkk4zXZQibdO2pFq3V+4J93ULaF0oFRaLAwCgfyBhKJ+DJc0wt3/YWwHfc5+1bGeBpKMlnVkJCcOvH+/UD+/npBsAAKC/YlrV8rHMdpukJzKUu99s51i2Q0IHAACAUJEwlM9eZvuq77ndGcq9ZLaNknYvQ1wAAABAn7iCXT6TzTbbPGir025PlbSw2BdOdGfKT4rT09NTsrorQaK7W4nu2E6P5Temo7c6UFqJRHcft/ObcSTR3a1EhBZQqvT4gSjr63sDiKJ4bbCn+CQM5TPEbNuylEt/fkiGcjlbt2ZlENX0amvbAEkDS1Z/1L35xmptr9/xhKutMyZpZFF1oHzWr1v79u1tPfn9HlrWrta2mugke5UeP1Ap0r83gCgaN2lKoPWRMJRPo9lmGyHc0cs+RRk3aUrJzgi+MUn6xvtKVXsl6D2nW3NVrw/nVQfC8ezkqWGHUJRKjx8AED2MYSif1OrN2SamT5+HcnsJ4wEAAACyImEon81mOzhLufTLzZszlAMAAABKjoShfF4z20lZyqU/v7iE8QAAAABZkTCUz4tmu4dlO5m6Je1vtpslLStDXAAAAECfSBjK526zbZQ0O0O5uWbr+Z7L1DkAAAAIFQlDmfie+4Kk58zdy3srY9nOHEkHmrs3ly86AAAAoHckDOV1qaQeSXMs27nesp3hqScs27Ek/d7cvd333PnhhQkAAAC8JZZklc+ysmzn05LmmTUwOsw4heGSxpoij0qa63tutgXeAAAAgJIjYQiBZTv7S/qspGNNotAm6WVJt0q62ffcnrBjBAAAAETCAAAAACATxjAAAAAA6BMJAwAAAIA+kTAAAAAA6BMJAwAAAIA+1YYdAABUCst2Zkj6iqSjJDVLWi3pYUnf8j13WdjxAYgey3b2Mt8bh0saI2mlpIckfdf33OVhxwfkglmSACAH5p/+o5JaJX1b0iJJ+0r6lqSYpHf6nvt62HECiA7Ldg6UtEDSCklXSnpd0gGSvikpIekAkgZUAloYACA335I0TNIhvue+ah57xLKdTWYNlfPMVUQASLlSUlzScb7nrjaPPWzZzhZJN0s6X9KXQo4RyIqEAQBy8ytJt6UlCynPme2UEGICEG1/lPSntGQh5UmznRBCTEDeSBgAVCzLdmolfV3SFeYq3rd8z/1mDvsdIukCSbPNauvbTRejv0qa53tu+877+J57dx/V7WW2i4s+IAAlV+bvjd/2Ud3eZvti0QcElAGzJAGoSJbtzJL0hKSvmX/6ue53haTHJH3cDFx+XVK7pIMkXS3pect2xuVY12hJP5K0RdKNRR0QgJIL+3vDsp2Rlu2cJulaSU9J+nnRBwWUAQkDgIpi2U7Msp2LTFegd0m6J49932f6FNdImidprO+5e/ieO17SYZKWS5ol6TbLdmJZ6hov6V7TpeB033NXBXKAAAIXhe8Ny3aSktZL+rOkv0uyfM/dGthBAiVEwgCg0pxk/mnXSPq8JDuXnSzbqZF0lbl7h++5F/ue25p63vfcJySdJikp6RBzu6+6DpD0tKQZkk71PfeOIA4MQMmE/r0h6Z2Sjpb0OUknSHrBsp29M5QHIoOEAUClqZX0sqSDfM/9qe+5uc4NfbA5wZekH/ZWwPfcZ80UiJJ0Zm9lLNs5WdIjkjolHeZ7rlfQUQAop1C/N0y5f/meu8D33OskHSFpPF0ZUSlIGABUmmckvcv33H/nuZ9ltttMH+a+3G+2c8zgyP9VYDu2GeD4rKR3+57LgEWgMpT9e8OynSGW7Zxp2c7xOxc2XRiXm1YHIPKYJQlARSlirEBqNqNXfc/tzlDuJbNtlLS7pIV665//O0yy8Lgk2/fc7QXGAaDMQvreaJf0E0mbLNvZK/07w7KdCWYqZmZXQ0UgYQBQLSabbbYTh/T50qemEgbT/7le0jWS9rJsZ+f9OmhxAPqdgr83fM/tsmzni2aBtvst27nWlJtmFmurM9O7ApFHwgCgWgwx27Ys5dKfH5J2+1iz7WuA83IWbwP6naK+N3zP/ZVlO69L+qykH0tqkrRW0vOSzvI996nShA0Ei4QBQLVoNNvOLOU6etlHvudmnGYVQL9U1PeG3vru8CX5wYcGlA+DngFUi9QqrPVZyjWk3WacAlDd+N4ASBgAVJHNZjs4S7n0bkibM5QD0P/xvQGQMACoIq+Z7aQs5dKfZwYToLrxvQGQMACoIqkZjPawbCdT94L9zXazpGVliAtAdPG9AZAwAKgid5tto6TZGcrNNVsvj9VgAfRPfG8AJAwAqoXvuS9Ies7cvby3MpbtzJF0oLl7c/miAxBFfG8AbyFhAFBNLpXUI2mOZTvXW7YzPPWEZTuWpN+bu7f7njs/vDABRAjfG6h6sWSSljMAlcOyHU/S+J0e3s9s3zCLIqWzfc99exVWy3Y+bVZtrjVzpy+TNFzSWFPkUUlzfc/NtlATgArB9wZQHBZuA1Bp3iFpch/PjU37B56yw0BF33NvsGznSbPy6rFmdeY2SY9IulXSzb7n9pQufAAh4HsDKAItDAAAAAD6xBgGAAAAAH0iYQAAAADQJxIGAAAAAH0iYQAAAADQJxIGAAAAAH0iYQAAAADQJxIGAAAAAH0iYQAAAADQJxIGAAAAAH0iYQAAAADQJxIGAAAAAH0iYQAAAADQJxIGAAAAAH0iYQAAAADQJxIGAAAAAH0iYQAAAADQJxIGAAAAAH2qDTsAAEDhLNv5p6QDJd3le+57wo4HKIZlOz+SdImkrb7nDg47HgBvIWEA0G9ZtnOWpFuKqOJs33N/E1AsX5DU7nvuL4KoL2iW7UyQdIakYyXtIalJUlzSRkmvSnpI0u98z10SdqzpLNt5n6R9JV3te+62PPdNJVuP+Z57ROmiDIf5nZ4p6ThJsySNkFQvaauklZKel+RK+rvvuYmw4wUQXSQMAPqzDZJe6OO5PSQ1mpOnxRn2L5plO8Mk/UjSy5IilTBYtlMr6XuSLpbUYB7eYk4oGySNlzTb/HzVsp0bJF3ie257yKGnfFXSOyVdJymvhKE/s2znfEnXSBpgHmqT9Lq5PVbSO8zP6ZKesmznZN9z3wwxZAARRsIAoN/yPfcfkv7R23OW7fxL0n6S/ul77tElDuXdkmIlfo28WbbTKOku06ogSX+T9ENJz/ie22PKxCXZkr4o6UhJF0h6h2U7x/ue2xWB+PcOM4YoMq0uqcTUN0nVM77nJtPKzJT0eUmflnSwpL9KOiq8qAFEGQkDAJTeu8MOoA8/N8lCUtKnfc+9cecCpqvKHZbteOYq/qclHS3pW5KuCCfst71TUl3IMUTRV8z2JUm277ndOxfwPXehpPMt22mX9DlJsy3bmet77t3lDxdA1JEwAECOTPedj0v6kDlZHWG6NC0zV3Kv9T13VVr590i6I62KvSzbSV3l/bnvuRellR0h6UJJJ5nuUkNNF5tFku6U9FPfczcGeCzvlvQJc/dnvSUL6XzPTVi28xnTNWm0pIF91HuApItMuXGmZWWdpCcl3eR77vw+9htsjv8USXtKGmLGT6yRdI+km33PXZRWdstOVbxp2Y4k/cf33LK1OhR6vGZfy5ysH2SOd4UZU3C1+f+8xhQ92vfcBTnGEzctZ5J0X2/Jwk6+bxLG/5ixKr3VeZCkz5oWprGS2k35P0j6ZW8tTeZv5Qzzt7KvpFGSuk1Xtwcl/dj33F5fL8vx1Uo6O63e4ZI2S3rRtJDd5HtuR771AsiMaVUBIAeW7YyU9LCkX0s6wZwwLzYJw/6my84rlu2ckLZbqxlD0Wrut5v7L5gTp1Tde5irwd+RdIikHpMoJCUdIOnrkv5l2c5uAR7SJWa7VdI3c9nBnHweI2mc77mf2/l5y3aukPRPc0I3VdJacxI83pzg3W/Zzi8t24nttN84MwD3KkmHSUqY4++StI+kyyS9aNnOKWaXhHkPV6VV85J57JVi3pR8FHq8Zt9LJN1nunuNMp+HweZz9LSkaWnF8xkvkky7nfXz4nvuOt9zv+B77q98z32tlzi/ZJKfj5o4XzPv/6GS5kl61CS76fsMkPSApF9JOt4kQ0vNif0MSeeaz/PcPI5Llu2MkfSEpBvNQO6YiWeQafWaJ+lp83kCECASBgDIze/MSVKHuTI/0vfcd/ieO9Fc0X3RnPD9xbKdiXrrZOwR33P3l3S/qWOJ77n7m5+r0ur+rTnJ3Cxpju+5Tb7n7ul77jBJp5mWht1MF6KimRNYy9y9w/fcTbnua04wd5lRx7Kd90u60pzE/UnSeN9zp/mem5pxaZ4peq65Ip/uO5KmmyvzR/ieO9q8txPM4/eZAdi/smxnoO+52837mv4eHmPe1/cX9KbkqZjjtWxnb0k/MHefljTN99zpvueOM+MIGiRdn7ZLzjMYmbEnz5q777Ns59zeEpYcj/EU0wIRk/QN85nf0/fckeZz2W5aR67faddvmNYImXESI3zP3cP33GaTXL9qJhz4jWU7vbZU9RJLjaS/SHqXpDckzZU0xvfcWSZh+LCkFtPq8IdCjxlA70gYACALy3YOM12FJOly33NvSe+G4Xvuv01Xmk7TlWiXq+8Z6p5iujfJdDvaoQuL77m3SbrB3J1r2c7QAA5puqSR5vYTAdQnc/Isc7J6uu+5b6Se8D13s++5F5tuW5J0helakpIadP1r33MfS6/UXPX+kKRHTeIVlavHxRzvRWbK2k5Jp/meuzRt34clvUfSXkXE9g3T0lAj6ZemdeYblu0cYdlOQw77p3zfbP/me+6307v6mM9l6j34oGU7k9P2e5/ZPux77k93+lt5wbSiSNIY0zKQi1PTBmU7vufekxrE7Xtuj++5fzYzPsnUeVwexwkgCxIGAMjug2bbIenm3gr4nrssrSXBybVi33OX+Z7bYE7gr+6j2DNmG8+lm0kOxqTdXpWhXE4s29lf0kxz9/rUDEu9uMlsm01rTUqqG8343nbyPXeT77lH+p77kSisAxHA8aa6rT3ge+7KnXfyPfd5SbcXGp/vufeYLkSpMS97mW5nj0jabNnO45bt/MCynaPMmIfejnEfM+2qJP2+j5e6RdJnzGu93W3K99yZprXtvX3s90za7d1zPKxUMvCU77m9Jrm+595nurJJUllamoBqwaBnAMjuXWb7ou+5WzOU+6fpk767ZTvDfM9tzVB2B1kGNLel3W7Mtc4MhqTdznQ8uXpX2u0nM5T7Z9rtd5oTWJkr8edJOsMMCr9B0tMZTsTDVvDxWrYzSFLqavy/Mux7Tz6J5858z/2TmdnqHEkfMF2H4mbhtkPNz2WSVlq2896G0mIAAAlnSURBVFPTupXe9Sl9Zq9e1zIxA/yv6+O5rRk+W4V8ng8225eylHvKjJM4MMd6AeSAhAEAskt1g1mRpdzqtNtj0gY7Z2XZznvNldoDzEw0g0q4dsP2tNtBdHFK7yaU6T1Kf3/Gpt2+3PRtP9isTHympA2W7SwwycTtvueu7qW+sBRzvE1pv9dMx7SwiPgk0zVK0k8k/cQsHniopMPTEoaBkiaaRQVPMtOqprodTUiral2+r23ZzoGSPmVeZ7JJUgvq1WDGI6Te83Ms2zknh92i0nUN6BdIGAAgu0Fmm222mvTnB2Uo9zbTt/3Paf2+JelNM2tO6uRtqJmFJyjpJ7nTMpTLVfqx9vke+Z7bYVoQYun7+J7batnOkWa2obNN4jDSXGF3JM2zbOcPkj7ne24gq28XqZjjTR/km2n6z5yTzVyY1q57zI/MWIZTJX3XXJE/xiRu3za7pB9jZz6vZdnOpWZQdypB2GJmM0q1ONSY2a9y1WBaR2QGPK/NYZ+2HMoAyBEJAwBklzrRGZClXPrzuZ6wXJCWLNwl6fOp9QZSelnPoVjLJK0302QelTa4tVDpXU8G9HWCaVZmTl1d3+H9MQNjb5R0o5k+c44ZDH2quSr/cUkzLds5vLdZmsqsmONNTxIyLTo3JMNzRTMtCX+xbOd+M8PXeNN9KZUw5HSMOzPjO1LJwkLTyvBoeveyPtbRyBRru2U73eac5Vbfcy/N51gBFI9BzwCQXWpg8KQs5VLP9+R4FVSSPmK2qyW9b+dkwWjKsa6cmJO3u8xdy8zUlBPLdna3bOday3bSByinD5zO9B6lP9dndxwzdesffM/9pDmRTU1BenDa+xWmYo43fazKGPWtqJafnWZl6pNpsbnT3J2Y9lSux7izD6WdW5zme+7DvYxFKeTznBocnk8sAAJCwgAA2T1ttvtYtpPpym9qJpxXfM/NtYUhNQD2Kd9z+7qKe1IfjxfjWpPY1Ej6WS47mL7kN0m6WNK/zQBepb0/Mn3k+5I+U1D6TDl9nuD6ntvle+6X0rpR7Z9LrCVW8PGawe0t5rFM3XLyWtQsxbKd6yzbWSLpJbN2QS5SLWPrd47XOKSP1xpl2c7N5id1rKnP80bfc/saoFzI5zn1ns/OdFyW7dQXUDeALEgYACC7P5ltvVmIaxdmMa7UPPF/3Onp1BXW3ro0pRKLXq+6WrZz4k6z5QQxS5J8z30urSvSyZbt/CTTYlfmhP6WtDUTvpOaMcqcGKZODs/vbapOc5J3gbm7ODWDkGU7J1q2s1DSsr7WCDBxpd679EXm0q9cZ+suFphijtd4OFVs51WSzb777jSmJR9tZqrSPXJZD8SynUlmDRGZBfKkt47xRUkvm7vn9XGSfprpxnSOpNTYktTneUhvv0+zqOHX0x7K9fP8B7NtNoPiezuWAWa19Wcs28l1fQcAOSBhAIAsfM/9p6S/mrtXWrZzZvpJolnY7Xbznbqyl6km15jtFMt2DjL7pGYnSp08HmHZzofT6hxi2c4lklxJX02r60gF55tp8/1/TtKjlu2cYNnO233rLduptWznVEmPp52oXed77rU71fUls91P0q2W7TSl1THarGadmhrzy6lFt8yUnRPNrDz/sGxnVnqllu2MMu9nk0kQ0tcnWJN2+/2W7cSytAAFqdDj/f/t3V+IlFUYx/GfrBLSphe2VEhbpIgFEVJdJYXJC/KyF53LuiivIugm2goVgugiS9eI/lAU/WEhrJveYOlEHAiFyAqhKCOCokSSwUJkYcVqa7r5vXka9jTjKrMR3w/IuDvv+86c2V04z3vO8zyS9KofRyW9VdXhsuzc2yS9L+nAIt/X7qwXwb6qDi9Vdbiu96CqDquqOtzjxn2rnWT9aM9hu/x4k6RX8qaBzquZ8pfvpNh86/+3v8/LJe1pV46qOoxUdQguQzsjqe2nsXnAcc1kZXhf8N/g36tS7hvxgYsDrJP05YDXBTCAZd1ud4DDAOD/parDF57sHUyx6Xs30mUpZ7IJ+ynvS78024t+XFLtbrb5uds8CWz97j4Dm6s6rHO34NV+ruO7tONe0Zjy5PSYS0X+6cnWAyk2sarDYdecfy/FZmIRn8My1+N/3K8nl1097gDoyqxAxil3un65cK1JSXud6Dvvyjgjkq72Y1fSjhSbPT3n3Snpjez1T3jbzirfUV7ucU+m2DyTnTfm1xjNPtcVklak2MwPMPb2s5vzKkA/T6fYTJ/veH3utBO5JemPbBxXeGL8kHsKSNLNDloHUtVhraTpbDVIkmb9M53379ra7KbhEUl3eVWh91o7JD3hMZ5xwvyYE+blrUvb2upV3hJ0yOWB5UCk41yUSxwITUh6LWuIeMxdvh+r6jAlaVLSXIrNaM97udy5N+21Z51rsSb7G/zFnaA/GvTzAtAfKwwAMACXpdzisp/Jk9MNnqB+4rux1/YGCzrbefcRSUd93klJn/u5730n+m1PlNe4pGWSNJFi87CrAm2X9I3PH+lJnj2fcXVTbJ7yndmdkj70JG/ck8qOpCjpfklXlYIFX2ufJ3OvexI47onij76rvmmhyXOKzX7nJjzvO8MrJW10adXvXD3pxjxY8Hk/u6PvV64+NOefxbk2fLvYwWO/f/9IUl7seG27pPs84T7jQKEj6UFJWyWdzo49p/Gk2PyUYrPVW+Se8/7/37xVaaMn7kccpN0h6YaFggVf60nnMLzpcr/XuMzpp85luSUvdes8nNvd/+EHl5Edk/S1u0JX3sq2U9JBj/MiX7vfuDp+L/e6q/qvktb76cNeibueYAG48FhhAADgP8ZJxB/7yw2F6lkAMBSsMAAAsAQWSnjOtHkH8z0lTgFg6AgYAAAYoqoOoarDCUknqzpsKhx2tx8/S7E5XTgGAIaCgAEAgOE64L39krTf3ZEld0Gu6vCspFv9rb1L8xYB4CxyGAAAGDJXznrXCb9yBaNZJ5+339udYrPrXy4DAENBwAAAwBKo6rDelYa2uBfFSlfKOiTpxRSbxfZiAIALioABAAAAQBE5DAAAAACKCBgAAAAAFBEwAAAAACgiYAAAAABQRMAAAAAAoIiAAQAAAEARAQMAAACAIgIGAAAAAEUEDAAAAACKCBgAAAAAFBEwAAAAACgiYAAAAABQRMAAAAAAoIiAAQAAAEARAQMAAACAIgIGAAAAAEUEDAAAAACKCBgAAAAAFBEwAAAAACj6C1ee5PXJS/FtAAAAAElFTkSuQmCC\n"
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwwAAAMMCAYAAAD+fyB7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAewgAAHsIBbtB1PgAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOzdd5wkdZ3/8Xd3T9zZvLCRZQM5o0j4oYJyFGopYsGZxYCeIMbzjBjO8/QORU/v1PMMHGa9Ay09tVAKQSUpIEiWBZbdhY3s7myandTd9ftjv4PNMN1d387V/Xo+HvPonumqru/M9EzXpz7fz+ebiqJIAAAAADCVdLMHAAAAAKB1ETAAAAAAKIqAAQAAAEBRBAwAAAAAiiJgAAAAAFAUAQMAAACAoggYAAAAABRFwAAAAACgKAIGAAAAAEURMAAAAAAoioABAAAAQFEEDAAAAACKImAAAAAAUBQBAwAAAICiCBgAAAAAFEXAAAAAAKAoAgYAAAAARREwAAAAACiKgAEAAABAUV3NHgAAoHM4rvc8SdebT78dBv4bmzwk8HsBUAYBAwDUyaSTsGLGJe2R9LikeyUFkn4cBv5wg4aJIhzXWyjpZZLOkHSMpP0kzZY0ImmbpAcl3SjpJ2Hg39fs8QJAvRAwAEBzdUuaYz6OkfRqSZ9xXO+CMPB/3ezB1cFec6ItSRubPJYpOa43R9I/SrpQUt8Um0w3H8sknSXpk47rXS3pnWHgP9KEIddCy/9eADRPKoqiZo8BANrSpAzDw5K8KTbrlrS/pGdJukDSQebrWUnPDQP/Dw0ccsdzXO9IST+TdLD5Uk7SLyVdbX6H2yRNk3SYJFfSOQUX34YknRsG/jVN/BYAoOYIGACgTiYFDPeFgX90me17JfmSXmS+dH0Y+GfUf6TQvp//gZL+ZKYeSdIfJb251HQjx/UONb+zI82XRiSdEgb+XY0ZNQDUH12SAKBFhIE/KukfCr50muN6PU0cUsdwXC8j6aqCYOF6SWeUq00IA3+VpFMl3Wq+1CfpW47rpeo/agBoDGoYAKCFhIH/gON642aqUsacwG6YeNxxvU+Y+fWSdLak30i6xNQ+LJX0QBj4x09+Xsf1XiDpVZJOlHSgmVYzJOkxU7j79TDw7yg2Lsf17pR0vKSdYeDPNl97sZlGdYKkhZJGJT0i6ReSvhAG/uAUz1OyG0+tjlOBV5qfjcy0o9eEgb83zo5h4O90XO+tJjsxKOk2U5Oy3Yx/uaRHzeZrw8BfXur5HNeLim1r8/t3XO+Nkq4w275T0n9Keo+kt0haIWm04Gfcqr8XAC2AgAEAWojjet0F/5sjSTvL7PJtSS8v8XwzJf2oYJpToZmSjjIfb3Vc79Nh4H+syFM9efLsuF7anIi+ftI2vZKeYT7Od1zvOWHgry8z/mYdZ7L3F9y/LAz8TTY7h4F/l+N6zzRTz3JVjsVGyd//JJdO+j5HLY7TrN8LgBbAlCQAaC3PlTQxneX2MPCHSmz7bHOyeLUpwH2G6exT6L8LgoUNkt4r6TRztfgMcxI5ao75UXNVeiqFJ8H/ZE4Wf22uzJ9gxv0+c4VdkpZL+mIF33+jjvMkx/UWm5/HxPEvr+R5wsC/u8HBQpzf/4Tlkv5e0h8knWu2fanFsRr+ewHQOsgwAECLMO08/63gS58qs8vfmY4+Xhj4T+tg4bje0ZLOM5+OmTn5D07a7Hoz3eR/zOcfk/StKY6VN7fTJX1I0qemyEbc6LjebZJ+Zz5/meN6s8LAL5clacZxCp1ecP++MPC3Vvg8jVby9z/JGyX9WdLpYeCPVXCsZvxeALQIAgYAaIxecwI/Wbek+eZq8d+ZueDjkt4WBv7/lXnOeZLeX+JksU/SV0wdxMYpgoUJV0r6khnHSsf1loWBv7bIthlJdxTMo3+KMPB/77jeI6Y9bJe5cv+7qbYto1HHUUELVZmT6qQo9/ufvO2rKgwWCjXy9wKgRRAwAEBjHCzpnjLb5CV9U9Lnw8D/S4znvDsM/IeKPRgG/u2Sbi/3JGHgR+Ykb7750mJJxQIGSbo8DPx8icfvL1hPYn6J7cpp1HHmFdzfVsXzNFrJ3/8kOyRdV6PjNur3AqBFEDAAQOtImw42Jziu93VJ3wwDP1tie+te/2ba02zTJamw9Wd3wf3eMk9TLgjZVXB/mu0Ym3Cc6QX3Y3VGahE2v/97ypzk22jU7wVAiyBgAIDGKLpwm+N6A5IOMNOSLjZFpF+V9CrH9c4OA393kefcGOfAjuudIemtkp4naUFV38U+5a7CFwY51axHUPFxikz/KvRgGPjj5v5wwddn2g2xqWL9/ivYtpxG/f4BtAgCBgBoMtMJ6UFJDzqud4Wkr5l6htPN/dcU2XW4yNelfSfNKdN7/6IaD7lRnYCqOU656V8rJK0x9wtbqC6s4piNVvL3X8W25TSyExSAFkBbVQBoIaaA9V2StpgvvdpxvUMrfLp3TQoWfiLpxaZGYVoY+KmJjw4vTH2g4P7JTRwHALQkMgwA0GLCwB9xXO+3kl5hvvQ8SatsnsNkFz5Q8KXPhYH//hK7dJd4LHFMEBTXDWaRvJSkAx3XOzIM/PvrOLyiHNfjfRlAyyHDAACtqbB3/bwS2xVzsMkkyKzB8M9ltl9ewTHaQhj4T5igYcI7K3kex/Ve4bjezx3XO2HSQ4VtTzNlnoauQgBaDgEDALSmJQX3K2n1uX/B/cfDwN9VbEPH9Z5dEFx0qsJVid8yxUl/SY7r7SfpC5JeIul2x/UKF4MrrB+YVeapmBIFoOUQMABAi3Fcb96k1YdvqeBpCtuDzi1xrIykSyd9ua2mJ8URBr5fsE5Bl6T/cVzvwDj7Oq43TdKPC4Ku68PAL6wJGSzoHDTDcb2lJZ7ubZV9BwBQPwQMANBCHNfrl3SFpAHzpRvCwC/X8Wcqf5E0au7PdlzvrCmO1WeOdbKkmwseWlbZ6BPvdZIeN/cPknSj43ovKLWD43pHmulMp5kvrZP06sJtTPvWuwu+9PYiz/UBSWdK2lPtNwIAtURxFQA0Rm+JtQF6zfoIJ0l6Y8EJ+yZJb67kYKZw+ofm+STpR47rfVLSH8xiWieYDkorJV1ixnCq2fa9ZuXnXWHg/6mS4ydRGPgbHdc7TdLVkg6TtFTSrxzXu1mSb076n5DUJ+lwM/3onIK6hHsluWHgb57i6b8n6Znm/gcd1ztAUmCyD4tMkHGmaaN7iqTjGvitA0BJBAwA0BgHx1gboNBvJb0lDPxHqjjm+00QcKikOWaO/WSfCwP/X82c/X80XzvCTM9Z22nF0GHgP+q43jPNz+IdJrg6tSCYmsoeSV+S9Mkw8EeKbPNlE1xMTDV7rfkoFEh6t6Q/ms95jwbQEpiSBADNNyZpq6TbJH1F0mlh4D+/ymBBYeBvNVmLT0m6zxTfDpkWrZdLOmWi1arJJLzGbDciabOka2r2HSZIGPh7w8D/oKQDJV1o6hNWSdptFi3bI+kh8/W3SjowDPxLSgQLE9OSzjJrY9wkaYekcbMCc2imQ50dBv5owW7TGvMdA0BpqSiKYmwGAAAAoBORYQAAAABQFAEDAAAAgKIIGAAAAAAURcAAAAAAoCgCBgAAAABFETAAAAAAKIqAAQAAAEBRHb2KpON6XZI+LukSSRlJ/xQG/idi7HeKpIslnSZpgVkM6SFJV0n6UqnFe6rZFwAAAGi0js0wOK53uKRbJH3MBAtx97vErNJ5vqSFktaZVVFPkvRZSXc6rreo1vsCAAAAzdBxAYPjeinH9d4h6Q5Jz5L0K4t9z5X0afNz+5KkBWHgHxYG/mJJp0paK+lwST9xXC9Vq30BAACAZum4gEHSi80Je1rS30ty4+zkuF5a0qXm05+Hgf+uMPB3TjweBv4tks6TFEk6xdyvel8AAACgmToxYOiSdL+kk8LA/2IY+FHM/U6WdIi5f9lUG4SB/ydJvzOfvqFG+wIAAABN04kBw22SnhUG/t2W+znmdq+pfSjmWnN7pimqrnZfAAAAoGk67qQ0DPz1Fe56lLl9MAz8bInt7jW3fZJWSlpV5b4AAABA03RihqFSy8xtuYBjQ8H9FTXYFwAAAGgaAob4ZpjbPWW2K3x8xqTbSvYFAAAAmqbjpiRVoc/cjpXZbnSKfarZt2obH1sTt7AbAAAACbdo6fKatugnYIhvYgXmnjLb9RbcH67BvlWbv+iAJ+/ncllt27JJkjRv/kJlMrwEgKTg7xdILv5+kWS8WuPbZW6nl9mucCrRrkm3lexbtUzX1L/mTKar6GMAWht/v0By8feLpKGGIb7V5nZpme0KH3+4BvsCAAAATUPAEN895vYwx/VKTS063tzukrSmBvsCAAAATUPAEN/V5rZP0mkltnuRuQ0KVpGuZl8AAACgaQgYYgoD/y5Jd5hPPzjVNo7rnSnpBPPpN2uxLwAAANBMBAx23icpL+lMx/W+6rje7IkHHNdzJH3ffPqzMPB/U8N9AQAAgKZIRVFnzXxxXC+QtHjSl48zt5slbZr0mBsG/pMrMDuud5GkL5kOU6Om1mC2pAVmkxslvSgM/Kct0lbNvlV68pecy2a1ZePjkmm3SpcGIDn4+wWSi79fNFhN12HoxAzDkSZAKPyYsGCKx55SpBwG/n9JOlHSt0yAsdwEADdIulDS6cVO+KvZFwAAAGiGjsswdCgyDEAb4O8XSC7+ftFgZBgAAAAANAYBAwAAAICiCBgAAAAAFEXAAAAAAKAoAgYAAAAARREwAAAAACiKgAEAAABAUQQMAAAAAIoiYAAAAABQFAEDAAAAgKIIGAAAAAAURcAAAAAAoCgCBgAAAABFETAAAAAAKIqAAQAAAEBRBAwAAAAAiiJgAAAAAFAUAQMAAACAoggYAAAAABRFwAAAAACgKAIGAAAAAEURMAAAAAAoqqvZAwAAAACSauv4uG7YuVPrR0c1HkWx9jl5xgydOmtW3cdWKwQMAAAAwCS7s1ndsHOnHhge1tqREU0OBcajSPcPDWkon7d+7t50moABAAAAaLbRfF7/88QTunPPHj08PKyxmBmAXdls7G07AQEDAAAA2s4De/fqo48+qjWjo80eSuIRMAAAYCmfj7RqS163rc1p75h06IK0TlqW0UBvqtlDAzrSjmxW9w8Nac3oqMbzed2xZ49u3LWr2cNqGwQMAABY2LAzr/dcOaIbHs495esLZ6b0yZf06uxju5s2NqDTjOXz+s7mzbpi82aNVFBLgHgIGAAAiOmJ3Xmd9R97tW3o6XObN+2K9NYfjOjLOem8ZxA0ANUYzuef0nUoG0UayuU0lMtpJJ/XSD6vjWNjumLz5mYPtSMQMAAAENMl/zc6ZbBQ6AP+iE5antHSOSx1BNi6b2hIX924Ubcwnail8N8MAIAYBvdG+sU92bLb7R2Trrm//HYAnuq6wUG9edUqgoUWRMAAAEAM927Ixdhqn5tWx9+2k0S0qUQRd+/Zow+vWRN74TM0FlOSAACI4er74mcNbLZtpnw+0prtkdbvyGv3SKThcWlkPNLIuDSS3Xc78bXJt6mUdPD+aR21KKMXHtWlmX2lO0Rdvyqrf/nVqL752n4tm8f1Skh7cjldMzioP+zapd/s2NHs4aAEAgYAAGLYXqZ2oRbGspGuvGNcD2zKa/veSP3dKc3ul/LRXz+i6Kmf5yMpykv5KHraduN5aXAo0o7hSKNZaTwXaTwnjeX2HWvXSHXjve7BnKRx6UppRq/0rGUZLZyZ1iHz01owM6Vjl2Q0Mh7p0l+P6jcP7su6/PPVo/rm6/pr8wNDIkVRpCu3btVXN2zQrlx7ZeNmZjJ6xvTpWtTTo1Ih9LEDAw0cVfUIGAAAiGFmf33XWLjx4aze95MRrd2ezCkZu0el61flJJU+AfzlvVndvDqrU1dyCtIpslGkP+zapVXDw1ozMqJfbt/e7CFZ6U2ltLK/X0dOm6aD+/vVlXr6/4JZmYwOnzZNS3p7mzLGeuOvFQCAGGaVmXIzWRRFSk1xYjGV1VvzuuC7w9rdIQvS/uPPR/Wrd2aUSbPQXTuLoki/2bFD/7F+vdaPjTV7OE86acYMXbx4caxt+9NpLe/rmzJI6CQEDAAAxDCjz2774XFpWk+8bd9zZecEC5J078a8/udP43rNiTF/QGhZD+7dq3uGhvTIyIhyBQXLm8bGdFOLdTua3dWljyxdqjPmzGn2UBKHgAEAgBhmWU5J2jUSaVpP+X0G90a6fV3nrVB76a/HdPYx3ZphmblBa9idy+nSdev0q8HBZg+lqBfMmaOFPT2a3dWlYwYGdNS0aepJU3BfCQIGAABi6O2yO7HdORxp4czy292+NqdO7CT5xJ5I//HbMX3khe0557udPTE+rreuWqV1o62XFhtIp3XhokV6zfz5sacEojwCBgAA6iBuB6JGdF9qVV+/YUyvO7GbNqsJsiub1TseeqgpwcIBvb0aSKfVn06rP5NRbyqltAkKZmUyOri/X2fNmaO53d0NH1u7I2AAACAG2yzAruF4OwyPd27AMJajzWqSDOdyevcjj+jhkSr78Vo6rL9flx92mPqZTtQ0/OQBAKiDHTEDhpHxug+lpV37l6we39F5NRxJMx5Fet/q1bp7aKihx13S06PPr1xJsNBk/PQBAIghkl0mYNdIvO33dnCG4aXHdumG9w7ogNmcjrS6723erD/s3t3QY54xe7a+eeihWtSmaxskCVOSAACog50JyjBk0tJh89Ma6E2pv1vq706pr1vmI6W+Lqm/Z9/XutLS6ici3bMxp3vWV5YZOGZJWp98Sa9OWcFpSBJsHBvTNzZubMixLlq0SAf19+vw/n4tJlBoGfylAgAQg3UNQ8wMg20Nw8WndSudSimVktKTPlIpKZ0u+FwpDfRK8wZSmt6bUk9G6u5KqTsj9WSk6b0pdWWk/QZS6rHsAiVJa7fldfV9WX3xulHtNNPaZ/XpyfuTHbx/Wu84vUcvf2aX0izalhg/3bpVo3Vs5bVfd7fevnixzp47l85GLYqAAQCAOtg5HG87mwzDO5/Xo0taqA3psnlpXXRajy467ekLsA2PR3pgY16Dw5H6u/Ztu3hWihPChMlHkX6xfXvNn9eZPVsr+vq0sr9fp82apV5qFFoaAQMAADHYXl+NOyXJJsPQn6Bukf3dKT3zwEyzh4Eq3b57tzaNjdXkuVb09em9S5bo1FmzavJ8aBwCBgAA6iDulCSbDEN/N1fn0Vg/ryC78Mr999f0zF+DxdldXTqkv18nTJ/+5LoJSBYCBgAAYrCdwl2XDMPTZ/4AdbM7l9NvBget9gmPOYaF09oQAQMAAHVQjwxDXwWFycB4Pq+7hoa0anhY28bjv+B+um2bVbHzmxcuJFhoUwQMAADEYF/DEG87mwxDH+disHTnnj3613Xr9EidV2dOSTp3v/3qegw0DwEDAAB1sGskUhRFZbsCUcOAerlvaEgXPfSQsnVsiTrhpBkztLCHOXPtih5WAADUQS4vDcVoLkOGAfUwnMvpQ48+2pBgQZLOnjevIcdBcxAwAAAQQyXnXXEKn60yDD1kGBDPVVu3akON2qGWM5BO6/mzZzfkWGgOpiQBAFAnu0YiLZn0tT2jkdZtz2vt9rzWbY+0Y69FhoF3bcQwnMvpO5s3N+x4L5g7V30svNbW+NcDAECdXHnHuLrSWT02uC9AWLs90vahyqeIkGFAHFdt3art2WzDjnf23LkNOxaag4ABAIA6+ervLeYbxUANA8ppdHZhWW+vjhkYaNjx0BzkjwAAiKFBtaMl9RMwoIxGZxcuWrSobCcwJB8BAwAACUFbVZTS6OzCs2fOlDNnTsOOh+ZhShIAADE0O8GQSUu9vGujhEZlF1KSXjt/vi5evJjsQofgXw8AAAlwxMK0MmlOzjC1SrMLf2uxOnNPOq1D+/t17MCAlvX1WR8LyUXAAABADM2uYTj9EN6yUdzVg4NW2YVZmYx+fvTRGshk6joutAdqGAAAaHELZ6b0ruf3NHsYaGHXDg5abf+6BQsIFhAbAQMAADE0K8OwdE5K335Dv2b2MR0JUxvJ53Xnnj2xt5+VyeiV++9f1zGhvZDfBACgxfR2SUctSuuFR3XpdSf1aM40ggUUd/eePRqziGjJLsAWAQMAADHUOsGwcGZKS+ektWxuSsvmpnXg3LQONPcXzEgpTYEzYvrj7t2xt+1Pp8kuwBoBAwAAdTDQIy2bm9bSuX8NCvZ9vi9QYE0F1MqtFgHDCdOnk12ANQIGAABisKlhOGl5Rj+9sJ8e9ai7ndmsHti7N/b2J8+cWdfxoD1R9AwAQI3NG0gRLKAhbt+922q63EkzZtRxNGhXBAwAAMRgc1JGqIBGsalfmNfVpYNYcA0VIGAAAABIKJv6hZNmzCDzhYpQwwAAaDtb9+T1h0dz2jYUaemctJ61LFP1OgY2NQyck6ERNoyO6rHR0djbn0T9AipEwAAAaBsj45E+dfWoLr95/ClfnzNNes8ZvXrLqd20K0XbsMkuiPoFVIGAAQDQFnL5SK+8fFi3rsk97bHBvdI//mJUO/ZG+sBZvXUfCxkGNIJNwLCst1cLe3rqOh60LwIGAEBb+MaN41MGC4W+cN2YnnNwRqeutH/7q/XCbehc2SjSupERrRsZUelXbHFRFOnXg4Oxtye7gGoQMAAAEm/vWKQvXBdvLvdVd2QrChhskGDAVHJRpGtGRvW9++/XzlyloUJlqF9ANQgYAACJ9+M7x7VrJN621/4lW9lBSDGgClEU6St79uqakfhFyrWSlvSs6dMbfly0D9qqAgASbTwX6d+vH4u9/RN7Iu0aqe/ZPzUMmOyXg4NNCRYk6Yhp0zSzi2vEqBwBAwAg0a66I6v1O+wCgEe35q2PQ4IB1fjxtm1NO/bJ1C+gSgQMAIDEGs9F+uL19ldtH91mHzDYIMGAQk+Mj+u+4eGmHZ/6BVSLgAEAkFhX3ZHVuu321/4ryjCQYkCFHh2JWWBTB72plI4dGGja8dEeCBgAAIlUaXZBjcgwkGJAgXVNDBhOmDFDvWlO91AdXkEAgESqNLsgSWsqCBgiqhhQoXWjzSl2lqSX77df046N9kHAAABInGqyC5K0emuduyTV9dmRNGualGE4acYMPWfWrKYcG+2FgAEAkDjVZBckaduQfWtVahhQqWZkGE6eMUOfX7lSaebHoQZoygsASJRqswsTHt2a13EHZGoypqfhHA3GeD6vDZYBw5HTplV0rL50Wsv7+vS8WbN06syZShEsoEYIGAAAiXLlHeNVZRcmPLrNLmAgwYBKrB8bU85i+2uPOUZzurvrOCLAHlOSAACJMZ6L9MXr4q/qXEolrVUBWzYdkmZkMprNisxoQQQMAIDEuPKOcT02WJtr/batVW1qGJgIgglrLKYjLevtZRoRWhIBAwAgEWqZXVCFrVUBWzYZhmV9fXUdC1ApAgYAQCL80y9Ha5ZdUAWtVW225iIxJth0SDqwt7euYwEqRcAAAGh53/njmC6/ebymz1lJa1XA1lqbgIEMA1oUAQMAoKXd9EhWH/lZffrY2xQ+U8MAW0O5nLaOxw90l5FhQIsiYAAAtKxHt+b1d98fVrZO5Qa2hc+ADdsF25iShFZF7y4AgLWR8Uj3b8xr1Za8xnOR8tG+K/D5SR/7vhY9+XkuX2a7/FO/dv2qrAb31u/7qFdrVWoYIElrLQqeF3R3qz9Tp4UEgSoRMAAAYsvmIn3txjF9LhzTSLbZo6meTYbBZkoSINuCZ+oX0MKYkgQAiCWKIr3l+yP61NWtGywcMj+t95/ZE3v7erVWJcEAWWYYmI6EVkaGAQAQyw9uG9ev72/RSEHSnGnSt1/fr79szsXex6a1KgkG2LLpkETBM1oZAQMAIJZv3FTbtqa11JWWvvHafq3YL62xXPxT+4nWqjP7apsToIYBURSxaBvaBlOSAABl7R6JtGpL63YU+vQ5vXr2QfuugR041+6tLXbhMykGWNiWzWooH/9vhgwDWhkBAwCgrPU78i1b9PvmU7v1+pP/WrfQ353S4lnxL/HXo7UqCQbYZBcykhYRMKCFETAAAMoai18W0FCnH5LRJ1789BOtFfPiv73FzTC0aLyEFmVTv3BAb6+6mMeGFkbAAAAoK9uCAcNB+6X0tdf0qyvz9BOtFftZBAz1yDBw8tfxbDokUb+AVkfRcwUc18tIOl/SqyUdL2mOpFFJayX9VtJXwsB/oMT+p0i6WNJpkhZIGpb0kKSrJH0pDPz4/2UAoAHG8611fX3BjJS+/YZpmtU/9Ym5TYYhbmvVVp2ShdZktQYD05HQ4sgwWHJcb56kmyRdIeksSTMlrZG0V9JRkt4u6S7H9d5WZP9LzP7nS1ooaZ2kEUknSfqspDsd11vU+O8MAIobb6Fuqicvz+jnb5umg/Yv/ha2Yr/4V/htWqsCcZFhQDshw2Dvu5JOlpQ1wcHlYeDntC8YOFjS1ySdIekrjuvdHQb+TRM7Oq53rqRPm0+/JOljYeDvNI/9P0k/lHS4pJ84rndqGPi8iwFoCeMWs3am90qnHdyldFpKp/Z9pFJ/vZ9JSelUSqmCx6faLp2S0unUk/cXzkzpuCUZHb80U3YMKy2mJMVtrWrzD5kJSZ0tG0V6fGws9vZ0SEKrI2Cw4LjeQZJeZD799zDwv174eBj4Dzuu90pJj0nqk3ShySbIcb20pEvNpj8PA/9dk/a9xXG98yTdJukUSeeZKUoA0HQ2GYZlc9O6/Pz+eg6nrEpaqx53QPlABIhj49iYshZz2A4kw4AWx5QkO4cU3L9hqg3CwN8q6cEptj+54PPLiuz7J0m/M5++oSYjBoAasKlh6GqB8+56tFa1qmEgxdDRbKYjTUuntV8X12/R2ggY7GwsuD+jxHbTzO2mgq855navpFtK7HutuT3TcT3+gwBoCTZdkrpb5J2lHq1VgThsC57pqoVW1yL/1hPjPkmPmPuvnGoDx/UOk7TSfPrLgoeOMrcPhoFfKrl/r7ntK3geAGgqm3UYuqdoc9oMtW6tapVgaI0fAZqEgme0G65gWwgDP2u6H/1M0ksc1/uepM9JWiVpuqRTJX3GLNr4W9NJacIyc7u+zGE2FNxfYZ67KrnsX+OTXG7q+wBaXzP/fj6e3GEAACAASURBVMfG40cMXenoKf93mmXZnPin+I9uzZcdc5SPn4WI8uWfD+3LJmBY2t3NawU1l6nxNDcCBkth4IeO6z1X0ofNOgyvnbTJWkkfk/TZie5JxsQUpj1lDlH4eKlpT7Ft2fj4lF/ftmXTlF8H0Poa/fe7fXuvuS5SXpQd0ZaNT9R9TOXMTXebztflPfJEtuyY9+zuL5hxWtrI3iFt2bgl1rZoP2v27o297ezhoaLv00ClFi1dXtPnY0pSZU6RdJj5+Y1JeljSxDvDIpNpOG7SPhM5x3J91gonPpKnBNASsvn4c2y6WuSd5cBZ8TMCg8Np7R5lHhGqNxJFesIiG7Uk0wJdAoAyyDBYclzvCklvlLRd0gWSvlOwDsMSSf8s6U2Snu+43rlh4F9tdp3IT/aUOURhM+bhWox5/qIDnryfy2WfvDI5b/5CZTK8BICkaObfb9/qcbP8THkD0/o0f9Gsuo+pnBn7RQX/essb6l6kgxYVj3YGpsf/GUwbGND8RXNiHxvtY9XwsLR1MPb2xy1ZqukEDWhxnC1acFzvpSZYkKTXhIH/68LHw8BfL+kCx/VmS/Ikfc1xvZWmyHmX2axcTr9wGtKuEtvFVmweWybTVfM5bgAao9F/v9kofg1DT3e6Jf63TO+SFs8a1Yad8WoZ1u5I6RnLSow7Hf9nkEq3xs8Ajfe4RT3CvK4uzWLRNiRAiySOE+M8c7t5crAwyY/M7dKCqUmrC75WSuHjD1c4TgCoKYua55Zpq6omtlZlclPnWkeHJLShFvq3ngiLze3OMtsV5iIXmNt7zO1hjuuVmpZ0vLndJWlNheMEgJqyCRi6WqStqmrcWtVq4TZ0rLWWazAASUDAYGciEFjmuF6pn93igvvbze1ELUOfpNNK7PsicxuEgc/bE4CWYLNwW08LTce2yTCsibEWQ1ysw9C51lsEDGQYkBQEDHZuMLe9pqVqMS83t3sk3al99Q13SbrDfP2DU+3kuN6Zkk4wn36zZqMGgCqN5+Jfv+hqpYBhv/hn7qu3lv4euYKDOHbn4kfXB/SU64MCtAYCBjvfKlhY7UuO673Rcb0n3xod15vtuN7nJL3YfOnzYeAXXmp4n6S8pDMd1/uqKY6e2NeR9H3z6c/CwP9NQ74jAIjBZkpSK2UYVlpMSdo2FGnXSG3CAhIMnWvIoqXqDArjkRAEDBbCwN9tpgytkzTHrOQ87LjeQ47rPSRpq6R/MJtfIemTk/a/XtLbTV++iyRtclzvL47rbZJ0jaT5km6U9LrmfIcAMLVxi9k6rVTDcOBcu7e5koXPpBgQw16LDMNAmtMwJAOvVEth4N8t6ShJ75F0vaQdkpabuoVHJX1P0hlh4F8QBv7T3nnCwP8vSSeabMVms2+Xme50oaTTw8Avtxo0ADTUeDb+2XIrdUnq705p8az4AUy5wue4qGHoTFEUacgiYJjG+gtICHJhFTAn9P9uPirZ/89mcTcASASbDEN3i72zrJiX1oad8U7iSmUYSDCgnLEoksXsPTIMSAxeqQCAsuzWYWity+u1bK0KlGIzHUlkGJAgBAwAgLKsAoYWOweqVWvVyGIhhtYKmdAoNgXPktRPhgEJwSsVAFBW1qKtassFDDVsrQqUMmxTv5BOK02xCxKCgAEAUNaY1UrP9RyJvVq1VrUJJTgP7Ew2GQamIyFJCBgAAGXZrfTcWmfLNW2tCpRAS1W0K16tAICykpxhqFVrVYsSBnQoMgxoVwQMAICysvn4Z8uttNLzBJvCZzIMqJRNhmEaGQYkCK9WAEBZNl2SulrwnaUWrVVtMgzUMHQmqwwDAQMShFcrAKAsu7aqrXe2XKvWqkApVhkGpiQhQQgYAABlJbmtqmrUWtWqS5LFtmgfey0yDAMEDEgQAgYAQFlJLnpWDVurAqUMUcOANsWrFQBQlk1b1VacktTo1qrUMHQmMgxoVwQMAICyxi3On1txSlItWqvSVhXlkGFAu+LVCgAoazxrUcPQou8sjWytSoKhM9lkGCh6RpK06L91AEArscowdNVzJJWrtrUqCQaUw0rPaFe8WgEAZVm1VU235vX1RrZWpYahM5FhQLsiYAAAlBRFkd3CbS16HlRta1VqGFAOGQa0K16tAICScpYX23taNGBoZGtVMgydyWqlZzIMSBACBgBASTZrMKiFMwyNbq2KzhJFERkGtC1erQCAkrLWGYbWvLxei9aqQDEjUSSbVwwZBiQJAQMAoKQxi5aqauEMg6psrWpTw9CaIRPqySa7INZhQMLwagUAlGSbYWjVdRhUg9aqQDE2AUNaUh8BAxKEVysAoCSbDkmplJRp4XeWalqr2uRZUlQ9dxybguf+dJrXCBKlhf+tAwBagd0aDK19slxta1WgGKuCZ+oXkDAEDACAksZz8U+cu1v8PKia1qrUMKAUq5aqTEdCwvCKBQCUZJVhaPGAgdaqqBebDAMBA5KGVywAoKSs1SrPrX1tvZrWqlYTlFr7x4A6YNE2tDMCBgBASeMWF9lbdZXnQtW0VgWKGSbDgDbGKxYAUNK4xToMrbwGw4RKW6tSw4BSbDIMrPKMpOEVCwAoySbD0MprMEyoprUqUIxVDQNTkpAwCfjXDgBoJrui59a/tl5pa1W7dRgsB4XE20uXJLQxXrEAgJJs2qomYUpSNa1VgWKGqGFAG+MVCwAoyaZLUhKKnhvRWpUEQ+exyTCwcBuShoABAFDSWBu1VVUVrVVtip7RecgwoJ3xigUAlGSTYUhC0bMa0FqVGobOY5Nh6CdgQMLwigUAlDRmUcPQ3VXXodRMJa1VSTCgFJsuSbRVRdLwigUAlJRts7aqorUq6oCVntHOEvKvHQDQLO3WVlUVtlZl4TaUYrUOAxkGJAyvWABASTZtVbsTcuGU1qqopXwU2XVJImBAwvCKBQCUZJNhSMI6DKq0tapNhoEUQ0cZsQgWxJQkJBABAwCgJJuAoSchU5Iqba0KTMWmfkFMSUIC8YoFAJTUjhkGVdBa1WZSUjLCJtSKTf1CRlIPKSgkDAEDAKCkbD7+qXISVnqeUElrVWAqVmswpFJKETAgYQgYAAAljWXjb9uVoHcV29aqkUWbJM4HO4vNKs/9vDiQQAn61w4AaAardRgSUsOgClurAlOxmZJEwIAkSsianACARtm6J6+71ud1z/qc7lmf1y2Pxk8xJKWtqipqrRr/uTkl7Cw2Rc/9vDiQQAQMANChoijSpl2R7lmf1z0bcrrbBAgbd1V+NT1JRc/WrVWpY0ARVou2kWFAAhEwAEAHiKJIj++IdM/6nO42AcI96/N6Yk9tp9okqeh5orXqhp3xfgZWAQPnhB3FLsPAiwPJQ8AAAG0miiKt2RY9GRTcvT6nezbkNLi3/sfuSlANg0zh84ad8a4Oj4zXfThIKJsMQx8BAxKIgAEA2sAjT+R15R3jum1tTvduyFnNt6+l7oS10lixX1o3rbZYaCImTgk7i21bVSBpCBgAIMHGc5E++n+j+s4fW+Py9zKLVqWtwKa1KlAMbVXR7ggYACDB3vW/I/rpXRYLJdRRKiUduyRZJ+A2rVVtcE7YWWwyDBQ9I4mS9Z8dAPCk3z+UbZlgQZLOP6lb82ck623FprUqUIzVOgxpAgYkD/8pASChfnxna0xDkqTjDkjrQy/obfYwrNm2Vo2Li8idhRoGtDsCBgBIqPs3Nn9dgJl90ptP7dZP3jpNc6Yl70RoorUqUA1qGNDuqGEAgITavre2ayjEsXxeSscszuiYJWkdszijk1dk1N+d7BMgm9aqwFTIMKDdETAAQELl6phgSKX2ze8/dnFaxy7ZFyActSij2QnMIpRTj9aq7fdTQilWNQy8OJBABAwAkFDjNQoY0inpkPlpHWuyBscsSevoxRlN7+2MMxtaq6JarPSMdkfAAAAJlc3ZT0nqSkuHL0jrGJM1OHZJRkcsTGtaT+eexNSjtSrnhJ0jF0Uaoa0q2hwBAwAk1LjFLJoPntWj5x3apcMXpNWX8JqDWqO1KqphU78gMgxIKAIGAEiorMV5yjnHdmsFJ8ZTqkdrVU4JO4dN/YIk9REwIIF49wCABIqiyCrD0JWp52iSjdaqqIZNwNAlqZuAAQlEwAAACWTbIambgKGkWhc+c07YOWwKnqlfQFIRMABAAtl2SOriv31JTNdCpexaqhIwIJn4DwkACZS1XDagO8OJSik1zzBQxdAxWLQNnYCAAQASyKbgWUxJKqserVXRGcgwoBMQMABAAtkGDBn+25dU69aqnBd2DhZtQyfgLQQAEsimQ5IkdfPfvqR6tFZFZ7DLMNR1KEDd8B8SABLIZpXndEpKpzlTKaXWrVX5aXcOqwwDf4dIKAIGAEggmylJ1C/EU+vCZ3QGahjQCRq20rPjegOSTpF0gqQVkhZImmYe3itps6RHJd0h6Q9h4O9p1NgAIGmsFm3jPDiWFfulddNqy7lexXBe2DFsuiSxDgOSqu4Bg+N6L5N0gSRHUk/M3cYd17tW0hWSfhIGfvzcOwB0ADIMtUeGAZUYIsOADlC3gMFxvZdK+qykQ8yXJv5KIklbJG00mYWUpH5JiyTNN5/3SHqR+XjYcb0PhIH/s3qNFQCSxirDwBoMsdBaFZVgHQZ0gpoHDI7rzZH0TUkvKwgSbpX0U0k3SLojDPzhIvv2S3qmpOea/U8yAcdPHNf7maS3hIG/vdZjBoCkyebjJ17pkBRPLVurclrYOcgwoBPUNGBwXO9oSb+QdKCknKRvS/pCGPj3xdnfBBI3mY9LHdc7UtLfS3qDpHMkPdNxvZeEgX9vLccNAEljl2Go50jaB61VUQkyDOgEtc4w3CRphqTfSro4DPy/VPNkYeDfL+nvHNf7vKT/lPQ8k6WYU7shA0DyZC0CBmoY4plorbphZ/Vlc5wXdg66JKET1DpgmCbpfWHg/1stn9QEHmc4rvdeSZfW8rkBIInGLYqeM/R+j23FvLQ27KxRpyR0BFZ6Rieodf71BbUOFgqZ535hvZ4fAJIiZ9MliZk2sa2oUR0Dp4WdY5gMAzpATTMMYeBfZ7O943o9BdOLBsPAH6v1MQCgHVHDUB+0VoWNbBRpNIo/ha2feAEJ1bCF2yY4rrdI0vskvdQs4Dbx55N3XO8hSf8r6d/CwN/V6LEBQFJYdUkiYIitVq1VuZDcGWzqF0SGAQnW0EspjusdJunPpvPRQZKGJK2XtMl0VTpc0sck3eG43pJGjg0AksRupWdOUuKqZWtVtD+b+gURMCDBGp1huFTSXEkflvTtMPA3TTzguF5K0omSPinpLLPt+Q0eHwAkAl2S6qNWrVU5LewMNhmG3lRKGQIGJFSjA4bTJP0wDPzPTH4gDPxI0q2O651jsg4UNwNAETZdkqhhiK+WrVXR/mzWYBjI8IeI5Kp57tVxvesd11tR5OF+SdtK7R8G/qikQUkDtR4bALQLqwwDs2ys1KLwmQvJncFmledpaf4QkVz1ePWeLulux/XeOcVjD0p6heN6Bxbb2XG9l5v6hgfqMDYAaAtZqwwDZ682atVaFe3PZkoSAQOSrB5Tkt4g6YuSvmhO/i8IA/9h89h/SLpc0oOO610v6S+SdpnAZX9JJ0k6XlIk6bI6jA0A2sJ4ji5J9UKGAXHZFD1PY0oSEqzm4W4Y+N+VdISkn0p6jqS7HNd7r+N6qTDwr5D0LknDpkbhPZI+Lumjki6U9AxJT5gg40e1HhsAtAubKUkZLmxaqVVrVbQ/mwzDABkGJFhdXr1h4G8JA/88Sa82rVMvk3ST43qHhYH/ZUkLJD1f0sWSPmI+3maKopeEgf/teowLANqFzZQkahjs1KK1KiFHZ7DKMBAwIMHq2iUpDPz/cVzvN5K+Iunlkv7suN4nJF0WBv7vJP2unscHgHZFDUP91Kq1KtqfTYahn4ABCVb3V28Y+FvDwH+lpPMk7ZD0L5L+4LjeUfU+NgC0K5uF26hhsDPRWrUa1DB0Bpu2qtQwIMkaFu6Gge9LOlLSDyQ9S9KfHNf7qON6/AUBgCWrDAMXNq3VovAZ7Y8aBnSKhr56w8AfDAP/fEkvNesx/JOk2xzXO66R4wCApKNLUn3RWhVxWGUYCBiQYE159YaB/wuTbfi2aaN6q+N6/+S4XqNXngaARKKGob7IMCAOq4XbmJKEBKvLCbrjetNM16OzJR0uaY6krKQtku6Q9D0zRekCx/V+JOkbprXqyxzXuyAM/D/VY1wA0C6sahg497VGa1XEYZNhYEoSkqzmr17H9ZZIulvSZ02b1PmSuiX1S1omyZN0leN6P3NcLx0G/jWSjjJBw9GSbnFc718c1+up9dgAoF3YrMPQxYVNa9W2VqXouTNYZRgIGJBg9Xj1fkbSSkk3SzrLrODcLanHBAyvl7RW0kskXaR9U5T2hIF/kSRH0uOSPiTpzjqMDQDawrjNOgwEDNZorYo46JKETlGPKUkvMCs5O2Hgj0x67DFJ33Nc7y5Jd5ni5/+ceDAM/Osc1zvaBB0X12FsANAWshZFz11pLnfbmmitumFn/J9zIX7incGmSxIZBiRZPV690yU9MUWwUGiduZ01+YEw8PeGgf9OSafXYWwA0BZoq1p/FD6jHJuVnqlhQJLV49W7WtJSx/VOK7HNm83tw8U2CAP/xtoPDQDag03AwJSkylTTWpUahvY3ls8rG8XPQDElCUlWjylJV5iC5185rvdjU4swaDK0CyU919Q25AunIwEA4qPouf7IMKAUm+yCzJSkobqNBqivegQMn5e0WNI7Jb1W0msmPZ4yi7a9PQz8W+pwfABoe3ZtVbncXYlqWqvyE29/NvULktRPwIAEq3nAEAZ+JOm9jut9TtILJR1hahVyBeswXBMG/nCtjw0AncJu4bZ6jqR9VdtaFe3NdpXnNPPUkGA1DRgc10uZgEFh4G+Q9N+1fP7JxwCATpTNSzuH4/8bpIahMtW0VuXcsP3ZZBj6KXhGwtX6FXy143oza/ycT3Jcb5akq+v1/ADQ6jbvSeutP52pB7fYtFWt65Da1kRrVWAqVh2SKHhGwtV6StJZku50XO9NYeD/vpZP7LjecyV9S9LyWj5vpRzX65J0oanROFxSn1l07iZJXwoDv+jCc47rnWLWmThN0gKzbsVDkq4y+5ZqSQugQ123Kqd3/e8s7RixiwC6M5z0VmrFvLQ27LSbqy5JKaoY2h5rMKCT1PoV/B1JKyRd57jetxzXW1rtEzqut8RxvSskXW+e+7u1GWpVY5prVrL+sqRTJe2VtNGM702SbnVc7/wi+15igorzTdeodZJGJJ1kukvd6bjeosZ/VwBa1Xgu0qevHtXrvzNmHSxIUk892lt0iGpaq6K92dQwkGFA0tX0P2EY+G+U9EFT4Hy+pIcd1/uh43ovMFfkY3FcL+O43t84rvc9SY9Ier1pw/ohc4ymcVwvJcmXdKJZrfr4MPCXhoF/sKQDJP3YZG4ud1xv+aR9z5X0afNz/5KkBWHgHxYG/mITeKw12YqfmOMA6HDrd+R13tf36su/G6v4OSjerVylrVWpYWh/Q2QY0EHq0SXpMsf1rpP0dUnPkPQK87HHcb0/SvqTWdxtk7kyH0maZq62r5T0TEknS5qohUiZtRwuDAP/9lqPtwKvNVOJNks6Kwz8LRMPhIG/xXG915mxbzbTp9ZoX7CQlnSp2fTnYeC/q/BJw8C/xXG98yTdJukUSeeZKUoAOtS1f8nqXf87rMG9lT/HinkpHTCbs9dKVdNaFe3NakoSGQYkXF0S1WHg/8lxvWdJep2k90s6WtIMSX9jPsqZ+A99n6TLJH23hTojvcfcfq4wWJhg6g/OmmK/kyUdYu5fNtUTm5/b7yQ9T9IbCBiAzjSei/SZa8b0lSqyChPe7/QqxeXuipGdQTEUPaOT1G1mqznB/66k7zqud5Kkc82V+eNNgfBURkw24QZJPwkD/9Z6ja8SpibjBPPplba7m9u9kkotWHetCRjOdFyvKwz8bIXDBZBA63fk9bYfDuu2tXaryE7lH/6mR97x3TUZV6eqtLUqIVr7o+gZnaQhpXDmxP/Jk3/H9RZLmm+mIsmcRG8OA39jI8ZThRPN7WAY+Gsd1ztA0gWS/p+kuZKekPRbSd8IA3/npH2PMrcPlgkC7jW3fWaK1qo6fB8AWlD4QFbvvrK6KUiS1N8tXfqyPr3iBIKFak20Vt2ws1WS3GgVFD2jkzSld4ZZ1G1DM45dpSPM7WOO673UZFAmrzvxYkkfcFzvnDDwCzMJy8zt+jLHKPy5rKhFwJDL/jU+yeWmvg+gecZzkT4TZvVfN1b/N3nY/JS++qoeHTo/9ZS/fVRu+Vz7gCHK55TLkmdoZ3ss/r76eP9Fg2W6anuKT7M9O/uZ27mSvm9avX5S0j2Spks6W9LnJO0v6ReO6x0bBv5EgDDD3O4pc4zCx2eU2C62LRsfn/Lr27ZsqsXTA6jCxt1pffia6bp7U/XZgHOOGNEHnjuk/py0pdXztQmysH+gxEzaqe3aOagtG0frNiY03yND5d7O/yq3e6e2Zf/6euD9F/W2aGltly0jYLAzYG4PkPRzSecUFGOPSvqW43r3mhqFuZI+LOkd5vGJd5tyVYyF7zB271AAEuV3j3brH38zXbtGq5vf3NcV6ZLn7dFLDqu+SBpPt3RWJQu3MYWpna3P5vR4Lv6UpJnUMCDhCBjsFL4DfGqqzk1h4N/uuN4vJZ0jySsIGCZWb+4pc4zegvvD1Q9Zmr/ogCfv53LZJ69szJu/UJkMLwGgkYbHIj2yNdKP/5zVN262PxGd7LAFKf3XK3t1yPxpMbZGJY5ZkZNusQvGZs6eq/mL+P/arq594glJk0sVizth0RLN68rw/ovE4tVqZ3fB/btKbHezCRgWO643yxRA7zKPTS9zjMJpSLtKbBdbsXlsmUxXzee4AfirKIp09/q8fnFPVg9symnVlrwe3xEpqtHF59ec2K1/PrtX03qYK19PBy9IxUgOP1U6k+H/axu7cffuGFvts6SnR8umTVO+oKsS779IGl6tdh4ruF/qHXpHwf0BcxlitVmQbWmZYxQ+/nCF4wTQZI/vyOvN3x3W3eurb486WX9XpEtf1qNXPItZi41QaWtVtKfd2azu3BO/fuG0WbNYCwWJx39BO3cX3F9RYrvFBfcngod7zO1hjuuVmpZ0vLndNbFKNIBkeWwwr3O/trcuwcLBc7P63it26Lzjud7TKBOtVW1wfti+bt61SzaTCU+bNauOowEag4DBzs0F04ReVGK7Y83t6jDwJzqqX21u+8wCdsVMPG/QQqtbA7DwuXBUjw3W/s/31Sdk9O2/3akVc2ofiKC0FfN4u8Q+v98Zv3ZhIJ3WM6aXm4kMtD7+A1oIA3/UtFOVpH9wXG/25G0c1ztc0kvNpz8p2PcuSXeYTz841fM7rndmwUrS36z1+AHU3+DeSP93d217rE/rkb78yj5d5vWon7XYmmLFfnZvlyQY2lM2inTzrvjlhafOnKluOiShDfAqtvcJSdvMtKPAcb2DJh5wXO84EyRkJG2V9PlJ+75PUl7SmY7rfbUw4HBczykIRn4WBv5vGvYdAaiZW1ZnNVLDeOGIhWn9+p0DOu8ZRArNRIYBknT3nj3alYs/Iem5TEdCm2jYJFjH9VJmYbO/NVfRF0l6OAz8kwq2OUvSXWHgb27UuGyFgb/FcT1XUiDp/0la5bjeakndBas5D0rywsDfNGnf6x3Xe7ukL0m6SNKbHNdbI2m2pAVmsxslva7x3xmAWrhvY+2mC73upG598uxe9XdzvbrZVuxHDQPspiOlJT2bgAFtoiGXTBzXO8DM//clvVbSEeYkeXLA8q/mBPz5jRhXpcLAv9V8D5+R9IAJfuab+5+TdGQY+DcW2fe/JJ0o6VuSNktabn4ON0i6UNLpYeDHb78AoKXct6H6gGGgR/rKq/p02bl9BAstYqXllCS0J5uA4diBAc2mdSraRN1fyY7r9UkKJR1qpnXeKemP5gp74XbdkvrNOgRXOa53TBj4G+o9vkqFgf+EpA+ZD9t9/yzpTfUZGYBmundjdYuxHbkwra+9tl8H788Jaiuxba1KmNd+1o2MaO3oaOzt6Y6EdtKId6SLJB0maZOk54SBf0IY+BdP3igM/HFJx0m61mQf3tyAsQFAzQzujbR+R2XdkbrS0oXP6dYv3j6NYKEFVdJaFe3FJrsgAga0mUbkys6VFEl6Wxj4N5faMAz8ccf13i3pPtNp6J8bMD4AqIn7LbMLxyxJ65lLMzp6cVp/c1iXFs0iUGhlB+2f1oad8X7HC2cSXLSbGywChiU9PVrex8KKaB+NCBiOkDQcBv7/xdk4DPwHHNfbHGNFZABoKfda1C8sm5vSNe8cqOt4UFtnHNalGx6OFzActThT9/GgcVjdGZ2uEZezZkpaZ7nPdjMtCQAS4z6LDMORizihTJqXHtul3hiX2V7xzC7N7ONksZ2wujM6XSMyDIOS9o+7seN6XZIOMPsBQGLcb9FS9ehFTD9KmsWz0vrC3/bp4h+NFN1m0cyUPv7i3oaOC083ms/rrqEhPTI8rN0W6yYU87WNG2Nvy+rOaEeNCBjuMguVvSQM/F/E2P4C0ynppgaMDQBqYiwbadWW+AEDU1aSyTu+W+mU9KmrR/X4pAL3vzksoy++vE/zBggGm+l3O3bo848/rvVjY005Pqs7ox01ImD4gSRH0hWO670iDPzrp9rIZBYuNKsjR5J+2ICxAUBNrNqS17jFhcyjFnNCkVTnHNetFx7VpVtW57R+R17pVErPOSijpZatV1F7v92xQ+9bvVqV9SqrDaYjoR01ImD4rqS3SHq2pGsd17tP0r3msSWO6/2nKXA+1dQtpMwib99rwNgAoCZsFmyb3S8toUVnovV2pfS8Q1mUq5VsHB3VR9esaWqwkJZ0KgED2lDdL4eEgZ+XdLakX5lg4GhJrzRZhP1MVsGV87IQSAAAIABJREFUNMc8/itJLw0Dv5l/8wBgxWbBtqMWZeigAtTYf2zYoOF89SutV4PVndGuGvKqDgN/hyTXcb0zJb1W0smSlkiaJmm3pMcl3SrpB2HgX9eIMQFALdlkGJiOBNTWnXv26JrB5vdKYToS2lVDw+Aw8K81KzkDQNuIosiqpepRtFQFaiYfRfr84483exgSAQPaGJe5AKBKjw9G2lW80+bTHEVLVaBmfrF9ux7Yu7fZw9CBvb2s7oy2xbsWAFTJpn6hOyMdMp9/vUAtDOVy+vL69c0ehiTpdfPnU5uEttWQKUmO6x0l6X2SniNpkaT+GLtFYeBTOQSg5dnULxw2P62eLk4qgFr4702btC2bbfYw9Izp03X2vHnNHgZQN3U/IXdc72RJ10vqNV2QAKCtrBuk4BlotMdHR/X9LVuaPQydMXu2PrFsmXpYrA1trBFX8D8hqU/SkKQfSbrHdEZqbu8zAKiR4fH42x68PycVQC38+/r1Go/id2DPSHrh3Lk1mYvdlUrpwL4+nThjho6YNq0Gzwi0tkYEDKeYNRdeHAb+7xtwPABoKItzFnVnSLQC1bp9925dt2OH1T4v339/vX/p0rqNCWhnjbjU1StpM8ECgHaVtwgYqIkEqpOroI3qrExGb120qG5jAtpdIzIMa+nGBKCd2WQY0gQMQFV+tm2bVg0PW+1z0eLFmsUKzEDFGvHX87+SPuK43sow8Fc34HgA0FAW8QKdH4AStoyN6btbtui23bu1YXRUUzUsHsvblUAe1Nenc/fbr2ZjBDpRI678XyrpTklXOa63rAHHA4CGiixSDDRSAaZ2665dOvf++/WDLVv00PCwhvJ5jUzxYdsx5b0HHKAu5gICVal7hiEM/GHH9U6T9ENJqxzX+21Bp6SS77Jh4H+y3uMDgGrZTEnitAV4unuHhvTuRx7RmM0fUwynzZqlU2bOrOlzAp2oEeswdEn6uqSXmPfKM81HHAQMAFoeRc9A5QazWX1g9eqaBwtdqZT+fsmSmj4n0KkaUcNwiaTXFny+g3UYALQTqxoGAgbgSbko0kcefVSbxy0WM4npVfvvrwP7+mr+vEAnakTA8BrzfvpjSX8fBv76BhwTABrGKsNQz4EACfO1jRv1x927a/68c7q69BbaqAI104iAYamkMUnnh4E/2oDjAUBD0VYVsPf7HTt0+aZNdXnuixcv1oxMpi7PDXSiRgQMQ5K2ESwAaFdWRc8EDIAeHx3Vx9aurctzH9rfr3PmzavLcwOdqhEN/m6XtMBxPZoJAmhLNjUMaSIGdLiRfF4fWL1ae3JTrbJQna5USh9eulQZ/s6AmmrESfynJQ1Ien8DjgUADUdbVSCeKIp06bp1etBypeY4UpIuWbpUx06fXvPnBjpdI9ZhuMlxvXMkfdNxvZMkfVnSX8LA31jvYwNAI9BWFYjH37ZNP9++vabP2ZNK6bjp0/WuxYt15MBATZ8bwD6NWIdhlbmbkfQy8yHH9crtGoWB34gaCwCoCjUMQHn3Dw3ps489Zr3fst5efWblyilXa+5KpbSop4eVnIE6a8QJ+cENOAYANA0ZBqC0HdmsPvDooxq3XJytL53WZStX6qD+/rqNDUB5jQgY3ilpRFLOsjYQABLBrui5jgMBWlAuivTRNWu0cWzMet+PH3ggwQLQAhpRw/CVeh8DAJopsrhqSryATvONjRt1y65d1vu9av/99YK5c+syJgB2aHUKAFVi4TZgao+OjFS0ONuxAwN6z5IldRkTAHsEDABQJWoYgKl9c+NG5S33mdvVpc+sWKHuNKcoQKtoRJek1RXslpHUGwb+wjoMCQBqihoG4On25nL6zY4dVvukJf3LihWa39NTt3EBsNeIouflFttGBVN8KZAGkAiWjV+AjnD77t3WXZHesXixTpwxo25jAlCZRgQM3y7zeErSXEnPkrRQ0nWSrm7AuACgJpiSBDzdTZaFzs+bNUuvX7CgbuMBULlGdEl6U5ztHNdLS3qDWQn61jDwL6n32ACgFpiSBDxVFEW62SJgWNrbq08sX64UETXQklqmoigM/HwY+FdIerekDzqu9/JmjwkA4ogsqjo5HUInWDM6qg0W6y6cP3++ZmQydR0TgMq1TMBQ4DuSxiVd3OyBAEAcdhkGQga0v5t37rTa/tRZs+o2FgDVa7mAIQz8MUk7JB3T7LEAQBzUMABPZVO/sLKvT4voigS0tEYUPVtxXK/fFEHbtm4GgKZg4Tbgr4ZzOd2xZ0/s7U+dObOu4wFQvZbLMEj6uAlkNjZ7IAAQh1XjSAIGtLnb9uyxaqf6bAIGoOU1YuG2/46xWVrSbEnPlLTEvP/SWhVAIthMSSLDgHZnU7/Qn07r+OnT6zoeANVrxJSkN1pcgJt4K10n6ZN1HBMA1IzNlCTiBbQz23aqJ82YoZ50K052AFCoEQHDuhgBQyRpRNJjZuG2r4WBb7eePAA0SWQRMVD0jHa2dnRU6y3aqVK/ACRDIxZuW17vYwBAM7FwG7DPTZbtVKlfAJKBPCAAVMmqrWo9BwI0mU071RV9fVrU21vX8QCoDQIGAKgSbVUB2qkC7aymU5Ic1/t4LZ8vDHwKnwG0PJsMAykGtCvaqQLtq9Y1DJ+wbUleBgEDgJZHhgGwb6f6DNqpAolRj6Jn3g4BdBSrBAP/IdGGaKcKtLeaBgxh4PPXD6Dj2GUYiBjQfminCrQ3TvABoEos3IZOZ5NdEPULQOIQMAD4/+zdeZwcVbn/8e9Mz2S2rGQjIQFCIImEJQmyr4EUkFLAgut2VRZBFPSiV3HjXkVcEb0oohdkceGKXv0JJQJFoAiyQ4AAYRPCHgiBkBCyzD49/fuDM7mdZKanz3RXdXX35/165VW9nKo+PZnqqafP85yDAllNq0rEgApks/4C06kC5SeOlZ6l92ZQqpN0oiRP0lxJEyW1SNok6Q1JD0v6Uxj4t8XVJwAoBhZuQzVr7+1lOlWgwsUSMDiut6uk6yTtYR7K/pM52vx7n6STHde7Q9LHw8BfE0ffAKBQLNyGavbIxo3qYjpVoKJFHjA4rtci6TZJO5m/lW9JWmpGFTokNUmaKmlfSWMkHSnpRsf1Dg4Dvzfq/gFAoaxqGIgYUGFs6heYThUoT3GMMJwtaWdJb0s6Iwz8G/tr5LheStInJP1S0n6STpb0uxj6BwAFoYYB1SqTyVjVL+zLdKpAWYrjrD3OpPh+aqBgQe9NyZoOA/8aSaebkYiPxdA3ACiC/CMGahhQSVYwnSpQFeIIGGZJWmtRzHydpPWS5kTcLwAoCqZVRbW6j+lUgaoQR8AwStLqfBubuoWVpp4BABKPlCRUK5v6hZ0bGjSZ6VSBshRHwLBR0gTLfcaa6VYBIPHsVnqOsidAfNp7e7V048a82x88alSk/QEQnTgChmcljXVcb34+jR3XO8Ks0fBs9F0DgMIxwoBqtNRyOlXqF4DyFUfAcKNJ273Gcb0DcjV0XO9QSdeaCsK/xdA3ACiYzcJtBAyoFDbpSI21tZrHdKpA2YpjWtVfSfq8pCmS7nNc73FJD0p6bat1GA42C7vVSHrZ7AcAicfCbag2mUxG99pMpzp8ONOpAmUs8oAhDPxNjusdK+nvknaRNHeAGZD6/o4+K+n4MPDbou4bABSFVQ0DIQPKn/V0qtQvAGUtlnA/DPxnJO0l6UuS7pPUbgKEvn9tku6SdJakuWHgvxBHvwCgGKhhQLVhOlWgusSRkiS9FzS0SfqFpF84rldjplttkdQqaX0Y+DZpwACQGDYfXsyShKTq7u3V4nff1T/b2vR6Z2fO3+tn2/JPAtipoUE7MJ0qUNYiDxgc1/uapGvDwF/Z95gJDt41/wCgrLFwG8rdU62t+u6rr+rFjo6iH5vpVIHyF8cIw4WSfui43p2SrpF0XRj4rTG8LgDEgpQklLNVnZ36txde0IZ0OpLjM50qUP7iSkmqlTTf/Ptvx/V8Sf8jKSQVCUC5Y1pVlLMfvvZaZMEC06kClSGOoucdJZ0r6REzGt8s6V8l3SJppeN6P3Fcb68Y+gEAkbBKSSJgQIJsSqe1xLKA2ca+w4ergelUgbIXx7Sqr0u6WNLFjuvtLOmj5t8cSdtL+rKkLzuu95RJWfpjGPirou4XABRDxiZaoOgZCfNEa6uiGVt4D9OpApUh1rA/DPxXwsD/cRj48yTNlPRtSc+YkYc9JV0kaYXjerc6rveJOPsGAENhU78gip6RMKst1lIYCqZTBSpDbNOqbi0M/OclfV/S9x3X213SRyR9yKzX4EhaIOnaUvUPAPJhOcDACAMSZW13d2THntHUxHSqQIVIRGKhWdjtQkn/IemGUvcHAPJlPcJAwIAEWdPTE9mxT544MbJjA4hXyUYY9N4aDaPMqMK/SDpKUvZXEa+WsGsAkBfbad4YYUCSRDXCsHDMGB09ZkwkxwYQv9gDBsf1xpgg4cOSjpRUn5XWu1bS/zMLvd0Xd98AwJZtShKQJGuKHDA019bqkxMm6PRJk5RiOA2oGLEEDI7rjZXkmSDhCPO6fZ8k7ZL+buoVFoWBH934KAAUGSlJKGc2AcNJ48Zpl8bGfp9L1dRox4YGva+5WSPrSpq8ACACkZ/VjuuFkg6XlDIP1UhKS1psggQ/DPxNUfcDAJKglogBCZHJZLTWoobhhLFjNbulJdI+AUimOL4GOCrr9sMmSPjfMPBXx/DaABApplVFuWrr7VVHb2/e7cfV10faHwDJFUfA8LwJEv4YBv4LMbweAMTGelrVRMxNB9jXL2xHqhFQteI4+38oqZ1gAUAlYoQB5cpmhqTRdXWqJ9oFqlYcZ//Vkr4Vw+sAQOxYuA3lymYNhrGMLgBVLY6A4Q1JTMYMoCLZzqpKzTOSwiYlifoFoLrFETD8VtJkx/VOjuG1ACBWvZZDDAQMSAqblCQCBqC6xTHG+B2z1sJPHdebL+lPkpZJWhMGfjqG1weAyNimJBEvIClsRhhISQKqWxyfAE+bbaukk80/6b01GnLtlwkDn08oAIlmHTAQMSAhbNZgGMsIA1DV4rggnxXDawBASdjWMFD0jKQgJQlAvuIIGC6I4TUAoCSYVhXlyioliYABqGqRBwxh4BMwAKhYTKuKctSTyWidRUrSOGoYgKrGKiwAUADrEQYCBiTAup4eq3Q6UpKA6hb7VwaO6zVI2kvSJEk9YeAHcfcBAIrFfh0GIgaUnk060rCaGg1PpSLtD4Bkiy1gcFxvb0nnS/pA1usukxRktblI0sth4F8WV78AoBA2KUnECkgK24JnAl2gusWSkuS43ickPSTpBEn1pu6vv0+fT0n6peN6F8fRLwAolFXAEGVHAAs2AQMFzwAiDxgc19tV0m9MoPBPSV+UdGA/7VKS/tuM8H/Rcb3Dou4bABTKJmCg4BlJwaJtAGzE8Snw7yZYWCTp+DDwe9TPom1m1efvOa7XI+kHkk6XdHcM/QOAIbMpeiarA0lhs2gbBc8A4khJOtKMGpzVFywM4heSuiTtH0PfAKAgNkXPjDAgKViDAYCNOAKGKZJWh4H/aj6Nw8BvlfS6mUUJABLNaoQhyo4AFmwCBkYYAMQRMNRKWme5T0YSc7gBSLyMRREDKUlICquUJGoYgKoXx6fAKkm7OK43PAz8TYM1dlxve0nTJL0UQ9+KxnG90ZKeljRZ0qth4O+co+0Bks6WdJikiZLaJT0v6a+SLg0DvyPe3gMYKmoYUG4ymQwpSQCsxDHCcLcpej5/sIaO69VI+qUZub8rhr4V0y9MsJCT43rnSbrPTCG7vaQVkjok7SfpIkmPOa5HOhZQgahhQBK09faqo7c37/akJAGIY4ThEkmnSPqy43oTJP3cfBO/meN6YyUdIelcU+zcK+nSGPpWFI7rHWcCgHSuVCrH9U40M0DJvL9vhYG/3jx3oKQ/SZol6XrH9Q4KA992EVkAMWMdBpQbmzUYJGk7UpKAqhf5CEMY+MsknWf+Vn5S0iMmBScjaU/H9dokrZb0l6yZkb4VBv4TUfetGBzX207SFebuNTna1Uq60Ny9MQz8c/qCBb33c3pA0knm53KAuQ0g4UhJQrmxSUcalUqpvjaWNV4BJFgsnwJh4P9Y0sfN7Ec1Wf9Skhqz7r8q6eNh4P8ojn4VyS9NatGfB1k3Yn9Ju5nbP+mvQRj4S7NSsU4pflcBFBsLt6HcrGENBgCWYvvaIAz8P5ti5vmSvmFScq42KUrnmgLgXUy7suC4nmcCodWSvjBYc7Ntk/RAjna3m+0Cx/UYBwYSjhEGlBublCQCBgCKqYZhszDwe8036OVW0LwNx/XGSbrc3D0rDPw1W69evZXZZvvcIAvYPWW2jZJ2kbS8OD0GEAWbQqMaIgYkADMkAbBVkm+wHddLSRplLorbJK0vwwLf/5Y0QdKfwsC/Po/2O5ntykHavZF1e1oxAoZ01vBzOt3/bQBD09OT/2wzNcpscT7a4vxFMazp6sq77XapVEG/s/g/nL+IU6rIkxXEFjA4rreXpM9KOsp8c549m1CX43rPSrpF0q/zXRW6VBzX+7CkD0t6M49UpD4jzHawtSiynx+Ro13eVq96vd/H165+sxiHB6raO2+nJI3Or3Fv74Dnoy3OXwzVG5sGXRJps4a2TUX7ncX/4fxF1CZNHXA5sCGJpYbBrD2wVNLnJM0wgUp28XODpL0lfV3Ss47rnRFHv4bCcb3xZnRBkj4bBv47ee7aaLaDfbXT2c8+ABKqN5N/mhEZSUiCdRZrMIxhhiQAcYwwOK73QUnfN3e7JN1j8vTfMhfHjWaWob0lHWSCh187rvd8GPhJrHW4TNI4Sf8TBv7fLfbrW7152CDtGrJutw+hf9uYMGnK5tvpdM/mbzbGTtheqRR11UAhRvf0bhXnDyyVqt3ifLTF+YtiWL9uQ95tdxk/UROGD4+0P9WC8xflLI7f1nPM9j5JHw0D/42BGjqut5NZj2FfSV9NWnG043ofN+sjvCHpi5a7931CD/bJm52GlP+neg4D5bGlUnVFz3EDqk1tbTr/tjU1RTvnOH8xFD2ZjNZZ1CRMaGjg9ywCnL8oN3GMNc4zKyDnDBb03ixKr0r6iFnpef9cbePmuN5EMxVsr6STw8BfZ3mIl8x26iDtsp9/wfI1AMSs12IhBlKSUGrrenqsZvZiWlUAimmEoUXSi4MFC33CwH/Vcb0X87iwjtuxksaa27cPMoXqTo7r9X0m/z4M/FMlPWnuz3Rcb1gY+APVMswx2w2SXilO1wFExW5a1Qg7AuTBZg2GYTU1Gp5K5dESQKWLY4ThLUlNlvvUmv2SpFvS+kH+9dUcZLIeazOP3WK2jWaRuoEsNNugDKeaBaqORf2oiBdQarZrMLB2CADFNMKwWNLJjutNDQP/tcEaO643yaw/cHUMfctbGPh/lPTHXG0c1ztV0m8lrQgDf4v5rMLAX+a43qMmRevrWSs6Z++/QNI+5u5VxX4PAIrPJqpnwhmUGqs8AxiKOP58/dCk11zluF5zroaO69Wb1ZM3SvpxDH2L27mmBmKB43qXOa63efJ2x/UcSdeauzeEgb+4dN0EkC+LEgZGGFByay0KnsdSlAvAiOPT4A1JJ5hvzF92XO93kh4wj2+UVC9psqT9JJ1iUnY+LanHcb0d+ztgGPgrYuh30YWB/w/H9T5viqc/J+k0x/VeMas+TTTN7pX0yRJ3FUCebAKGWiIGlJhtShIAKKaAIXtJyRrzLftg/prjuUycK1QXWxj4lzuu96CZlvVISTubn9E9kv4g6aow8C2yogGUUq/NCAMBA0rMJmAgJQlAnzguvLf+E1mxfzLDwP+dpN/l0e5xSafF0ysAUbKaJSnCfgD5IGAAMBRxBAzHmVWO05Z/WwEg8axqGBhiQIlRwwBgKCL/NAgD/+aoXwMASoWUJJQTZkkCMBSRz5LkuN6vHNfbN+rXAYBSsJpWlYABJdSaTqvdYuEQip4B9IljvPEsSZ9zXO85k9//h3xXfQaApGNaVZQLm9EFkZIEIEscnwbvmmlDZ0n6kaQfOK53uwke/hYGfmcMfQCASDCtKsqFTf3CqFRK9aw0CMCI49Nggil8vtZMH5qSdIxZNflNx/Uud1zvoBj6AQBFRw0DysXb1C8AGKI4ip57JN0s6WbH9RokfUDSx8x2lKTPSPqM43ovmlGH/wkD/7Wo+wUAxZCxGGIgYEApUfAMYKhiTVA06UfXS7recb0WScdL+rikoyXtKul7kr7ruN6dkn4r6fow8Nvj7CMA2LBah4GAASVkEzBQ8AwgW8kSFMPAbw0D/09h4B8vaaKkM81qx7WS5ku6RtIbjutd4rjezqXqJwDkYpWSFGVHgEHYLNpGwTOAbEmpaNrFjDBMNV/Y1Zh/oyR9QdJzjutd6LheqtQdBYBsFD2jXNgUPZOSBCBbyb5CcFxvkqSTJZ0qaYZ5uO/P6RJJv5H0pqSvSDpM0lcl7eO43kJTFwEAJWe30nOUPQFyIyUJwFDFGjA4rlcv6UMmSDjajHD0/QldLekPkq4OA/+fWbvd6Ljeh0xNw5GSvmlqHQCg5Fi4DeXCKiWJgAFAllgCBsf15kk6zRQ4jzEP10hKS1pkRhNuHGjkIAz8vzmul5Z0g6RTCBgAJAU1DCgH6UxG6yxSksZTwwAgS+SfCI7rLZO0h7nb9/fyeTNi8Psw8Fflc5ww8G90XO8tU+cAAIlgl5JEyIDSeKenR70W7RlhAJAtjq8Q9jTbVkl/lfSbMPDvGeKx1ktqKGLfAKAgLNyGcmBTvzCspkYjUswxAuD/xBEwPGhSjv43DPxNBR7rKMuUYQCIFDUMKAe2Bc+MhgHIFsdKzwcV8Vgri3UsACgGq5SkKDsC5MAaDAAKkZR1GACgLDGtKsoBazAAKETRv0ZwXO+OIh0qEwb+UUU6FgBEgoXbUA6YUhVAIaIYdzyiCHUGNdQqACgHFD2jHNgEDIwwANhaFAHDE4Nc7M80Mx09EcFrA0CsMhbfbRAwoFRsip4JGABsregBQxj4c3I977jeY5L2CgN/brFfGwDixsJtKAc2NQwUPQPYGkXPAFAAahhQDqhhAFAIAgYAKAA1DEi6tnRa7b35r/NMShKArREwAEBMGGFAKdiMLoiUJAD9IGAAgAKwcBuSzqZ+YVQqpfpaLg0AbIlPBQAoAClJSDqmVAVQKAIGACiA3UrPRAyIHwXPAApFwAAABWBaVSQdazAAKBQBAwAUwGZJeoqeUQqswQCgUAQMAFAAahiQdKQkAShU0b9KcFzv0UGazMizXSYM/H2K1zMAiAALtyHhSEkCUKgoxh7nmD+hg/1pnDPI8zYj/QBQEowwIOkYYQBQqCgChru52AdQLTIWH3fEC4hbOpPROosahnHUMADoR9E/GcLAP6LYxwSApLKZVpWUJMRtXU+Pei3ak5IEoD8UPQNAAWxSkhhiQNxs0pGG1dRoRCoVaX8AlCcCBgAoANOqIslsCp7H1tezuCCAfhEwAEABei3yPbgUQ9xYgwFAMRAwAEABGGFAkjFDEoBiIGAAgALYFD2T7YG42QQMFDwDGAgBAwAUwG6WJCIGxItF2wAUAwEDABSASZKQZFYpSdQwABgAAQMAFIBpVZFkNkXPjDAAGAgBAwAUgIXbkGS206oCQH8IGACgADYjDJQwIE5t6bTaLOb9JWAAMBACBgAoANOqIqlsRhdEDQOAHAgYAKAAVtOqRtkRYCtrLOoXRqVSGlbLJQGA/vHpAAAFyFhEDIwwIE6swQCgWAgYAKAA1DAgqSh4BlAsBAwAUABWekZSsQYDgGIhYACAArAMA5KKNRgAFAsBAwAUgJQkJBUpSQCKhYABAArAwm1IKquUJAIGADkQMABAAahhQFIxSxKAYiFgAIAC2C3cRsSAeKQzGa2zqWGg6BlADgQMAFAAqxqGKDsCZFnX06Nei/akJAHIhYABAApAShKSyKbgub6mRiNTqUj7A6C8ETAAQAGYJQlJZFvwXMMvJ4AcCBgAoAB2NQwRdgTIYrUGA/ULAAZBwAAABbBKSYqyI0AWplQFUEwEDABQAGoYkERMqQqgmAgYAKAAGYuIgZQkxMWm6JmAAcBgCBgAoABMq4oksqlhGEsNA4BBEDAAQAFsip5JSUJcqGEAUEwEDABQAKZVRRKRkgSgmAgYAKAANkXP1DAgDm3ptNp681/nmREGAIMhYACAAjBLEpLGZnRB1DAAyAMBAwAUwKqGIcJ+AH3WWBQ8j0qlNKyWSwEAufEpAQAFsEtJImRA9GxGGEhHApAPAgYAKABFz0gaFm0DUGwEDABQAKZVRdJYjTBQvwAgDwQMAFAAi8loqGFALGxqGEhJApAPAgYAKIDNCAPTqiIOrMEAoNgIGACgANQwIGlY5RlAsREwAEAhWLgNCWNV9EwNA4A8EDAAQAF6LeZVZYQBUUtnMlpnUcNAShKAfBAwAEABWLgNSfJuT48s6vBJSQKQFwIGACiAzcJtjDAgajbpSPU1NRqZSkXaHwCVgYABAApA0TOSxHaV5xp+KQHkgYABAArAtKpIEqs1GCh4BpAnAgYAKIDVCEOUHQFsZ0iifgFAnggYAKAQVtOqEjIgWizaBiAKBAwAUABqGJAkVou2kZIEIE8EDABQAJtZkqhhQNTWsgYDgAgQMABAAWyKnoGo2c6SBAD5IGAAgAKQkoQksUpJImAAkCcCBgAoAClJSIq2dFptvfmv80xKEoB8ETAAQAEYYUBS2NQviKJnABYIGACgIPlHDIwwIEo26UgjUykNq+USAEB++LQAgAKwcBuSgjUYAESFgAEACkANA5KCGZIARIWAAQAKQA0DksImJWkc9QsALBAwAEABWIcBSWFT9MwIAwAbBAwAUABSkpAUrMEAICoEDABQAFKSkBRWKUkEDAAsEDAAQCGsRhiIGBAdm5QkahgA2CBgAIACMK0qkuDp1la9Q0oSgIgQMABAAWyKnllCbK9aAAAgAElEQVQnC1G4e/16nfn88+q12IeUJAA2GJMEgAIwwoBSuu7tt3Xha69ZBQt1NTUamUpF2CsAlYaAAQAKYDNLEiUMKJZMJqPLVq3S1W++ab3vhPp61fDLCMACAQMAFIBZkhC37t5efW/FCt38zjtD2n/fESOK3icAlY2AAQAKYFPDQLyAQm1Kp/W1l17Sko0bh3yMI0ePLmqfAFQ+AgYAKIRFThILt6EQb3d16ZwXX9Ty9vYhH8MbO1aHjBpV1H4BqHwEDABQAFKSEIeX2tv1by++qDe7uoZ8jENHjtRXp04tar8AVAcChiFyXM+TdKqkfSWNk9Qp6VVJiyX9Igz8F3Pse4CksyUdJmmipHZJz0v6q6RLw8DviPfdABgqq2lVCRgwBI9u3Kgvv/SSNqbTQz7GSePG6WtTp6qOqBXAEDAruCXH9Voc17tZ0vWSjjfBwquSuiXNlnSOpCdNQNHf/udJuk/SpyRtL2mFpA5J+0m6SNJjjutNiv+dARgKplVFlG5bt05nv/BCQcHC5ydP1jcJFgAUgIDB3tWSXEm9kv5D0sgw8HcLA387SYdKeklSk6Q/Oq63Y/aOjuudKOkH5ud+qaSJYeDPDAN/sqSDTOAxS9L1juvxyQ6UAaZVRVSufestffPll9Vt80uWJSXpgp120qe3355pVAEUhJQkC47r7SHpo+buj8LA/2H282Hg3+u43sclLZHUKOnTkr5j9q2VdKFpemMY+Odste8DjuudJOlhSQdIOsmkKAFIMGoYyktnb69WdHTonZ6eUnclp7vWr9ef3357yPu31Nbqol120QEjRxa1XwCqEwGDnXmS1kjaTtIV/TUIA/8hx/XWmFSlOVlP7S9pN3P7JwPsu9RxvbskHSHpFAIGIPlsvvylhqF01nV364o339T1a9aoZ4jf2JeLcfX1+sX06ZrZ3FzqrgCoEKQkWQgD/5ow8MdLGhYG/oocTdebbX3WY47Ztkl6IMe+t5vtAsf1COiAhLNLSSJiKIV3urt12vLl+svbb1d8sDCtsVG/mzmTYAFAUREwDEEY+ANWnzmuN07STubuU1lPzTbb58LAzzUW3rdPo6RdCu8tgCixcFvy/ecrr+i1zs5SdyNy84YP129mzNCkYcNK3RUAFYZvsIvv6+bn2ivp91mP9wURKwfZ/42s29MkLS+0Q+msXN10uv/bAIYmY/GNdaY3rXTP0L/h5vy190J7e0GrIpeLBaNG6fypU9Ww1Wc+koPzF3FK1RX3Ep+AoYjMVKpfNncvDQP/maynR5jtpkEOk/38iBzt8rZ61ev9Pr529ZvFODxQ1Xp6xuQ9WPvu2tVaXVecCwXO3/zc2NpW6i5E7kNNjfp0fa3Wv/VGHq2RBJy/iNqkqTsX9XgEDEXiuN6nzJSrtZL+IemrWzVpNNvBlunMHjdvzNEOQALYLdxW2fnzSfRkd+V+k1sj6YyWZp3QzJ8KANEiYCgCx/W+Jem75u6tkk4KA797q2Z9qzcPllzakHW7vRj9mzBpyubb6XTP5m82xk7YXqkUvwJAQWryP023GzdREyYNvXSM89dOV2+vlq9ZV+puRGJYTY2+M3WqFoweXequIE+cvyhn/LYWwHG9BjOq8Anz0JWSzh6gqHmD2Q4f5LDZaUgbcrTL20B5bKlUXdFz3IBqk1FN3uMMdXUppepSRXldzt/BPbtpk7oqcFakkamULp4+XXOHD/bnBEnF+Ytyw2/rEDmuN0pSYFZo7pH0lTDwf5Fjl5fMgmxTBzl09vMvFKm7AIqoozujV9/p1UtretXRnf8FKbOqxuvRCix2njRsmC6dPl3TmppK3RUAVYSAYQgc12uWdLMJFjZI+nAY+LcNstuTZjvTcb1hYeAPVMvQt9jbBkmvFLHbACx09WS0Yl1GL695LzB4eW3v5tsr12es1l/ow8Jt8Xp002BzTJSX/UeM0AU776zx9fV5tAaA4iFgsGQWU7tB0sGS1kpaEAb+43nseoukH5lC5sOyFmjb2kKzDcLAr7yxdCChWjszuvmpHt3ydI/++WZar7+bUbq3uK/BCEN8ejIZLWttzbv92Lo6DU8VJ12smJpTKe3a2KjDRo/W/FGjWPwPQEkQMNg7X9ICU8R8bJ7BgsLAX+a43qOS5pm1GrYJGBzXWyBpH3P3qqL3HEC/nn0zrdP/0K6X1kQbo3OpF59n29rU3pt/xPeTXXbR3tQEAEC/WOnZguN6u0j6hrn7jTDwH7E8xLlmQbcFjutd5rje5uktHNdzJF1r7t4QBv7i4vUcwEDWtvbqxCuiDxbECEOsbNKRGmpqtHtzc6T9AYByxgiDnX/L+pl9xnG90wbbIQz8OVm3/+G43uclXSrpc5JOc1zvFUmjJU00ze6V9MnI3gGALfzo1i6ta4sn+6+xjoghLo9ZBAx7DR+u+lq+PwOAgRAw2BmTdXv2UA4QBv7ljus9KOmLko6UtLNZ3fkeSX+QdFUY+EXOnAbQn0wmo0VPx7OwV1O9NGUMAUMc0pmMVcAwj1QkAMiJgMFCGPinSjq1CMd5XNKgoxMAorVqQ0ZrW+MZXTh4ekoppkmKxYvt7dqYTufdnoABAHJjDBZA1VrfHk+wUFcrfcttyKMlisGmfqGupkZ7tLRE2h8AKHcEDACqVkd39K/RMky64hONmjEheVN2ViqbgGF2c7MaqV8AgJxISQJQtdotVmm2NWV0jdw96nTy/sM0fTwXpHHJZDJWAcM+pCMBwKAIGABUrfYCRxjGNNdo+rgaTRtXq2lja7XLuNrNt0c0Uq9QCq90dmpdT/6F7HNHjIi0PwBQCQgYAFStDosRhrEtNTr1gHpNG2cCg7G1Gt1MUJA0j27cmHfblKS9qV8AgEERMACoWjY1DNPH1+pch8LlpLNJR5rV3KyWFLUlADAYEmsBVC2bGobG+ki7giKwrV+YS/0CAOSFgAFA1bIZYWhilebEe6OrS6u78/9PZf0FAMgPAQOAqmVTw9A0LNKuoAiWWowu1EiaQ8AAAHkhYABQtWxmSWqk4ivxHrMIGHZtatKoOv5TASAfBAwAqpbNCENjPSlJSWdTv0A6EgDkj4ABQNWyqmEgJSnRVnd16fXOzrzbU/AMAPkjYABQtexSkhhhSDKb0QUxwgAAVggYAFQtu5SkSLuCAtkEDDs1NGhsPf+hAJAvAgYAVavNJiWJGoZEo34BAKJDwACgajHCUBne6e7Wyx0debefN2JEpP0BgEpDwACgatkUPTNLUnI9Tv0CAESKgAFA1Wq3WbiNEYbEslmwbfKwYdp+GFNeAYANAgYAVctqWlVGGBLLZsE2RhcAwB4BA4Cq1dFDDUO529jTo+Xt7Xm3J2AAAHsEDACqVntX/m0ZYUimx1pblX/YR8AAAENBwACgajFLUvl7bOPGvNuOr6/XlIaGSPsDAJWIgAFA1eroyb8tsyQlk+36CzU1/D8CgC0CBgBVqSedUXc6//bMkpQ8bem0/tnWlnf7uaQjAcCQEDAAqEo2owtihCGRnmhtlUXMp30IGABgSAgYAFQlm/oFMcKQSDbpSKPr6jStsTHS/gBApSJgAFCVbGZIqqmRGuqi7A2GwiZgmNvSQv0CAAwRAQOAqtRusQZDQ5242EyYzt5ePdXamnf7eSNGRNofAKhkBAwAqhKrPJe3p1tb1Z3JP+hj/QUAGDoCBgBVqd2ihoH6heRZapGONDyV0m5NTZH2BwAqGQEDgKpkM8LAom3J85hFwDCnpUUpUsoAYMgIGABUpfYumxEGLjaTpDuT0TKb+gXSkQCgIAQMAKqS3SrPUfYEtp5ta1NHb2/e7Sl4BoDCEDAAqEpWKUl1jDAkyaMbN+bdtrG2VrOamyPtDwBUOgIGAFXJquh5WKRdgSWb9Rf2bmlRPfULAFAQAgYAVcmu6JkLzqRIZzJWBc9zqV8AgIIRMACoSjYjDI2s8pwYz7e3q9WifmEfAgYAKBgBA4Cq1G6zcNswRhiSwiYdqb6mRrNbWiLtDwBUAwIGAFWpgxGGsmRT8LxHS4saavkzBwCF4pMUQFWihqH8ZDIZqxEG1l8AgOIgYABQlaxmSWIdhkR4uaND69PpvNsTMABAcTDQDqAq2YwwsNJzMiy1GF1ISdqL+gVUsO7ubqUtAmiUr1Qqpfr60n5zRcAAoCpZ1TAwwpAINtOpvq+5Wc2pVKT9AUphw4YNWrNmjTo7O0vdFcSooaFB48aN08iRI0vy+gQMAKqS1SxJjDCUHPULwHvBwsqVKzV8+HCNGzdO9fX1qmFhwoqWyWTU3d2t9evXa+XKlZJUkqCBgAFAVWKEoby83tmpt7vzj/LmjhgRaX+AUlizZo2GDx+uKVOmEChUkaamJo0YMUKvv/661qxZU5KAgaJnAFXJZoSBWZJKz2Z0oUbSXOoXUGG6u7vV2dmpUaNGESxUoZqaGo0aNUqdnZ3qtvjypFgIGABUJZsRBmZJKj2bgGFGU5NG1DGAjsrSV+Bc6uJXlE7f/30pit0JGABUJbt1GKLsCfJhEzDMpX4BFYzRhepVyv97AgYAVcluHQb+QJfSqq4uvdHVlXf7fQgYAKCoGLMFUDVeWdurW57u0S1P9+jd9vz3Y4ShtGymUxUjDABQdAQMACrauraMfnN/l256skfPvtU7pGNQ9Fxaj27cmHfbaY2NGkOONwAUFQEDgIp1zZIu/WhRp9VoQn8oei4t1l8AtpTJZLSpAtZtG95gl5d/a3iHfvqzSyVJF1/0A+25x+79tkun0/rEqWdq7dp35CyYr699+Zwtnrv73vt1x5336PkXXtSG9RvU2NSo8ePHab/37yP3mAWaNGn7bY7puJ4k6dijj9JXvvSFAft45dW/11+u+5skKQz8zY9/5ev/qSeefDrn+5u9+yz9/Kc/GvTnUAoEDAAq0s1PdevrfnH+olLDUDpru7v1qsWKtgQMqAabOqUZ37FL1Uui5d8ZrhGN9vvV19crWBQOGDA8/Mij2rBh25HJ9es36ILv/1hPPfNPHXLQATrz9FM1ccJ4dXZ1afnzL+immxfpbzfcpC+cfaaOcY7s93XvvPs+nXXm6Wpubtrm+XQ6rdvvuEv19fUDTn168UU/0LBhw/p9rr9jJgUBA4CKs6Ejo3//fx1FOVZjHTUMpWRbv0DAAFS+uXP20j333a8vnHWGWvpZc2VRuFh77TlbSx99fPNjmUxG3/3hRXr6n8/qW9/8qg495MAt9pk3Zy+dcJyrb1/wQ118ya80Yfw4zZ2z1xZt5uy1h5Y+tkz/uOsefWDh0du87pKHl+qddes0b+7eevSxZf32fdfp09TUlNzAYCDMkgSg4jz4UlobizRcv8+OKaVqGWEoFZt0pCkNDZowwDd3ACrHoQcfoM7OLi3+x93bPLfu3Xe15KGlOvjA/bd4/IEHH9ITTz6t4z5w7DbBQp+mxkad9/Uva9iwYfr1Vb/b5vnRY0Zr9vtm6ZZbw373X3Tb7Zo1c4bGjt1uyO8tqQgYAFScJa/0FO1YC2YxEFtK1C8A2Nqk7bfXrJkzFCza9sL99jvuUo2kww89aIvH77nvQUmSe6yT89hjRo/WwQfupxdfelmvrnhtm+fnH3Gonlv+gl56+ZUtHl+37l099PCjOurIw4f4rpKNgAFAxVnbmv8aC7nsv3NKZxxMPlKprO/p0Qvt+VesM50qUD0WHnOUXnzpZS1//sUtHr/1tsU68ID9NHLkyC0ef3XFCqVSKU3beadBj73r9F0kSa+9vnKb54484lA1NjRsE6zcdvs/VFtbqyOPOHSI7yjZ+OoMQMVpzX+NrwHNn5HSz/6lUXUp0pFK5fFNm2QT+rFgG1A95h9+qC6/8re65dZQM3abLkl65tnn9OqK1/TZM07dpn1bW7saGxvympWpublZkvotnG5padGhhxyoO/5xt848/ZTNBcy33r5YBx+4v0aOGJHz2Mef9K8DPvfRD3s647STB+1fKRAwAKg4rZ1DG2ForJfmz6jTyfvX64gZfDyWmk060sT6ek2mfgGoGk1NTTr80IN1x5336LNnnKbGxgYtuvV2jR83VvvMm7NN+9GjR2nVm28pnU4rlUrlPHZra+vmffqz8BhH4eI7dc99D+io+Yfrqaf/qddeW6mzP3vGoP2+5L9+pGHDGvp9bsyY/l8vCfiLCKDi2IwwjGmWnFl1Wji7ToftVqfmYYwoJIXNDElzhw+3ms8dQPlbeMwCLbptse665z4dduhBuuvu+/Sh4z+g2tptM+533mlHPf3Ms1r+/It636wZOY+7/IX30pym7bRjv8/vucfumjplBwWLQh01/3DdGi7W+PHjNG+rWZX6M23nnZglCQCSoK0r/xGGn5zYqEs+0qRjZ9cTLCRIazqtZ9va8m5PwTNQfXZ/3yzttONU/eOue3T/A0vU3tGhY47edv0EmWJlSfr7TbfkPOa6de/qwQcf1h6z39fvAm59jnGO0pNPPaM3Vq3S3ffcr6MXzO83UKkUlfvOAFQtm4ChhSAhkZa1tipt0X7eIHnDACrTsUcfpSeeeEqL77hLe+6xuyZPmtRvu7333EOHHXKQbr/jTt1y6+39tmnv6NAPL7pY6XRaZ3/29Jyve7QzX6lUSpdf+dv3ApUF/QcqlYKUJAAVp9ViDYaWBgKGJHps47bFhgMZU1ennRv6zwkGUNmco+brN7/7gx5e+pi+9pVzcrb9ype+oJ6eHl18ya90/4MPaf5hh2jixAnq6urS8udf1E3BIm1qbdV/fvNc7bbr9JzHGjN6tPbfbx/dd/8Szdlrj5yjEZWAgAFAxWm1GmGItCsYoqWW6y9Qv4BqMrxBWv6d8k/DG16EOH/UqJE68ID99MjSx3TowQflbNvc3KQLvv1N3f/gQ7p98Z367TXX6p1176qhYZgmTpgg56j5WnjsAo0fNy6v1154jKP77l+iY44+qvA3knA1mUxx5itHom3+T0739Gj1qtclSRMmTVGqjpgRlSWTyWjKeZvUm+dH24NfbdFOY8sjO7Nazt+O3l4dvmyZevL8+/TVKVP0sQkTIu8XUIhCz9+Ojg69/PLLmjZtmhobGyPqJZLM8negqN+ilMdfSQDIU0eP8g4WJKmZEYbEeaq1Ne9gQRQ8A0DkCBgAVBTbNRioYUgem/UXRqRSml6GUxQCQDkhYABQUdos1mCoqZEaKzOrp6zZBAxzhw9XivoFAIgUAQOAimJT8NxcL9XWcrGZJN29vXrCMmAAAESLgAFARbEZYWChtuR5pq1NndQvAECiEDAAqCg2NQwtTN2fODbpSE21tZrV3BxpfwAABAwAKozdGgyMMCTNYxYBw94tLaqjfgEAIkfAAKCitJKSVLZ6Mhk9brlgGwAgegQMACpKm80IAylJifJ8e7tae3vzbj9vxIhI+wMAeA8BA4CK0taZf9vmekYYkuTRjRvzbjuspkazqV8AgFgQMACoKFY1DIwwJMpSi3SkPVtaNKyWP2EAEAc+bQFUFIqey1Mv9QsAkFgEDAAqSqtFSlJLAwFDUrzU0aH16XTe7QkYACA+daXuAAAUk03Rc/OwSLsCCzbrL6RMShJQrTKZjNUEAUnVUlurGoupkW8N79BPf3bpoO1mzZyhS3/2483tP3/WZ/Sh49x+2z645GF964If6lP/+lGd/MmP6ZeXXakbbgz07fO+pkMPOXDA11j37rv6xMmf0eTJk3TV5b/Qm2+t1qdO+6wOPfhAffs/vpb3eyoXBAwAKgrTqpYnm4Ln2S0takqlIu0PkGStvb06fNmyUnejYHftvbeGD+Fc/shJH9Jhhx484PNNTY1D7tMJx7n6+0236Kbg1pwBw63hHeru6dHxH1w45NcqJwQMACqKXQ1DpF1BnjKZjNUIw1zSkYCqNn7CeM2csWskx546ZQfN3XsvPbbsCa18Y5V2mDxpmzaZTEa3LArV3Nws56gjIulH0lDDAKCitHXazJLECEMSrOjs1NqenrzbU78AIEonHLdQmUxGN99ya7/PL31smd5Y9aaOXjBfTU1NsfevFAgYAFQUm5QkZklKBpvRhVpJexMwAIjQ/vu9XxMnjNdt4T/U1d29zfM3B+8FEsd94NgS9K40CBgAVBSKnsvPYxYBw4ymJo2gfgFAhFKplD7oHqP1Gzbo3nsf2OK5te+8oweWPKx5c/bWjlOnlKyPcaOGAUBFYYSh/Ngs2DZvxIhI+wIg+X512ZX61WVXDvj8JRdfqN1nzcy7fX8WHuPommv/rJuCW3Xk/MM2P77o1sVKp9M64bjqKHbuQ8AAoKK0WtUwRNoV5GFVZ6fe7Mo/yqN+AcDHPnyiDj/skAGfn7LD5LzbP/X0M/rV5Vdt8/ioUSN1xGEHK1x8p15d8Zp22nGqent7dcutoSaMH6/993t/Ed5J+SBgAFAxenszat823XRATKtaejb1C5I0h4ABqHpjx43VrtOnFaX9mjVrBtzvhONchYvv1E3Brfr8587Qw488qrdWv63TT/2kUlWWGkkNA4CKYRMsiJSkRLBJR5re2KgxdXzPBSAeM2fsplkzdtPiO+5Sd3e3Ft22WPX19Vp4jFPqrsWOgAFAxbBZg0EUPSeCTcEz6UgA4nb8cQu1cdMm3Xn3fVry8FIdcdjBGjVqZKm7FTu+qgFQMVo782+bqpUa+AQsqbe7u7WiM///NAIGAJL09uq39dzyF3K2mbbzjkV5rcMPO0RXXPU7XXbF1eru7tYJx7lFOW654c8lgIphu8pzTQ0pSaX02MaNVu3nMkMSIElqqa3VXXvvXepuFKyldmiJLn+57m/6y3V/y9nmiv/++RB7taVh9fU69hhH//uX6zRrxm6aOWO3ohy33NRkMnZD+ChLm/+T0z09Wr3qdUnShElTlCIfGBVkySs9+tDl7Xm1nTSyRo+eV17fWFfa+XvhihX6fzkKDrPt2NAgf/bsyPsERKXQ87ejo0Mvv/yypk2bpsbGxoh6iSSz/B0o6jdi1DAAqBhtFmswNDcwulBqNjMkzSUdCQBKhoABQMWwWYOBgufSWtfToxc7OvJuT/0CAJQOAQOAimEzwsCUqqX1uOX6C/sQMABAyRAwAKgYtkXPKB2b6VS3HzZMkxpYlhsASoWAAUDFaLMJGKhhKKmlFjMkkY4EAKVFwACgYtisw9BcH2VPkMvGdFrL2/ObzUoEDABQcgQMACqGVUoSIwwl88SmTeq1aE/AAAClRcAAoGK02kyrStFzydhMpzq2rk47Ur8AbMb6WdWrlP/3BAwAKkabxbSqLVyDloxNwDBv+HBW5AYkpVIpSVJ3d3epu4IS6fu/7/tdiBMBA4CKwbSqydfe26unW1vzbj9vxIhI+wOUi/r6ejU0NGj9+vWMMlShTCaj9evXq6GhQfX18Rfh2a1LDgAJZlPDwMJtpfFka6vSFu1Z4Rn4P+PGjdPKlSv1+uuva9SoUaqvr2cErsJlMhl1d3dr/fr12rRpk3bYYYeS9IOAoQQc1ztA0tmSDpM0UVK7pOcl/VXSpWHg57/8KYDN7NZh4I9sKTxqMZ3qqFRK0xsbI+0PUE5GjhwpSVqzZo1WrlxZ6u4gRg0NDdphhx02/w7EjYAhZo7rnSfpeyYdrFPSq5JGSNrP/Pu043pHhoG/qtR9BcqNzbSqzJJUGjb1C3OGD1ct354CWxg5cqRGjhyp7u5updM243UoV6lUqiRpSNkIGGLkuN6Jkn5g7l4q6Vth4K83zx0o6U+SZkm63nG9g8LAJ0kRsEBKUrJ19fbqKZv6BdKRgAHV19eX/CIS1YOAISaO69VKutDcvTEM/HOynw8D/wHH9U6S9LCkAySdZFKUEu3dtozWtxPXIBlabWZJqpCUpNVdXeoqkwLI5W1t6rTo6z4UPANAIhAwxGd/SbuZ2z/pr0EY+Esd17tL0hGSTimHgOE393fpJ7dbTE0DJESljDB84+WXtcziW/ty0VJbq92amkrdDQAA06rGyjHbNkkP5Gh3u9kucFyPgA6ICDUMybb38OGqo34BABKBgCE+s832uTDwe3K0e8psGyXtEkO/gKpUKSlJlYr6BQBIDr7Bjs9OZjvYPGhvZN2eJml5oS+c7vm/+CSd7v/2UPX29hZ8DKAUGmp7lO4pr6Ch3/O3TOoXbM1patriswsod8X++wvkkqor7iU+AUN8+qr3BptTMPv5olT8rV71er+Pr139ZsHHbt3UJKm54OMAcaqvzWjd6vKew7zv/O3uqrwaomGSxq5/R6s3rCt1V4BIFOPvL5DLpKk7F/V4BAzx6Vt9aLC/7tkzyRdlxaJJU3eO7GvU86dK558Y1dGBKJVm8Zti+5+ppe4BAKDSUcMQn77Vmwebm6Uh63Z7hP0BAAAABkXAEJ8NZjtYJV92GtKGHO0AAACAyBEwxOclsx0sgSD7+Rci7A8AAAAwKAKG+DxptjMd18uVljTHbDdIeiWGfgEAAAADImCIzy1m2yjpsBztFpptEAZ+Zc6XCAAAgLJBwBCTMPCXSXrU3P16f20c11sgaR9z96r4egcAAAD0j4AhXudK6pW0wHG9yxzXG933hON6jqRrzd0bwsBfXLpuAgAAAO+pyVToKqFJ5bje5yRdatbA6DR1CqMlTTRN7pW0MAz8wRZ4AwAAACJHwFACjuvNkfRFSUeaQGGTpGck/UHSVWHg95a6jwAAAIAIGAAAAADkQg0DAAAAgAERMAAAAAAYEAEDAAAAgAERMAAAAAAYUF2pO4Dy4bjeKDMl7KckXRcG/r+Uuk8ABue43m6S/kPS4ZK2l/SGpLslXRAG/iul7h+AgTmuN9ucvwdLmiDpdUl3Svp+GPivlrp/qA6MMCAvjusdJelJMxUsgDJhLjYeknSEpO9JOlrSxZKOk7TUcb0dS91HAP1zXG8fSUskzTVBwzGSfiXpw5IedVxvp1L3EdWBEQYMynG97SWFkq6UdImkp0vdJwB5u0DSKEkHhIH/nHnsHsf13jVrv6P1sqIAABZKSURBVHzWXIgASJ4fSEpJOioM/DfMY3c7rrdR0lWSzpL0jRL3EVWAEQbko1vSiWHgf1ZSW6k7A8DK1ZI+mRUs9HnUbHcuQZ8A5OdPks7KChb6PGi2O5SgT6hCjDCUKcf16iR9W9J55tuHC8LA/04e+x0g6WxJh5lVptslPS/pr5IuDQO/Y+t9wsBfK+lvkb0ZoMrEfP7eMsDhZpvtCwW/IaCKxHz+/n6Aw+1htk8W/IaAPDDCUIYc15sl6QFJ3zIfVvnud56k+0zR8vaSVkjqkLSfpIskPea43qRoew9UtyScv47rjZf0U0kbJV1R0BsCqkipz1/H9bZzXO8kkx68xNQzAJEjYCgjjuvVOK73BZNK8H5Jiyz2PdHkQtaamY4mhoE/Mwz8yZIOkvSqpFmSrndcrybadwJUn6Scv47rTZZ0q0ll+EQY+CuL8gaBCpaE89dxvYyktZL+bEb9nTDwW4v2JoEcCBjKywfMh02tpH+X5Oazk+N6tZIuNHdvDAP/nDDw1/c9Hwb+A5JOkpSRdIC5DaC4Sn7+Oq43z8yYtJukE8LAv7EYbwyoAiU/f81MSUdI+pKZLWmZ43p75GgPFA0BQ3mpk/SMpP3CwP95GPiZPPfb31wgSNJP+msQBv5SSXeZu6cUp7sAspT0/HVc7zhJ90jqknRQGPjBkN4FUJ1K/vc3DPzHw8C/Kwz8X0o6RNJkUgoRFwKG8vKwpPeHgf+E5X6O2baZ3MuB3G62C0xRF4DiKdn567ieaworl0raNwx8CiUBO7Gfv47rjXBc7xTH9Y7eurFJJXzVjDoAkeOisIwUkGvcNxvKc2Hg9+Ro95TZNkraRdLyIb4egK2U6vx1XG93EyzcL8kNA799iP0AqlaJzt8OST+T9K7jerOzz13H9XYwUyIzyxliQcBQHfpWghzsAy97nudpWRcck83QpyT1zeIwxnG995vbnXxjCUSmoPPX5F0Pk/RfkmY7rrf1fpy/QHSGfP6Ggd/tuN5XzQJttzuud4lpN90s1lZvpncFIkfAUB1GmO2mQdplPz8i6/aZks7fqu2RZohWZliUxZ+AaBR6/h5ptgMVOHP+AtEp6PwNA/9qx/VWSPqipIsljZP0pqTHJJ0aBv6SaLoNbImAoTo0mm3XIO06+9lHZkGaQRelARCJQs9fpkkGSqeg81fvncOhpLD4XQPyR9FzdehbPXLYIO0asm6T5wwkA+cvUL44f1ERCBiqwwazHT5Iu+w0hg052gGID+cvUL44f1ERCBiqw0tmO3WQdtnPM/MCkAycv0D54vxFRSBgqA59M6DMdFwv17DoHLPdIOmVGPoFYHCcv0D54vxFRSBgqA63mG2jpMNytFtotoHFKpYAosX5C5Qvzl9UBAKGKhAG/jJJj5q7X++vjeN6CyTtY+5eFV/vAOTC+QuUL85fVAoChupxrqRes+z8ZY7rje57wnE9R9K15u4NYeAvLl03AfSD8xcoX5y/KHs1mQwjX+XCcb0ga8XlPnub7VtmMZdsbhj4m1ePdFzvc2bV1zoz5/MrkkZLmmia3CtpYRj4gy0wA8AS5y9Qvjh/Ue1YuK287J61zPzWJmZ98PTZosAqDPzLHdd70KwYeaRZ3XWTpHsk/UHSVWHg90bXfaCqcf4C5YvzF1WNEQYAAAAAA6KGAQAAAMCACBgAAAAADIiAAQAAAMCACBgAAAAADIiAAQAAAMCACBgAAAAADIiAAQAAAMCACBgAAAAADIiAAQAAAMCACBgAAAAADIiAAQAAAMCACBgAAAAADIiAAQAAAMCACBgAAAAADIiAAQAAAMCACBgAAAAADIiAAQAAAMCA6krdAQDA0Dmu94ikfSTdHAb+B0vdH6AQjuv9VNJXJLWGgT+81P0B8B4CBgAVy3G9UyX9toBDnBYG/u+K1JcvS+oIA/+/i3G8YnNcbwdJJ0s6UtJMSeMkpSStk/ScpDslXRMG/oul7ms2x/VOlLSXpIvCwG+z3Lcv2LovDPxDoutlaZj/01MkHSVplqQxkoZJapX0uqTHJPmS/hYGfrrU/QWQXAQMACrZO5KWDfDcTEmN5uLphRz7F8xxvVGSfirpGUmJChgc16uT9ENJ50hqMA9vNBeUDZImSzrM/PtPx/Uul/SVMPA7Stz1Pv8paa6kX0qyChgqmeN6Z0n6L0lN5qFNklaY2xMl7W7+fULSEsf1jgsD/+0SdhlAghEwAKhYYeD/XdLf+3vOcb3HJe0t6ZEw8I+IuCv7SqqJ+DWsOa7XKOlmM6ogSddJ+omkh8PA7zVtUpJcSV+VdKiksyXt7rje0WHgdyeg/3uUsg9JZEZd+gLT0ARVD4eBn8lqM0PSv0v6nKT9Jf1V0uGl6zWAJCNgAIDo7VvqDgzgVyZYyEj6XBj4V2zdwKSq3Oi4XmC+xf+cpCMkXSDpvNJ0e7O5kupL3Ick+g+zfUqSGwZ+z9YNwsBfLuksx/U6JH1J0mGO6y0MA/+W+LsLIOkIGAAgTyZ951OSPmouVseYlKZXzDe5l4SBvzKr/Qcl3Zh1iNmO6/V9y/urMPC/kNV2jKTPS/qASZcaaVJsnpd0k6Sfh4G/rojvZV9JnzZ3f9FfsJAtDPy043r/ZlKTxktqHuC48yR9wbSbZEZWVkt6UNKVYeAvHmC/4eb9Hy/pfZJGmPqJVZIWSboqDPzns9pu3OoQbzuuJ0lPh4Ef26jDUN+v2dcxF+v7mff7mqkpuMj8fV5lmh4RBv5defYnZUbOJOm2/oKFrfzIBIxPm1qV/o65n6QvmhGmiZI6TPs/Svp1fyNN5lw52Zwre0kaK6nHpLr9Q9LFYeD3+3qDvL86SadlHXe0pA2SnjQjZFeGgd9pe1wAuTGtKgDkwXG97STdLek3ko4xF8wvmIBhjknZedZxvWOydltvaijWm/sd5v4yc+HUd+yZ5tvg70k6QFKvCRQykuZJ+rakxx3X27GIb+krZtsq6Tv57GAuPudLmhQG/pe2ft5xvfMkPWIu6KZJetNcBE82F3i3O673a8f1arbab5IpwL1Q0kGS0ub9d0vaU9LXJD3puN7xZpe0+RmuzDrMU+axZwv5odgY6vs1+35F0m0m3Wus+X0Ybn6PHpI0Pau5Tb1IJuv2oL8vYeCvDgP/y2HgXx0G/kv99PMbJvj5V9PPl8zP/0BJl0q61wS72fs0SbpD0tWSjjbB0Mvmwn43SWea3+eFFu9LjutNkPSApCtMIXeN6U+LGfW6VNJD5vcJQBERMABAfq4xF0md5pv57cLA3z0M/CnmG90nzQXfXxzXm6L3LsbuCQN/jqTbzTFeDAN/jvl3Ydaxf28uMjdIWhAG/rgw8N8XBv4oSSeZkYYdTQpRwcwFrGPu3hgG/rv57msuMLeZUcdxvX+R9ANzEfe/kiaHgT89DPy+GZcuNU3PNN/IZ/uepF3NN/OHhIE/3vxsdzCP32YKsK92XK85DPx283PN/hnONz/XfxnSD8VSIe/Xcb09JP3Y3H1I0vQw8HcNA3+SqSNokHRZ1i55z2Bkak+WmrsnOq53Zn8BS57v8XgzAlEj6XzzO/++MPC3M7+XHWZ05LKtdj3fjEbI1EmMCQN/Zhj425vg+jkz4cDvHNfrd6Sqn77USvqLpPdLekvSQkkTwsCfZQKGj0laY0Yd/jjU9wygfwQMADAIx/UOMqlCkvT1MPB/m52GEQb+EyaVpsukEm3z7XuOY+9s0ptk0o62SGEJA/96SZebuwsd1xtZhLe0q6TtzO0HinA8mYtnmYvVT4SB/1bfE2HgbwgD/xyTtiVJ55nUkj59Rde/CQP/vuyDmm+9PyrpXhN4JeXb40Le7xfMlLVdkk4KA//lrH3vlvRBSbML6Nv5ZqShVtKvzejM+Y7rHeK4XkMe+/f5kdleFwb+d7NTfczvZd/P4COO6+2Utd+JZnt3GPg/3+pcWWZGUSRpghkZyMcJWUXZXhj4i/qKuMPA7w0D/89mxieZYx5l8T4BDIKAAQAG9xGz7ZR0VX8NwsB/JWskwcv3wGHgvxIGfoO5gL9ogGYPm20qnzSTPEzIur0yR7u8OK43R9IMc/eyvhmW+nGl2W5vRmv69KXRTO5vpzDw3w0D/9Aw8D+ehHUgivB++9LW7ggD//WtdwoD/zFJNwy1f2HgLzIpRH01L7NN2tk9kjY4rne/43o/dlzvcFPz0N973NNMuypJ1w7wUr+V9G/mtTanTYWBP8OMtn1ogP0ezrq9S55vqy8YWBIGfr9Bbhj4t5lUNkmKZaQJqBYUPQPA4N5vtk+Ggd+ao90jJid9F8f1RoWBvz5H2y0MUtC8Ket2Y77HzGFE1u1c7ydf78+6/WCOdo9k3Z5rLmBlvon/rKSTTVH45ZIeynEhXmpDfr+O67VI6vs2/vEc+y6yCTy3Fgb+/5qZrU6X9GGTOpQyC7cdaP59TdLrjuv93IxuZac+Zc/s1e9aJqbA/5cDPNea43drKL/P+5vtU4O0W2LqJPbJ87gA8kDAAACD60uDeW2Qdm9k3Z6QVew8KMf1PmS+qZ1nZqJpiXDthvas28VIccpOE8r1M8r++UzMuv11k9u+v1mZ+BRJ7ziud5cJJm4IA/+Nfo5XKoW833FZ/6+53tPyAvonmdQoST+T9DOzeOCBkg7OChiaJU0xiwp+wEyr2pd2tEPWoVbbvrbjevtI+ox5nZ1MkDqkrAZTj9D3Mz/dcb3T89gtKalrQEUgYACAwbWY7WCz1WQ/35Kj3WYmt/3PWXnfkvS2mTWn7+JtpJmFp1iyL3Kn52iXr+z3OuDPKAz8TjOCUJO9Txj46x3XO9TMNnSaCRy2M9+we5IudVzvj5K+FAZ+UVbfLlAh7ze7yDfX9J95B5v5MKNdi8w/mVqGEyR933wjP98Ebt81u2S/xy6b13Jc71xT1N0XIGw0sxn1jTjUmtmv8tVgRkdkCp7fzGOfTXm0AZAnAgYAGFzfhU7TIO2yn8/3guXsrGDhZkn/3rfeQJ9+1nMo1CuS1pppMg/PKm4dquzUk6aBLjDNysx9365v8fMxhbFXSLrCTJ+5wBRDn2C+lf+UpBmO6x3c3yxNMSvk/WYHCbkWnRuR47mCmZGEvziud7uZ4WuySV/qCxjyeo9bM/UdfcHCcjPKcG92etkA62jk6muH43o95prlD2Hgn2vzXgEUjqJnABhcX2Hw1EHa9T3fm+e3oJL0cbN9Q9KJWwcLxrg8j5UXc/F2s7nrmJma8uK43i6O613iuF52gXJ24XSun1H2cwOm45ipW/8YBv4Z5kK2bwrS/bN+XqVUyPvNrlWZoIEVNPKz1axMAzIjNjeZu1Oynsr3PW7to1nXFieFgX93P7UoQ/l97isOt+kLgCIhYACAwT1ktns6rpfrm9++mXCeDQM/3xGGvgLYJWHgD/Qt7gcGeLwQl5jApvb/t3evoVZUYRjHH1ELSfODSkZpklEWlEkXgsywWCQLoxb1ofpQQdAVQrJCo0KKrmpXo+iOVBZEU0kTMRAaol2kQq0oigzLDmUmklFpnT70TK12e9zb4+kY8f+BzNl7z6y915x9ZL0za72vpPu6OcBzyR+RdKWkNV7Aq+z8yHPkm+SZgvJMOY0D3KostldlMSebRnV0N5/1X9bn/npx+yY/t7NpObtU1KwWYloUYvpM0jrXLuhGfWfsu9bPayc0vNeoENOj/lf3tf4+f1+VRdMC5b58n+tzPm1n/Qox7dWHtgF0QMAAAJ096+1eLsT1Dy7GVeeJX9Lycn2Ftd2UpjqwaHvVNcQ0oyVbTn9kSVJVFu9mU5FODzHdvbNiVx7QP5HVTLi5zhjlgWE9OLysXapOD/Iu98NP6wxCIaYZIaZPJK1vqhHgz1Wfu7zIXH7lutN0sX6zO/21N+rdWqsk+9ijWta07IofnKr0sG7qgYSYxrmGiFwgT/qjj2slfeiHlzQM0s/yNKaLJNVrS+rv84h2v08XNbwxe6rb7/Mz3o71ovh2fRnmauvvhJi6re8AoAsEDADQQVUWqyU974e3hJguyAeJLuz2kv9P/bJNqsmvvZ0QYjrex9TZierB49QQ0zlZmyNCTLMlFZKuz9o6Sf1nXpbvf5akFSGm00JMf86tDzENCTGdIWllNlBbVJXFvS1tzfF2sqSnQkyjszbGuJp1nRpzbl10yyk7D3RWnpdDTJPyRkNMo3w+RztAyOsTfJ39fHaIaVCHO0D9qa/9laTHvB0u6dkQ037ZsSdLelXSsj5+rtuyWgQLQ0wPhZiOaN0pxLRviOkCF+4b6UXWN7Tsdp23x0p6JC8a6HU1C/zwhaosPvbP9fd5iKQ76ztHIabBIabkNLRLJdX1NKZ22a+lWRreB/w3+OddKdeNeM3JASZKWtNluwC6MKi3t7eL3QDg/yXE9L4He8ursuh4NdJpKZdmA/Ytnpc+OpuLvlFSdDXb/NgZHgTWtrvOwNQQ00RXCx7p13p8lXa872gs8OB0g1NF/ubB1qyqLMoQ02rnnH+lKouZfTgPg5yP/ya/n5x2daMDoHFZgowtrnT9cENbsyXN90LfHc6MM1jSBG97Jc2pyuLOluPOlfRk9v7feNrOvr6iPMT9nl2VxT3ZcWP8HsOz8zpU0tCqLHZ00ff63G3zXYBO7qrKYvHu9tfHLvZCbkn6NevH/h4YX+2aApJ0nIPWroSYDpC0OLsbJElb/Tvd4e/aAdlFw3WSzvNdhda25ki61X38yQvmx3jBvDx1aUadvcpTglY5PbAciPR4LcoIB0IzJT2eFUTc4Crf80JMCyTNlrStKovhLZ9lrNfe1G1v9VqLUdnf4CZXgl7R7fkC0Bl3GACgC05LOd1pPysPTg/1APVNX409vDVY0F+Vd6+V9IWP2yzpPb/2ma9EP+eB8iintKwkzazK4hpnBbpQ0kc+fnDL4tnd6VdvVRZ3+MrsXEmve5A33oPKHkmlpCskHdQULLithR7MPeFB4HgPFNf7qvqUdoPnqiyWeG3CIl8ZHiZpklOrfursScfkwYKP+9YVfdc6+9A2/y52teDbPg4eO/372yLlvvbXLpR0qQfcPzlQ6JF0laRTJf2Y7btL/anK4quqLE71FLn7Pf//F09VmuSB+zoHaWdKmtwuWHBbt3sNw9NO93uw05y+5bUsJ+apbr0O5xTXf/jcaWTHSPrAVaGDp7LNlbTc/dzbbXfqV48/y8Wuqv6zpEP88mrfiTuSYAHof9xhAADgP8aLiFf64aEN2bMAYEBwhwEAgD2g3YLnTL3uYEdLilMAGHAEDAAADKAQUwoxfSNpc4hpSsNu53v7dlUWPzbsAwADgoABAICBtcxz+yVpiasjS66CHGK6T9I0PzV/z3xEAPgLaxgAABhgzpz1ohf8yhmMtnrxef3cbVVZXLeTZgBgQBAwAACwB4SYDnGmoemuRTHMmbJWSXqwKou+1mIAgH5FwAAAAACgEWsYAAAAADQiYAAAAADQiIABAAAAQCMCBgAAAACNCBgAAAAANCJgAAAAANCIgAEAAABAIwIGAAAAAI0IGAAAAAA0ImAAAAAA0IiAAQAAAEAjAgYAAAAAjQgYAAAAADQiYAAAAADQiIABAAAAQCMCBgAAAACNCBgAAAAANCJgAAAAANCIgAEAAABAo98BceizF7j48yoAAAAASUVORK5CYII=\n"
           },
           "metadata": {
-            "bento_obj_id": "139790919180592",
+            "bento_obj_id": "140557461788848",
             "needs_background": "light"
           }
         }
       ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "2de1b2a0-c148-4f1d-8bfe-5a1055079869",
-        "showInput": true,
-        "customInput": null,
-        "customOutput": null
-      },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
     }
   ]
 }


### PR DESCRIPTION
Summary:
Currently, the MOMF tutorial
- Runs MOMF to optimize Branin-Currin, iteratively adding another batch of two points 30 times
- Replicates 3x this by doing the same thing for MOMF 3 times
- Runs qEHVI to optimize Branin-Currin with 30 iterations, doing the same thing 3x for 3 replications
- Computes CIs over the 3 replications to produce the error bar figure at the end of the tutorial

We don't really need to replicate the analysis to statistically demonstrate that MOMF is outperforming qEHVI here. It is clearly much better, and having these replications (confusingly called "trials") makes the tutorial more complicated.

This diff just runs MOMF once and qEHVI once, so that the tutorial only takes ~2/7 as long. It was already running in ~15 minutes on GH actions, so it should easily run within the 30 minute time limit now.

I also changed the copy, added type annotations, and made various small clean-ups.

Differential Revision: D43758377

