### PR TITLE
Fix get_infeasible_cost for objectives that require X

### DIFF
--- a/botorch/acquisition/multi_objective/objective.py
+++ b/botorch/acquisition/multi_objective/objective.py
@@ -188,7 +188,7 @@ class FeasibilityWeightedMCMultiOutputObjective(MCMultiOutputObjective):
             from botorch.acquisition.utils import get_infeasible_cost
 
             inf_cost = get_infeasible_cost(
-                X=X_baseline, model=model, objective=lambda y, X_baseline: y
+                X=X_baseline, model=model, objective=lambda y, X: y
             )[objective_idcs]
 
             def apply_feasibility_weights(

--- a/botorch/acquisition/multi_objective/objective.py
+++ b/botorch/acquisition/multi_objective/objective.py
@@ -188,7 +188,7 @@ class FeasibilityWeightedMCMultiOutputObjective(MCMultiOutputObjective):
             from botorch.acquisition.utils import get_infeasible_cost
 
             inf_cost = get_infeasible_cost(
-                X=X_baseline, model=model, objective=lambda y: y
+                X=X_baseline, model=model, objective=lambda y, X_baseline: y
             )[objective_idcs]
 
             def apply_feasibility_weights(

--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -244,7 +244,7 @@ def get_infeasible_cost(
             return Y.squeeze(-1)
 
     posterior = model.posterior(X, posterior_transform=posterior_transform)
-    lb = objective(posterior.mean - 6 * posterior.variance.clamp_min(0).sqrt(), X)
+    lb = objective(posterior.mean - 6 * posterior.variance.clamp_min(0).sqrt(), X=X)
     if lb.ndim < posterior.mean.ndim:
         lb = lb.unsqueeze(-1)
     # Take outcome-wise min. Looping in to handle batched models.

--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -244,7 +244,7 @@ def get_infeasible_cost(
             return Y.squeeze(-1)
 
     posterior = model.posterior(X, posterior_transform=posterior_transform)
-    lb = objective(posterior.mean - 6 * posterior.variance.clamp_min(0).sqrt())
+    lb = objective(posterior.mean - 6 * posterior.variance.clamp_min(0).sqrt(), X)
     if lb.ndim < posterior.mean.ndim:
         lb = lb.unsqueeze(-1)
     # Take outcome-wise min. Looping in to handle batched models.

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -577,7 +577,7 @@ class TestGetInfeasibleCost(BotorchTestCase):
     def test_get_infeasible_cost(self):
         for dtype in (torch.float, torch.double):
             tkwargs = {"dtype": dtype, "device": self.device}
-            X = torch.zeros(5, 1, **tkwargs)
+            X = torch.ones(5, 1, **tkwargs)
             means = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], **tkwargs).view(-1, 1)
             variances = torch.tensor([0.09, 0.25, 0.36, 0.25, 0.09], **tkwargs).view(
                 -1, 1
@@ -589,6 +589,11 @@ class TestGetInfeasibleCost(BotorchTestCase):
                 X=X, model=mm, objective=lambda Y, X: Y.squeeze(-1) - 5.0
             )
             self.assertAllClose(M, torch.tensor([6.0], **tkwargs))
+            M = get_infeasible_cost(
+                X=X, model=mm, objective=lambda Y, X: Y.squeeze(-1) - 5.0 - X[0, 0]
+            )
+            self.assertAllClose(M, torch.tensor([7.0], **tkwargs))
+            # test it with using also X in the objective
             # Test default objective (squeeze last dim).
             M2 = get_infeasible_cost(X=X, model=mm)
             self.assertAllClose(M2, torch.tensor([1.0], **tkwargs))

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -586,7 +586,7 @@ class TestGetInfeasibleCost(BotorchTestCase):
             # means - 6 * std = [-0.8, -1, -0.6, 1, 3.2]. After applying the
             # objective, the minimum becomes -6.0, so 6.0 should be returned.
             M = get_infeasible_cost(
-                X=X, model=mm, objective=lambda Y: Y.squeeze(-1) - 5.0
+                X=X, model=mm, objective=lambda Y, X: Y.squeeze(-1) - 5.0
             )
             self.assertAllClose(M, torch.tensor([6.0], **tkwargs))
             # Test default objective (squeeze last dim).


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

The method `get_infeasible_cost` is currently not able to also handle objectives that require also `X` values, which will be the new default in one of the next releases. This PR fixes it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.
