### PR TITLE
speed up composite multi-task bo tutorial

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -24,9 +24,7 @@ IGNORE_ALWAYS = {  # ignored in smoke tests and full runs
     "bope.ipynb",  # flaky, keeps failing the workflows
     "preference_bo.ipynb",  # failing. Fix planned
 }
-RUN_IF_SMOKE_TEST_IGNORE_IF_STANDARD = {  # only used in smoke tests
-    "composite_mtbo.ipynb",  # TODO: very slow, figure out if we can make it faster
-}
+RUN_IF_SMOKE_TEST_IGNORE_IF_STANDARD = {}  # only used in smoke tests
 
 
 def _read_command_line_output(command: str) -> str:

--- a/tutorials/composite_mtbo.ipynb
+++ b/tutorials/composite_mtbo.ipynb
@@ -1,709 +1,666 @@
 {
- "metadata": {
-  "dataExplorerConfig": {},
-  "kernelspec": {
-   "display_name": "python3",
-   "language": "python",
-   "name": "python3"
+  "metadata": {
+    "dataExplorerConfig": {},
+    "kernelspec": {
+      "display_name": "python3",
+      "language": "python",
+      "name": "python3"
+    },
+    "captumWidgetMessage": {},
+    "outputWidgetContext": {}
   },
-  "captumWidgetMessage": {},
-  "outputWidgetContext": {}
- },
- "nbformat": 4,
- "nbformat_minor": 2,
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "originalKey": "2c421274-e807-4d93-8b0e-d23afdb49a2d",
-    "showInput": false
-   },
-   "source": [
-    "## Composite Bayesian Optimization with Multi-Task Gaussian Processes\n",
-    "\n",
-    "In this tutorial, we'll be describing how to perform multi-task Bayesian optimization over composite functions. In these types of problems, there are several related outputs, and an overall easy to evaluate objective function that we wish to maximize.\n",
-    "\n",
-    "**Multi-task Bayesian Optimization** was first proposed by [Swersky et al, NeurIPS, '13](https://papers.neurips.cc/paper/2013/hash/f33ba15effa5c10e873bf3842afb46a6-Abstract.html) in the context of fast hyper-parameter tuning for neural network models; however, we demonstrate a more advanced use-case of **[composite Bayesian optimization](https://proceedings.mlr.press/v97/astudillo19a.html)** where the overall function that we wish to optimize is a cheap-to-evaluate (and known) function of the outputs. In general, we expect that using more information about the function should yield improved performance when attempting to optimize it, particularly if the metric function itself is quickly varying.\n",
-    "\n",
-    "See [the composite BO tutorial w/ HOGP](https://github.com/pytorch/botorch/blob/main/tutorials/composite_bo_with_hogp.ipynb) for a more technical introduction. In general, we suggest using MTGPs for unstructured task outputs and the HOGP for matrix / tensor structured outputs.\n",
-    "\n",
-    "\n",
-    "We will use a Multi-Task Gaussian process ([MTGP](https://papers.nips.cc/paper/2007/hash/66368270ffd51418ec58bd793f2d9b1b-Abstract.html)) with an ICM kernel to model all of the outputs in this problem. MTGPs can be easily accessed in Botorch via the `botorch.models.KroneckerMultiTaskGP` model class (for the \"block design\" case of fully observed outputs at all inputs). Given $T$ tasks (outputs) and $n$ data points, they assume that the responses, $Y \\sim \\mathbb{R}^{n \\times T},$ are distributed as $\\text{vec}(Y) \\sim \\mathcal{N}(f, D)$ and $f \\sim \\mathcal{GP}(\\mu_{\\theta}, K_{XX} \\otimes K_{T}),$ where $D$ is a (diagonal) noise term."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "8f5c4d81-1359-4305-bad3-2973e747e853",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "6db6ec8c-6245-4efd-9089-5e2e54d0c285",
-    "executionStartTime": 1668655887003,
-    "executionStopTime": 1668655887649
-   },
-   "source": [
-    "import os\n",
-    "import time\n",
-    "\n",
-    "import torch\n",
-    "from botorch.acquisition.monte_carlo import qExpectedImprovement\n",
-    "from botorch.acquisition.objective import GenericMCObjective\n",
-    "from botorch.models import KroneckerMultiTaskGP, SingleTaskGP\n",
-    "from botorch.optim import optimize_acqf\n",
-    "from botorch.optim.fit import fit_gpytorch_torch\n",
-    "from botorch.sampling.normal import IIDNormalSampler\n",
-    "\n",
-    "from botorch.test_functions import Hartmann\n",
-    "from gpytorch.mlls import ExactMarginalLogLikelihood\n",
-    "\n",
-    "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")"
-   ],
-   "execution_count": 1,
-   "outputs": [
+  "nbformat": 4,
+  "nbformat_minor": 2,
+  "cells": [
     {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "I1116 193126.356 _utils_internal.py:179] NCCL_DEBUG env var is set to None\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "2c421274-e807-4d93-8b0e-d23afdb49a2d",
+        "showInput": false
+      },
+      "source": [
+        "## Composite Bayesian Optimization with Multi-Task Gaussian Processes\n",
+        "\n",
+        "In this tutorial, we'll be describing how to perform multi-task Bayesian optimization over composite functions. In these types of problems, there are several related outputs, and an overall easy to evaluate objective function that we wish to maximize.\n",
+        "\n",
+        "**Multi-task Bayesian Optimization** was first proposed by [Swersky et al, NeurIPS, '13](https://papers.neurips.cc/paper/2013/hash/f33ba15effa5c10e873bf3842afb46a6-Abstract.html) in the context of fast hyper-parameter tuning for neural network models; however, we demonstrate a more advanced use-case of **[composite Bayesian optimization](https://proceedings.mlr.press/v97/astudillo19a.html)** where the overall function that we wish to optimize is a cheap-to-evaluate (and known) function of the outputs. In general, we expect that using more information about the function should yield improved performance when attempting to optimize it, particularly if the metric function itself is quickly varying.\n",
+        "\n",
+        "See [the composite BO tutorial w/ HOGP](https://github.com/pytorch/botorch/blob/main/tutorials/composite_bo_with_hogp.ipynb) for a more technical introduction. In general, we suggest using MTGPs for unstructured task outputs and the HOGP for matrix / tensor structured outputs.\n",
+        "\n",
+        "\n",
+        "We will use a Multi-Task Gaussian process ([MTGP](https://papers.nips.cc/paper/2007/hash/66368270ffd51418ec58bd793f2d9b1b-Abstract.html)) with an ICM kernel to model all of the outputs in this problem. MTGPs can be easily accessed in Botorch via the `botorch.models.KroneckerMultiTaskGP` model class (for the \"block design\" case of fully observed outputs at all inputs). Given $T$ tasks (outputs) and $n$ data points, they assume that the responses, $Y \\sim \\mathbb{R}^{n \\times T},$ are distributed as $\\text{vec}(Y) \\sim \\mathcal{N}(f, D)$ and $f \\sim \\mathcal{GP}(\\mu_{\\theta}, K_{XX} \\otimes K_{T}),$ where $D$ is a (diagonal) noise term."
+      ]
     },
     {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "I1116 193126.357 _utils_internal.py:188] NCCL_DEBUG is INFO from /etc/nccl.conf\n"
-     ]
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "8871a990-f29b-45c2-b378-ac2befef0a1f",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "e32e501e-2fe4-4b41-b1fd-4a3cf218833e",
+        "executionStartTime": 1678932909107,
+        "executionStopTime": 1678932912073
+      },
+      "source": [
+        "import os\n",
+        "import time\n",
+        "\n",
+        "import torch\n",
+        "from botorch.acquisition.monte_carlo import qExpectedImprovement\n",
+        "from botorch.acquisition.objective import GenericMCObjective\n",
+        "from botorch.models import KroneckerMultiTaskGP, SingleTaskGP\n",
+        "from botorch.optim import optimize_acqf\n",
+        "from botorch.optim.fit import fit_gpytorch_torch\n",
+        "from botorch.sampling.normal import IIDNormalSampler\n",
+        "\n",
+        "from botorch.test_functions import Hartmann\n",
+        "from gpytorch.mlls import ExactMarginalLogLikelihood\n",
+        "\n",
+        "import warnings\n",
+        "warnings.filterwarnings(\"ignore\")\n",
+        "\n",
+        "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "I0315 191509.128 _utils_internal.py:179] NCCL_DEBUG env var is set to None\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "I0315 191509.131 _utils_internal.py:188] NCCL_DEBUG is INFO from /etc/nccl.conf\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "de394597-4088-4f32-94c7-7c611876eebc",
+        "showInput": false
+      },
+      "source": [
+        "### Set device, dtype and random seed"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "015a9aab-e3a5-4d09-bd5d-209f9b41cbdb",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "00e96c89-1a35-4c00-852c-1f5dda614d9a",
+        "executionStartTime": 1678932914757,
+        "executionStopTime": 1678932914766
+      },
+      "source": [
+        "torch.random.manual_seed(10)\n",
+        "\n",
+        "tkwargs = {\n",
+        "    \"dtype\": torch.double,\n",
+        "    \"device\": torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\"),\n",
+        "}"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "f151402e-238e-4c5c-be43-55a73f07664e",
+        "showInput": false
+      },
+      "source": [
+        "### Problem Definition\n",
+        "\n",
+        "The function that we wish to optimize is based off of a contextual version of the Hartmann-6 test function, where following [Feng et al, NeurIPS, '20](https://proceedings.neurips.cc/paper/2020/hash/faff959d885ec0ecf70741a846c34d1d-Abstract.html) we convert the sixth task dimension into a task indicator. Here we assume that we evaluate all contexts at once."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "48fabc12-b1ee-4b88-aa97-9ce4bfe83fd4",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "0429d2a2-cc39-4838-9b87-f3eebd49e140",
+        "executionStartTime": 1678932917176,
+        "executionStopTime": 1678932917215
+      },
+      "source": [
+        "from botorch.test_functions import Hartmann\n",
+        "from torch import Tensor\n",
+        "\n",
+        "\n",
+        "class ContextualHartmann6(Hartmann):\n",
+        "    def __init__(self, num_tasks: int = 20, noise_std=None, negate=False):\n",
+        "        super().__init__(dim=6, noise_std=noise_std, negate=negate)\n",
+        "        self.task_range = torch.linspace(0, 1, num_tasks).unsqueeze(-1)\n",
+        "        self._bounds = [(0.0, 1.0) for _ in range(self.dim - 1)]\n",
+        "        self.bounds = torch.tensor(self._bounds).t()\n",
+        "\n",
+        "    def evaluate_true(self, X: Tensor) -> Tensor:\n",
+        "        batch_X = X.unsqueeze(-2)\n",
+        "        batch_dims = X.ndim - 1\n",
+        "\n",
+        "        expanded_task_range = self.task_range\n",
+        "        for _ in range(batch_dims):\n",
+        "            expanded_task_range = expanded_task_range.unsqueeze(0)\n",
+        "        task_range = expanded_task_range.repeat(*X.shape[:-1], 1, 1).to(X)\n",
+        "        concatenated_X = torch.cat(\n",
+        "            (\n",
+        "                batch_X.repeat(*[1] * batch_dims, self.task_range.shape[0], 1),\n",
+        "                task_range,\n",
+        "            ),\n",
+        "            dim=-1,\n",
+        "        )\n",
+        "        return super().evaluate_true(concatenated_X)"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "a2fbe3e8-98cf-49e0-9891-8d6009790955",
+        "showInput": false
+      },
+      "source": [
+        "We use `GenericMCObjective` to define the differentiable function that we are optimizing. Here, it is defined as \n",
+        "$$g(f) = \\sum_{i=1}^T \\cos(f_i^2 + f_i w_i)$$\n",
+        "where $w$ is a weight vector (drawn randomly once at the start of the optimization). As this function is a non-linear function of the outputs $f,$ we cannot compute acquisition functions via computation of the posterior mean and variance, but rather have to compute posterior samples and evaluate acquisitions with Monte Carlo sampling. \n",
+        "\n",
+        "For greater than $10$ or so tasks, it is computationally challenging to sample the posterior over all tasks jointly using conventional approaches, except that [Maddox et al, '21](https://arxiv.org/abs/2106.12997) have devised an efficient method for exploiting the structure in the posterior distribution of the MTGP, enabling efficient MC based optimization of objectives using MTGPs. In this tutorial, we choose 6  contexts/tasks for demostration. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "5938fb26-f773-4f68-a389-c0630e0687eb",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "80cec36b-8b73-4c09-9511-f79f59df0af8",
+        "executionStartTime": 1678932920811,
+        "executionStopTime": 1678932929399
+      },
+      "source": [
+        "num_tasks = 6\n",
+        "problem = ContextualHartmann6(num_tasks= num_tasks, noise_std=0.001, negate=True).to(**tkwargs)\n",
+        "\n",
+        "# we choose num_tasks random weights\n",
+        "weights = torch.randn(num_tasks, **tkwargs)\n",
+        "\n",
+        "\n",
+        "def callable_func(samples, X=None):\n",
+        "    res = -torch.cos((samples**2) + samples * weights)\n",
+        "    return res.sum(dim=-1)\n",
+        "\n",
+        "\n",
+        "objective = GenericMCObjective(callable_func)"
+      ],
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "5a85661a-3668-4128-b5f4-8150dbcdce7d",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "d1742d93-d229-4400-b3d9-55e5fee5eed6",
+        "executionStartTime": 1678932929407,
+        "executionStopTime": 1678932929411
+      },
+      "source": [
+        "bounds = problem.bounds"
+      ],
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "df727b70-30bb-458d-81cc-55dc6a5a3ef2",
+        "showInput": false
+      },
+      "source": [
+        "### Define helper functions\n",
+        "\n",
+        "Define helper functions used for optimizing the acquisition function and for constructing the batch expected improvement acquisition, which we optimize for both the batch GP and MTGP."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "6975db14-12b3-481a-b854-0812ee8d9916",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "886cc446-5045-430e-8390-1eab64c3113c",
+        "executionStartTime": 1678932929417,
+        "executionStopTime": 1678932929421
+      },
+      "source": [
+        "def optimize_acqf_and_get_candidate(acq_func, bounds, batch_size):\n",
+        "    \"\"\"Optimizes the acquisition function, and returns a new candidate and a noisy observation.\"\"\"\n",
+        "    # optimize\n",
+        "    candidates, _ = optimize_acqf(\n",
+        "        acq_function=acq_func,\n",
+        "        bounds=bounds,\n",
+        "        q=batch_size,\n",
+        "        num_restarts=10,\n",
+        "        raw_samples=512,  # used for intialization heuristic\n",
+        "        options={\"batch_limit\": 5, \"maxiter\": 200, \"init_batch_limit\": 5},\n",
+        "    )\n",
+        "    # observe new values\n",
+        "    new_x = candidates.detach()\n",
+        "    return new_x"
+      ],
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "762b9e33-c2ac-40c2-90e9-7f6a31b92911",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "e8db986c-2aa0-416f-a2b9-8ed1fe34984f",
+        "executionStartTime": 1678932929428,
+        "executionStopTime": 1678932929431
+      },
+      "source": [
+        "def construct_acqf(model, objective, num_samples, best_f):\n",
+        "    sampler = IIDNormalSampler(sample_shape=torch.Size([num_samples]))\n",
+        "    qEI = qExpectedImprovement(\n",
+        "        model=model,\n",
+        "        best_f=best_f,\n",
+        "        sampler=sampler,\n",
+        "        objective=objective,\n",
+        "    )\n",
+        "    return qEI"
+      ],
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "53414433-e097-4556-90e9-e99e35cdb390",
+        "showInput": false
+      },
+      "source": [
+        "Set environmental parameters, we use 20 initial data points and optimize for 20 steps with a batch size of 3 candidate points at each evaluation."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "51f24269-b5de-4dd8-b2b4-18d269f3f3c2",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "63c971a6-7e24-4b8a-8ec8-15d0ef21f6ff",
+        "executionStartTime": 1678932929437,
+        "executionStopTime": 1678932929440
+      },
+      "source": [
+        "if SMOKE_TEST:\n",
+        "    n_init = 5\n",
+        "    n_steps = 1\n",
+        "    batch_size = 2\n",
+        "    num_samples = 4\n",
+        "    n_trials = 4\n",
+        "    verbose = False\n",
+        "else:\n",
+        "    n_init = 10\n",
+        "    n_steps = 10\n",
+        "    batch_size = 3\n",
+        "    num_samples = 64\n",
+        "    n_trials = 3\n",
+        "    verbose = True"
+      ],
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "eff2dc86-0797-40a7-962d-04e8c539c21a",
+        "showInput": false
+      },
+      "source": [
+        "## BO Loop\n",
+        "\n",
+        "Warning... this optimization loop can take a while, especially on the CPU. We compare to both random sampling and a batch GP fit in a composite manner on every output. The batch GP does not take into account any correlations between the different tasks."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "de8d4079-6c17-4041-9ec4-9ebd09d46cd7",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "34279809-d637-4ea5-99c2-aaa3957c37ba",
+        "executionStartTime": 1678932930875,
+        "executionStopTime": 1678934072848
+      },
+      "source": [
+        "mtgp_trial_objectives = []\n",
+        "batch_trial_objectives = []\n",
+        "rand_trial_objectives = []\n",
+        "\n",
+        "for trial in range(n_trials):\n",
+        "    init_x = (bounds[1] - bounds[0]) * torch.rand(\n",
+        "        n_init, bounds.shape[1], **tkwargs\n",
+        "    ) + bounds[0]\n",
+        "\n",
+        "    init_y = problem(init_x)\n",
+        "\n",
+        "    mtgp_train_x, mtgp_train_y = init_x, init_y\n",
+        "    batch_train_x, batch_train_y = init_x, init_y\n",
+        "    rand_x, rand_y = init_x, init_y\n",
+        "\n",
+        "    best_value_mtgp = objective(init_y).max()\n",
+        "    best_value_batch = best_value_mtgp\n",
+        "    best_random = best_value_mtgp\n",
+        "\n",
+        "    for iteration in range(n_steps):\n",
+        "        # we empty the cache to clear memory out\n",
+        "        torch.cuda.empty_cache()\n",
+        "\n",
+        "        mtgp_t0 = time.monotonic()\n",
+        "        mtgp = KroneckerMultiTaskGP(\n",
+        "            mtgp_train_x,\n",
+        "            mtgp_train_y,\n",
+        "        )\n",
+        "        mtgp_mll = ExactMarginalLogLikelihood(mtgp.likelihood, mtgp)\n",
+        "        fit_gpytorch_torch(\n",
+        "            mtgp_mll, options={\"maxiter\": 3000, \"lr\": 0.01, \"disp\": False}\n",
+        "        )\n",
+        "        mtgp_acqf = construct_acqf(mtgp, objective, num_samples, best_value_mtgp)\n",
+        "        new_mtgp_x = optimize_acqf_and_get_candidate(mtgp_acqf, bounds, batch_size)\n",
+        "        mtgp_t1 = time.monotonic()\n",
+        "\n",
+        "        batch_t0 = time.monotonic()\n",
+        "        batchgp = SingleTaskGP(\n",
+        "            batch_train_x,\n",
+        "            batch_train_y,\n",
+        "        )\n",
+        "        batch_mll = ExactMarginalLogLikelihood(batchgp.likelihood, batchgp)\n",
+        "        fit_gpytorch_torch(\n",
+        "            batch_mll, options={\"maxiter\": 3000, \"lr\": 0.01, \"disp\": False}\n",
+        "        )\n",
+        "        batch_acqf = construct_acqf(batchgp, objective, num_samples, best_value_batch)\n",
+        "        new_batch_x = optimize_acqf_and_get_candidate(batch_acqf, bounds, batch_size)\n",
+        "        batch_t1 = time.monotonic()\n",
+        "\n",
+        "        mtgp_train_x = torch.cat((mtgp_train_x, new_mtgp_x), dim=0)\n",
+        "        batch_train_x = torch.cat((batch_train_x, new_batch_x), dim=0)\n",
+        "\n",
+        "        mtgp_train_y = torch.cat((mtgp_train_y, problem(new_mtgp_x)), dim=0)\n",
+        "        batch_train_y = torch.cat((batch_train_y, problem(new_batch_x)), dim=0)\n",
+        "\n",
+        "        best_value_mtgp = objective(mtgp_train_y).max()\n",
+        "        best_value_batch = objective(batch_train_y).max()\n",
+        "\n",
+        "        new_rand_x = (bounds[1] - bounds[0]) * torch.rand(\n",
+        "            batch_size, bounds.shape[1], **tkwargs\n",
+        "        ) + bounds[0]\n",
+        "        rand_x = torch.cat((rand_x, new_rand_x))\n",
+        "        rand_y = torch.cat((rand_y, problem(new_rand_x)))\n",
+        "        best_random = objective(rand_y).max()\n",
+        "\n",
+        "        if verbose:\n",
+        "            print(\n",
+        "                f\"\\nBatch {iteration:>2}: best_value (random, mtgp, batch) = \"\n",
+        "                f\"({best_random:>4.2f}, {best_value_mtgp:>4.2f}, {best_value_batch:>4.2f}), \"\n",
+        "                f\"batch time = {batch_t1-batch_t0:>4.2f}, mtgp time = {mtgp_t1-mtgp_t0:>4.2f}\",\n",
+        "                end=\"\",\n",
+        "            )\n",
+        "        else:\n",
+        "            print(\".\", end=\"\")\n",
+        "\n",
+        "    mtgp_trial_objectives.append(objective(mtgp_train_y).detach().cpu())\n",
+        "    batch_trial_objectives.append(objective(batch_train_y).detach().cpu())\n",
+        "    rand_trial_objectives.append(objective(rand_y).detach().cpu())"
+      ],
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\nBatch  0: best_value (random, mtgp, batch) = (-2.59, -2.59, -2.24), batch time = 7.94, mtgp time = 24.85",
+            "\nBatch  1: best_value (random, mtgp, batch) = (-2.59, -1.81, -0.96), batch time = 7.85, mtgp time = 34.36",
+            "\nBatch  2: best_value (random, mtgp, batch) = (-2.59, -0.55, -0.96), batch time = 7.79, mtgp time = 27.06",
+            "\nBatch  3: best_value (random, mtgp, batch) = (-2.59, -0.55, -0.59), batch time = 8.08, mtgp time = 28.97",
+            "\nBatch  4: best_value (random, mtgp, batch) = (-2.59, -0.55, -0.25), batch time = 5.48, mtgp time = 22.59",
+            "\nBatch  5: best_value (random, mtgp, batch) = (-2.59, -0.55, -0.25), batch time = 2.10, mtgp time = 27.15",
+            "\nBatch  6: best_value (random, mtgp, batch) = (-2.59, 0.08, -0.25), batch time = 2.40, mtgp time = 43.78",
+            "\nBatch  7: best_value (random, mtgp, batch) = (-2.59, 0.08, -0.25), batch time = 3.29, mtgp time = 39.30",
+            "\nBatch  8: best_value (random, mtgp, batch) = (-2.59, 0.24, 0.24), batch time = 5.23, mtgp time = 46.04",
+            "\nBatch  9: best_value (random, mtgp, batch) = (-2.59, 0.24, 0.24), batch time = 6.26, mtgp time = 24.59",
+            "\nBatch  0: best_value (random, mtgp, batch) = (-1.01, -0.99, -0.85), batch time = 11.02, mtgp time = 36.32",
+            "\nBatch  1: best_value (random, mtgp, batch) = (-1.01, -0.25, -0.85), batch time = 6.50, mtgp time = 43.20",
+            "\nBatch  2: best_value (random, mtgp, batch) = (-1.01, -0.25, -0.36), batch time = 8.03, mtgp time = 33.29",
+            "\nBatch  3: best_value (random, mtgp, batch) = (-1.01, -0.25, -0.36), batch time = 7.04, mtgp time = 34.46",
+            "\nBatch  4: best_value (random, mtgp, batch) = (-1.01, -0.25, -0.36), batch time = 8.44, mtgp time = 38.58",
+            "\nBatch  5: best_value (random, mtgp, batch) = (-1.01, -0.25, -0.36), batch time = 7.73, mtgp time = 28.10",
+            "\nBatch  6: best_value (random, mtgp, batch) = (-1.01, -0.25, 0.24), batch time = 7.58, mtgp time = 31.19",
+            "\nBatch  7: best_value (random, mtgp, batch) = (-1.01, -0.25, 0.25), batch time = 7.56, mtgp time = 26.13",
+            "\nBatch  8: best_value (random, mtgp, batch) = (-1.01, -0.25, 0.27), batch time = 8.01, mtgp time = 23.28",
+            "\nBatch  9: best_value (random, mtgp, batch) = (-1.01, -0.25, 0.27), batch time = 8.35, mtgp time = 32.61",
+            "\nBatch  0: best_value (random, mtgp, batch) = (-0.75, -0.75, -0.75), batch time = 4.93, mtgp time = 29.13",
+            "\nBatch  1: best_value (random, mtgp, batch) = (-0.75, -0.75, -0.69), batch time = 7.95, mtgp time = 29.69",
+            "\nBatch  2: best_value (random, mtgp, batch) = (-0.75, -0.75, -0.69), batch time = 8.24, mtgp time = 30.30",
+            "\nBatch  3: best_value (random, mtgp, batch) = (-0.75, -0.35, -0.69), batch time = 7.53, mtgp time = 28.95",
+            "\nBatch  4: best_value (random, mtgp, batch) = (-0.75, -0.35, -0.69), batch time = 7.89, mtgp time = 29.90",
+            "\nBatch  5: best_value (random, mtgp, batch) = (-0.75, -0.03, 1.36), batch time = 7.28, mtgp time = 28.37",
+            "\nBatch  6: best_value (random, mtgp, batch) = (-0.75, 1.76, 1.36), batch time = 2.02, mtgp time = 33.39",
+            "\nBatch  7: best_value (random, mtgp, batch) = (-0.75, 1.76, 1.36), batch time = 2.19, mtgp time = 26.23",
+            "\nBatch  8: best_value (random, mtgp, batch) = (-0.75, 1.76, 1.36), batch time = 2.58, mtgp time = 33.60",
+            "\nBatch  9: best_value (random, mtgp, batch) = (-0.75, 1.79, 1.36), batch time = 2.98, mtgp time = 36.00"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "b567ab22-f3b4-41e3-aaae-75e6fe820cfc",
+        "showInput": false
+      },
+      "source": [
+        "### Plot Results"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "8ec120a6-bc85-42cc-9c59-9963964a0da3",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "b1f7777e-e686-4325-a0e0-d0c8578ec106",
+        "executionStartTime": 1678934072894,
+        "executionStopTime": 1678934073463
+      },
+      "source": [
+        "import matplotlib.pyplot as plt"
+      ],
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "3585efc5-bcb5-49f0-9fe1-e50d2deccfd2",
+        "showInput": false
+      },
+      "source": [
+        "Finally, we plot the results, where we see that the MTGP tends to outperform both the batch GP and the random baseline. The optimization procedure seems to have a good deal less noise than the batch GP.\n",
+        "\n",
+        "However, as demonstrated above, optimizing the acquisition function and fitting the MTGP tend to take a bit longer."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "70c1d378-10d6-4293-ae08-ee311005f796",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "ab0b8ca4-6f68-4026-a402-33be50c08063",
+        "executionStartTime": 1678934073491,
+        "executionStopTime": 1678934073506
+      },
+      "source": [
+        "mtgp_results = torch.stack(mtgp_trial_objectives)[:, n_init:].cummax(1).values\n",
+        "batch_results = torch.stack(batch_trial_objectives)[:, n_init:].cummax(1).values\n",
+        "random_results = torch.stack(rand_trial_objectives)[:, n_init:].cummax(1).values"
+      ],
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "ba0c4d29-2335-488e-8fe0-c68e99a2ddb9",
+        "customOutput": null,
+        "collapsed": true,
+        "requestMsgId": "ba0c4d29-2335-488e-8fe0-c68e99a2ddb9",
+        "executionStartTime": 1678921395668,
+        "executionStopTime": 1678921396332
+      },
+      "source": [
+        "plt.plot(mtgp_results.mean(0))\n",
+        "plt.fill_between(\n",
+        "    torch.arange(n_steps * batch_size),\n",
+        "    mtgp_results.mean(0) - 2.0 * mtgp_results.std(0) / (n_trials**0.5),\n",
+        "    mtgp_results.mean(0) + 2.0 * mtgp_results.std(0) / (n_trials**0.5),\n",
+        "    alpha=0.3,\n",
+        "    label=\"MTGP\",\n",
+        ")\n",
+        "\n",
+        "plt.plot(batch_results.mean(0))\n",
+        "plt.fill_between(\n",
+        "    torch.arange(n_steps * batch_size),\n",
+        "    batch_results.mean(0) - 2.0 * batch_results.std(0) / (n_trials**0.5),\n",
+        "    batch_results.mean(0) + 2.0 * batch_results.std(0) / (n_trials**0.5),\n",
+        "    alpha=0.3,\n",
+        "    label=\"Batch\",\n",
+        ")\n",
+        "\n",
+        "plt.plot(random_results.mean(0))\n",
+        "plt.fill_between(\n",
+        "    torch.arange(n_steps * batch_size),\n",
+        "    random_results.mean(0) - 2.0 * random_results.std(0) / (n_trials**0.5),\n",
+        "    random_results.mean(0) + 2.0 * random_results.std(0) / (n_trials**0.5),\n",
+        "    alpha=0.3,\n",
+        "    label=\"Random\",\n",
+        ")\n",
+        "\n",
+        "plt.legend(loc=\"lower right\", fontsize=15)\n",
+        "plt.xlabel(\"Number of Function Queries\")\n",
+        "plt.ylabel(\"Best Objective Achieved\")"
+      ],
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Text(0, 0.5, 'Best Objective Achieved')"
+          },
+          "metadata": {
+            "bento_obj_id": "140039743181152"
+          },
+          "execution_count": 15
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": "<Figure size 432x288 with 1 Axes>",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAERCAYAAABowZDXAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOydeZgcVb2w31p6nX1LJpOEkBC2sC9hUWRRGrARuO2CiuhVvC7Xq+KOKIriingFReSKn4oKioK0qLRIAwKyBGUPe0hC9klm33urOt8fXTPpnunprp7pfc77PPNMd1V11TndVed3zm9VhBBIJBKJRJILtdwNkEgkEkl1IAWGRCKRSGwhBYZEIpFIbCEFhkQikUhsIQWGRCKRSGwhBYZEIpFIbCEFhkQikUhsoZe7AdPx+QMrgV8CpwArw6Hga+Vuk0QikUgqbIXh8wcCwDpgS7nbIpFIJJJ0KkpgAK3AycBv5vBZMde//p7uOX+2Uv9qrU+yP5X/V2t9qrX+ZOmTbSpKJRUOBX9OcqWxvJTXNQ2zlJcrCbXWJ9mfyqfW+lRr/aEAfSqZwPD5AzpQP9v+cCg4OJ/z9/d0z/nLSCTi9HbvnM/lK45a65PsT+VTa32qtf4wS5/aO7tsf76UK4xTgfBsO33+gCccCkbmevLWjs45N6y3e2deX1o1UGt9kv2pfGqtT7XWHwrQp5IJjHAoeA+glOp6EolEIikslWb0lkgkEkmFIgWGRCKRSGxRUV5SPn/gZWBFiiB72ecPCOA34VDwQ2VunkQikSxoKkpghEPBA8vdBolEIpFkRqqkJBKJRGKLilphlIsNsTgjkQheVcWraXhVFU2RDl0SiUSSihQYwKBpEo+khIAoCm5FmRIeXk2jTlVxa1rBl2QKoErhJJFIqgApMDIhBBEhiJgm/UW+VLOuc3j9rAHwEolEUjFIG0aZGTQMImbt5ayRSCS1hxQY5UYI9sRi5W6FRCKR5EQKjApgdzxe7iZIJBJJTqTAqAAmDIPhRKLczZBIJJKsSIFRIchVhkQiqXSkwKgQemIxTJFX8SuJRCIpKVJgVAgJIeiTaimJRFLBSIFRQeyW3lISiaSCkQKjghhIJIjLmAyJRFKhSIFRQQghpPFbIpFULFJgVBgyiE8ikVQqUmBUGKOGwZhhlLsZEolEMgMpMCoQafyWSCSViBQYFcieeBwhYzIkEkmFIdObVyAx02QgkaDV4Sh3UyQSSQ4MIYiW0bvRoao4SlRTRwqMCmV3PC4FhkRSwURMk53RKN2xGIkyagRWezx0uVwludasAsPnD+xj8xyOcCi4sXBNkgD0xuPEhSjZzEEikdhjKJFgRzRKbyIBC0x1nG2F8Rpg99vQCtQeiYUQgt54nCVOZ7mbIpEseEwh2BOPszMaZXQBezFmExi+lNf7AZ8CfgG8bAmINcCFwBUlaOeCZHcsJgWGRFJGYqbJzliMXbGYzMKQTWCEQ8F7J1/7/IHLgHeFQ8FnUw75k88fuAu4Bril6C1dgAwnEkyYJh5VOrNJJKVk3DB4NR4nPjKS02PRFAKjjKqpmGkSNU00RUEvsgrbrtH7WODFDNvXA0cXuE2SFHbHYuzrdpe7GRJJzRNNCPoiBq+OR9gViTMwIPDGZ6qfEsKk24ixPRFhRyJCdyJKwrb2vnhcsnw553d0FPUadgXGNuDjPn/gmnAomPrNfBTYUajG+PyBxcCVwFmAB3ge+FI4FLy/UNeoNvZIgSGpAgxTMBwBx0T5B85cxA3BRAzG49b/mGAwZrDbiDIs9pYYGJ+AqJoUED0iym4RYbeI0COiLFTllF2B8VXgd8ClPn9gq2UM3wdoA95XwPbcAQwARwKDwOXAX33+wAHhUHBnAa9TNURMk8FEgmZdekBLCke8gCqUiZjgme0G3btVmsaryyAcFQa9Il1QxCwBsUMbpy8xRt8CFhDTsTUKhUPB23z+wOPAO4DlgMsa3P8SDgWfKURDfP5Ao7WiuCocCnZb264EvgicANxeiOtUI3tiMSkwJPPCFIKBRIK+eJy+AqbRH5wQbOkXmCZMqFGazVFcqDjRcCkqLlQcqKgV5h6eKihGRYIeEWGPiLLHjDBIPKlg0uz7iZbTyqiioCqlaYOSbwoKnz+gh0PBkpSG8/kDRwNPACeGQ8F12Y7t7+kWpjG3h2Dd2BholesZrKFwtMuJlsdDl0jE0fXaCfyT/ZnDNYRgwDQZMEyGTBOjgHp2IaB7RKV3fO820zRRZ3HQcKLiEAouFBxCAcojQEwEO9QYW9UofUqCXjXBhJL/uOEVKh2mTrtw0GHq1KGilKlPxzVpHNFib/zKdN+1d3bZbritaavPH9CBLwAfAToAr88fqAOuAj4VDgVzZsuzzlE/2/5wKDg47fhG4JfAnbmEBUBrR6edrmREe20zdc0tc/58KVC8XtrzcLHt7d5Je2dXUdtUSuz0ZzwmeGKrQXu9wr5tKh5HZc1qUynW7xMxzeQqIh5n0DCmAsvqCniNmAGv9ZmMK+BNOfH42DDeusaMnxkWcbaYY2wV4/SLWAWYiPOjHp3FiptO1c1ixUW9UjmTl6ZWD+2LPbaOne99Z1fP8UXgg5aAuMra5rW8p74LfMbGOU4FwrPt9PkDnnAoGLFerwD+CuwB3m2zjTXN7nicRTImY1aiCcGTWw0mYrCtX7Bj0KCrSWFle2ULjvliCsFQIsFgIsFAIlH0oLLhqGBLnyCR4zJCCAaxhIQ5ziDVVRisCQethspSZwOLFTd1ilQJk4fAeA9wXjgUfNbnD3yP5Iqgx+cPvAt40I7ACIeC99hZh/r8gbWWsAgCnwiHgtV1pxWJgUSCF8fHbRyZZDAWp8fG8W26XvWCKG4kVxbjKetc04TtA4KdQwZLGpOCw+usfsEhhGDUMKYExJBhlCyzcfewYNewmFWvLxD0mlG2inG2mGOMUBLN9bxRgXbFxSLFzSLFRYfiwqVojMeG8aqzKkUWJHYFxj5WzMV0tlqeUgXB5w8cCtwFXBEOBX9YqPPWBELQk0edjGHTIG7j+J5YjN3xOKs9nqoMEDRMwVPbDEYjmfebJuwYTAqOzkaF/TqqT3BMpAiIwUQi70R3hmXw7o3H6bWM3vlkVxUCRqKCDCEJKdeAXY5xxo2BvNpWDtyoaQKiTXHlZR9cyNgVGDuBtcC/pm0/14rRmDc+f0ADfgX8RAqL0jIQj/NEIsEKt5tlTidKlTw8Qgie3WEyaGPhJQTsGhJ0DxssblTYr12lzlXZ/YyYJq9OTNBvo867YeU6ShUKPZYtYyCRKI1baJavUwEWK25WKF6O1lpoUstnAxDW/WAiEOz9LxCYKf8RGo2KnvRCQkGz/pIeSdZr638576R2vXQOO3YFxjXAn33+wE8BzecPXGxFeJ8PfL5AbTnROuehPn9g+jl/Ew4FP1Sg60gyYArB5okJemIx9vd6aahgr7FJnttp0jOS32xbCOgeEuweNnCUsYvDAxqNw5lVNkII+kSMHjO7/78Qgh4RZaMxxmZjjEiFRQuowBLFwz6ql+WKlwZFZ5nqxa1UwL01ywgvhGBTr+DBVxO8ursR0lbdIo98rKXDpYNDU/jkaU4CRxZXENuNw7jO5w/0Ap8Gxq1AvleA94dDwd8XoiHhUPChsvnaSaYYNQyeGh1lmdPJCre7YpfqL3Ub7Bqa+8MrBMTKqGKPGZmvPyEMdokJomL2wX9QxNhsjrHZHGO0wuwEGgpdiocVqpdligenJRy8isZSxYOuVKbacywmeGSTwQMbEmwbmLyv1IoUEJkRDJYgyt6uW+0qSzAURDhIKhwh2B6N0huPs7/HQ0uFFXLa2GOytb9aHmR7GELQIyIMiMzqpzGRsITEKANz8DjyoFGv6DSi06A4cBUhzEuLxljhacUxTSi0Kk4WKa6KU3UKIdiwx+T+DQb/2mJktdFIkthVSb3q8wceAm4E/hAOBUeL3C5JBRAxTdaPjdHhdLLa7cZRAUbxbf0mG3sqS/UyX4ZFnN1mJC2BnRCCIZLbXxNj7BbRnOdxoNCuuGhQHDSg06AkhUM9+oxBvBiMi+G06yhAp+qmWaksL7yRiODhTQke2GCwcx6r1IWIXYHxJuCdVmLAa33+wJ8s4XHPtGSEkhqkJxbLy0PLNlY6Zl1RcFr/HSl/ulWr2KEojJkmg/1xXuw2C1bkTLFUKMnUCqWf/caFSbeIMCoSRKxUFT0iSq/1F7ehDlGB5YqXlWodSxVvyVWIYxF4bZfCtj0KI+P16JbtSwE8ioaGAHILu1IRM+CFXSaJLHMORYEjlqqsXTLBis7MgYiVxKp2lc4mhcUNxZ8U5JUaxPJkOtMSHucBo8BN4VDwi0VtpT3mPIz8rQoivfNleLCfxubWcjejYOzYPUBPvKloFTFVS3hoSoo3jIA4gngRjMl9Y4PsdCv0WEIin5gFBehU3KxS61mueHGW0C6QMGD7HoXN3Qqbd6nsGagsNdN8aK9TOHl/jTes1mn1KgwP9tHYXLCogaJxcKfK8lZ798Askd6FTQ0ySTgUNIAQEPL5A0daUd+ftyLBJWXEFDAeg7GoYCwuGB1Wqcs2jaoShBD0mDG2D8VxusYKd14ggSAqDKKYRCb/YxAVJlGS74u2fHZCvnKoXXGyUqlnX9WLp0SRx0JAzyBs7lanVhIJo3aEhKbAUctVTt1f55AlKqpaO30rBnnddT5/4GDLlfZ84ADgH8D7i9c8yWwYZtKzYzQqGIvBeDQpNCYZj4JRxdkMhBBsFeM8awwxQCx5pxoLzHQWV1GG3SjDbtSeeoYiDp4Gns5wqALoqMn4ApEc6IXlLj21bTL+IA8pOBaBsUjtDaKLGxRO2V/jpP10mjy1179iYddL6jJLDbXGivj+BfDbcCi4q/hNrG229psMjCeT5eqq9We91lRl6r2mJKNpx6KC0ShMxKvI4y8PTCHYIsZZbwxWXf6h+SBMiA+5iPe5iVl/xqijAJ7mxR0MFWBFm8KhSzQ6XGPU1TcU9XqFoLVOYWVbeexW1Y7dOeiHrQJK7w6Hgs8VuU0LimFrZWAmyDA81qBEmAVTCF4TY6w3hhiqIEFhxlTMuApmgQcXAfFhJ/H+pHCI97sRRvm90OzQ6lU4tEvl0CUqa5ZoNLiT383woEFjcwUE5UmKhl2BsSIcCgqfP6D7/IGV4VBwc5HbtSCYSEC8suKuSo4pBJvEKOuNoayG3w5Tx63l554pBAyNQd+wQqYkrsJUMKPazL/Y3v8FFxRViFuHgzpVDl2icWiXSmejUnExFZLSYFdguH3+wA+BD1imOpfPH2gBbgYumF7LQmKPkSqof8xkhlQSBS3AA7BHRHnOGJo1WlkBVih1HK414RyP4HXZc3EUAjZsV7j/KY3+kcwDW0ez4HWHGHgs5zinVR0uWSVOQyuyKmdsbJi6abUjDAQxTGLCJI5JXJjEEWgoNCg6dYqes12qmvzeFCX5pyqgoOx9b+2z2z1NSer7dU0KCIl9gfEtK8/TW4E/WNtM6+9qS5BI8mQ4UvkCY48ZYZ3RV1J7ggKsVOo4TGumSXEk3VxFgjobAWDb+wR3PgGb9mTe3+CBM4+AY1cpOFUnXkXDhVZyffbwoGlLfWMKYQkAOWBLyo9dgXEucEY4FNzk8wcESRfbIZ8/8F9AQWp6LzRMAaOVE880A0OYPGUO8oI5XLJrKsB+Sj2HaU00WBXNVBT2Ub3ERIxG1T3rZ/vHBbc+GeeRTZnzO7h08B+i8+Y1Oq4qKqgkDbPlY3KlJtmLXYHRBWSyWwwAle8WUYGMRkXRgtDmS68Z5WGjt2TGZxVYrTZwqNqYVvpSBfZRPbgVjdnizGMJwd9eSPDX5xIZk/kpCpy8n8Zbj3TQ7JVPv8Qey1oUWpsNOruq2De9CNjOJQWcAfx92vYPWPskeVKJ6ihDCJ41B3nOHMporWiisEkINRQWq27WqI0zSmAqwLIsAWpCCB7fanLL43F6xzJ/l4d1qbzzGAfLW6rD+0hSfrxOWLNEo7VOobe73K2pPOwKjG8Ct/v8gdsA3ecPXAMcBbweuKDIbaxJhmepEFcu+kWUhxO9GTOh1qFxotZOl2qv0HwhWKp6Zq2jvLXf5OZ/x3lpd+ZQ6WXNCu861sFhXdLFU2IPRYF9WhVWd6hoMtp7VuzWw/iDzx/YCnwKeB54g1UP46RwKLiu+M2sLaIGRCsk1MAUgufMIZ4xBzOuKlYr9RyrtZY0X1GX6pmyYaQyHBHc/nSc+zcYGdV59S5425EOTtlfkw+9xDZ1LjhkiSZVljawraCzBMO7ituc2sEYmz1R0NAYkKdLrUCQvf5aOrGIiapmD/IYw2Cd1kefMtNC4BEaJ5ptLBMeK6Iwj/Y6LX/MObBEddM0TVgkDMF9G3X+/kqE8QyCVlPgTQdp/MfhDttlV10O2NdmwrZi0K+ZtLYX7/qTv9akYE399fKxnRlCMBKBwQmRMZalmlGUZJT66naZQ8ouswoMnz/wlXAo+A3r9RXZThIOBb9ajMZVK8aoSeSl2Z+ukWETPQ8Pqe3eCP9cMsCEnke2ukaAuYXHGNvqGVzfzt/i81DpaGAVP87jIwqaYgLp+rrxqGAoktml9rAulQuOddDVnN/ge+Bilc7G8gmMurigva16bCtCJFPSDE4IBscFQxOC8SJkvC8V9W44tEuj0S0FRT5kW2G8B/iG9fq9WY4TVslWiUWib/YpnMDKA2UTA8GDSwaI5CMs5ogR0Rh6YhGRHfVFv9bs2Jv+Lm5QuGCtgyOWqnnHKHQ0KGUVFtWIoig0uKHBrbDcCnaMJZJlQSeFSGwUPJVVK2kGCrCkSU3mkpKriryZVWCEQ8GDUl6vLFmLqhxhCoyB2Qf3SDyZaM4u2+sjJREWE9vqGXqyAzNa2W6EHgecd7iO7yB9TtHHmppMcyGZP05dYVGDwiLLsb7XbdDeWdn3j2R+5JvevB3wTt8eDgW3FrRVVYwxLBBZTAcTsfwG/1cbx9Pe66aCZk3CTaEQN/NLVz2dxKiT0VeaiWyr7HAaVRGctJ/O247cm446n+Jfk6xqV3Hrc/tsIRFC2G6DjPKWVAp205u/Bfg50D5tl2LpEKT/ooXRl10gZDLazkZUNdlWn67PP2tbOx0TTp7s07lnl4N4huR4R7QmOKppFLfTZe9CXuDAiayH6IqKXuD8SipY3lC5z+uOj9LS0AAbDebqkexxgjaksq0CBuDhAcFES/bvfJJFB7twyyywkgrA7grjB8C9VrLBCosgqBxEQpAYnH3WmDAhlofA2NQ4npYstTGm4R5xcMs2FxtHZg4gXl1w9rIYBzYZRKMGLlfhZtFLVGfRE/JlY2KeHjqKQjKArwKERb4MvBaj83A3itS5S8pMPqlB3hcOBRd4Mu7sJAZEVpvtRDy/AXy6Oqppdz0/e9nLRIYSmQc0Jjh7WYy6wgZjA9jKklrptNcrtl1uK434hGBkV4LGpUX4cSWSPLArMJ4BlgDbitkYnz9wGPBt4ETLm/9l4FvhUPBPxbxuociljpqI2RcYQ444PZ705cjjz7RgTBMWTlVwRleMI1qNok2eGzME0VUTDh2WNFWnsJhkeEccb4eG7pQGe0n5yBaH0ZXy9ivAT3z+wLXApunl68Oh4Kb5NsTnD9RbNcJ/Y6UbiQGfA27z+QOHh0PBF+Z7jWJiRgXGaHaBMJHFbz1uwp4Jld0Rhd0TKruWj6Xtj+7xYIynD9zL6wzOXR6jpYCqp+nU18DqYmmzUvWR36YBg1vitO9v0y4lkRSBbCuM7dOc4hXg7AzbCmX09gBftGqFj5MUItdaeawOBSpaYCT6s68uogkwph2yaUTl6X6d3RMqfdHUqjaCRSeMpv0441v2ejGpiuDUzjgndCQo9jiYKUVHNdHoUWjx1sasfLzXILrYwNUoDeCS8pBNYJxWwnYQDgV7gP83+d5y4b3UElz3lbItcyGnd9Q0ddS2MZXfbXIhMszenR0T6HV7zUUioRDZlgymW+Q2OW+fKIs9xXcLrfbVhaom01TXEgOb4yw+PP9gRYmkECh2fcEtlZEjHAoOWO9XAIPhUHDI5ud1YNYQ4tQyrz5/IGrZMJ4ALgyHgi/lOn9/T7cwp0/hbbJubAy0uc/azHGIv5L9mO5RlWiKy8Bt2xrYPJY5LLbp2N3UrdpbuEjZXkfniy10eRKsro+h25gwm6aJqs5vZr3YdFSMwDBMEy3P/ixuMOmoK1qT5oVhJNC0uQW5NS5X8HZUxu+SSiIRR9ere0WaSq31h1n61N7ZZftmshuHcSxwF/A/wO+tzW8DvuTzB84Kh4KP2zjNqUA4yzU84VAwQlJ4uKwVxieBR3z+wAnhUDDrkNza0WmnKxnRXttMXXPLnD8fGzGI188urEwTiJi4LJnUE1EyCosWp8miugRj+4ykGYl8ws2yfSY1f/ZSjEejE7hcc09HXq/o1NsoiVoqJsZG8NTZDy70OGDVYrViXVGHB/ppbGmd02fVCWhp86BVWOXA3u6dtHd22TiyOqi1/lCAPtmd4vwvcAPw55Rt11ohX1db6c6zEg4F77Ffeh7CoWAv8FWfP/AO4KPAZ+x+tpQIIUjk8o6Kp7vb/qsnXcJ3eQ3esyqKS4ONDeM8oO892JNQ6RovvaGz2m0Xy1srV1jMF9OAoW1xWldVjkCXLAzsrvGPAr4SDgWnQlPDoWAc+C5wRCEa4vMHzvb5A9t8/sB0JYICFDX+IzGPVE25UoEAjKfEX4wlYP1AuvrrhI7E1OpjeuzFfsNe1BKrharddlHNMRd2GduTIDZa/BxjEkkqdlcYY8C+wMZp2w8Cxmf5TL6ss+wW1/r8gc8CE8BHgNXA7QW6Rka2DKoc0pxMTJcvuYzdTHOnfbJPJyH2DmaNDpODmpJhzOOawc669Lznq4dnpO4qOtUcd+HQoKu5toUFVk2LgddiLD7UXe6mSBYQdgXGTUDI5w/8GNhszfoPsmwaNxWiIeFQsM/nD/iswL1XLOHxEhAodlW/iThs7jPZryO/ubwwsqcCAYgZkLDSWiRMeLw3fTA+LsU1dmPjOCmyhNaIg9ZoaQfvekUv+YrGLg4tKdR1FXRNQVOZ+tOtP4+j+mMu7BIdMRnrSVDXITPESkqD3TvtUmDECuCbTEDYC1xnDfAFIRwKPgu8pVDny4eRCGzrN9knjypsxqAgVxG81Oju5wc1xhJ7BzOnKjiyda8+a7o6avVw/kZrVYWuJpV4xMRbl9+SSVVgf7cLvQJdNkeGTBpbZPzBdAa3xPG0aqhzrHBYDhJRM68U/+UiERHEJ8rbUEUDVVVQVCrCJme3pncCuAK4wucPNALKpDut9b5CKlTPj74xcOiCJY32fphcxm5SBIYQ8Ng0Y/eRrQnc1hjY54oz4N4rPBQBq/JVRymwqFHBqSeNPvmO+60OB4656OUkZcOIC4a3x2leUdkGcCMuGO9JMNZrEMtSvriSGB4QxHZVTq5VxYrtnRIgWlKINC7V8baVZpWZ91XCoeAwSUFxhKWSejdQ2cUU8qB7SODUoK0u+2hrxgTGcHZ1lBB7q+ttHlXZE9k7GCsI1rbPvrpYOubCa+Q3o+6oV/DO0dVSAdp1qdqoRkZ2JahbpOPwVJawF6ZgYtBgbI9BZNDIq5a4ZCZCJPNqGGkFcASJPGvszId8Cyg5gHdYguIE4Fkr31NNsW1A4NDIWu/XyJEKBMuddvIhme5Ke1CTMZUDykSwaYY6Kr/VRXOdQsM86hO3Ohzo8wz0k5QHIWBgc4xFayrDAB4bTdpWxnsNjISUEsVkot/g6d8McvIX22nep/irTLuBe/tYsRAfBOosg/S54VDwzqK3sAwIAZv7BAcsUvDMYnPOVrd7ksl0IL0RhVen1a84rmPv6mJHXZSJlDKsDkNhn1H79ot6N7R65y4sFKBDri6qmsiQyciuOI4y5s0a2y1I7I4QG68OlVO1M7glxrO/HSI+Lrjnsj285doluJuKa+fLOkr4/IEzgI8DfivF+deA3wKvAeuL2rIyY5qwsdfkgEUqzmm/gTkuMCdyC4xJddRjPelf81KvwTLv3odqujpq5YgHXdgTAG4ndNTPb5BoczjyTrshqTwGXiuvKXFkQKC0SGFRCrqfifBCcBhheWCO7Exw39f3cOZ3O9GcxTOO55pW3mW5zR5teTBBUpAUrUGVRDxhCY0ONS1Gw46xO2EmPz+egPUD6V/z8R2JKYN0TDXZWp9eqtOuOsqhw+IGdV51MFRpu5BIqgYhBJvvG2Pz/TPD37ytmlUnvnwC4x7LqL3I5w/8HAgutKp7kVgyRmNVu4qqWKlAbNgvJtVRT2QJ1AN4rWECI0UY1cc0Fk/k1kVqGnQ2qXMKNkylVa4uJJKqwIgLXgwOs3t9dMa+Iy5s4qj3NRfd9TarwAiHgmf4/IH9LbXUDcB1Pn/gJutzC8aaNRKBbQMmK1pVzBGBsLHyn4iJzIF67ek1LGbGXnhRZpkhNCrJn0tRYN9WDXeWmL5RTaPekTvor02uLiSSiic6avLsbwcZ3pY+X1c0OPZDLRz69qaStCPnaBEOBTcAF/v8gUuB/wT+2zJ8/9aK/P7jQlh19I+Bgom+y0TYtF9kDNRr2/tVjTgSdHvTy/DtN4s6SkWhUXGiKLCqXaExhwulW9NodFa2b75EIsnN6O4Ez9w0SGQwXbPh8CocfkETK04qXfog29NLqwre9cD1Pn/gVOBjVjnVa6x63zVP34hA32GAkfvYXIF6WKlAUlk04aQpnvkn0SxDxbLm3MJCIpHUBn0boqz//TBGNH2S6m3XOPK9zXhataIauaczJ31EOBS8H7jf5w8sBT5c+GZVDoYwGSbBoIgxOhFHabbnBTIQVRhfNTFVMUoBGtoTPJ2SuvzlpumZaWd3pXWgsKhRob1BCguJZCGw7bFxXrlzdIbyv3U/B4e+swmHR8XVoOJtLZ1aeV5XCoeCO4DLC9ec8pEQJkPEGRJxBkWcIRFjUMQZJbH393KmZNKyQePS9PcvZjlWzZIKxOWAfRo0ljZKYSGpXkxDMNFnMDFQHVHfE6Mm0fqZBuZS0Lchxo5/TczYvnStmwPObpjKHdayb2nVzgvW4tkbj3Pz7t1sikR4Sh9lLNFX1vYsH3XjMqhB4BwAACAASURBVFMEggJ1TmjyqLgd0OaUwkJSPcTHTUZ3JxjpTjBq/Y3tSWBWnbXTVgXq4qPA/mfVs/xEz1Q997oODec8Y7DyZcEKDAH8es+e5JsyJ4FUBRzen0zHpajQ4IImr4oj5V5wVGAGWUnlEBkyGNgcRxjlmboLAUO7DGKDg4x2J4gOywC+QqE5FQ55RyMdB+2tvKlqlCQVyHQWrMBo13UaNI0RI7cFux6dJsVB84CGnsg+cMcF/LtHx0yRQgc2JuhwZ36QNaGwfMzF4oSTpnqFBpdCprAIp4yVkMzCyK44T/x8cIZhtDzEbBwjsYurUeWIC5toWJLuQNO41FFSY/cktgWGzx9QgZOBfcOh4I3WNq/lPVV1KIrCKrebZ8bGprY1TAoGxWn9d9CIA8VU+ds6lSe3qBg2U3ZM0ugwOePgCOpY5v0OB7R4FOoaZ4u+SFKJNSok5UeYgpf+PFIhwiI3znqVukUa2hyzKpeSeDyOw0YsU7Fwt2jse7IXV0N6biLdrdCwpDxzfbvJB1cAfwMOIOlUeqPPH9gXeMznD7wpHAo+V/ymFp73Ll7M+abJgxsGaPM0oSszZ/FCwF/Wabzw2txm+GunBeql4nXZS+2hpbjVSiSp7Ho6wvD2yjMMKCrUdejUd2rUdzqo79Sp79RxlVjnPh+GB/ppbGkudzNm0LzCUbZiSnbF1A+Ax4DXAbtIeki95vMHbrD2nVHcZhaH05qTN8N6RjIKC4BHn1fnLCycquCotswPc70bOhrsFUN1SHWUJAOJiMnGcPrStb5Tp6GrPLNPU4nStqKe+k6dug4dVZeTnELjbiqtG+107F75RODgcCg45PMHUte+3wF2FqltZeflrQoPPjO3dMHNTpMzl8bSAvUmafRAex4zLWnwlmRi8z/GiI3uNS6rOhx+QROeMpWyTc7I8y8rLLGHopTejXY6dgVGAzDTKTgZmVCThZa7++Gvj6R3za0JLto/Qqtr7vri5jol79oV0uAtmc7YngTb1qU/kitO8pZNWEiKT/1ivaz1TrCyW9vhMeCzqRt8/kB9iqqqphidgD/erxM39g7sqiJ4+77RuQsLBdrq8xcWyBWGZBpCCF4JjSBSPFfdTSor3lBXzmZJioimKzQtL58BfhK7K4zPAXf5/IGPAC6fP/A0sB8wBpxV5DaWlHgC/viAxshE+iB91qo4+9bP0bdcgY6GpMvsXJACQ5JKz4sx+jemp0xefVZ9WdwsJaWhcXll2IRsrTDCoeDTwGrgSuBHwL2WENnf2lcTCAGhdRq7+tK/lmMPMjiqzUbGwQwoCnQ2zl1YII3ekhSMuGDD30bStrWscrDoENesn5FUNw6PQv3iygiZs+tW+3XgV+FQ8PriN6l8PPycyotb0gfnVV0mbzzKRHkxf1WUqkJno5q1boUdnHKFIbHY8s/xtDTXigoH+Bum0kVIao+Wlc6K+X3tiq33AZf5/IFHgBuBW8Oh4HCR21ZSXtqi8NCz6QbD9ibBua83UE2Rd7koTYMlTTPrgeeLKmMwJBYTAwZb/pnuRrvseE/FzD4lhcfTouFuqhxHBlt3WjgUXOnzB04E3glcAfzI5w/cAfwKuDscChY8zNTnD7weeBD4RjgU/Fqhz59K94DGXx9N/1E8LsHbT0ngdu71D/M6wW1TT1znVHAU4HeW6ijJJBvuGk1L3ueoU1j1RmnorlUUJRmkV0nkU0DpUeBRnz/waeA04B3AL6w8fssK2SifP+ABfgmMFvK8mdg1ZHLHugYSqR5RqiDwBoPmZD5AFKs+d5NXxVPi30+qoyQA/Rtj9LyQnmp79Rn16G45oahVGpboOCqsWFrea9lwKCh8/sAIMAz0AyuK0K5vAy8VOyhwPCZ4/68nGIuk/yhnrjXYZ3HKoime1BW7y7Dy1+UKY8FjGoKX70w3dDcu01lypDttm6el9OmuUzE9Ck3t1ozKenyESFfnVkMdjEkMBzS0l0/d17isslYX5Jl88BjgfGtlsQy4x4r0DhayQT5/4CTgvcBhwO/sfq6/pxvTsO/2agr4XMjNszvSf5SjVk+w/5JxxlNUxfowOBMwMVb6lM11msawlr9uyzASDA/0F6VN5WAh96f7CZPxnvR7b+kbBCNDA2nbtDYFpYyul+72BHG9p2zXLzSeTgND7y3b9fuL8FUmEnF6u9Pn4e2dXbY/b9dLaiOwL/CU5Vb723AouCefhvr8AR2mKpbOIBwKDvr8Aa+livpUOBTc5fMHbJ+/taMzn+Zw7f1RwhvSUzHv12XiW6ujqo1p21XdoLlJ4HWX/mFsdblo1POf5STTNLQWpU3lYKH2JzpqsnNdenGvJUe76VrTOOPYJas8ZfXV7+3emdfgU+nUWn8oQJ/sjkS3AL8Jh4IvzflKcCoQnm2nZbf4NvBCOBS8aR7XscV/HO7g9qcSvLQ7OXPraBKce5KRsRaFEhN468rzIMqgvYXNxvBoWupy3a2w2jdz3qU7lYoI7JLUNrMKDJ8/cEo4FHzAensv0OXzBzKKpnAoeF+uC4VDwXuy1bazVFEXAIfbbPu8WN6q8uf/9vKxWyZ4eFOct51q4JpFZegQpFW/KyW1KDBMQ9D7coyhrXFMmxXiYlEDp2vExpHVgZ3+CAN2PRlJ27byjXUZ7RSOOmnrkhSfbCuMu4DJ1JP3WGasTKOXKFACwg8CjcBzKaqoJuA4nz9wbjgUPLoA10ijwa1w4/s8fOUffTTXz+KeaAi86mxdLy5KjRm9JwYMdj4+wc4nI2lZVvM4QxFaVU7y60/dIo1lx2XOBltOY7dk4ZBNYByY8nplCdryGeAr07bdCjwKfK9YF9VUhZZsOaLi4C1Tjp5aiMEwDUHvS1F2PB6hf2Ms7wBIyV4OOLsBVct8LzrlCkNSAmYVGOFQcGvK28+EQ8GLpx/j8weagGutSPB5EQ4FB4A0tw+fPxAFhsOhYPd8zz9XtITAU6ZyktUcgzH/1YQkla5j3bSumr0WghQYklKQ1ejt8weagVbgwz5/4JoMepk1wNsKITAyEQ4FTy3GefOhTiFnCdVUhBAkdpskeuY/SCqayS59blPyiXGTMW/pVThmAva8EM25mtBcCp2Hu/B22PO7iIyP4/Z6C9fQMpNPf7ytGm37zy4sNKciM9VKSkKup/U9wDVWSqNXM+xXLIN4zZLvxG3skTij/4zbODI3Q5P1cOdM5RmJG5fqdB3rYfFhLnSX/S93eCBCY0vtCIxC9keuLiSlIqvACIeC1/n8gZuB3bPU7R4Daia9eSby8aY1o4LRRwojLGqJ5GrCzdJj3TR0VV70arUjBYakVOTUB1gBdUeGQ8EXff6AOxwKRtirrhoqRuLBSsGlg26AXeVS9FUD5lY2oyaZ62pCkh+OMsUISRYedgP3Yj5/4GXgy8Bt1rYPAh/1+QNvDoeCmdRVVU+jB8Qe+/Iw8lIi7b3eqaK3zX2gbNQ11Dm688ZjURzO8hTVcTWoLD7MJVcTJUK61EpKhV2B8SNgHfBAyrYbrSp81wJvLlL7ykqDC4RNDZMZFUQ3pS8vms5y4uicW4iKAqzxevOzuKeQTD0xM32EpLbQHAq6UwoMSWmwe6e9DvhIOBScSocVDgX7rNiJE4rXvPKhKFCXx2Ad3ZiujtKaFPTFc3+QHUqe7lmSBYm0X0hKid27zbCirqezCPsq/qqi3gVKfO7qKPdB+rzKKtZiShBJ4ZH2C0kpsauSugO43ecPfBfYbGlMDgIutfbVHI1uBRGzJzDM2Ex1lPug+WVLqYUob0nxkSsMSSmxKzAutuwYt1urEsVaddwEfKrIbSwLjR4F02aEcnSjASkLDLVRQe+c34NczVHektIhBYaklNit6T0KXOTzBy4GVlmbN4VDwcqLDCsADj1ZXS8atXFwRnWUNi91FDWWdFBSHFQNWaJVUlJs320+f0AFjgGOCoeCz4RDwRGr4FHN0WhVvrSjkjJjIrnCSMF90PzLOsoVhiQX0p1WUmps3XE+f2AF8JyV5vyn1rZ9gc0+f+DQoreyxDRalfXsCIzYppnqKMeS+T/I0ugtyYVUR0lKjd077gfAY0D7pFdUOBR8DbjB2lczKAo0uJKDtRnLefhMddSB81dHIVcYEhtIgSEpNXbvuBOtOtuDpOcg/Q5wXJHaVhbqXKCpIOIip8OwiBdHHSVjMCR2kFX2JKXG7h3XMEt5MGeBqu1VDI1Tq4vc6qjoRiMtElxtUHB0SXWUpPioGjg8UmBISovdO+4x4LOpG3z+QH2KqqpmaPRM2i9yHxt5uTjqKBmDIcmFXF1IyoFd/cnngLt8/sBHAJfPH3ga2M9Kb35WkdtYMhw6eKx8ebkM3iIuktlpUyiEOgq5wpDYQNovJOXA1l0XDgWfthINXmkF8N1rCZH9rX01QWNKctdcK4zopmnqqHoFx9LCPMROucKQ5EC61ErKge0psRW8d31xm1NeGjx7Z/ZmNPsKo1jqKACZFFySC7nCkJSDWQWGzx8Ih0NBn/X6wRznEUAv8MNwKJjr2MokxZ2WHCsMkSieOgq5wpDkIBnhLdWWktKTbZTbnPJ6o41zrQJuBpYXoF0lp84Jeso4nc2GEd1kpAkUta5w6iikDUOSA4dXLdhqViLJh1kFRjgU/HDK6w/kOpHPH9CA4UI2rpQ0pszYhCEQidmPzaiOUgvzAOuKIgcDSVakOkpSLmzrUXz+wJnAW4F9gAiwFbg5HAr+i6RQMYC6ora2iDR68lBHbSieOkquLiS5kC61knJhN5fUx4G/WVHd45bN4lTgUZ8/8KHiN7O46Cp4UyzNWdVRmzOoo5YV7gGW9gtJLuQKQ1Iu8qmHcUE4FLwldaPPH7gQuBz4WSEa4/MHXgOWklbsFIDDw6HgK4W4RibqXekCIlsOqchL6U1zHVA4dRRyhSHJgaKCwyvvEUl5sCswlgC3Zdh+y2T22gLyoXAoeGOBz5mVBme6wJhthZH0jppZirWQyKSDkmw4y2jwjsfjDA4Ozro/EkvQ09NT0jYVk1roT3NzMw5H4Rz17Y5264AjgCembT8UeLxgrSkT9a7092KWGIzoawYipaiS6gXn8sKqB+QKQ5KNctkv4vE4fX19LFq0CHUWtWk8HsPhcJa8bcWi2vtjmiZ79uyhra2tYEIjWxzGySlvfwP8yucP/BJ4yVIZHQx8APh2QVqyl3f4/IFLgC5gA/C1cCj41wJfIw1t2hg9m0pqpjpKL6g6CplHSpKDctkvBgcHswoLSeWhqiqLFi2it7eXRYsWFeSc2VYY92fYdlWGbTdbqqms+PwBHaifbb+VOv1ZK+bjw8CIVS/8zz5/4PXhUPDRbOfv7+nGNOzV4J6OYSQYHuyfeh/rn+kpJQyIbFCscuZJlBUxxkdtZCnMg4lohGgBVhmGkWB4oN/GkdWB7E8Sx5hCpLv0q9BILI5hNGFMty6mIgTxeGGfh7JSI/2JRibo7d4JQCIRn3o9SXtnl+1zZYvDsOtBZVetdSoQznIeTzgUPHfa5it8/sB5lgDJKjBaOzptNmMm2mubqWtuAUAIwbgzkUzcnkJ0YyKtyLfigYYD6wu6wtAUhWZvYareDg/009jSWpBzVQKyP8kSKZ37egq+qrVDT09PTvVMtatwplMr/XF7vLR3dADQ270zLwExnXziMJqAlZZL7UYrtxThUDBLiNtewqHgPWnTc/u8ahndS8JsMRjT1VHuIqijpMFbkg2HVy2LsJBIJskpMHz+wBLgOuAtVrEkBYj5/IHbrCp8vYVoiM8fWAl8AbjUUk9Ncgjwj0Jcww6ZPKSEIYhsKK53FNLgLcmBjL+QlJuso561qlgHDAH/BbxgCY01wGeAR3z+wNGTq4150g2cAzT6/IFPALHJFOrA2wpwfltkWmHEthiIyN73ihuc+xT+4ZUGb0k2KjGl+d0v7J1IJQwDXbOlcJg3Z6wp/IRNkptc3/olliH6vHAomGpRfsznD/wa+JO1KvjqfBsSDgUnfP7A6VbNjQ3WSuZZ4NRwKPjyfM9vl0ylWSdeyKCOmu5aVQDkCkOSDUedvD/my2cvuYxn1z/PFZd/iROPXztj/2c+/2XWP/8Cn//MJ7jm2v+b2m4YBkIIdH3vkPnpT34M35tOBeCVDRv5w21B1j//AqOjY7jdLvZdsQ/+s3y86bRTpj7z9/B9fP/qa9PcXN0uFytWLOeCd72DtcccVcTez59cAuM84F3ThAVYuaN8/sBllpfUvAWGdc6XrGuWjdQ4CyYr670yTR1VpNmNFBiS2VCUZNCeZP60trQQuis8Q2Ds2LmLHTt3AbB40SLuuO2mKaP3937wI3bu3MU13//OjPP98+FH+c73ruad7wjw0Q9fRHtbK8PDw9z3wENcc+3/sW37Dt7/3gvSPvOX23+HpmkAjI9P8Jc77+IrX/sWV1/1bQ4+6IAi9n5+5LoDl4VDwfVZ9j9brenMZ2O6DSPy6rTcUfVKUdRRyDxSkiw4PNLgXShOPGEtjz/xFL196W7Nd919L8cfd0xe5xofn+DqH/6Ec88+i/+88N20tyU93xobG/mPc/x85dLPsbQru8+O1+vhne8IsKRzMQ89sm4OPSoduUYoxecPZAsRdGTI+1TVzBAYz09bXRxc2NxRqcgVhmQ2pDqqcLS2tHDYoWu4+577prYZhsE9997PG089Oetnp/PEk08zMjrK29+aWTFy3Npj8L3pNFvnMk0T3Vp1VCq5BMZLwClZ9p8OFC0pYDlIjfI2JwTRTeny0HNIcdRRmhWHIZFkQnpIFZazzjidu/5+D0IkJ4iPP/k0DofOEYcfmtd5duzahcfjpr29bc5tGR0d4+ZbbqWnt49TTz5pzucpBblGv98B1/j8gTPDoeCO1B0+f2A18EPg6uI2sXSIuIAUa03kpUTae61VQV9cnAdXekhJsiEFRmE56fUn8OPrb+CpZ9Zz9JGH8/e77+WM09+Yd2JHXdMwTRMhxNRnBwYGec/7p+rPYRgG3/vO1znisL3C6Jy3vnvqtcfjZtW+K7jyW19j5coVBelfscglMK4FzgVe9vkDvwNetD5zKHA+cC9wfYnaWnSm55CamKaO8hyiFy1TqFRHSWZDUWTRpELjdDh402mn8Le/h1m9al8e+/cTfPTDF+V9nuXLlhKNxtixcxfLliYjqFtamgnd8YepY3z+QDLcOYVUo3c1kfUutKK4zwC+YRVP+ibwZeAgK0binHAoOHu1oSoj1X5hDJnEt6c7hxXLOwq5wpBkQXcrqEVw417o+M/0sW7dv7n7nn9w2KFrWNTRnvc5jj7qCFpbW7j5d7dm3G+ac8tvV6nkHAHDoWDcio24sjRNKh+pAmPihfTVhaNLRW8p3qAu04JIZkOqo4rDypUrWLFiOb/9/W188mMfmdM5HA4HX/zcp/jq17+Nx+PmHW89jyVLOpmIRHju+Rf53e9vo72tjcWLC5MtttzIcMkUJt1nhRAzvaOKHFkqVVKS2ahkgZEacR2Pmzgc1TWkvPlMHz+/8Te87nXHz/kcRx15OD/+4VXc+sc/8bkvfpWh4SF0XWef5ct43QnHcc7ZZ1FXV1fQdpcLZdJLoAaYc0f+ZmWrjbyawBgUxHcb9P0yNRcIdHzci1ZE18ZVHg+eAqqlZHbXyiaf/ixa48LdVF59d09PDx1WxtPZqJXsrpPUSn9Sf7tZstXaHtiqazpQZCZXGJFpqUCcK7WiCguYkU19QaBq2NbNa07QnbWzCsunP5WYQ0qyMJECIwUREwghZtgvPEVWRymAtsCM3ppTYfFhLnSnvX47u1XaOz1Fb1epqLX+SBYGdoskPTXL9lafP7Cp4K0qA8IUiATEt5mYI3u1W4oDXAcUVx2w0FKCKCp0HGhfWEgkksogV3rzI4GjgTU+f+ADGXRdBwA1Yf6fVEdNj71w7a+hFlkVstAM3m2rnVLNIpFUIbl0LUuBj1k5o36eYf+4Fe1d9YioQCREMro7hWJ7R7HAYjCaljvwtklNqERSjWR9csOh4J3AnT5/YFs4FKyprLTTMWMQ3WSkpTdXPOBaWXzvlIVi8Pa2azQty5bLUiKRVDK2prbhUHC5zx9onnzv8wfqfP7AuT5/YE1RW1dCREzMTAVycHEKJU1nIdgwnPUqbfstFNEokdQmdo3e5wFbrNdOq2zrb4AnfP7A24veyhJgDJpEX51WWa9EZSD1GrdhaE6F9gOdsp6DRFLl2J3aftWyZQC8HWgAugA/cGkR21cyxp9OpFX20JoUHEtLM/Ov5bQg0iNKIqkd7E6h97dSnQOcDfwhHAqO+fyB+4H9iti+kjH+dDztvbuImWlTUQC9hlVS0iOqtnlwcHDqdcJIoGulWZWf3Nxs4yhJobH7JMcAh88fUIE3Andb293zSclRKSQGILY5PatksYP1JqllDynpESWRJNOb33Pf/eVuRkGw+zQ/YtW9MCwh84C1/aNAtprfVUFkWhldfbGK3i7VUfNBekRJKpHPXnIZzz3/4lQtCoeu097expveeArvPv9ttrQKPb29PPHk05x1xuklaHFlYVdgfNISGJ3A+eFQMO7zB9qByy0VVVUTeSz9falWF9Ro0J70iJJUMqedchJf/PynwaqG9+RTz/C1b15JQ30955x9Vs7PP/zIY9z/4ENSYMxGOBR8DXjztG29Pn+gKxwKjhetdSVgcGuMxPb0Qdu9Jj32QgFaHA7adN1e3W0VGpfam11rUBRbielRaGovzwy/bpEmPaIkVYGmaaw99miWLe1i67btAGzbvoPrf/pzXnz5FUxTsN/Kffnvj1zE/qv34+e//A1/+OOfEELgP+98fvC9b3LQgQdw1933cssf/khPbx+LF3fwnne9gzeddsrUdSYmInz7yh/w2L8ex+V2ce7Zb+bCC84vY8/nhu2ptM8f2Bd4P7BPOBScrGV4GPBYjo9WNJvuHUt771yhojUk1VEK0GoJinxsDe5Glbbl5Z1hx3WFpk6pEpJIshGNRnl03b/Z1d3NJ/8nWUTpim99j+XLlvKr//cTXC4XP/zx//H1b17JTTfewAc/8F76BgbYuXMX13z/OwA8u/55fnTdT7ni8i9x1BGH8a/Hn+Rr3/guHe3tHH7YIQD86c93cvHHP8oXP/8p/nznXVx3/c94/euOZ+W+lV3Dezq2BIbPHzjZMnQ/Z9XzvsgSIP/w+QMXhkPB2wvVIJ8/cBFwCbAC2AlcGw4Fry7U+VMRQrDpvnSB4V6jTwmKdl2fkweTp6X6avVKJAuFfzzwEA8+9CgAiUQCXdd57wXvZM3BBwLwo6uvRFUUVFXB4XByysknEb73fvr7B2htbZlxvj/95U7WHnMUxx59JAAnHr+Wy7/8BZqbm6aOOeH4tVPC48zTT+O663/G1q3ba1NgAN8CPhUOBf/P5w9MYKmpfP7Ae6wYjYIIDJ8/8E7rfO8EngZOB37g8wceCoeC/y7ENVLpeTHKyK6U6G4Nlh7qYbHHMa90455WKTAkkkol1YaRSCTYsnUbP7rup2x4dSNf/fIXePbZ57j5llvZtn0H0WiMySJzsXg84/l27NzFUYcflrbtdSemV/DrWtI59drpTGofItEo1YZdgXFISvLBVDfaO6yI70JxOfD5cCg4qea60/orChunqaPaD3TS1eia1zmdXhXdVbuushJJLaHrOvutWsmHLvpPPv35L7Ft+w6+/s0rOfccP9+4/FKampp5/MmnufSyr2c9T67YglLEdJUCuwJDAI1A37TtK4GCiEmfP7AEOBjQfP7A48CBwCbgW+FQ8A+FuEYqZkKw+f50gbHkiPkXtJGrC4mkenl03b+IJxK87z3vwuFIPsuvvrox62eWdi1hm2UwnyR87/0sXtQxpYaqFewKjBBwg88f+BzJwb3JqpNxld0VgM8f0IH6LIfsY/3/KPBuy37xX8Dvff7A7nAo+ECWz9Lf041pmNkOSWP30ybRob3Hay5wdowyPDCW9XO5cCxSiHeXfzaRSMTp7d5Z7mYUDNmf8hKJJYjHYzO2J4wUla6Y9r6IZGqLHYQQmKY59XkhBLu6d/OLX93EihXLOfigAwD49xNPcvyxR/PQww/y2L+fAGDnrp20tTbjdDjo7e2jr68Pp8uJ/8zTuexr3+aBBx/i+OOO4Zn1z/ODH17HNy6/dOo6hpFIeW3M2FZMIhMTU/dapvsuQ43vWbErMC4GbgYmRW2/5UT0d+DTNs9xKhDOsv8k6//Xw6HgBuv1Dy07yQdSggUz0trRmW33DLxrExj/Ncame0cZ2Bxn8aFumjsa8zrHdDSnwpL9KqPs5izF3qsW2Z/y0tPTg8Mx0/PvjW3tU6/j8VjGYyoJRVF44J+P8NAjj029b21p5ri1x3DhBefT0tzMBe98Oz+67qeYhslJrz+Bb37ty1z2tW9xxbeu4utfvZQzTj+NR9f9mw9+9JN84bMX87oTjuOT//MRfvHr3/K9H1zLoo52PnPxxzj2mKOnrqtp+tR3o6rGjG3FxO3x0N7RAQW475RJg44dfP7AQZaqyAReCYeCL8/5yjPPfSDwEnBUOBR8OmX7LUBLOBQ8M8cp5pyiZMPD2zEGGuedxqJ+sU7rqsp4YKptQMqF7E956enpocMadGajGgRGPtRKf1J/u1nuO9sqkbyss+FQ8KVwKHgH8CLg9vkDhdS9vAr0AsdP274a2FzA68ygZT+Vln3nf2NId1qJRFLL5JxS+/yBj1jG6N+FQ8HHfP7ArcDbrBn9ep8/cHo4FOydb0PCoaDh8wd+AFzu8weeAp4FPgQcZf0vKnUdOtGRuesTFRXcTdI7SiKR1C5ZRzifP3ApcLVlf7jb5w9cYtXBOAk4GRgAvlLA9nwXuA64zfLIej9wTjgUfKqA18iIt01jPp5v7iaZDkMikdQ2uVYYFwKBcCj4dyuo7pfA8eFQcD1JgfIhy/B9cSEaEw4FhRUk+K1CnC8fVF3B06Ix3m/YOHome2OAQgAAE4pJREFU0p1WIpHUOrl0KEtTPJvuAFzAC5M7w6Hgq1YG25qgbtHcjN6KIu0XEomk9sklMJzhUNAkKRwiQDQcCk6fgteMHsbdrKLp+XfHWa+iOWrma5BIJJKMSCttCoqi4G3Pf6UgVxcSiWQhkEsH4/T5A7/O8h6gpnJo13XojHTnF60q7RcSiWQhkEtgPAQsT3n/z2nvJ4+pGZz1Kg6PQnzCXhyg7lZweORCTSKR1D5ZBUY4FDy1dE2pHOo6dAa3Zk5lPB2vXF1IFjBbH91bcNNIJND00uSS2udEb0muU0h++aubufcfD3DTjTeUuylzpnTFq6sIb4fG0LY4drKmuJulwJBIqoXPXnIZzz3/Ipq297l16DpLl3bx9sC5vPG0k8vavkpHCowM6E4VV6NKZCh79ltNV3A1SnWURFJNpBZQwirT+uBDj3Dl//4Qh8PBG046saztq2SkwJgFb7tOZCh7qhB3s1ozhVEkkoWKy+XC96bTuO/+f/LAPx/mDSedyAsvvsQNP/8Vr23ZiqIoHHzQgXzivz/EEqty3rve+0HOf9t/sHXbdh785yOgwKknn8QnPvZhFEXBNE1+fdMt/D18H+MTE7z+xONobEzPhr179x6u/9kvePHFV4gn4qxauS8fuuh9HHjA/gBc/NlLWXPwgcRiMe65936cLicX/eeFLF/WxQ9//H90d+9h9epVfOmSz9DR3p6xb4VGTo9nwdumoeT4dqR3lERSO8TjcRRFIR6P85Wvf5v9Vq3kD7+9kZt++VOMhMFVV187dayuadz6xzs4/rhjufV3N3LZFz/HX+68i39ZtTPu/ceD3Hr7HVzyuYu57Xc3cuIJx3HX3fdMfd4wDL7w5a+hazo3/OQabr7xBg4+8AA+e8ll7NnTk7yGrnHPvf/gsEPW8Mff/5r/OOdsfvLTn3P7n/7KVd/9Bjf/+meMj09w6x/vKNl3JAXGLKiaktWgrSjSfiGR1AITExP8+a9/Y/1zL3DG6afhcDj4zS9+ygfffyFOh4O6ujpe/7rjeenlDWmfW3PwgZx4/Fo0TePoo46goaGe17ZsA+D+Bx9i7TFHceQRhyXVXK8/kUPWHDz12X8//iQ7d+7ivz9yEU1NjXg8Ht534bvQdZ37H9zreNrVtYRTTzkJXdc56fUnEIlEOPctb6a5qYnGhgaOPfpItm/fUbLvSqqkslDXoTPWmzm3lKtRRdWkOkoiqTb+8cBDPPjQo1Pv4/E4+6/ej8u//AXWHpssevTPhx/l9j/9he7de4jH45imOVUpb5KuriVp711OF9FosmL1nj09HHPUEWn7ly/tYsuWrQDs3NVNfX0dba2tU/sdDgedixezc1f31LbFixbtPb/LZW3rSNsWjRW/at8kUmBkwdWkojkVjNhMdympjpJIqpNUo7dpmnz681+mob6O152YLMXz3PMv8v2rr+VDF72P887x43K5uPNvd3PNtdennUfNYr+Mx+NMT39tmOlONJmK1wkh0uyiaoYM2IpaPsWQVEllQVEU6mZJFSIFhkRS/aiqyuc//XGefnY9fw39HYAXX3qZhoZ6AuedPTWr3/DqxhxnSqejo53du/ekbdu6bfvU62VLuxgbG6e3t29qWywWo3v3HpYtrdxKjFJg5KCuY+YizFmnojvlVyeR1ALLli3lA+97Dz/92S/ZvmMnixZ1MDY2zisbNpJIJLjjLyE2bX4NLFWTHU48fi3/fuJJ1j/3AvF4nAcefJhXNrw6tf+Yo49k+bKlXH/DLxgeGWFsbIyf33gTAKeeclKRejp/pEoqBw6virNOJTa2dzkpkw1KJElSI66ruQZ24Ly38NAj67jyqmv436u+xRmnv5EvffUbOB0Ozjj9jXzj8i/z2Usu46Of+AzXXv29nOc77xw/vX19fPM73ycSiXDC8Wt563nncOdddwOgaRpXfPVSfnLDL3jPf34Yp9PBAfuv5prvfzvNrlFpKJn0aFXKnDsyS2H0KUZ2xhnYsjdVSOdhbpz1lb3CyNWnakP2p7z09PTQ0dGR9ZhqFhiZqJX+pP52s9x3tr13KnvUqxC87fqU/UpzKhUvLCQSiaQYyJHPBppTwd2UVENJdZREIlmoSIFhk7oOKTAkEsnCRgoMm3haNWulIb8yiUSyMJGjn00UVaF1lRMlQyCNRCKRLASkwMgDqY6SLGRMM3u6f0nlYZpmxojyuSIFhkQiyUlzczN79uyRQqOKME2TPXv20NLSUrBzysA9iUSSE4fDQVtbG729vbPWgIlMTOD2eEretmJR7f0RQtDW1obD4SjYOStGYPj8gZOBuzPscgC/DoeCHyhDsyQSiYXD4WBRSvbU6fR276Q9R3BfNVFr/SkEFSMwwqHgg4A7dZvPH+gCngVuLF/LJBKJREIV2DBuAG4Nh4IPlLshEolEstCpmBXGdHz+QAA4Driw3G2RSCQSSQmTD/r8AR2on21/OBQcnHbs88C14VDwx3bO39/TLUxjbh4ciUQcXS+cYagSqLU+yf5UPrXWp1rrD7P0qb2zy3ZwWSlXGKcC4dl2+vwBTzgUjFhv3wa0A7+we/LWjs45N6zaMofaodb6JPtT+dRan2qtPxSgT/+/vTONkqq4AvA34kZAIy4k0bgQUdCgxy1HcY1HK2iJSyVRo1Fj4sY5ilFQcYmihkGNWwwuKBjkqAE3SpCpqOWCMaAxUVFzEBAVlChRDKCCIAr5MbedR5/u6dfdDD2Pvt+fnqn3+r2qd6vrVt267941pjBi8E+VEUb3FODBGPySNq6WoiiKkpJ2lw/DWNcJmA/8IgY/vtb1URRFUZppj15SvcS99rVaV0RRFEVpoT0qjK3kM13yXEVRFGWN0O5MUoqiKEr7pD2uMBRFUZR2iCoMRVEUJRWqMBRFUZRUqMJQFEVRUtFuY0m1Nca6jsD1wLHAxhKK5KIY/DO1rlulGOtmi5fZ13mHdo3Bz6xRtcrCWNcNGAUcBHSLwc9OHMuczEq0J3PyMtZ9B7gOOAzoKDK4NAY/iQzKKEV7siijXYChQG9gfWAG0BiDf5QqZVS3CgO4XR7owcAcoB/QZKzbNQb/Vq0rVwVnxOAzGQ5eAk4OBx4vckqmZJaiPWRQXuOBBcBuwEJgMDDRWLdjDP6DrMkoRXvIkoyMdZ2BZ4F7gROBL4ELgIdFBtOqkVFdmqSMdZtKFNxBMfhpMfjFMfgbgTfl4Sm1YVPgQOnsq5BRmRVtTxYx1uVmo+fH4OdJ7LfrgE7APlmTUan21Lp+FdIRuBi4LAb/WQx+GTAM6AD0qlZG9brC2EPa/s+88pcy3FFyHGusGwRsCbwFXBmDn1jrSqUhBn83zT/krQsczpzMSrQnR2bkFYP/FDgtr/gH8vlB1mSUoj05siSjj4GRuf+NdZsDlwBzgWeqlVFdrjCAXJ7JT/LK5wOVh72tPa8DM4FDga2BCcAEY13vWldsNbA2yizT8pIZ+iigKQb/YtZlVKA9ZFlGxrplEjHjIMDE4OdXK6N6XWEUowHI7KvvMfij8oquNtYdDZwJvFCjarU1mZVZluVlrNsWmAh8BJxQ4vR2L6Ni7cmyjGLwG8gK41xgirGutRVEKhnV6wpjnnzmZ3jvmji2tjAL+F6tK7EaqBeZtXt5Get+JCaMycBhMfjP5FAmZdRKe4rR7mWUIwY/PwZ/BfBf2aOoSkb1usJ4WbwHegMPJcr3lVlG5hD3zYuAS5LZC4EfitdE1lmrZJZVeRnreonX19Ux+FvyDmdORq21J4syMtYdIZ55PWPwixOHGoCvqpVRXSqMGPwiY93dwDXGumniWjYQ2FZczrLIPOBIYGNjXf+EO90OksEw06yFMsucvIx1HYDRwO0FlEXmZFSqPVmUEfCivHsxzFg3EPgCOAvoDoyrVkZ1G63WWLeBuNCdCGwETAUGxuCn1LpulWKs6ylt2l9mFK/L7Khd21pzGOtmSMddB1hPfqArgXtj8GdkTWYp2pMpeRnr9geeT7QjSeZklLI9mZIRze3aVV7c21uUx3RgSAz+Maoc++pWYSiKoijlUa+b3oqiKEqZqMJQFEVRUqEKQ1EURUmFKgxFURQlFaowFEVRlFSowlAURVFSUZcv7im1wVj3Y+DZGHxDO6hLD+ARYHvgZzH4UOs6pcFYtxTol5X8DJVgrDsQeBLYOQb/Tq3ro7SgCqPOMNZNkhwNB8TgJ+cdu4fmN3ZPrVkF1xxnAN8GNgeW5B801p0qkUuXFfjuwhj8Gom+aqw7CZiSGzhj8BuugXuuC5wN/BLoKS+svQ+MA66PwS9qy/vH4P8GtHk7lfJRhVGfzAfuMtbtHoP/staVqRRjXQOwTgw+P31mGjYD5uTF2ylE5xj8VxVWsSqkfTdL9NQ1MtM21q0HBElLej4wCVgO7AI0AlONdfvG4D9sq/vH4Je3xbWV6lGFUZ+MBI6WxCpXFTrBWLcd8K7E0X9KyrpLApmDY/CTjHWTJcTzhsApErfmUskhPBzoBrwCnBCDn5u49qHALcB2kmvgvBj8c7TkG/6D5BvuJPdrjME/IsevBPoCUcI2Hw08VaD+BwLXSKC4xcBzwIAY/DxjXQD6AA1i4jk2FzahHKQup8fgv58oGwKcFIPfzli3g7SvD3ChBHz7HzA4Bj+KlgF6KHAy0Bl4FRgATJNz1weCse7xGPxRxrqVkjJ0pHz/LOAcedYfAg9KIL1lxjojpp29JetaL+A/kmGuqUizfgvsJ8Hr3kuUvyZhvadKzCEn98+vz7qiYH6dM5sZ684W5bMV8B5wH3BtDH55zkwJ/Aq4ERhurHtaynaIwc9K0Sc2k/YdIs/wfeDGGPyIcmWqtI5uetcnX4pJ5mJj3U5VXGe5KIrnZcY+TBTBeZIveGtJMn9B3vf6yyDaVb7bJHH7AW4C9pTsX12AIcBYifuTIxefqYtkEVsFUWxPiwllS7neFkA01jXE4K2kTZ0Sg9+wEmVRxvMB+L0MmBsD9wB3SKpMRGkfI2bCLsDfgSckpWYPOccWyMuQM5vdIMHjusiAerI8w+T9rwSOAzaREN6jZPVSiJOAMXnKAppNRV/L/foa67qkeQDGuuMlT3ZOIR4PnA4Myjv1SAnqN7jAZUr1iUYxLfaQ2Ej9gZuNdTunqaOSHl1h1Ckx+CnGulHACGPdATH4SoOKzYrBP0Dz4DBOBsfbJFUkxronxJyRpDG34jDWDZYZch9j3QRRZH1i8LPl3HFSfqYMpkiu7MZWzGn9gLclVzHAEmPdZcA/gL0KpKdsa0bH4P9Nc3sfAi6X6KEvyeDWGIOfScsK5XUJVliKc4D7Y/BPyv9TjXW3Ar+T6Ko5bo3Bz6FFRqeKAv2owDV7yAqgGNNk3OgGLEhRxwHAnYlgfVONdTfIimtI4rzRuRDixrpvCo11G6XoE98FVgBLY/ArZGKwURV9WimCKoz65uJE8vc7KrzG7MTfuc3jOXllHfO+82bujxj8AmPdQmAb8VjqICaY5I99nbzsZp9IPuZidE/eQ5ghn9uXqTA+Tw5gwuQY/CFlXGNW4u8v5PNbxrrcpvs3+xOypzKGlsGyNbrLSinJDJlld02UFbx/kWt+VWJc6CCfaceOHsAexroLE2UNNLdv/URZsT2aNH3icmA8MM9Y94zktxgLtNZHlApQhVHHxOA/NdadA9wjM7ZSFDJhrkhZliR/k7oBWJr4Xu8Y/CutfD/NRn2+ySVX93JnneVueqd9RiTqWKmb8cqU7SwljySzZK+jGDvJ9WYWOZ7f/hXAoBj8TYVOTijjYjIt2Sdi8G/IftG+wE/E/HeFsW6f5N6ZUj26h1HnxOC97APcmncoNxNNzgK3WU23/WbfRDYsN5HN0HdEmeyePNlYt41spqZlBpBvv87ds9hAVwlf5D0fynlGYoKZL66rILNuY91AyfZWipmyqZ9kJ2BhEXNTGsYAxxnrdsw/IAmHBgITExnolpboIzMLyLOrsa5zyvqU7BPGuk3EW+75GPzlovCWAD9PeQ8lJbrCUBCf+zeBzxIeRx8BnwCHizmgk5y3OrhMVjaLgKvFFv54DH6xsW6k2OBfEVv+foCXe49Nef3hwPnGuguA22RDfijwUgz+1dXUBuSZbWGs2ysG/y9j3R7AoTKIpuU24Gzx3JouKUEHAH9O/D57GutejsHn7xn8CbhT9kWeBXaT5zQiBr+ygCktDX8Efgr81Vh3rvSHpFvtpsARec/gMGPdHWI6GiRmreT1RhvrHgUmiCPEA5IqtF+pysTgP2+tTxjrHhAT42PGuqvEDLWLmPrequQBKMXRFYZCDP4D2c/YKlG2EjgNONxYN1u8jobJ4UonGuvJrHyErGo+Fs+Xvon3IQYATWKHXiznXhGDT6ssiMG/K+62J4hr6gvA24CtsN7FmAjcBUw01k0XU8hNZT6focDDMjAvEAV9eAx+gTgO3A9cLzb6VYjB3y9eRXfKQHmfrBQvrbRB4khwMPAXeQdkkSiMJmAusGduA13oLxvg74tTwXhZ4awr1xsrG9zXAp/LJvUU8aRLS9E+If30GFlRviuTnjFyvJjrsFIhmnFPUZSiSAiV6cBRbeh+rGQEVRiKorSKsa5JXrLsC8zVN7HrFzVJKYpSit/I5vMbeS7TSp2hKwxFURQlFbrCUBRFUVKhCkNRFEVJhSoMRVEUJRWqMBRFUZRUqMJQFEVRUvF/GjKZQqusOd0AAAAASUVORK5CYII=\n"
+          },
+          "metadata": {
+            "bento_obj_id": "140039744374384",
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "cff9a0bb-8e81-4324-8da6-d2ca4d667446",
+        "customOutput": null,
+        "collapsed": false,
+        "requestMsgId": "1094e900-749f-4225-9c50-93f626d29b73",
+        "executionStartTime": 1678934073511,
+        "executionStopTime": 1678934074038
+      },
+      "source": [
+        "plt.plot(mtgp_results.mean(0))\n",
+        "plt.fill_between(\n",
+        "    torch.arange(n_steps * batch_size),\n",
+        "    mtgp_results.mean(0) - 2.0 * mtgp_results.std(0) / (n_trials**0.5),\n",
+        "    mtgp_results.mean(0) + 2.0 * mtgp_results.std(0) / (n_trials**0.5),\n",
+        "    alpha=0.3,\n",
+        "    label=\"MTGP\",\n",
+        ")\n",
+        "\n",
+        "plt.plot(batch_results.mean(0))\n",
+        "plt.fill_between(\n",
+        "    torch.arange(n_steps * batch_size),\n",
+        "    batch_results.mean(0) - 2.0 * batch_results.std(0) / (n_trials**0.5),\n",
+        "    batch_results.mean(0) + 2.0 * batch_results.std(0) / (n_trials**0.5),\n",
+        "    alpha=0.3,\n",
+        "    label=\"Batch\",\n",
+        ")\n",
+        "\n",
+        "plt.plot(random_results.mean(0))\n",
+        "plt.fill_between(\n",
+        "    torch.arange(n_steps * batch_size),\n",
+        "    random_results.mean(0) - 2.0 * random_results.std(0) / (n_trials**0.5),\n",
+        "    random_results.mean(0) + 2.0 * random_results.std(0) / (n_trials**0.5),\n",
+        "    alpha=0.3,\n",
+        "    label=\"Random\",\n",
+        ")\n",
+        "\n",
+        "plt.legend(loc=\"lower right\", fontsize=15)\n",
+        "plt.xlabel(\"Number of Function Queries\")\n",
+        "plt.ylabel(\"Best Objective Achieved\")\n",
+        "plt.show()"
+      ],
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": "<Figure size 432x288 with 1 Axes>",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAENCAYAAAAc1VI3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOydd3wjV7mwnzMzqu51vb2l7ZLeGySBKARRRQuEDpdyuSW00Gvo5UsCAXKBC4QSShIQuRCRRAmpkJ5s2qZtNtnNru1de91t1Znz/aGxLcmyPbYlW5LP8/vJko5GM2dk6bzzdiGlRKFQKBSK2dCWegIKhUKhqAyUwFAoFAqFI5TAUCgUCoUjlMBQKBQKhSOUwFAoFAqFI6pJYMj53vp6uuf93nK9Vds5qfMp/1u1nVO1nc8M5+SYahIY88YyraWeQtGptnNS51P+VNs5Vdv5UIRzMoo2kyIRCIZWAN8GzgV8wOPAZ6OR8K1LPTeFQqFYzpSjhnEtsAI42r6/DfhbIBhatdQTUygUiuVMWQmMQDBUb2sUH41Gwt3RSDhuaxs1wMlLPT+FQqFYzpSVSSoaCQ8B78sb3mTfdy7BlBQKhUJhI8q5lpStcdwBvBCNhF8107Z9Pd1yvg6ddDqFYbjmO82ypNrOSZ1P+VNt51Rt58M059TasUo4fX9ZaRjZBIKh9cDfgP3AW2fbvrmtY97H6u3upLWjulwk1XZO6nzKn2o7p2o7H4pwTmXlwxgnEAydANwL/BM4NxoJDy/1nBQKhWK5U3YaRiAYOhy4HrgoGgl/f6nno1AoFIoMZSUwAsGQDvwK+LESFgqFohhYlsSUkLZASrAcum1Hk+BNFNfHK+15mJYkZY4/hpQpMa3M87Q9bjn0L29o0WivWxxjUVkJDOAU4Fjg8EAwdGHea7+JRsLvX6J5KRTLkp29FgdGnS1cgwc0GhJmyec0HaYlsSwwZWYRNiVYtpCYD0MDOvUjS3c+TknUL96xykpgRCPhOwHHHnuFQlFa9vRbxFPOth2KCyyHwkVRmZSl01uhUCw9ownpWFgolgdKYCgUioI4NUUplg9KYCgUioIogaHIRwkMhUIxBcuS9CmBochDCQyFQjGFgVgm0kihyEYJDIVCMYUDo0paKKZSVmG1CoWiPOgdcW6OsqREAmkkKTlV0CyWYUtmHUnmjOc/Egg7fl/Yj7XsMaEi+6dDCQyFokpISUnaYZaalBJTStL2gm9KiQmYUpJIWzw7ZmIhsSDnXiKxZO7YOGNaHL81UsIzXDwEENfi1Jkj6EKgIzDI3OuIvDFtSZPHTLl4R1cCQ6GoEp4cG6M/tfDEib4xyYEybnuwGEjARJLEKqwildHHsyLtYwO+RTmW8mEoFFWAKSUD6XRR9jUcL6PVUFFWKIGhUFQB/ek0xWqGNpwoym4UVYgSGApFFdBXBFMUQCwNqeIoKooqRAkMhaIK6CuWOSqmzFGK6VECQ6GocIZNk6RVnLyJIeW/UMyAEhgKRYVTjMgoyDQWGlX+C8UMKIGhUFQ4B4pkjhpJSMfd6BTLk2nzMALB0DqH+3BFI+FnizclhULhlJRlMWwWpyucMkcpZmOmxL3n55CeohdpPgqFYg4cSKfn34M0DxVOq5iNmQRGIOvxZuAjwC+Ap2wBsRV4O3DRIsxToVAUoFjhtCkL4smi7EpRxUwrMKKR8M3jjwPB0OeBt0Qj4UeyNvlLIBi6HrgU+EPJZ6pQKHKwpKRfZXcrFhGntaSOB54oMP4ocGyR51S29I1miq81+QSapipaKpaWQdPELJI5SvkvFE5wGiX1AvCfgWAof5X8ELC3BPMqS57pMXlgl8UtT5s8uNtk1wGLkYT6oSmWhmKZowCG40XblaKKcaphfBH4PfCZQDC023aGrwNagHeWeI5lQTwlGRzLPDatTL+A3hEJ+8Djgma/oLVW0Fwj8BhK+1CUnmKF08ZSkC5OoJWiynEkMKKR8DWBYOh+4E3AWsADXAv8NRoJP1z6aS49+4en1yQSKegalHQNZrap9cKxa3W8LiU4FKUhZprEixVOu4zKgaRN58IxkRJo0wQCmEh6idPJGPuIZ8qgzxE55cH8qqZfsweMTsG7W1fyrrVt89iDcxz3w4hGws8D3w0EQ0Y0El525clmEhj5jMQzAmRjqxIYitJQLO0CYKhKzKqWlfntDY0KhkdhaEwwNGY/H8s8H4vP5TfZnPNMuE28K0fxrhrFs2IMzV2kNrYLXCaSZCTNts4071pbnClNhyOBEQiGDOCTwAeBNsAfCIZqgO8CH4lGwlUdkJdMS/rH5vaj6hq02NiqEukVpaFY0VHTlQMxLbh9m8aOvRqmw3VRykaEWJrvvGnBSAxkUbvPSYz6ZEZArBzF3RJniU6vbHCqYXwaeJ8tIL5rj/nt6KlvAR8r4RyXnP0jcs65USOJTORJvVdpGYriki5is6SRROHv9i0Patz/1FzzcZc6f1eCyNzERINuCQKEfY+QaIZEuCw0l5m5d1sTz7MfG/UpjNriBRZUA04FxtuA10Yj4UcCwdB3yJioegLB0FuA26tdYPTMwRyVTdegRb13qX9EimqjmM2SCoXTPrlb5AoLIdHcJprPRPem0byF74UhJxZoyF2kM4s29qJelKlPYbGv/q24TnKfn1RXDel+r2P/g6ZlwlN1LfNYaKALe1zIzL3m/GOqc+nUuQVnHe9dwNk4w6nAWGfnXOSz246UqlrSpuTA6HwFhuSQdokQSstQFI9ShtP2D8Pf7xN41wzjWzuCuzWG5jGXvSlmnCZcrNH8rBE+Wms9iDoBBxXzCHNfK05r93D8isXp6e1UYHQCJwD35o2/xs7RqFp6RyXzbTWQTMOBUUlrrRIYiuJRrGZJSRPituwxpeQFM8atA2M0vWIUzVUdjvCFogEdwssa4WeN5qdWOI4Tqkqcnv2lwP8FgqGfAHogGLrAzvB+M3Bhiee4pOwbWtgPp3NQ0lpbtOkoljnD6TSpIjVL6o9Z7LXGeN4aZbccI4VE6yjKrpeMCdcFIuexljWmI3ALDTcaLjL3Oc9F5l7GY6zyNeFS6tUETvMwfhQIhnqBjwJjdiLf08C7o5HwH0s/zaXBsiS98zRHjdMzLEmbEkNXWoZi4UwXThszTXYlEqQd+DZMKXkqFuOhkVHi0pnwcaPhQ8cn9Cn3XnT8Qic9NorfXzexSDNRSkJMWchLgYCimn/HZFoJizychtVusgVD1QqHQhwYlSw0N8q0YN+wZHWjEhiKhVPIf7E/meSHXV1F64sBYMV0DvPWsNmooVm40R0sxGPE8S9zk0214/S/uyMQDN0JXAFcFY2ER0o8r7Jg3zyjo/LpGpSsbizKrhTLmIRlMZInFCwp+V1PT1GEhRnXib9QS2JvLecdZ7DSrS5yFLk4FRgvA84Dvg1cFgiG/mILj5uikXBVeseklPSMFOfU+sck8ZRUpUIUC6KQs/u2wUF2Jebf+UikNUZ21RJ7oY5kjw+k4NwT06xsrsqftWKBOPVh3ALcEgiG/gN4uS08rgZGAsHQb6OR8KdLP9XFpW9MkipS9QUpVakQxcLJN0ftTyb5e39/ztgKl4sWl2v2naU04ntruPO2OsjKjn7RBoujDlLCQlGYORkco5GwCUSASCAYOtrO+r7QzgQvCoFgyGfv901APfA48MloJPyPYh3DCXOpHeUEVSpEsRCsvOxuS0r+0NNDKsvJ7dc0PrxyJfXG9D/rRDqT3f3ATsmv7jByhEVLveTlJ5qotCHFdMxJYASCoS12KO2bgUOAW4B3F3lOPwZOAc4Cdtk9N64LBENHRiPhZ4p8rGkptsBQpUIUC2Ewnc5plnTH0BDP5ZmiXtfSkiMsLAljSRhNSEaTkpEkmGamunL4DoO0OfldNHTJ616cxu1AOVEsX5xGSX3eNkNttTO+fwH8LhoJdxVzMoFgqNnuE/7GaCS83R7+f4Fg6G224Ph4MY83HQNjkkQJSsioUiGKuSKlJGVCdyJFyo6APZBKcV1fX852h/n8HOGrZSAmGUlIRpMQSzKlTpSUcMM9On1DuRcuLz/RpE0FZihmwamG8QG7gdJbo5HwYyWcz7H2nO7LG78XOLmEx81h33CRyhbnoUqFKOZC95DFzh6LkQTsMBOkkEgpudHcn2OKciE4PNXME10za8UjMbjrcY3tu3JNo0dutjhik/JbKGbHqcBYH42EZSAYMgLB0MZoJPxciebTbt8fyBvvBWbMQe3r6cZyWoc5j3Q6RW9358TzHS/oxApoGHEsvI672hbmacOixV+6H2cyDdu6dPyGxYZEJ7Wekh1qUcn/H1U6M51Pz6jg+X6NUbtpQBKLQS1jfnpWi7PPyDVFHZn2Q3KMsWmONTCi8eAOH0/s9mBauRcrLfVpTtsyyNjows/JsizGRocWvqMyoVLOZ7BvlF7pzHJR6HvX2rHK8bGcCgxvIBj6PvAewAI8gWCoCbgSOD8aCQ84PuL8ELM1o2pum39Ng97uzokPbTgucfWZ5Jty49Kk0xplpeajQczf0JvwCFo7SmOWsizJfbtNjBroHThAcrSFZgTrmwVtdZXtcM/+H1UDhc5n/7DFDluj0P1Q78+MH7AS+GWCEZni0XRuVNQq4WWrt7Wg1trZK7hnu8ZTL4iCRe3chuT1Z0ga6uuLck5jo0P4a4qzr3KgUs6nodlHq8Pigwv9HTkVGF+3zUWvB66yxyz7doktSIpBt33fBuzJGm/Peq2kFErWs6Sk04ohgS4rhlfT8Ij5LfqlLBXyaKc10Xd8nL5RSd+opMZjsb5FY1W9QNOUSayc6LEFRX7l2HFGyJQzv8s8QJpcU9TJeq6wkBJ2dgrueUJj977pLxJ8HslrTzNpKf/1sOxpFK4lLUrYqC9epILTs3wNcE40Et4ZCIYkmRDbwUAw9G9AMXt6P2B3HDzFzvMY51Tgb0U8zrTsL+C/6JEJEnbPXgnssWJs0GoclUvIp1SlQp7Zb85YKHE0Ads7LZ7ZD2ubNNY1CdyGEhyzMWKa9KRSORFKxWAgleL5A6Ps7peMTCMoAMYSku6EyS59hC5X7oaHpZpJxQ3GdY7OXsHd23V6Bqb/v9bXSE7cYnHkZgu3quKxIAwEKzXfklew9WiLZz1weqargEJ+i36grliTsYXQz4FvBoKh7XZY7ceB9Xa4bUkZS0798Y7KNH0ytwNtEotuGWO18M/rOMUuFbJ3wOK5XmcLWioNO3ssnj8AK+sFjf6lFRqWlQn/NCWYlsw8tuybnHy9/4BOQ3xxWsmbUjJopThgpYjJ4tVnymZ4UKJ5c30RUmb6UezpEezp0djTI+gbEmg+aH95f473LLHPxw23NTnun9DeJDlpi8mW9ZkGPYqF0SBcrBDeeV00VjKOa0kB5wA35I2/x36tmHzULkFyiy2Mttnaza4iH2cK+VfoppR0WbGC2w7JND4rSbPmnvNxilkq5MCoxRPdc3f2WxbsHZDsHaiM6JihOMjpvLpFIibTDMgUQzJFaeLkJomb4LFgX5+wBUTmNhbP/05IGo/fj+aenJGVFgzcv8KRsFi/wuKkrRYbV8qJhDyfG9IWRatksJzQEazUvNQtwI9ZyTgVGF8D/hwIhq4BjEAwdClwDHAacH4xJxSNhBPAR+zborJ/JHeZ2CfjpGbwte+XcXxSwzdHlbRYpUJGE5KH91jzbvA0F6SUjltQFqvMdDwleazT4tFOk75hN4Zr/jWTpkMCaSxSyCyzU+lzZcZi9ewbyE2eK4Rv/TDelbmScviRVszR6RcsISSHrpWctNViZUvWf03AijroqNdImfBMj6WExhyoEwYdwouxjEueO60ldVUgGNptL+KPAy+2+2GcHo2E7y79NEtPPCVzHMbDMsWgnDl7TwJ7bX/GXL9ECy0VkkxLHnzBJF0ai0kOYzLNHiuG6VhkZPogaIjMTQj0rOe63dBGK3CF3D8qeXwPPL5HsmNfxjSVwbBjLEpFgUgiIXE1JTAaEsUvl+EGdwPMpp/WH9mb89w84MW1t57G8dDsrHnpekajOGGLRVOeodhjwLpmbSLM2mPAwW2aEhoO0BB0aN4FRUdWC44vjW3B8JbSTmfpyC4FkpYWXdYMnsgsUkg6ZYy1+Od0Vb2QUiGWJdm2xySWdLDxAumzkuyX8TmIigyZEDqZEaszvFlK6Dog2LFX8MwebUaHbcnRJO6mOO72GO62GO6WWFm1KtUteMNgAw2HzPLdzDPe1nmhpUZD7DXJT7dYY0LnoLXgvi8AngQYnhKUSFgiPAmo9Vo0CTc6aWKUp2SNaR5onrtpfD5MKzACwdAXopHwV+3HF820k2gk/MVSTG4xyRYYXTI+p6vpUWnSS4I24Z3TMedbKuSxLouBBdrzk6bkn8+aHJimo6CUkhFMEtKc6JtWbEbjgmf3Ckan2O0XCc3C3RLH3RbD0xbD1RJHM8pHQORzXG89DSnn5k9dg9ZaQY1n+s/XpcOqBq1oQqPS0REYQsOFwG8ZNIsqyXwtEjN9+94GfNV+/I4ZtpN2y9aKJWVmHNEAAzLJiJz7lUSvTOKTxpxC7OZTKuSZ/Sbdgwtb1Ebiku/dnOC5A072U1x7vuY2ca8Yw9sxhrEygX+zZKZYM10DtwsMzUIrYniPRBI3UtnFWsuaFWNutvY7bw7v90BrrYbh4CNbbkJDQ2AIgQsNHYFLaBgIjLwGsjGK7zOrdKZd3aKR8GFZjzcu2oyWgN5RgZSQlBb7HJqiCtFpxdio1TjuA5xMZ9rAttY6W7XmEj47HX2jku/elKBzgULHMfZVvKdjDM+KMVxNc/cHpO3bUuBFo114cRdJyxJxiYhJTNNE150J47qUwdb+moI+nyn7F9BSK+Zs6pyP0HChoQuBy74qT1gpfJpnYpbZMxD231LLZzFxpELHX4wZVDdzLW/eClMvCKOR8O6izmqR6R0TSJekS8YW5FY1keyRMdbjR3O4Kj7eZeHWnR11dIE+i+4hi+9Gk/ROY4YqDhKjLoWnYxTPijHc7bGyNvPkU6fprHN7Wefyst7tpVl3Fa1YpLQk6cfTkIb46Cgefw2WzJj/LNvVI2Um7wSZ8QNJ+97JL9UloKVWwzVPpbCQ0Mi5ArdNNYZ9ZZ6PhoZvESLMFEuH0/LmrwJ+DrTmvTRe46mivyWDcUHMSDJWhCStuDTZT5wO4ay2SyJFSUqp57Orz+J7NyUYylOgDmnXOHyVxrBMTWSzj2MJi9HaMYbrh4n7EkjhbOGXWuUIiGbDYLPXy2afj81eLy2GUbJqwqn9FklDgAFGWuL3FboWX1rGhUbXoEWN5aJOGGU1P8XS4lTDuBi42S42OH+bTZkSlxY9snj2yn6ZImFZ1JOpMePURFUqnt5ncvE/klMq8B63TuN9pxvs02IkpF36REr2yTjPWqO8IEdnzEOZL824Wal5WSl8eAvU5DJ0aKuBet+kAWF0eIiauuIWPqrRdRpn6E5XTKSUpOaRYLkUNLl1Nq/wsau3eG2Klwq3AX63wOsCvxu8LuHIrwMwNGBR31ia366U9m28qqr92LJ/btYcfnbNDk3axWAupUHeGY2EK/zrU5h9IgUUNxpiTJqMYYIEn9CpJ3O1VirhYUlJHJOYNElgMSySDFljPLUXfn87pPISxI7dJHntySZ7RTJTCkOm2GmNsNMaYZTiej596KwSPlZpXjqED980hRs1Ae31ghV1gvz6iEMxnXrP4kasCCHwCIGrCM725AETmdYmAs6k0PA53G/Ssor8HymMLgQdbveEED24TfLMfotUBTjChQCvC3wuYQuGjKDQF1BoUxcs6P2LhWcRS1k5PdTDwErghRLPZ0lICjlrAtVCiEmTGCb7JoSHQZ1wzVt4SClJYE0IiBhmjoYQx2JUJNmzO8FN92tYbpHjsj3qIItTD7fYh2SvGWOnHKFXFi+pQ0ewQnhZJbys0nw0UNgP4LKT+gBaagRrGqcviJgWGjUOncSO5ykEHk3DLUTmNv5Y03BrGq4imqa6d8ZJ+iYTv4biMep9zsyWUkqGTZPBdJphcy4B385pMAxWulzoWULM4xIcvkqb0rVvOkp5RT4bQoz/UZSSmfIwsoumfwH4cSAYugzYmZ9yG42Ed5Z0llXEpPBI4BU6tRiOHUApMlpEXJpTnPNJafGsNcJT1hBDpDMpxB2DtL9q6n72AX92eNXoQ2ejVsMmrYa6KV1CCqNnCYJCaAjahYdG4aKpRnDoCp0G38w/9t7RYVrrilbnclGJD5gkR+dvjhJCUG8Y1BsGppQMmSYDqRRjRagJ4xaClW43tdOZ5oRwvA4LAaICrsgV82cmDWNPXtMiAbyywFjFO72Xirg0iS/Q2NAvkzxlDbHTGs3plbAQDASHef0c6atlk8fnOOLLCa2Gi3VuLy6RieZpqan+ujxDncWLatCFoMkwaDIMUpbFYDrNgGmSmIfwaHG5aHe5ivr/VVQ3MwmMsxZxHoo5YEnJbjnGU9YQ+4rorD/I6+X4ujqOqqnBW+Qa2DW6zkE+Hw2L5GQuF5IjFvHB0ji7XZpGq9tNKxC3LIbTacdh4fW6jq/IJj5F9TNT4t5t2c8DwVAt4IpGwv328/XAQDQSHlyMiSoy5befsUZ4yhomNoNmIi2w4pP/Wp9HYhRYG1w61Ok6R9bUcFxtLc2u4hdXM4RgvdfLKre7ZOGq5UwxtYuZ8GoaXvfi1BNSLF+c5mEcD1wP/AfwR3v4DcBnA8HQudFI+P7STrM62WmNsNsas4v0zYxJJtx1pitIc0xndGcDYzsbsOIGHpfkjWearG2Yuv+mGtjQXFpzULvbzSavF/cy7diTilnE+iogxEihcIhT+8D/A34K/F/W2GV21vcldrlzhUOklDxkDfCYVRzlLLHfx+iOBuJ7axkvjlTntfjgy3RWNxU2OxzVolPnFUgpSY/fYOJxSkrSlpUpyTHH9qTL1fyUz3BXeq4fnUJR1jj9RR8DvDQaCU9cLkUj4VQgGPoW8MnSTa/6kFJyr9XHU9bwgvZjpQSxXfWM7mggPTSZn+DW4eVbDV68ZogVLS0F39vghy0NzhfzlMw0F3K69nmFWJbmp2zMpGR0f1WmLSmWMU5XjVFgA/Bs3vhhQIkbZ1YPlpTcZfbyrMzvSuCc9LCL0R2NjD1fh0xNag9CwIs364SOdtHsFwwNTL+PdU1zMxG5hChqTsJyYLg7pbQLRdXhVGD8FogEgqEfAs/Z4bSH2T6N35Z4jlWBKSV3mD3szmtMbSU0Bh9qw0rNvohbcYNUv2dKbZ8jV2ucd6yLNQ4EgccFHfVq8S8llikZ6VbahaL6cCowPgMM2wl84wUIe4EfAd8o4fyqgrS0uNXsoVPGcsbNmM6B21bnmJTmwrpmwfnHu9jS4Tw8cm2TtuzNRaVmZF8aS/m6FVWI057eaeAi4KJAMFQPiPFwWvt59fRlLDJJaXGLuW9KvoSMGfTeshpzZO6hkM218OajXZy0UZ9T0pWmwZpGJSxKibQkw11Ku1BUJ3MOY4lGwkNkBMVRtknqrUBl1mwoMXFpcrO5jwN5dZpqLINnb1qDFZvMezD02Q3eDX44+1CDwKEuXPrcF/6V9dPXalIUh9FeEzOpnBeK6mSuDZRcwJtsQXEy8AjwidJNr3KJyTTR9D4G8pSvJstF3eMreSZLWBzSBBeeMPVfke80nei4tj89q0pnDluk8uqZN7k0Bnbl2UoE6IZAGALNAE0XaOOPDYE2D8FUjkgpkZZdRtrKPC9FFb/hRUrUUyiWAqeJe+uADwHvA2rIlLZ7TTQSvq70U6w8RswU0fg+ht25pom2mIvAC63877O5GdUn1oLZM7vRey4FJuSoJJ2YPH6dV5DulQzNYR/Y0VeaIRD60hYDHeyzSHXHZt1O2g0GpARpypznCoViYcwoMALB0DnAfwJBu8T5l4HfAc8Djy7eNCuHIZniRrObMXeuAFg56ubsvS3sGzEYSE5GMxkCjm0s/bza5mk0lBLMlFxyL1U6DqmYWvUViqVkNg3jejts9thoJPzI+GAgGCr9zCqQlLS4Ob2PMZErLNaOeDirswVDCh7tz41oOqIB/CVOiPa4oMFbHaYlhUKxdMy2VN1kO7XbA8HQz4FwtXbdWyhSSu42DzBM7sezccjHS7qa0BGYFmwfyP3IT2oq/dzaaoVqLqNQKBbMjJle0Uj4HGAr8JRdS6ozEAxdbAsaZR/IYocc4bm8DO5NQz7OsIUFwLPDOrGsVqk1Ohxe3DbVU9B0aK5RwkKhUCycWVODo5HwM9FI+AJgNfAl4Gzb8f27QDB0XiAYWt4V5oABmeResy9nrClhcHp342RkE0wxRx3XhOOG9POlxb+wvsYKhUIxjuPlKhoJj0Uj4cujkfCRwEuBLuA31drn2ykpaXFbuofsTsuGJTirsxlDTn68cROeHsoVGCcuhjmqTgkLhUJRHOalHUQj4VuBWwPB0GrgA8WfVuVwn9nHYF4I0ckHGmlM5obOPjGgY8rJxbvVDZtrSju3Br/AoxL1FApFkViQOSkaCe+1zVTLkp3WCDvkSM7YJlHDIf3+Kds+1p/7UZ/YXHo/dGuJBZJCoVheLM9WaEVgSKa42zyQM1aPwUmyeUo4wGBSsGt0cc1RHgPqferfq1AoiodaUeaBKS1uS+8nnSUZNOAMox1XcupH+vhArrBY74cOb2nn2OKfS164QqFQzM6yj3CaD/dZ/fTn+S1O1FpoEm5EKnehlhIezTNHndw8+djjwrGfwbIkpgVp+zZduQtdh0af49NRKBQKRzgWGIFgSANeAmyIRsJX2GP+aCRctI57gWBoBfBt4FzABzwOfNZ2spcFz1ujPJ3XXnW98HOwVguASOWu4vvigp74pNahAcdllQJpqxW01c1P0TMtSdoiI0TMSWHiNkDE57VLhUKhmBZHK1UgGFoPPGZnfv/EHtsAPBcIhg4v4nyuBVYAR9v3twF/CwRDq4p4jHkzLFPcZfbmjNVicIreOtmUKLeS+RRn99Z6qM8KoHI57300BV3LREH53YJ6n0ZTjUZbnUaD8l0oFIoS4HRluRi4x+62Z5GJkHrezv6+uBgTsRsxPQ58NBoJd0cj4bitbdTYpdSXFFNKbjd7SE3xW7ThFpMfY7aGYVnYIPgAACAASURBVEl4LC9ZL78UiOpPoVAoKgWnJqlTgC3RSHgwEAxl21y+CXQWYyJ2Y6b35Q1vsu+LcoyF8KDVP6UR0nFaMy0ir71qlmvj+RGNkfSkMPFocFReZVr3AjQMhUKhWEycCow6oFAzAjfgaMmzS4jUTvd6NBIeyNu+HvglcF00Er57tv339XRjmfOLDLIsi7HR6TtF9IgUT7hy/RarLBfrkpKxvA4TnuHJKlsP9+YmQhxZm8KMxSc+SCFgbKg00UymmWaov8/BlpVBNZ2PlJKxAyZjPQccbA1WCtJxSTqeKfNuxiYfp+Ng2q+ZyaWt8CYBwf6lm0CRqZTzEXqmEdrWt+isO3Pm5TidTtHbnXv93drh3OLvVGDcA3zc1iggs6DXZpmqnHAmEJ3uxUAw5LPNUOM+k78B++1qubPS3NbhcBpT0Xbtwusv3DBCSsl2szvnh1iDzovdHXg8ef+ctMSwmyYlTXhmJFf7OLXNha9m0oHhdUF9U2lUjKH+Puqbmh1sWRlUy/mkYhYP/ryfkX0AszfNUiic4vM10NoxczXT3u7OOQmIfJwKjE8A1weCoQ8CnkAwtA3YDIzaEU2zEo2Eb8rIwZkJBEMn2MIiDPxXNBJe0tY9nTJOj0zkjJ2ut+ERBRb6LIvV00M6SWvydBsMODRPJin/xfLjuVtHGdmnBIWiMnEkMKKR8LZAMHQQ8A7gENvxfTnwu2gkPOxgF46wI66uBy6KRsLfL9Z+54uUkm1Wf87YauFjhVY46y7b4Z0fHXVCM+QXjVX+i+WFmZR0PajinRWVi9Oe3l8BfhWNhC8v1UQCwZAO/Ar4cTkIC4A9MjbF0X20PkM/VXvTkRQ8O5wbgHZygVIgLpU2uazofiROOp4VZecCf/PsVw2aIXD5NQyfwOXTcPkEhj9zn3mu4fILdK+2pH2yhgf7qWtYhBLMi0SlnE/jeoPadhfGInTVdLpkvRP4fCAY+hdwBXC1HdVUTE4BjgUODwRDF+a99ptoJPz+Ih9vRqSUbDNz/PCsFf6pUVFZjGsY2wcMZJb1bZUXVhfIvFYaxvJBSsmee3LjRtae7Oegc6aNA6k4XEmBu6Z6coAq5Xw8dTrehsVZTJyapDYGgqFTgPOAi4AfBIKha22N4MZoJLzg2IxoJHynEx/HYrFbjtHPHLSLLIExJfdimsq0yoexfBjcnWKkO6t9r4DVJ6r6LYrKYi4NlO6KRsIfAdYArwYGgV9UYwMlS0oeztMu1gs/TcI98xtTcCAu6IxNCgwBnDCNVqs0jOVDvnbRuEnga1RfAEVlMWd9y9YmhoEhoA8ocVfqxWeXHGUgKwNPAEfNol0k0/BsryDamStUDqmF5gJyRgglMJYLiRGL/dtzI+3aj1LapaLymEvxweOANwNvsrWMm+y8jHBpp7i4FNIuNooaGvO0CylhXx8816XxXLdgT4/Aslzkc+I0qQMundJ3UFKUBZ33x5BZkbS+Fp369Us5I4VifjiNknoW2AA8BPzADqct/xTIefCcHGWISVuzAI60tYuhUXiuW/B8l8bz3YJYYuYF3yXg2GkUE+W/WB5YpmTvfbnmqDUn+hCqnLCiAnGqYfzBjlR6ssTzWVIKaRebRS01los//1Pn6RecW/BcAt66FnzTmJ2UOWp50PtkgkRW+RfNBSuP8RKLK4GhqDymFRiBYOiMaCR8m/30ZmDVdGXGo5HwP0o2w0VkhxxhJEu70IAj9QYeelpzJCya3BaH1UmOqtc5tG56YcECy5orKoc99+ZqFx1HeXH5NGJKXigqkJk0jOvtJkbY/go5TdirdFqAsJwxpeSRPO3iIK2OGlw8+FRhYeFxSdZ3SDaulGzS07SMmbRpHqbP1Mh+b5EmrihbRvan6d+ZW9lmzUn+JZuPQrFQZhIYh2Y93rgIc1lSnrGGGcsqBqcBR2gNPN8t6BuelJOaJjnlRRabVkpWtkg0W5ZouzM5GG6HgWeu8s8HUiyQvXnaRcN6F3UdKr1fUblM++2NRsK7s55+LBoJX5C/TSAYagAuszPBK5Y0kketwZyxQ7Q6aoTBg0/nruyHrpW8+MipJclFUuIWGsJh7qHTPt6KyiSdsOjalmt3WqMS9RQVzoyXO4FgqBFoBj4QCIYuLWCS2gq8odIFxrNanFiWdqEjOEJrYHAUduzNPeVjD5mmf0UKvHNIa1E+jOqme1scMzFZAMFdq9G+1YmxUqEoX2bTj98GXGpbaHYUeF3YDvGKJWaabNdyTQeHanX4hMG9z2hIOSkw2hola9oKVEExJcKUeDRnUsDQQcsvXauoGgrVjVp1vBdNaZWKCmdGgRGNhH8UCIauBPYB5xTYZBTYVrrplZ4/9vSQEJNCwEBwuNZA2oSHd+RqDMcdYhbOtbP9mk79F25lxq5qBp5PMdozqbEKDVafoMxRispn1hXObp16tB1ie080Er7Nfvww8EA0Ek7Pto9yZcQ0+fW+fTljW7R6vELnqd2CsazEPI9LsnVj4RqLIiXxzMF/4dbVlWY1k69dtG3x4K1XNkhF5ePU6J4MBENPAa/KGnsf8LTdWKki+f3+/Qyak1eCLgRbtUxprHxn9+GbrOk1gyR45uC/UBpG9RIfNOl5Irdu1JqTlHahqA6crnI/AO4Gbssau8LOz7isRHMrKUPpNL/dn1vdZKvWgEfodPfB3t7cj2ZaZ/eEhuH8ClJleVcve++PIbO+KjXtOo0bVNKNojpwKjBOBT4YjYR7xgeikfAB4GPAyaWbXun4W18fI1nahRuNLRPaRe6KvqHDomWGmrwi6dx/gdIwqhYrLem8f2oorVBFJhVVgtNVzgQaCoy32/29K463tLXxrY0b2ejN9Od+kVaPW2jEE7D9eYehtDaetHDsvwBwKR9GVbJ/e4LkyOR3RfcIOo4u3P9doahEnF7rXgv8ORAMfQt4zg6nPQz4jP1axaEJQaCpiZc2NnLBfc+wwZtRIR7ZqZE2Jxf0er/koNUzNxT0JueWtu1RGkZVkl83auXRXgyPSulXVA9Ol64LbD/Gn22tRNhax2+Bj5R4jiVFF4L10oNLaEgJDz2T+wM/+mBrovxHQSyJx3LulNB00FUOxpKTTlg5iXULZeyAyeCu3LpRqgWrotpw2tN7BHhvIBi6ANhkD++MRsLDpZ3e4vJcl6A/r27UUQfNbI4Sqbn5L9QF5+IgLUlixCLWZ+be+jP3qbHiCYtCNG10UduuVElFdTGXjnsacBywIRoJX2GP+aOR8FhJZ7iI5IfSHrZOUjOLCdqXcp5/AeCqoGxfKSWj+016n0ow3JnOif5ZbFIpE5drcNbtLFMS6zeJ95tYS5ghpEJpFdWI045764G/A4fYpqgrAsHQBuCeQDD0smgk/Fjpp1paBkbmUDcqC1+quvwXZkrS/1yS3qeSHHg6QXygnGIaEg62WXq8TRqth6m6UYrqw+nydTFwjx1e20XGTPV8IBj6qf1aobIhFcW2Z7Sc2ortTZLVrbObLbwp3W4J4oxyLDoYHzI58FSS3qcS9O1MYqUcvKnCETq4fFrhDi8LoKZV5+BX1KKpSDhFFeJUYJwCbIlGwoOBYCh7dfwm0FmiuS0aaRMeftZh3agsBOBJCaw5CIzspL3EsEnvU0nSCYk0JUiwrIwjXVogZcYWLy3mbA5Kxk3c3pldTNKCwRdSjHRXbHWXGTG8Al+znrk16ZOPm3W89RpCBR8oFHPCqcCoA2IFxt3V0G3v6b1uYtl1o9ySrRtmFwI+oU8UHnSKyxBImUnwejoyXGI7e6F/2dzQDGja5KblEDee2qXz2I+NjuCvqZ11OyEEngYNX5OOy68iDBSKYuJUYNwDfNzWKCDj16jNMlVVNNt25nq2j9xk4XLwyfjRkam5RdsYpmT7n4bpfrh87fGeeo3WQz20HuqmaaMb3b30V+JD/WPUN6kkOIViKXEqMD4BXB8Ihj4IeALB0DZgs13e/NwSz7GkPLzHpLs/92M45mBn9h+f1JEp5yqCNZhm219GckpflwUCGtYYtB7qoeUQN7UdhipnoVAopuA0D2ObXZX2HXaklAVcDvyu0nMxrrgrmfN840qL5hnqRo0jAG9Kc2yRSuxIMHbHCDJPvuhuwcpjvGgugRCZ3glCE/Z91nNRoN/hDMTHxvD6/bNu567RaNrkxl2jzDcKhWJmHAd52sl7l5d2OotL36jkLw/nruBOQmmx/RfCgXIh05Kxu0ZJPDnVBFXTrnPEeQ3UlCDBa6g/Tn3T7AJDoVAonDLtShUIhqLRSDhgP759lv1IoBf4fjQSnm3bsuGPD6SIZy369TWSzauc+ST8GMjkzNuaQyYjNw9j9k41QXUc5eWw19SVhX9AoVAonDDTpe1zWY+fdbCvTcCVwNoizKvkWJbkV3fnmqOOma1uVBZ+MbPDO/l8ktHbRqYIFc2AQ15Zx6rjvMpPoFAoKoppBUY0Ev5A1uP3zLajQDCkA0PFnFwpueVpk119k4u5rkmO2uzMHCUAHzrp5FQPhrQksXvHiD8an/Kau1Hj6PMbqFupGuooFIrKYy61pF4OvB5YB8SB3cCV0Uj4XjJCxQRqSjrbIrKuWfDW412Et2XMUoetl/gdRm36hI4mREENI/ZArKCwcG1wc/gbaqlrLPPaIAqFQjENjgwwgWDoP+1aUicCY7bP4kzgrkAw9P7ST7P4HNyuc/EbvTz42VpecvgYJxzmPNTVb8vZfIEh05L4I3nJcgL8p/ipPbsWf23F5zgqFIplzFz6YZwfjYT/kD0YCIbeDnwJ+Flppld6mvyC4w+O4/Y7NxP5hY6UcorASPekc/oPCo+g7uV1GCsy+3aryFWFQlHBOBUYK4FrCoz/AfhJkedU1oz7L0hNrTmY7sr1abjWuSeEhUtH1S5SFBUhMnk07joNd62G21/8YorZpNIphoYHMsEaBY5T32Hi8Y2UbgKLTKWcT0wI4j2FX2tsbMTlKp7P1KnAuBs4Cnggb/xw4P6izSaLQDB0GnA78NVoJPzlUhxjPoz7L8zUVBNWKq+In9Ex+fG6letCsUBcPpERDLUanlodl18s2kVIKpViaLCf9o52tGlCCVOpJC6Xe1HmsxhU+vlYlsX+/ftpaWkpmtCYKQ/jJVlPfwP8KhAM/RJ40u6JsQV4D/CNoswk99g+4JdA2Yn3cf8FeeGy0pKk9+dpGB2T/ySXKnetyMLXAs0bnS1GhjsjKLQlbL41MDBAe/v0wkJRfmiaRnt7O729vbS3txdlnzNd995aYOy7BcautE1TxeQbtmAqu9LpfpFxXFt5/gvzgJlTuVb4BFrD5I9LaRiKcYSAutWi4lq4KmFReWiaVtR8r5nyMJxGUBX1Wx8Ihk63a1YdAfze6fv6erqxzPl1h7Msi7HR2VNIBIK0lWQIgdlnIUcnhUZqV66JSrRCfGxSQUrqFkOlbSOdg2mmGervW7wDlphqOh9vI7gw6e0uu+uhaYkn06RSyZk3knL2bSqJKjmfeCw28V1Lp1NTvnetHasc72sueRgNwEbb1fusXVuKaCTsqFyrLVimbWgQjYQHAsGQ3zZFfSQaCXcFgiGn06O5rcPxtvlou3bh9dfNup1f6DRomVSTRH8Cq2ZSQKX7hmxLXQbvGh/emsm+zi3Ngnrf4l2hDfX3Ud/UvGjHKzXVdD5th3kYTeyb0w91qenp6ZnVnl/pNv98quV8vD4frW1tAPR2dy7oezerwAgEQyuBHwGvspslCSAZCIausRf2XofHOhOIznAcn22K2h6NhH87p7NYJGqzP64sk5SUkvQUh3euk0n5MBTY1Ym9jRqj+5Z6JgrF3JlRYNhaxd3AIPBvwHZbaGwFPgb8KxAMHTuubcxENBK+aaYC3bYp6nzgyPmeTCkRQIOYFALZORjWgIlMTD4XLoHenJukp3wYCuye39VUQ+zG7ZMXSmnTxNAXp93vOVvVD2opmO1T/xTwCPDaaCSc7SC4JxAM/Rr4C/BJ4ItFmMv7gHrgsSxTVANwYiAYek00Ej62CMeYN3XCwBAZk5JMyZwe26muqeG02eGOug66ysFQQElK2Suc8/FPfZ5HHn2ci770WU456YQpr3/sws/x6OPbufBj/8Wll/3PxLhpmkgpMYzJ/99H//vDBF52JgBPP/MsV10T5tHHtzMyMorX62HD+nUEzw3wsrPOmHjPDdF/8L1LLssJc/V6PKxfv5bz3/ImTjjumBKe/cKZ7dv7WuAtecIC7NpRgWDo83aUVDEExseAL+SNXQ3cBXynCPtfEE1i0paZX4E23Z0bTptvjnKriiAKwFOn4VpEP5aiMM1NTUSuj04RGHs7u9jb2QXAivZ2rr3mtxM+jO9c/AM6O7u49HvfnLK/O/55F9/8ziWc96YQH/rAe2ltaWZoaIh/3HYnl172P7ywZy/vfsf5Oe/5659/j65nFoaxsRh/ve56vvDlr3PJd7/BlsMOKeHZL4zZBMaaaCT86AyvP1KscubRSLgf6M8eCwRDCWAoGgl3F+MY88WDhl9MflRyVv9F7sfqXsL4eUX5UNOmtIty4JSTT+CG6D/oPdBHa8tkIMX1N97MSScex99vuMnxvsbGYlzy/R/zmleey7ve/taJ8fr6el736iCrOlYwODRzBKbf7+O8N4W4/sabuPNfd5e1wJjtckcEgqGZUgRdOaFBRSYaCZ9ZDlnejSI3UkImJxUua8TCGs1SwHQw8hYGpWEohAb+VvVFKAeam5o44vCt3HjTPybGTNPkpptv5aVnvmTG9+bzwIPbGB4Z4Y2vf23B10884TgCLzvL0b4sy8LQy/s7MpvAeBI4Y4bXzwaeLvKcyop8Zzd5GkY633/RbiDyIqKUw1vhb9HRVKRc2XDuOWdz/Q03IWXmt3z/g9twuQyOOvLwOe1nb1cXPp+X1taWec9lZGSUK/9wNT29BzjzJafPez+LwWxL2e+BSwPB0MujkfDe7BcCwdBBwPeBS0o7xaWlQbjQ86Jasn0Ys/kvsAsPKpY3yhxVXpx+2sn88PKf8tDDj3Ls0Udyw403c87ZL51zBJuh61iWhZRy4r39/QO87d0T/ecwTZPvfPMrHHXEpDB69esnzVc+n5dNG9bz7a9/mY0b1xfl/ErFbN/iy4DXAE8FgqHfA0/Y7zkceDNwM3D5Is11Scg3R5GnYaS68+tHTf1I3erKclljeAXeBnXVUE64XS5edtYZ/P2GKAdt2sA99z3Ahz7w3jnvZ+2a1SQSSfZ2drFmdSYhrqmpkci1V01sEwiGplS2znZ6VxIzmqTsLO5zgK/azZO+BnwOOAz4BPDqaCS8iAUvFhev0PCJqf/UcYFhjVlYg9kNMJgoZ56NMkktb5R2UZ4EXx7g7rvv48abbuGIw7fS3tY6530ce8xRNDc3ceXvry74umXNr1xRuTLrNzkaCaeAb9u3ZUXTNNrFeA5GvjlKb9URrlxtQtNUlvdyRgioaa+8K8nlwMaN61m/fi2/++M1/PeHPzivfbhcLj79iY/wxa98A5/Py5te/1pWruwgFo/z2ONP8Ps/XkNrSwsrVhSnWuxSoy59pkFDUM9UbSHXHJXr8HYp/4UiD0+9hlHFrRazM65TKQuXq7KWlFe8PMDPr/gNp5560rz3cczRR/LD73+Xq//0Fz7x6S8yODSIYRisW7uGU08+kVe/8lxqamqKOu+lQoxHCVQB8z6R796zC3de8cEm4aJD803Z1hw0Se7OVLAc/PNApqy5TW2gDveGXK2kzis4qH3xF4xqKtZHBZ9P68Fu/K1TF9GFFoFbbHp6emizC9hNR7UU6xunWs4n+383zffOsQmkei99FkghcxRZEVJW0soRFhRI2EP5L5Y1mg6+ZqViKqoHJTAK4BM6ngLObrJMUvnZ3XqTjuad+nGqpL3lS02bofq4K6oKp02SHppmvDkQDO0s+qyWmCYxfXL7pMDIz78orEpUmElXUURUdJSi2pitvPnRwLHA1kAw9J4Ctq5DgOpw/9voCOoKOLvHGTdJzdb/YhyPipBalrj9Gu5apcArqovZLoFWAx+2a0b9vMDrY3a2d9XQIFxoM2R7ypSFTEvSPfkRUkrDUExS06ZskYrqY8blLBoJXwdcFwiGXohGwkWpSlvuTOfsBpCmRJqQ3p+GrHwcrU5Dq526QAgBVRxRqZgGIcCvzFGKKsTRchaNhNcGgqHG8eeBYKgmEAy9JhAMbS3p7BaZGqHjFtN/JJPmqNnrRwEYOsrpuQzxNenoLvV/V1QfTp3erwV22Y/ddtvW3wAPBIKhN5Z8lotEobpR2Yw7vKcm7BW+mvQoq8SyRHXVU1QrTr/ZX7R9GQBvBOqAVXZ9qe8B15RwjiVHjEiMtMSvCcwZ2ntYIybSkqT35WkYKwtrGC7VOGnZobsF3kZlh1RUJ04FxsF2qXOAVwJXRSPh0UAwdCuwuYTzWxSMvVDnhpRIzbqt2ZuGLAVD+ARafeEFQuVgLD9qWvU5l8iuZG4fGJh4nDbTGPriaFcvaWx0sJWi2Di9FEoCrkAwpAEvBW60x70LKclRLgigdobci2wK1Y+aboFQWd7lixCZTOxi3nRDKHOUYgqBYIib/nHrUk+jKDj9dv/L7nth2kLmNnv8Q8BMPb8rAg8ausNyKk4T9lAaRlkhBLhrNDz1Gp56HU+9pjrgLUM+/qnP89jjT0z0onAZBq2tLbzspWfw1je/wZF22NPbywMPbuPcc85ehBmXF04Fxn/bAqMDeHM0Ek4FgqFW4Eu2iaqiqZHOFC0p5dSEvWn8FwBu5cNYMoQAd52Gt17HU6fhrlMCQpHhrDNO59MXfhTsbngPPvQwX/7at6mrreXVrzx31vf/81/3cOvtdyqBMR3RSPh54BV5Y72BYGhVNBIeK9nsFgmPQ8uc2W8iE5MWOOEW6E3TqxHVUtpcCKhdYaAtYaio5RU0tM1uNhSarUnUaSqkWTEruq5zwvHHsmb1Kna/sAeAF/bs5fKf/Jwnnnoay5Js3riBf//gezn4oM38/Je/4ao//QUpJcHXvpmLv/M1Djv0EK6/8Wb+cNWf6Ok9wIoVbbztLW/iZWedMXGcWCzON759Mffcez8er4fXvPIVvP38Ny/hmc8PxwbXQDC0AXg3sC4aCY/3MjwCuKd00ysvpmgXK6YvLqfroFfBguWu0Wje7MZds7SRPylD0DBNvotCMV8SiQR33X0fXd3d/Pd/ZJooXfT177B2zWp+9b8/xuPx8P0f/g9f+dq3+e0VP+V973kHB/r76ezs4tLvfROARx59nB/86Cdc9KXPcsxRR3Dv/Q/y5a9+i7bWVo484kUA/OX/ruOC//wQn77wI/zfddfzo8t/xmmnnsTGDeXdwzsfRwIjEAy9xHZ0P2b3836vLUBuCQRDb49Gwn8u/VSXHqcJe1SB/0IIaFjrom6VsayifhTVzy233cntd94FQDqdxjAM3nH+eWzdcigAP7jk22hCoGkCl8vNGS85nejNt9LX109zc9OU/f3lr9dxwnHHcPyxRwNwykkn8KXPfZLGxoaJbU4+6YQJ4fHys8/iR5f/jN2791SnwAC+DnwkGgn/TyAYimGbqQLB0NvsHI2qFxhSyikRUsbK6T8+TwX7Lzy1Gs0HuXH5VD6BovrI9mGk02l27X6BH/zoJzyz41m++LlP8sgjj3HlH67mhT17SSSSjDeZS6YKh93v7ezimCOPyBk79ZTcDn6rVnZMPHa7MwnC8USi6OdWapyuCC/KKj6YHUZ7rZ2jUfVYwxZyNKuAlA5GgU5q41RiSK3QoGm9i/bDPUpYKJYFhmGwedNG3v/ed3HHP+/ihT17+crXvs3WLYdxxc9+SOTaq/jqlz83635myy2oFi3d6aoggfoC4xuByhOT82CKOardQMwQdVNpJilPvUbHkV7qVk2fV6JQVDt33X0vqXSad77tLfj9fgB27Hh2xvesXrWSF2yH+TjRm2/lkUcfL+lclwKnAiMC/DQQDG0k49NoCARDZwF/BK4r7RTLg7mE01JBEVKaDk0bXax4kVdpFYplh5SSvZ1d/PLXV7Jh/TqOODzjZ3ho2yOYpsXtd/6Le+9/EID9+3sA8Ho8HDjQx9DQEPF4gte88hU8uO0R7vzX3ZimyQMPbuOS7/8Iy7JmPHYl4tRwcgFwJTAuavvsBOkbgI+WcH5lQ6orV8NwzRKx4zQHw1Or4fJrIDImISGwHwuEyH0+J3oEzW2zN7D3NmoYHiUoFPMju0RHKpXE5Zr9O7fUZDu9hRA0NzVy4gnH8fbz30xTYyPnn/dGLv7Bj7BMi9NPO5mvfumzfP7LX+eLF32Dr3zxM5z90jP457/u4Z3v+3c++fELOPXkE/nv//ggP/vFr/nmdy6hva2Vj17wYY4+6ohZ51JpiHGHjhMCwdBhwKFkukE8HY2Enyrp7ObGnEuUSClJxyV/+mUXLuFHJiQyKZEJC5mUWAmZGUtYJHckJ98ooOldzYgZ8hKOWK1hzJIoZrgFHUd50UrgIO/t7qS1Y1XR97tUqPNZWnp6emhra5txm0oRGE6plvPJ/t9N871zvADNyTUbjYSfBJ4MBEMHATWBYEhEI+GKrCWViln8LrQby7Y0xRh0/F69zZhWWGg6bGwWswoLgOaD3CURFgqFQlEKZrVFBIKhDwaCoUsDwdBJ9vOrgaeBB4GH7BIhFYfhFch5mhhd04TTelxwaLtGvQNfQO0KA29DhTg6FAqFYjaBEQiGPgNcApwJ3BgIhj5l98E4HXgJ0A98YfGmWzyEELjr5m6712o1vEf4pozX+wSHrtDwOiifYXgFjetV1rJCoagsZjNJvR0IRSPhGwLB0HnAL4GTopHwo2QEyvttx/cFizPd4uKp1UjHJJYuER4dzSMQboHwCIRbs+9FZtyjIbwiE06b54Burxesbhj3UM+MENBykFsVwlMoFBXHbAJjNRC1H18LeIDt4y9GI+EdgWCoY/q3lzev+9/VYVFYdwAAFE9JREFU6C7BVb/qxOOtm/P7NQ3WNAla5lBnqW6lgadOmaIUCkXlMdtK545GwhYZ4RAHEtFIOL+HacVeKusLqL7q0uGgNm1OwsLt12hYq0xRCoWiMim7AhaBYOi9wKeA9UAncFk0Er5kqeeVjd8Dm1q0OfXsFiITFaVKbisUikplNoHhDgRDv57hOUDRLpltP8kXgfOAbcDZwMWBYOjOaCR8X7GOsxCaagTrm8ScF/76Na4lLxGuUCgUC2E2gXEnsDbr+R15z8e3KRZfAi6MRsLjPTauK6fSI+31gtWNc1/03bUa9avLTplTKBSKOTHjKhaNhM9crIkEgqGVwBZADwRD99sZ5TuBr0cj4asWax7T4XHBqvq5m5OElomKUgX9FNXI7rsmG26a6TS6kZ5x+2Kx7hT/ohynmPzyV1dy8y238dsrfrrUU5k3i3bZGwiGDKB2hk3W2fcfAt5q+y/+DfhjIBjaF42Eb5tp/3093Vjm/DLxLGkRGx2ecZu2Roth58ngE9StEQwOCuaQSF4U0ukUvd2di3vQEqLOZ2mJJ9OkUskp42Y6W0DIvOelo9BcnPCpz32Fx7c/ga5PLn2GYbB61UpCr30lZ51x+uTGUs77OIUwLRO5gLnPl3gsNvFdK/S9m0uJmsW0k5yZFaJbiPH/1FeikfAz9uPv202a3gPMKDCa2+Yf3auJTjw104fVNvgFa1rnbory1GuseJF33vNaCJVWq2g21PksLT09PQXrKmVrFBkNY3GWlPnWeBJCcNYZL55ooITdpvX2O//F9y75IT6vjxeffgqUoJaUrumIBcx9vnh9PlpnriXlmEUTGNFI+KaZQnADwdCh9sP+vJd2AitLO7vp0TRY3Th3c5KmQ8vmyi9cplBUOx6Ph8DLzuIft97BbXf8kxeffgrbn3iSn/78Vzy/azdCCLYcdij/9e/vZ6XdOe8t73gfb37D69j9wh5uv+NfIODMl5zOf334AwghsCyLX//2D9wQ/QdjsRinnXIi9fW5LYX27dvP5T/7BU888TSpdIpNGzfw/ve+k0MPyfSku+Djn2HrlkNJJpPcdPOtuD1u3vuut7N2zSq+/8P/obt7PwcdtInPfupjtLUuToWmcgrb2QH0AifljR8EPLdEc6K9Tsyr3WrjejeGt5w+XoVCMROpVAohBKlUii985Rts3rSRq353Bb/95U8w0ybfveSyiW0NXefqP13LSScez9W/v4LPf/oT/PW667n3vgcAuPmW27n6z9fyqU9cwDW/v4JTTj6R62+8aeL9pmnyyc99GUM3+OmPL+XKK37KlkMP4eOf+vxE3w3D0Lnp5ls44kVb+dMff83rXv1KfvyTn/Pnv/yN737rq1z5658xNhbj6j9du2ifUdmsaHZC4MXAlwLB0ImBYMgbCIb+CzgG+MlSzMnjgo66mYWF0MBdo1HTptO43kX7Fg+rjvNSu0JFRSkUlUAsFuP//vZ3Hn1sO+ecfRYul4vf/OInvO/db8ftclFTU8Npp57Ek089k/O+rVsO5ZSTTkDXdY495ijq6mp5ftcLANx6+52ccNwxHH3UEbhcLl582im8aOuWiffed/+DdHZ28e8ffC8NDfX4fD7e+fa3YBgGt94+GXi6atVKzjzjdAzD4PTTTiYej/OaV72CxoYG6uvqOP7Yo9mzZ++ifVbltqp9yxZi1wAtwJPAq6OR8ENLMZk1jZP5FkIDwyNw+TX7JnD5NAyvUBFQCkUFkd1ACVuzOPigzXzpc5/khOOPBeCOf97Fn//yV7r37SeVSmFZFqaZW+Ri1apcS7nH7SGRyHSs3r+/h+OOOSrn9bWrV7Fr124AOru6qa2toaW5eeJ1l8tFx4oVdHZ1T4ytaG+f3L/HY4+15YwlkovnRC8rgWH31vi6fVtUhAbCJTI3t6ClSWPTBgPdKzA82oLKiCgUivLhrDNOn3B6W5bFRy/8HHW1NZx6SsYa/tjjT/C9Sy7j/e99J699dRCPx8N1f7+RSy+7PGc/2gwXiqlUakoxUjOvZWuh5nVSypwLUK1AgrDQls4wVDYmqaXE2KThfZEPzyFe3Bs9eNa6OfJID/5WA0+troSFQlGlaJrGhf+/vXuPsqqqAzj+HXAIEgwch0rAtEC01OUjl2JlaWwfW5R2ZS3Tyh4aaymVYOEjwRSwwlfhGxVcaWoPdyrs1F0+MtAsjbSQl4pKBMMQKA6MgEN/8LtwuOveuWfuzHjnzP19/pmZc+49Z++zz5zfOXvvs/d55zL/+ReYHR4G4MWFi+jXry9u9Enb7+qXLH2pxJZ2Vl+/B6tWNey07LXXl2//ffCgPWlq2kBj45rtyzZt2sTKVQ0MHtR1e89pwABq8hq1967rwXt7aZBQqhoMHjyIb3ztdG6eMZPl/1nBwIH1NDVtYPGSl9iyZQv3Pxh4+ZVlIFVNaYw44nD+9uxzvPCvBWzevJkn/jyXxUuWbl9/2KEHM2TwIG685XbeXL+epqYmbpt1JwCfSb4L0sV0qSqprqBPL/hwnQYLpdJIvnGd5Tmw3ehR/GXe0/x02rVcNW0Kx408losmXk6v2lqOG3ksl0+6mPETfsSYseOYfs3PSm5v9MmWxjVrmHzFlTQ3N3PkEYfz+dEnM+ehRwDo2bMnl028kBtuuZ3Tv342vXrVsu+woVx75dSd2jW6mppC9WgZVXZG/FOr2PV9dQAcMqQH9WXMxNfVZO3FsFI0P5W1evVq6uvrW/1MlgNGId0lP8myK3Lepb5Dzv6VsQPV96vpFsFCKaU6g14dRY8eMPz9ejiUUqoYvUIKbehWSqnWacAAetdqQ7dSSpWiAQMYVvdOwRdklFJK7aABA+jfp9IpUKrra2kpb74ZVTktLS0F3ygvlwYMpVRJ/fv3p6GhQYNGhrS0tNDQ0MCAAQM6bJv64p5SqqTa2lrq6upobGwsOthm88aN9O7TfR7Xs56frVu3UldXR21tbYdtUwOGUiqV2tpaBiZGT83XuHLF9pnduoPulp+OoFVSSimlUtGAoZRSKhUNGEoppVLRgKGUUioVDRhKKaVS0YChlFIqle40H4ZSSqlOpE8YSimlUtGAoZRSKhUNGEoppVLRgKGUUioVDRhKKaVS0YChlFIqFQ0YSimlUqna4c2NdX2AacCpwG7Av4EfxuAfrXTaymWsWwYMAt7JW3VQDH5xhZLVJsa6fYCZwKeBfWLwyxLrMldmJfKTufIy1r0f+ClwAtBHyuCiGPzjZLCMUuQni2V0IDAVGAH0AhYBU2Lwv6edZVS1AQO4QQ7oMcCrwBhgjrHuoBj8kkonrh3OisHPqnQiymGsc8BNwENFPpKpMkuRHzJYXvcDa4GDgXXAJGC2sW7fGPyKrJVRivyQpTIy1vUFHgN+CXwF2AScD/xWymBBe8qoKqukjHW7A2cAE2LwC2LwTTH4q4AX5eCpytgdOFpO9p1ktMyK5ieLjHW5u9HzYvArY/DNcne+K3Bk1sqoVH4qnb4y9QEuAC6Owa+Pwb8NTAd6Age0t4yq9QnjUMn73/KWP5PhEyXnVGPdBGBPYAlwaQx+dqUTlUYM/ja2/SMPKbA6c2VWIj85mSmvGPybwLfyFn9Yfq7IWhmlyE9OlspoNXBr7m9j3R7AhcBy4NH2llFVPmEAuXkm1+QtbwQ+UIH0dJTngcXASGAI8ADwgLFuRKUT1gG6Y5llurzkDn0mMCcG/3TWy6hAfshyGRnr3gZWS/uZicE3treMqvUJo5gaILOjMcbgT8lbdJmxbjRwNvBUhZLV2TJbZlkuL2Pdh4DZQANwWomPd/kyKpafLJdRDP498oTxXWCesa61J4hUZVStTxgr5Wf+DO8DE+u6i6XAByudiA5QLWXW5cvLWHe4VGHMBU6Iwa+XVZkso1byU0yXL6OcGHxjDH4isEraKNpVRtX6hPGs9B4YAfwmsfwoucvIHOm++UPgwhj8usSqj0mviazrVmWW1fIy1h0gvb4ui8H/PG915sqotfxksYyMdSdJz7z9YvBNiVU1wJb2llFVBowY/BvGutuAK4x1C6Rr2XjgQ9LlLItWAicDuxnrxia60w0DvlDpxLVXNyyzzJWXsa4ncAdwQ4FgkbkyKpWfLJYR8LS8ezHdWDce2Ah8BxgK3NfeMqraCZSMde+RLnRfAfoB84HxMfh5lU5buYx1+0mePil3FM/L3VGXrmvNMdYtkhO3B1Ar/6BbgV/G4M/KWpmlyE+mystY90ngyUQ+kjJXRinzk6kyYlu+DpIX946Q4LEQmByDf5B2XvuqNmAopZRqm2pt9FZKKdVGGjCUUkqlogFDKaVUKhowlFJKpaIBQymlVCoaMJRSSqVSlS/uqcow1n0GeCwGX9MF0jIc+B3wEeALMfhQ6TSlYaxrBsZkZX6GchjrjgYeAT4ag3+50ulRO2jAqDLGusdljoZPxeDn5q2bxbY3ds+sWALfPWcB7wP2ADbkrzTWnSkjl75d4LvrYvDvyuirxrozgHm5C2cMvve7sM9dgHOA04H95IW114H7gGkx+Dc6c/8x+D8DnZ5P1XYaMKpTI3CLse6QGPymSiemXMa6GqBHDD5/+sw06oBX88bbKaRvDH5LmUlsF8nfNTJ66rtyp22sqwWCTEt6HvA4sBk4EJgCzDfWHRWD/29n7T8Gv7kztq3aTwNGdboVGC0Tq/y40AeMdXsDr8g4+n+UZUNlApljYvCPG+vmyhDPvYGvybg1F8kcwjcB+wDPAafF4Jcntj0S+Dmwt8w18P0Y/BPsmG/4ZzLf8K6yvykx+N/J+kuBUUCUYZtHA38skP6jgStkoLgm4AlgXAx+pbEuAMcDNVLFc2pu2IS2kLR8OwY/OLFsMnBGDH5vY90wyd/xwA9kwLf/AZNi8DPZcYGeCnwV6Av8AxgHLJDP9gKCse6hGPwpxrqtMmXorfL97wDnyrH+L/BrGUjvbWOdkaqdI2TWtQOA/8gMc3OKZOt7wCdk8LrXEsv/KcN6z5cxh5zsPz89u0iA+Uau2sxYd44En0HAa8CdwE9i8Jtz1ZTA14GrgJuMdX+SZcNi8EtTnBN1kr/PyjF8HbgqBj+jrWWqWqeN3tVpk1TJXGCs278d29ksgeJJuWOfLoHg+zJf8BCZZP78vO+NlYvoQPnuHBm3H+Bq4DCZ/WsAMBm4R8b9ycmNzzRAZhHbiQS2P0kVyp6yvXogGutqYvBWpk2dF4PvXU6waMPxAbhcLpi7AbOAG2WqTCRof06qCQcAfwEelik1h8tnbIF5GXLVZlfK4HED5IL6VTmGyf1fCnwJ6C9DeM+Up5dCzgDuzgsWsK2q6B3Z3yhj3YA0B8BY92WZJzsXEL8MfBuYkPfRk2VQv0kFNlPqnJgiVYvDZWykscA1xrqPpkmjSk+fMKpUDH6esW4mMMNY96kYfLmDii2Nwd/LtovDfXJxvF6misRY97BUZyRNyT1xGOsmyR3y8ca6BySQHR+DXyafvU+Wny0XU2Su7CmtVKeNAV6SuYoBNhjrLgb+Cny8wPSUne2OGPy/2Jbf3wCXyOihz8jFbUoMfjE7nlCel8EKSzkXuCsG/4j8Pd9Ydx3wIxldNee6GPyr7CijMyWANhTY5nB5AihmgVw39gHWpkjjOODmxGB98411V8oT1+TE5+7IDSFurNu+0FjXL8U58QGgBWiOwbfIjUG/dpzTqggNGNXtgsTk7zeWuY1lid9zjcev5i3rk/edF3O/xODXGuvWAXtJj6WeUgWT/GfvkTe72RqZj7mYocl9iEXy8yNtDBhvJS9gYm4M/rNt2MbSxO8b5ed7jXW5Rvft7RPSpnI3Oy6WrRkqT0pJi+Que2BiWcH9F9nmlhLXhZ7yM+21YzhwqLHuB4llNWzLX6/EsmJtNGnOiUuA+4GVxrpHZX6Le4DWzhFVBg0YVSwG/6ax7lxgltyxlVKoCrMl5bKk/EbqGqA58b0RMfjnWvl+mob6/CqXXNrbetfZ1kbvtMeIRBrL7Wa8NWU+S5VH0lJp6yhmf9ne4iLr8/PfAkyIwV9d6MOJYFysTEueEzH4F6S96CjgOKn+m2isOzLZdqbaT9swqlwM3ks7wHV5q3J3osm7wL06aLfb202kwbK/NIa+LMHkkOSHjXV7SWNqWouA/Prr3D6LXejKsTHv+NCWYyRVMI3SdRXkrttYN15meytlsTTqJ+0PrCtS3ZTG3cCXjHX75q+QCYfGA7MTM9A1lzhHFhcoz4HGur4p01PynDDW9Zfeck/G4C+RgLcB+GLKfaiU9AlDIX3uXwTWJ3ocNQBrgBOlOmBX+VxHuFiebN4ALpO68Idi8E3GululDv45qcv/BOBl3/ek3P5NwHnGuvOB66VBfirwTAz+Hx2UB+SY1RvrPh6D/7ux7lBgpFxE07oeOEd6bi2UKUHHAbcn/j/3M9Y9G4PPbzP4BXCztIs8Bhwsx2lGDH5rgaq0NK4FPg/8wVj3XTkfkt1qdwdOyjsGJxjrbpSqowlSrZXc3h3Gut8DD0hHiHtlqtAxpRITg3+rtXPCWHevVDE+aKz7sVRDHShVfUvKOQCqOH3CUMTgV0h7xqDEsq3At4ATjXXLpNfRdFld7o1GrdyVz5CnmtXS82VU4n2IccAcqYduks9OjMGnDRbE4F+R7ranSdfUp4CXAFtmuouZDdwCzDbWLZSqkKvbeHymAr+VC/NaCdAnxuDXSseBu4BpUke/kxj8XdKr6Ga5UN4pT4oXlZsh6UhwDPAreQfkDQkYc4DlwGG5BnQxVhrAX5dOBffLE84usr17pIH7J8Bb0kg9T3rSpVX0nJDz9HPyRPmK3PTcLeuLdR1WZdIZ95RSRckQKguBUzqx+7HKCA0YSqlWGevmyEuWo4Dl+iZ29dIqKaVUKd+UxucX8rpMqyqjTxhKKaVS0ScMpZRSqWjAUEoplYoGDKWUUqlowFBKKZWKBgyllFKp/B/IAS+QQsT7dQAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {
+            "bento_obj_id": "140061083212528",
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "a7b528a3-b353-4795-93aa-be6276d918f7",
+        "showInput": true,
+        "customInput": null
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": null,
+      "outputs": []
     }
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "originalKey": "de394597-4088-4f32-94c7-7c611876eebc",
-    "showInput": false
-   },
-   "source": [
-    "### Set device, dtype and random seed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "7f4bd86f-7f22-4c28-b439-976650d67384",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "5ec09ff7-9453-4382-992f-e25058b3e06e",
-    "executionStartTime": 1668655887891,
-    "executionStopTime": 1668655887985
-   },
-   "source": [
-    "torch.random.manual_seed(2010)\n",
-    "\n",
-    "tkwargs = {\n",
-    "    \"dtype\": torch.double,\n",
-    "    \"device\": torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\"),\n",
-    "}"
-   ],
-   "execution_count": 2,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "originalKey": "f151402e-238e-4c5c-be43-55a73f07664e",
-    "showInput": false
-   },
-   "source": [
-    "### Problem Definition\n",
-    "\n",
-    "The function that we wish to optimize is based off of a contextual version of the Hartmann-6 test function, where following [Feng et al, NeurIPS, '20](https://proceedings.neurips.cc/paper/2020/hash/faff959d885ec0ecf70741a846c34d1d-Abstract.html) we convert the sixth task dimension into a task indicator. We assume that we evaluate all $20$ contexts at once."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "2aa23c26-1132-4421-b869-5464e2959141",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "333e9297-d842-400d-a4b5-db7ba2b1e051",
-    "executionStartTime": 1668655888207,
-    "executionStopTime": 1668655888299
-   },
-   "source": [
-    "from botorch.test_functions import Hartmann\n",
-    "from torch import Tensor\n",
-    "\n",
-    "\n",
-    "class ContextualHartmann6(Hartmann):\n",
-    "    def __init__(self, num_tasks: int = 20, noise_std=None, negate=False):\n",
-    "        super().__init__(dim=6, noise_std=noise_std, negate=negate)\n",
-    "        self.task_range = torch.linspace(0, 1, num_tasks).unsqueeze(-1)\n",
-    "        self._bounds = [(0.0, 1.0) for _ in range(self.dim - 1)]\n",
-    "        self.bounds = torch.tensor(self._bounds).t()\n",
-    "\n",
-    "    def evaluate_true(self, X: Tensor) -> Tensor:\n",
-    "        batch_X = X.unsqueeze(-2)\n",
-    "        batch_dims = X.ndim - 1\n",
-    "\n",
-    "        expanded_task_range = self.task_range\n",
-    "        for _ in range(batch_dims):\n",
-    "            expanded_task_range = expanded_task_range.unsqueeze(0)\n",
-    "        task_range = expanded_task_range.repeat(*X.shape[:-1], 1, 1).to(X)\n",
-    "        concatenated_X = torch.cat(\n",
-    "            (\n",
-    "                batch_X.repeat(*[1] * batch_dims, self.task_range.shape[0], 1),\n",
-    "                task_range,\n",
-    "            ),\n",
-    "            dim=-1,\n",
-    "        )\n",
-    "        return super().evaluate_true(concatenated_X)"
-   ],
-   "execution_count": 3,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "originalKey": "a2fbe3e8-98cf-49e0-9891-8d6009790955",
-    "showInput": false
-   },
-   "source": [
-    "We use `GenericMCObjective` to define the differentiable function that we are optimizing. Here, it is defined as \n",
-    "$$g(f) = \\sum_{i=1}^T \\cos(f_i^2 + f_i w_i)$$\n",
-    "where $w$ is a weight vector (drawn randomly once at the start of the optimization). As this function is a non-linear function of the outputs $f,$ we cannot compute acquisition functions via computation of the posterior mean and variance, but rather have to compute posterior samples and evaluate acquisitions with Monte Carlo sampling. \n",
-    "\n",
-    "For greater than $10$ or so tasks, it is computationally challenging to sample the posterior over all tasks jointly using conventional approaches, except that [Maddox et al, '21](https://arxiv.org/abs/2106.12997) have devised an efficient method for exploiting the structure in the posterior distribution of the MTGP, enabling efficient MC based optimization of objectives using MTGPs."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "e1dd2e2b-042c-4507-86aa-c1f519ad4df7",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "df6d70a8-87a3-4f9b-a7ff-0680a69f36e1",
-    "executionStartTime": 1668655888638,
-    "executionStopTime": 1668655892409
-   },
-   "source": [
-    "problem = ContextualHartmann6(noise_std=0.001, negate=True).to(**tkwargs)\n",
-    "\n",
-    "# we choose 20 random weights\n",
-    "weights = torch.randn(20, **tkwargs)\n",
-    "\n",
-    "\n",
-    "def callable_func(samples, X=None):\n",
-    "    res = -torch.cos((samples**2) + samples * weights)\n",
-    "    return res.sum(dim=-1)\n",
-    "\n",
-    "\n",
-    "objective = GenericMCObjective(callable_func)"
-   ],
-   "execution_count": 4,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "1c078c31-ac02-4847-adb8-7d777de57a4d",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "f8601186-90e6-47fd-bb5d-438ff162db65",
-    "executionStartTime": 1668655892643,
-    "executionStopTime": 1668655892728
-   },
-   "source": [
-    "bounds = problem.bounds"
-   ],
-   "execution_count": 5,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "originalKey": "df727b70-30bb-458d-81cc-55dc6a5a3ef2",
-    "showInput": false
-   },
-   "source": [
-    "### Define helper functions\n",
-    "\n",
-    "Define helper functions used for optimizing the acquisition function and for constructing the batch expected improvement acquisition, which we optimize for both the batch GP and MTGP."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "e7b55a90-4947-4863-bd11-3413e1d5c9af",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "96a3c2f7-b803-44f2-8627-4ab41c6bed54",
-    "executionStartTime": 1668655892956,
-    "executionStopTime": 1668655893040
-   },
-   "source": [
-    "def optimize_acqf_and_get_candidate(acq_func, bounds, batch_size):\n",
-    "    \"\"\"Optimizes the acquisition function, and returns a new candidate and a noisy observation.\"\"\"\n",
-    "    # optimize\n",
-    "    candidates, _ = optimize_acqf(\n",
-    "        acq_function=acq_func,\n",
-    "        bounds=bounds,\n",
-    "        q=batch_size,\n",
-    "        num_restarts=10,\n",
-    "        raw_samples=512,  # used for intialization heuristic\n",
-    "        options={\"batch_limit\": 5, \"maxiter\": 200, \"init_batch_limit\": 5},\n",
-    "    )\n",
-    "    # observe new values\n",
-    "    new_x = candidates.detach()\n",
-    "    return new_x"
-   ],
-   "execution_count": 6,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "38cc0aa9-f319-4e79-ab11-b50a122f2968",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "b3fc104e-4684-40ca-9474-0c45c4767e2a",
-    "executionStartTime": 1668655893255,
-    "executionStopTime": 1668655893264
-   },
-   "source": [
-    "def construct_acqf(model, objective, num_samples, best_f):\n",
-    "    sampler = IIDNormalSampler(sample_shape=torch.Size([num_samples]))\n",
-    "    qEI = qExpectedImprovement(\n",
-    "        model=model,\n",
-    "        best_f=best_f,\n",
-    "        sampler=sampler,\n",
-    "        objective=objective,\n",
-    "    )\n",
-    "    return qEI"
-   ],
-   "execution_count": 7,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "originalKey": "53414433-e097-4556-90e9-e99e35cdb390",
-    "showInput": false
-   },
-   "source": [
-    "Set environmental parameters, we use 20 initial data points and optimize for 20 steps with a batch size of 3 candidate points at each evaluation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "518830e7-d391-49ad-a5a9-3a74e2c00e02",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "2f589746-3113-44b5-ab25-e9d7f6f2a4f5",
-    "executionStartTime": 1668655893481,
-    "executionStopTime": 1668655893494
-   },
-   "source": [
-    "if SMOKE_TEST:\n",
-    "    n_init = 5\n",
-    "    n_steps = 1\n",
-    "    batch_size = 2\n",
-    "    num_samples = 4\n",
-    "    n_trials = 4\n",
-    "    verbose = False\n",
-    "else:\n",
-    "    n_init = 20\n",
-    "    n_steps = 20\n",
-    "    batch_size = 3\n",
-    "    num_samples = 128\n",
-    "    n_trials = 3\n",
-    "    verbose = True"
-   ],
-   "execution_count": 8,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "originalKey": "eff2dc86-0797-40a7-962d-04e8c539c21a",
-    "showInput": false
-   },
-   "source": [
-    "## BO Loop\n",
-    "\n",
-    "Warning... this optimization loop can take a while, especially on the CPU. We compare to both random sampling and a batch GP fit in a composite manner on every output. The batch GP does not take into account any correlations between the different tasks."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "a9ec9107-cbba-4c04-a509-fea4d9d41dc7",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "b65dd0ba-649c-42ac-b688-4ef2bdb1e43f",
-    "executionStartTime": 1668655893801,
-    "executionStopTime": 1668658416621
-   },
-   "source": [
-    "mtgp_trial_objectives = []\n",
-    "batch_trial_objectives = []\n",
-    "rand_trial_objectives = []\n",
-    "\n",
-    "for trial in range(n_trials):\n",
-    "    init_x = (bounds[1] - bounds[0]) * torch.rand(\n",
-    "        n_init, bounds.shape[1], **tkwargs\n",
-    "    ) + bounds[0]\n",
-    "\n",
-    "    init_y = problem(init_x)\n",
-    "\n",
-    "    mtgp_train_x, mtgp_train_y = init_x, init_y\n",
-    "    batch_train_x, batch_train_y = init_x, init_y\n",
-    "    rand_x, rand_y = init_x, init_y\n",
-    "\n",
-    "    best_value_mtgp = objective(init_y).max()\n",
-    "    best_value_batch = best_value_mtgp\n",
-    "    best_random = best_value_mtgp\n",
-    "\n",
-    "    for iteration in range(n_steps):\n",
-    "        # we empty the cache to clear memory out\n",
-    "        torch.cuda.empty_cache()\n",
-    "\n",
-    "        mtgp_t0 = time.monotonic()\n",
-    "        mtgp = KroneckerMultiTaskGP(\n",
-    "            mtgp_train_x,\n",
-    "            mtgp_train_y,\n",
-    "        )\n",
-    "        mtgp_mll = ExactMarginalLogLikelihood(mtgp.likelihood, mtgp)\n",
-    "        fit_gpytorch_torch(\n",
-    "            mtgp_mll, options={\"maxiter\": 3000, \"lr\": 0.01, \"disp\": False}\n",
-    "        )\n",
-    "        mtgp_acqf = construct_acqf(mtgp, objective, num_samples, best_value_mtgp)\n",
-    "        new_mtgp_x = optimize_acqf_and_get_candidate(mtgp_acqf, bounds, batch_size)\n",
-    "        mtgp_t1 = time.monotonic()\n",
-    "\n",
-    "        batch_t0 = time.monotonic()\n",
-    "        batchgp = SingleTaskGP(\n",
-    "            batch_train_x,\n",
-    "            batch_train_y,\n",
-    "        )\n",
-    "        batch_mll = ExactMarginalLogLikelihood(batchgp.likelihood, batchgp)\n",
-    "        fit_gpytorch_torch(\n",
-    "            batch_mll, options={\"maxiter\": 3000, \"lr\": 0.01, \"disp\": False}\n",
-    "        )\n",
-    "        batch_acqf = construct_acqf(batchgp, objective, num_samples, best_value_batch)\n",
-    "        new_batch_x = optimize_acqf_and_get_candidate(batch_acqf, bounds, batch_size)\n",
-    "        batch_t1 = time.monotonic()\n",
-    "\n",
-    "        mtgp_train_x = torch.cat((mtgp_train_x, new_mtgp_x), dim=0)\n",
-    "        batch_train_x = torch.cat((batch_train_x, new_batch_x), dim=0)\n",
-    "\n",
-    "        mtgp_train_y = torch.cat((mtgp_train_y, problem(new_mtgp_x)), dim=0)\n",
-    "        batch_train_y = torch.cat((batch_train_y, problem(new_batch_x)), dim=0)\n",
-    "\n",
-    "        best_value_mtgp = objective(mtgp_train_y).max()\n",
-    "        best_value_batch = objective(batch_train_y).max()\n",
-    "\n",
-    "        new_rand_x = (bounds[1] - bounds[0]) * torch.rand(\n",
-    "            batch_size, bounds.shape[1], **tkwargs\n",
-    "        ) + bounds[0]\n",
-    "        rand_x = torch.cat((rand_x, new_rand_x))\n",
-    "        rand_y = torch.cat((rand_y, problem(new_rand_x)))\n",
-    "        best_random = objective(rand_y).max()\n",
-    "\n",
-    "        if verbose:\n",
-    "            print(\n",
-    "                f\"\\nBatch {iteration:>2}: best_value (random, mtgp, batch) = \"\n",
-    "                f\"({best_random:>4.2f}, {best_value_mtgp:>4.2f}, {best_value_batch:>4.2f}), \"\n",
-    "                f\"batch time = {batch_t1-batch_t0:>4.2f}, mtgp time = {mtgp_t1-mtgp_t0:>4.2f}\",\n",
-    "                end=\"\",\n",
-    "            )\n",
-    "        else:\n",
-    "            print(\".\", end=\"\")\n",
-    "\n",
-    "    mtgp_trial_objectives.append(objective(mtgp_train_y).detach().cpu())\n",
-    "    batch_trial_objectives.append(objective(batch_train_y).detach().cpu())\n",
-    "    rand_trial_objectives.append(objective(rand_y).detach().cpu())"
-   ],
-   "execution_count": 9,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/f3b9a99e517e0a13/bento/kernels/__bento_kernel_axoptics__/bento_kernel_axoptics#link-tree/botorch/optim/optimize.py:306: RuntimeWarning:\n\nOptimization failed in `gen_candidates_scipy` with the following warning(s):\n[OptimizationWarning('Optimization failed within `scipy.optimize.minimize` with status 2.')]\nTrying again with a new set of initial conditions.\n\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "\nBatch  0: best_value (random, mtgp, batch) = (-9.52, -9.52, -9.52), batch time = 3.31, mtgp time = 45.77",
-      "\nBatch  1: best_value (random, mtgp, batch) = (-9.52, -9.52, -9.52), batch time = 2.02, mtgp time = 12.52"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/f3b9a99e517e0a13/bento/kernels/__bento_kernel_axoptics__/bento_kernel_axoptics#link-tree/botorch/optim/optimize.py:306: RuntimeWarning:\n\nOptimization failed in `gen_candidates_scipy` with the following warning(s):\n[OptimizationWarning('Optimization failed within `scipy.optimize.minimize` with status 2.')]\nTrying again with a new set of initial conditions.\n\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "\nBatch  2: best_value (random, mtgp, batch) = (-9.52, -9.52, -9.52), batch time = 2.14, mtgp time = 53.70"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/f3b9a99e517e0a13/bento/kernels/__bento_kernel_axoptics__/bento_kernel_axoptics#link-tree/botorch/optim/optimize.py:306: RuntimeWarning:\n\nOptimization failed in `gen_candidates_scipy` with the following warning(s):\n[OptimizationWarning('Optimization failed within `scipy.optimize.minimize` with status 2.'), NumericalWarning('A not p.d., added jitter of 1.0e-08 to the diagonal')]\nTrying again with a new set of initial conditions.\n\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "\nBatch  3: best_value (random, mtgp, batch) = (-9.52, -9.52, -9.52), batch time = 1.98, mtgp time = 53.48",
-      "\nBatch  4: best_value (random, mtgp, batch) = (-9.52, -9.52, -5.75), batch time = 4.06, mtgp time = 39.60",
-      "\nBatch  5: best_value (random, mtgp, batch) = (-9.52, -3.53, -2.88), batch time = 8.28, mtgp time = 28.05",
-      "\nBatch  6: best_value (random, mtgp, batch) = (-9.52, -3.53, -2.52), batch time = 8.07, mtgp time = 30.54",
-      "\nBatch  7: best_value (random, mtgp, batch) = (-9.52, -3.52, -2.45), batch time = 7.99, mtgp time = 12.40",
-      "\nBatch  8: best_value (random, mtgp, batch) = (-9.52, -2.64, -2.45), batch time = 7.83, mtgp time = 19.01",
-      "\nBatch  9: best_value (random, mtgp, batch) = (-9.52, -2.64, -2.45), batch time = 7.75, mtgp time = 28.12"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/f3b9a99e517e0a13/bento/kernels/__bento_kernel_axoptics__/bento_kernel_axoptics#link-tree/botorch/optim/optimize.py:306: RuntimeWarning:\n\nOptimization failed in `gen_candidates_scipy` with the following warning(s):\n[NumericalWarning('A not p.d., added jitter of 1.0e-08 to the diagonal'), OptimizationWarning('Optimization failed within `scipy.optimize.minimize` with status 2.')]\nTrying again with a new set of initial conditions.\n\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "\nBatch 10: best_value (random, mtgp, batch) = (-9.52, -2.64, -2.45), batch time = 7.24, mtgp time = 63.18",
-      "\nBatch 11: best_value (random, mtgp, batch) = (-9.52, -2.64, -2.45), batch time = 7.85, mtgp time = 45.08",
-      "\nBatch 12: best_value (random, mtgp, batch) = (-9.52, -2.64, -2.22), batch time = 8.53, mtgp time = 24.61"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/f3b9a99e517e0a13/bento/kernels/__bento_kernel_axoptics__/bento_kernel_axoptics#link-tree/botorch/optim/optimize.py:306: RuntimeWarning:\n\nOptimization failed in `gen_candidates_scipy` with the following warning(s):\n[OptimizationWarning('Optimization failed within `scipy.optimize.minimize` with status 2.')]\nTrying again with a new set of initial conditions.\n\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "\nBatch 13: best_value (random, mtgp, batch) = (-9.52, -2.64, -2.22), batch time = 7.75, mtgp time = 62.04",
-      "\nBatch 14: best_value (random, mtgp, batch) = (-9.52, -2.64, -2.22), batch time = 8.15, mtgp time = 19.19",
-      "\nBatch 15: best_value (random, mtgp, batch) = (-9.52, -2.64, -2.22), batch time = 8.05, mtgp time = 26.64",
-      "\nBatch 16: best_value (random, mtgp, batch) = (-9.52, -2.64, -2.22), batch time = 7.63, mtgp time = 24.20",
-      "\nBatch 17: best_value (random, mtgp, batch) = (-9.52, -2.48, -2.22), batch time = 8.36, mtgp time = 29.47",
-      "\nBatch 18: best_value (random, mtgp, batch) = (-6.07, -2.48, -2.22), batch time = 8.25, mtgp time = 26.25",
-      "\nBatch 19: best_value (random, mtgp, batch) = (-6.07, -2.20, -2.22), batch time = 4.29, mtgp time = 26.26",
-      "\nBatch  0: best_value (random, mtgp, batch) = (-5.28, -3.10, -3.23), batch time = 5.20, mtgp time = 41.11",
-      "\nBatch  1: best_value (random, mtgp, batch) = (-5.28, -3.10, -3.23), batch time = 8.81, mtgp time = 49.68",
-      "\nBatch  2: best_value (random, mtgp, batch) = (-5.28, -3.10, -2.89), batch time = 8.38, mtgp time = 27.30",
-      "\nBatch  3: best_value (random, mtgp, batch) = (-5.28, -3.10, -2.70), batch time = 8.10, mtgp time = 28.32",
-      "\nBatch  4: best_value (random, mtgp, batch) = (-5.28, -3.10, -2.70), batch time = 9.32, mtgp time = 31.53",
-      "\nBatch  5: best_value (random, mtgp, batch) = (-5.28, -3.10, -2.70), batch time = 8.29, mtgp time = 35.85",
-      "\nBatch  6: best_value (random, mtgp, batch) = (-5.28, -3.10, -2.51), batch time = 8.31, mtgp time = 29.49",
-      "\nBatch  7: best_value (random, mtgp, batch) = (-5.28, -3.10, -2.51), batch time = 9.07, mtgp time = 20.94",
-      "\nBatch  8: best_value (random, mtgp, batch) = (-5.28, -3.10, -2.51), batch time = 7.90, mtgp time = 23.02",
-      "\nBatch  9: best_value (random, mtgp, batch) = (-5.28, -3.10, -2.51), batch time = 7.99, mtgp time = 23.84",
-      "\nBatch 10: best_value (random, mtgp, batch) = (-5.28, -2.92, -2.24), batch time = 8.04, mtgp time = 22.89",
-      "\nBatch 11: best_value (random, mtgp, batch) = (-5.28, -2.92, -2.24), batch time = 8.06, mtgp time = 38.07",
-      "\nBatch 12: best_value (random, mtgp, batch) = (-5.28, -2.92, -2.24), batch time = 8.84, mtgp time = 28.94",
-      "\nBatch 13: best_value (random, mtgp, batch) = (-5.28, -2.34, -2.24), batch time = 8.67, mtgp time = 28.40",
-      "\nBatch 14: best_value (random, mtgp, batch) = (-5.28, -2.34, -2.24), batch time = 7.78, mtgp time = 25.74",
-      "\nBatch 15: best_value (random, mtgp, batch) = (-5.28, -2.34, -2.24), batch time = 8.06, mtgp time = 56.54",
-      "\nBatch 16: best_value (random, mtgp, batch) = (-5.28, -2.34, -2.24), batch time = 8.42, mtgp time = 40.27",
-      "\nBatch 17: best_value (random, mtgp, batch) = (-5.28, -2.34, -2.24), batch time = 8.58, mtgp time = 34.44",
-      "\nBatch 18: best_value (random, mtgp, batch) = (-5.28, -2.34, -2.24), batch time = 7.94, mtgp time = 43.83",
-      "\nBatch 19: best_value (random, mtgp, batch) = (-5.28, -2.34, -2.24), batch time = 8.81, mtgp time = 53.25",
-      "\nBatch  0: best_value (random, mtgp, batch) = (-7.10, -7.10, -4.90), batch time = 2.41, mtgp time = 12.40",
-      "\nBatch  1: best_value (random, mtgp, batch) = (-7.10, -3.49, -4.02), batch time = 8.21, mtgp time = 44.55",
-      "\nBatch  2: best_value (random, mtgp, batch) = (-7.10, -3.49, -2.70), batch time = 8.13, mtgp time = 37.52",
-      "\nBatch  3: best_value (random, mtgp, batch) = (-7.10, -3.49, -2.39), batch time = 8.63, mtgp time = 18.00",
-      "\nBatch  4: best_value (random, mtgp, batch) = (-6.70, -3.49, -2.39), batch time = 8.25, mtgp time = 51.32",
-      "\nBatch  5: best_value (random, mtgp, batch) = (-6.70, -2.93, -2.39), batch time = 8.16, mtgp time = 50.34",
-      "\nBatch  6: best_value (random, mtgp, batch) = (-6.70, -2.93, -2.39), batch time = 7.95, mtgp time = 42.04",
-      "\nBatch  7: best_value (random, mtgp, batch) = (-6.70, -2.93, -2.39), batch time = 8.18, mtgp time = 45.74",
-      "\nBatch  8: best_value (random, mtgp, batch) = (-6.70, -2.93, -2.39), batch time = 8.06, mtgp time = 39.82",
-      "\nBatch  9: best_value (random, mtgp, batch) = (-6.54, -2.93, -2.39), batch time = 8.39, mtgp time = 39.64",
-      "\nBatch 10: best_value (random, mtgp, batch) = (-6.54, -2.93, -2.39), batch time = 8.15, mtgp time = 46.49",
-      "\nBatch 11: best_value (random, mtgp, batch) = (-6.54, -2.77, -2.39), batch time = 7.89, mtgp time = 27.89",
-      "\nBatch 12: best_value (random, mtgp, batch) = (-6.54, -2.77, -2.32), batch time = 8.45, mtgp time = 33.86",
-      "\nBatch 13: best_value (random, mtgp, batch) = (-6.54, -2.77, -2.32), batch time = 8.55, mtgp time = 19.53"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/f3b9a99e517e0a13/bento/kernels/__bento_kernel_axoptics__/bento_kernel_axoptics#link-tree/botorch/optim/optimize.py:306: RuntimeWarning:\n\nOptimization failed in `gen_candidates_scipy` with the following warning(s):\n[OptimizationWarning('Optimization failed within `scipy.optimize.minimize` with status 2.')]\nTrying again with a new set of initial conditions.\n\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "\nBatch 14: best_value (random, mtgp, batch) = (-6.54, -2.77, -2.32), batch time = 8.09, mtgp time = 45.71",
-      "\nBatch 15: best_value (random, mtgp, batch) = (-6.54, -2.67, -2.32), batch time = 8.03, mtgp time = 24.59",
-      "\nBatch 16: best_value (random, mtgp, batch) = (-5.50, -2.67, -2.32), batch time = 8.65, mtgp time = 22.76",
-      "\nBatch 17: best_value (random, mtgp, batch) = (-5.50, -2.67, -2.18), batch time = 8.15, mtgp time = 26.27",
-      "\nBatch 18: best_value (random, mtgp, batch) = (-5.50, -2.67, -2.18), batch time = 8.01, mtgp time = 54.98",
-      "\nBatch 19: best_value (random, mtgp, batch) = (-5.50, -2.67, -2.18), batch time = 6.50, mtgp time = 34.56"
-     ]
-    }
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "originalKey": "b567ab22-f3b4-41e3-aaae-75e6fe820cfc",
-    "showInput": false
-   },
-   "source": [
-    "### Plot Results"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "e0aa4e12-c620-4ad8-ae62-93e5d86aa749",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "411477be-fc76-4e40-b3f9-164f10ca0a0b",
-    "executionStartTime": 1668658416908,
-    "executionStopTime": 1668658417004
-   },
-   "source": [
-    "import matplotlib.pyplot as plt"
-   ],
-   "execution_count": 10,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "originalKey": "3585efc5-bcb5-49f0-9fe1-e50d2deccfd2",
-    "showInput": false
-   },
-   "source": [
-    "Finally, we plot the results, where we see that the MTGP tends to outperform both the batch GP and the random baseline. The optimization procedure seems to have a good deal less noise than the batch GP.\n",
-    "\n",
-    "However, as demonstrated above, optimizing the acquisition function and fitting the MTGP tend to take a bit longer."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "de92c2b6-186d-4ade-a943-b3059715924f",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "bec8d564-29a6-400a-85d4-aeeace3674c4",
-    "executionStartTime": 1668658417232,
-    "executionStopTime": 1668658417315
-   },
-   "source": [
-    "mtgp_results = torch.stack(mtgp_trial_objectives)[:, n_init:].cummax(1).values\n",
-    "batch_results = torch.stack(batch_trial_objectives)[:, n_init:].cummax(1).values\n",
-    "random_results = torch.stack(rand_trial_objectives)[:, n_init:].cummax(1).values"
-   ],
-   "execution_count": 11,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "df7c4448-7664-400c-9c1a-def393c26b6a",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "ef47e1cc-aaf5-47b9-9b20-dc0259de2465",
-    "executionStartTime": 1668658417567,
-    "executionStopTime": 1668658417873
-   },
-   "source": [
-    "plt.plot(mtgp_results.mean(0))\n",
-    "plt.fill_between(\n",
-    "    torch.arange(n_steps * batch_size),\n",
-    "    mtgp_results.mean(0) - 2.0 * mtgp_results.std(0) / (n_trials**0.5),\n",
-    "    mtgp_results.mean(0) + 2.0 * mtgp_results.std(0) / (n_trials**0.5),\n",
-    "    alpha=0.3,\n",
-    "    label=\"MTGP\",\n",
-    ")\n",
-    "\n",
-    "plt.plot(batch_results.mean(0))\n",
-    "plt.fill_between(\n",
-    "    torch.arange(n_steps * batch_size),\n",
-    "    batch_results.mean(0) - 2.0 * batch_results.std(0) / (n_trials**0.5),\n",
-    "    batch_results.mean(0) + 2.0 * batch_results.std(0) / (n_trials**0.5),\n",
-    "    alpha=0.3,\n",
-    "    label=\"Batch\",\n",
-    ")\n",
-    "\n",
-    "plt.plot(random_results.mean(0))\n",
-    "plt.fill_between(\n",
-    "    torch.arange(n_steps * batch_size),\n",
-    "    random_results.mean(0) - 2.0 * random_results.std(0) / (n_trials**0.5),\n",
-    "    random_results.mean(0) + 2.0 * random_results.std(0) / (n_trials**0.5),\n",
-    "    alpha=0.3,\n",
-    "    label=\"Random\",\n",
-    ")\n",
-    "\n",
-    "plt.legend(loc=\"lower right\", fontsize=15)\n",
-    "plt.xlabel(\"Number of Function Queries\")\n",
-    "plt.ylabel(\"Best Objective Achieved\")"
-   ],
-   "execution_count": 12,
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": "Text(0, 0.5, 'Best Objective Achieved')"
-     },
-     "metadata": {
-      "bento_obj_id": "139939757883888"
-     },
-     "execution_count": 12
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": "<Figure size 432x288 with 1 Axes>",
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAENCAYAAAAhRzNRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOydd5gkVb2w36rOE3fS5kzYZclLRiQ3YqlwW0W9gnrVq3L9rhcVBVRUxHQRFRQFxQfEACqgLV5ogQZBJCPBJS5p8+zsTk6dq873x9TMdPd091T3dJ7zPk8/M11VXXVOh/OrX1aEEEgkEolEki9qpQcgkUgkktpEChCJRCKRFIQUIBKJRCIpCClAJBKJRFIQUoBIJBKJpCDmkwARhT4GensKfm01PuR8qvdRT3Opt/nU01zynE9W5pMAKRhDNyo9hKIi51O91NNcqLP51NNcKNJ8pACRSCQSSUFIASKRSCSSgpACRCKRSCQFIQWIRCKRSApCChCJRCKRFIQUIBKJRCIpCClAJBKJRFIQUoBIJBKJpCDslR6AZJrndurEEjkTP+eMoigslrcNEomkCEgBUiWE44K9I6UVHhMIEobKihVluJREIqlr5L1olTAwXg7hMcHuUaXkmo5EIql/pAZSJZRTgBgCdgwK9ulSzOeCqMXWxnZFwaEoJR6hRCKpBaQAqRIGQsUXIIYQ6BmKaUYweK4/QqxBEDYMxg0DYVGALHQ6Wd/QUPSxSiSS2kMKkCogFBNE48U5lxCCcXRGRJxRESdTvc2QGqUhHoFBha6m/LSJ4USiOAOVSCQ1jxQgVUB/EcxXUaEzKOKMiHhGrSMTe0cFnU0K+YiQqGEQNgw8qnSfSSTzHSlAqoC5+D8MIegTUfpFLO/XxhIwGBK0N+SnhQwlEniczryvJ5FI6ouaEyBezecBrgTOAVqAF4GLggH/3yo9tkIZLND/MS4S9BgRYhkNVdbYO1qYAFkiBYhEMu+pRTvEtcDpwClAJ/A74C6v5tuv0gMrhLGoIJanW0EXgt1GmO1GaE7CAyAcg5FIfgJM+kEkEgm1poF4NV87cB7w3mDA/5K5+QdezXcucD5wYYWHmDf5mq/CIsEuI0zcop/DCntHBS1u61pIzDAI6zoem61oY5BIJLVHTQkQYKM55qfStj8JHFuhMc2JfATIoBFjj4gUUXRMMBqB7YMGah6WLGUsRpc9uxnLaVdY21mLCq5EIrFKrQmQhebf/rTtfcDiXC8c6O0puIl8IhGnr6e7oNfmQgjYustGYpZhGQj2KnFGFb0o1zUMg9D4SMq20Hh+5xgQ4ywW2QWIqkBTXM9LKBVKqT6fSlBPc6HO5lNPcyGP+XQuXpp1X60JkGwokPvGvL0rp3zJSV9Pd843sVBGIoKGwdxCISYMdooQunBSrPS90PgIDY0tczyLQoutOecRnjYbzXmYxgqlVJ9PJainuVBn86mnuVCk+dSajaHH/NuVtn1h0r6aYTCH+SokEnQbYd40xoiKuTnKS4GOICpyC798nfMSiaS2qDUB8jQQA45L23488EiFxlQw6eVLdCEYNGK8aYyxzQgxLIrpKi8+oVkEyKgUIBJJXVNTJqxgwD/s1Xw3AN/1ar6XgG1m5NUqM7y3JuiORtkeifDcqIGRtAYnEFUtMNIJkaCN7H4QqYFIJPVNTQkQk88BVwAPAM3Ac8AZwYB/W6UHNhtCCN6MRNgVjTIWhahe2wvs+GwaSHRizoqs3iuR1CU1J0CCAX8U+Kz5qBl0IdgcCtEXn6iaOB6tbeFBkh/EpWTOB9F1CMehQSatSyR1SVYB4tV8Ky2ewxEM+N8o3pDqj5hh8GIoxGhSBvdoHQgQTC0kmwBhMtLMKTUQiaQeyaWBbJ0tNDaJeZeSPKbrlkt67IpGiRjTkVRxA8ajJRxcGRknQfssfpDFc40YlkgkVUkuAeJN+n8f02R0I7DZFBgbzLIil5dhnFVHXzzO9kikoNfuHDQw6kMBITxrJFbZhiKRSMpMVgESDPjvn/zfq/kuBT4QDPg3JR3yZ6/muxu4Gvh9yUdaZcSNwnIzRiKCoVDRh1MxdAQRoePOYsaSkVgSSf1iNQ/kSODlDNufN+tTzTviFlvAJmMI2D5YfwtqSGQ35cUTEInX35wlEol1AbID+G+v5kv3hp4P7CrBuKqeQgRI97BBvA4rofeLGDuNELuNML1GhAEjxqiY7tErEwolkvrEahjv18y+G1/yar7tpnN9JdABfLjEY6xKYnkKkPEY9I6VbDgVJYFgNF0LEbBUFbQqTkYi0JW7bJZEIqlBLGkgwYD/dmA/sxPgo8AzwDXAEcGA/5bSD7P6yEcDEUyUS6+pNPMi0GNEiAlDaiASSZ1iOZEwGPBvBa70aj57MOCvQ0OMdYQQJPJwou8dFUTyb1le8xhAtwjTHG6Yj5HeEkndY0mAeDWfHbgI+JRZCbfBq/kaTY3ks8GAf14tj/loH1Edeobn7x14WOjsjMWI63YcNplQKJkfRAyD4USC4USCIV1nJJEgUYDftJgssNs5tqW4SVlWNZBLgI+bAuNKc1uDGZ31v8DnizqqKicfAdIzXD85H4XSJ6LsGnewukXWNMlF2DDo1XX0WGnvxwSwJxbjzUhk4hEOsyUSYagkve4F7N5TgvNWAmtzEQX4SMvBIY2NFRMg5wJnBwP+TV7N9z0mTFq9Xs33AeAhKUAyE07AQB3lfMyF50fCLG92YC+wsGJCCHpjMdLTFoUQ7InH2Ts+TlQIIoZBzDCovg4qqQgzGXVrJMK2SISt0Sg9k4JjT2+lh1dkqm8xLZzancv2geL/KqwKkJVmzkc6281IrHmF1STC3UPzz3GejcGYzpvhMPt6PJaOV4CQYfDYyAh/Hx7m4eFhRvQcWe+96V2OJRJJMuOx4i9GVgVIN3AU8GTa9rPMHJF5hRUNZCwKw+GyDKcmGIoa3Nrba8lMMmlieTUcnqFxSCS1gDDAiNowYjaMmIoRtSGMyvoAF6quop/TqgC5GviLV/P9HLB5Nd8FZgb6+4AvFn1UVY4V++bukWo3opQPQwjuieyhN1wnFSRLhAosUFXsttSItWw+NMOY2KcLgSHM4yzeZDqFjRbdRWvSo0F3oFDYIjcQEtz7UoK9Y1LlBhC6YurR1cO+K4vfgNaSAAkG/D/1ar4+s5lTyEwsfBX4j2DA/4eij6rKmU0DGYkIxmQRwSleMIbpFXMXHk02G622meHANkOnweHEpaq4VRWnoqCWsImVbgh6RqB/3KDAkmgA2AwbrpgTd9SJO+bEFXMyNhYlpLsYDAkGQzAUFmUMwpirvld9i2Y90eaBZW0qyxcorGhTWdqqWIpsdDthaatKq7v4n43VMN61pqCYd8IiE7OF4+2ax2G76QyKGJuMoYJfv8jh4OTWBZzYsoCDGxszOuH7e3bTsXiJpfMlvzofGRPXYc+IwZ3PJ/j903He7CvFZ2wADvNv7WNXod1jYMsg9IuKAh4HNLsUWtwKLR6FVg9FDxuPhMZxNzSmbFMV6GxUWNKqsKRVpatJobNJwWkv7rWdNmh0VZ9wtmrCet2r+R4GbgJuDQb8dVqUwxqxHLedA6H5mTSYCUMIHtX7UpbDJlXltAULAAjFJ+pkJTLc+LoUG4eqrSxXG1DGFEbG4JEsC+vIkI2Wkdx3z0KY/ebFhJVHCOvxDQLYtMvgL5vibBuQNwe5cNvh+H1saAfaOXODHX20h85F1oT7XFDV0i+ufT0DdC6edzFDObEqQE4D3m/2Ir/Gq/n+bAqT+4IB/7z7RWUzYRlificNpvOiMUy/SJWmX16xkrWJVgIvJnh5i86/dukMZgl1vg0AK7bABqB+IxYanRN3usmoCrR4FDoaFbqaFLqaFToaVZwVSvhXVdiwWOWk/e14HNOD7Rsrz+IuqQyKyCPhxav5bMDbTGFyNjAG/DYY8F9S0lEWh4JX9r6ebjoXL516/ujISMZSJkNhwZaSmDaKS2h8hIbG0rYJHBIx7kx0p+gMCyNNuDYt51+7dCLxHC+uEY5cpXLw0uI6JkV0nP2Xt7CmU2WfToWFLSquIptDykn6b6eWqae5kN98sn4BLdfCYsKZrgMBIODVfIeZWelfNDPV5wVCiKw+kLE66XM+VwwheCTNdKXEVTbd04URrf3A3KNWqVxwspNT19tRiuys7+sZpHOxzNiX1AZ5CRCv5jvADN19H7A/8ADwH6UbXvWREGLCgJ6BsXkYpaoLQbcIMy4SRNCJYDAi4jNMV/1PdWFE8/q6lQTFdJ4r5hOry7/LDocss/GRYx28bYMdt6N2tQKJpFhYjcK61DRbbTAz0m8EbgkG/LtLP8TqIpv/QzcgXAdmmXxICIM7E92MkDs5sDPWQPfO1IYgrW44fIWNjSttbFisziliZmSon5YFpXVuuh1wwGKVrubix9JLJLWK1VvCT5oNpf49GPC/UOIxVTXZkgjH43mE9dQJW8T4rMLDiUpbd2eKGfWEfWx86ywnLW6VJpeCc46KSX+PTsfi3N7jyasryoQDWskzjLfYpiqJpB6w+tNdFQz4hVfz2b2ab00w4N9S4nFVLdk0kPF5aL7qMXJHSKnACbZO/tXnSNl+2no76xYVz5zltFPTjmaJpFax+it2ezXfj4CPmllOLq/mawNuBj4YDPgLzxSrMbIVUhyfZw50IQQ9IlWA7K8204oDt6Lixka74sSl2Lh3MHVxP3CJNANJJPWA1V/yt83aV+9OSpM1zMdVJRxf1ZFJAxFmz/P5xCgJkksd2lE4Sm3nAFsLa9QmlqgeXIoNXYf+4dTXbpACRCKpC6xqIGcBZwQD/je9mk8wEdI77NV8/wn8q7RDrC4yCZBwnDnVRKpF0s1XXYoLW6YyIyOgJ1UhXdIykfAmkUisEx7U0eOFWTlsDgVPW2kyTK0KkKVAJr/HINCcYXvdkkmAzDfzFTDDfLVYcWc8bm+6+arIiXcSSb2TiBn0bY5myx6YFVeTWjIBYvXX/DpwRobtHzX3zRsy+UDmWwLhhP8jtXRINgGyJ02AbFhSoVobEkmNMrY7UbDwKDVWNZBvAX/yar7bAbtX810NHA68BfhgicdYVWTUQOaZ/2OEOJGkPHM7Ch1K5mY1e4dSBchB0v8hkVjG0AVje0rRq744WPo1BwP+W82Cii7gReCtZpfCE8x984b0PJBoAuLV+/mWhHT/x0LFnbH/hhAzTVhSA5FIrDO+N4FRxdV/LAfjBwP+x4EPlHY4s+PVfFuBZRm63xwSDPhfLfX10zWQUvQZrnas+j/GwhCOTgsQtwNWd8h8DYnECkIIRnuq++40qwDxar6vBgP+b5r/X57rJMGA/2ulGFwOPhEM+G8q8zUnhEeaAJmP/o89FgVIuv9jvy4VmyztLZFYIjyok4hU9/qSSwM5F/im+f+HchwnzBa3dU8mB/p8838Mp/k/HCi0K5mrx6abr9Yvlv4PicQqo93VrX2QS4AEA/71Sf+vKduIrHGOV/NdbIYXvwZcFgz47yz1RdPNVwmDuuhrkQ9W/R9kECAHzFKvSiKRTBAd04mOVn9yWb7l3DvN9m8pBAP+7cUYjFfz2YGmbPvNkimbgDfMAo+jwGeBv3g131uCAf9j2V470NuDoRf2gSQScfp6uhnQdUbi0xJjJKoQGqs9k4xhGITGRwp67S77aEroRXscQtHM59rbvyDl+Qr3AH09xf9RTH4+9UA9zYU6m0855zK0xSAyWJxzOWJg65mp/VudT66mU1bLub8TuAHoTNulmCasYt1angwEc4zDEwz4z0rbfLlX851tCpSsAqS9a3HBg5rs3BWPRmkJT+c/jA0bNDQWfNqKUWhHQiEEfYnUsmcrXAtoUGeG8MYSMDg+/bVQgOM2LKSjqfhmrHrqFFdPc6HO5lOuuSRiBuGtEZxtxTmfq0mlc/FMP2Ux5mNVA/khcL9ZPNFKk+qCCAb89+Vqn5iD14ElJRhSCjMjsEp9xepiiDhRi/6P3iElpbr9wmaFBQ21p61JJOWmmhMH08mnlMmHgwF/Rb06Xs23BrgI+FJaBeADze6IJSU5B8QQEJpnJdzT/R+Lcvk/BlK3r+qQEViS6iMeNhh43dqd4NCAgd5bsvvnKWKh6vd9TGJVgPzLvMPfUeLxzEYP8C6gxav5PgPEgC8A+wHvKfXFkzWQUGxCiMwnrOZ/APQPpZqqVrdL4SGpPga3xIiOWVuw4+MQddbO4l4OcuWBJBvHvgpc69V81wBvJpV0hwnT05slHeX0dcJezXc6cIUZfaWYTvWTgwH/5lJfP5EkQMIFVsasVTLlfyxSpwWIE5UGxUaDYqcBG7cNxkhu0bi2U4bwSqqL0ECCyLAUCHMhlwayk9QmrQrwjgzbiulEn5VgwP8KcHa5rpdMLCkPJFHF3ztdCEaIMyziJMhQ/FGNkNAThIVOCJ2QSBDPcFw6saRjnKi0MeH/WKA4WKJ6pvYZQrBzKFXA7tMlBYikehCGYGjrPIvBLwG5BMgpZRxHTZBswtKrxH4lhKBfxOgWYQZFjCERZ4R47vbs9nQdMn8WKa4p/4c9Le5h76ggmuQta3LB4hZpwpJUDyPdCRLzrIpEKciVSPj35OdezdcEOIIB/6D5fBUwFAz4h7Odo95IFiCVbCBlCMFeEWW7GGe7ESI0oyxY6VmmTKcD2dJqcm4fSP1hrmxTcdikAJFUB4mowcguqX0UA0t2Ba/mOxLYmtYT5D3AG+a+uicuBCJZA6nAzcuQiPGk3s/tiR3cq/fwijFaEeGxXPGwrzqd72lPi8TaPpgqXVe2q9ilBUtSJQxtjSOq2ARdS1iNwvoBcD3wl6Rt15hZ6VeZ5d3rmkSaylEuDcQQgu0ixGZjdIYTOxcN2GhTnLgz3SMkEjQ7PBNOb+x4FBsu1BkJOMqIgLRgAbtQcKKm2sAUnUTSi7f1pAq1ZTaDeG+c4Tm+aXaXQkOnDSVL6LBEMhuRYZ3QQBXXR68xrAqQw4FTgwH/1DsfDPjjXs33v2ZeRt2T3gckUSINRBeCIWIMihj9IsZ2I0R4Fi3DjsJSxcMSxU2b4mSB4sSpZL/lD0VHaHBPZKIbBjz/hjKjci4ClCGBYsHX41EM1CSvy+tpJRiWxA1iPYLhIsS3j/aotK914pR91WsCkaa5VxQxEbYrKR5WBcg4sNqsQZXMeiBUgnFVHelZ6IXeTPeLKK8Zo4yJmTmZYaEzbCkeaiILfIXSwEq1gaWKB3sOgZGLB55VeeqV0gXR2RRY7AJ7kZSG2JjBnucjNC+x07LcgVrlvpXYuEF0WEe3GPY92iewRyuzyCmqgmID1aag2kC1K1j9WgkBekwQDxskwubfiGB4QBBuC1s4g6QWsSpAfgsEvJrvJ8AWM3x3PfD/zH11T7oAydcHsteIsMkYplvM7ce0UHGxTm1mpdKIbY6mnJEQPP1qae/kl7rBroKtiJcRYiKKJtSvs2Clg9iYIDpSPWaJ2LhBZNggOqLn3U1ufFBgi1V/GW+JhDwEyJfMyrdfTSqo2Af8FPhOCcdXNST3AtGFYG8iStyCeSeCwcvGSF7+i3TsKOyjNrG/2kxbltpThfDPV1QMo7R38CeZ35ZiCpBJElFB32sxRgYFid55VldGIqkCLAkQswbW5Wbl2xZAmQzfNZ/XfUzcpAYSNgyu6e5md7x0ZoZG0wHebj6WKB4cBZqoshGJwXOvpZ7zsH11uhZMFPpS91iz0akotCiOGdsVYIUH9jGDtVRZB0siqTvy6gfChDAZYUJwHGqasP4daC7J6KqISSf6C+Pj7I7NTXh0KS7Wq81mNNM0NlQWKA7cSukT+597TSWWFDrV4BacfqSB3QbKqIFNt2Z7cSkqXRkESDoyjFciqT/ybSjlAM4xBcexZh2qL5RueNXDZB2s/njhytYSxc3B6gIWKa6KhqImdHjqldQV/ch1E8IDQBmz7uCZGfybmSr3dUskkgKw2lBqJXA+8HGgEXACZwUD/rtKP8TqYNIHMpYWftVk5lHkohk769RmutTs1WvLyeYdLsYj0yu6wy7YuN/0vJRx6wLEZlWASA1EIikIQxeEB/SCkx9jowrOZhW7U6F56ezWgnzIKUC8mu8M4L8BzSzpfhlwi5mV/nxRR1LlTJqwxtJMO4fZFrBWzdqFt+oQAp553ZOy7bB9DdyTTQXjAiWSjwZi4RhV+kAkkkIY25Pg2ZuGiFksOZ+Lrg0u3vnj4vbdm00DudsM090YDPg3TW70ar6iDqIWmHSij6cJEHf5ChEXhdd2KgyOTY9ZVQRHri9M+wBQLYgQKTskkvwRQvDKHSNFER6lYjYBcp/pJF/o1Xw3AP5KdyWsBHpSNm26BuIucnRUqXnipdTxHrBa0JrU1z0f/wdgKRdFmq8kkvwZeCPG8I7qXm5zCpBgwH+GV/PtZ5qxrgd+6tV8vzVfVyX1CUpPchJhug+kWBrI3kHYPaCU9F0djyjs6ktdzY85IFUg5itArMgGKUAkkvwQQrDlb+Mp2xwNSkElfBRVwe5WaF6cd9DtrMx6xmDA/xpwgVfzfQn4CPBfpiP9FjMz/Y/1rpVMxl0ZQhBK00BcRRAgL7ypcOdjxf9wZ2PtUoOFbUkbIgIlzyJfVqKw7NKGJZHkRSbt47APL6BlWf5OcFeTyqKDSxPAY1mcBQP+UDDgvy4Y8B8CnArsBn5TBX3SS04iKYkwWf9woMy5nEhChweerYwf5ZgNqdpUvtoHFqOwpPyQSKyTSfvoXOcsSHiUmoJue4MB/4PAg17Ntwz4ZPGHVV1M1sGb4f8ogvbxyjYlJaS2XKxebLByYarAUMfzd9ZZ0UCkCUsisc7AG/EZ2seaUxqzHl9J5mQ3CQb8u4CvF2841clkg9h0AeKaY8a4EPDPzamr69IOg84FczrtrDS5whx9oJMU5ckQBURgyRwQiaSYCCHY8kCq9tGxf3VqH8xVgMwXpkJ4ZzjQ57Yy7upV6BlIPofgXW/RaStxYZjQeAS3M7UooxISefdJl0mEEklxGXgjzvD21GoXa6tU+yAfH8h8ZnJdLbYJK1372HeZKLnwyEa+2gd5+DaK1QtEIqlnsmofy6tT+0BqIPkx04RVuPwdHofNO1JX1uSEvpIhBOooKHqaA320NA50pAYiqVIG3oix47GQ5Ra3hq6j2vpLNyADQv2pY6lm7YN8BIhX86nAicDqYMB/k7mtIRjwz4uOhBRZA3nmVRUhphfgrlbBqkVlSK2JgmMX2Fxzb8AkfSCSWiTUn+C1u8foe6WQqtrla1xW7doHVk1YXs23CnjBzEz/ubltNbDFq/kOKvkoq4QZZUwKdKLHEvCv11Pf+iPW65SjQK8SLp6Qsi5ApA1LUnkSEYPX7xnj8WsGChQe5aVaI6+SsaqB/BB4AjjezP8gGPBv9Wq+6819Z5R2mNXBzCz0wm6tX9yiEolNL6pup+DA1eVJ7FdCRRQgFiWe7AUyvxCGYNc/w+x+LkJ0JFFas08exEMTfdqrHgVWn9hAa5VrH+QhQI4DDggG/MNezZf8CXwX6C7R2KqOGT6QAkxYQsDTm9M7ARo4yuSNKqYGYtUHIhWQ+cP43gQv3zGaFklUPf3q02ldYWft6U04m2a/yxkfGaaxpbXkY3I1qTgaauOuy+qy1QyEM2x3Qo2Vo50DxTBhbe1R6BueXlEVRbBx/zJV29QFSrSYJixrSB9I/WPogm3/CLHlwXFE9cqLKVwtKvue0cSiQ6w3dzMcCk1tMu4oGavvxhPAhabGARM+kKYk01bdI4TI4ETPb2UUAh57MfU161YIWspk6lTCoqjFGm1WSrnLXiA1iaEL+l+NMbo7MfHFnYXeV2KM9VR/STybU2HF8R5Wv7URm1N+L+eKVQHyBeBur+b7FODyar7ngH2AceDMEo+xKogIkaKI21Gw5xnG+9iLKtv3pLWSLUforkkxzVdYrcQrf6M1RSJq0P1MhB2PhogMze272bnOyaKjdVo6Sm/2sYq71YYqE5OKhiUBEgz4n/Nqvn2BDwH7m7l11wG3BAP+0dIPs/LM9H/kJzy29ij8Y1Pqa1YsNFjWWUanXiYj5BywEoWlznPzlR4TxMYNhG7tc46MCOx6+e/kDR16NkXY9WR4zo5mR4PC/u9oZtHBLkaHBmmQZp+6xWpP9G8AvwoG/NeVfkjVyVz8H6Mh+MvDtpS8D49L8M7jyxO6O0kxI7CqIYmwb3N0ItJnTMfuGCrdhfJACEiEDWLjEw8jbuFFMxgo/sDKxKKDXez/juaC+lZIag+rtwYfBi71ar5HgZuA24IB/0gpBuTVfGuAXwInAWuCAf/WtP0e4ErgHKAFeBG4KBjw/60U45mk0CRC3YA7HrYRiiYvuIKz3qKndAIsObH8e33kwnoIb2kk5PCOOJtuGUZMWVmqP66/1lDtsOgQN+7W2b/rqg3a1jppXVH9oaeS4mHVhLXGq/mOA94PXA782Kv57gB+BdwbDPiLsjJ5NZ8P+JnZiz0b15phxacA24Dzgbu8mu8Qs/lVSSjUgf7gsyo7e1OPPeFggzVLyhuPXgn/ByUM4d32j/Ek4SEpJnaPwvJjPKw4psFSeKtk/mLZOBkM+B8DHvNqvs+Zi/c5wI1ma9vlRRpPu1kuZYWp9aTg1XztwHnAe4MB/0vm5h94Nd+5piC5sEjjmEEhpdw3b1d46pXU49YsMTj+oPKvfMU0X5GHCasUSYThQZ3eGsgkBlBs4GxUUR0WQ0V1HdVWmch4Z6PKooNdLN3okRFKEkvk7d0KBvzCq/lGgRHTWLuqWIMJBvw3MCEoVmQ5ZKM55qfStj8JHJvr3AO9PRh6YQu3ricYCEVSttlicUJGditeQoe7n2xL2dbk0Tn9sGEiRdYGrOAYADU68b9hGESjc/Oo24VKWMy+iEcQjCjFne+Oh/SUcGR3B6x4a/XcKdvcCg4P2BvA5sRyngGAroOtYqFrAogwPh6ZiK8sArqeYGSwdn06ydTqXBwxsPXM/H0kEnH6embPA+9cvDTrvnyKKR4BvM/UPJabdbG+C/gtvt4ONGXbHwz4rXhBF5p/02sj9AGLc72wvSvn7py8uWMbMYcDotGpbc2uBhrU7LXXt/YohKPTH5qqCt59oqCjvQL12g2BnQS4Js/Iew4AACAASURBVJ5Go2FcLs+cTtmgOPAos9u7mxcotLQUb3HXY4K+F/tSti3eqLLyiM6iXaOSjAwO0NLWXulhFI16mk+tzsXVpNK5eGZP9L6e7pzCwQpWo7DeAFYDzwI/NsN39+Z5rZOBYI5reIIBfyTb/llQKGqK3ExmRGHN4kTfujv1LvLA1YKl5QzZTSZa/HfHai/4Yofc92yKkEjS4OwehY710twikVQCqxrI74HfBAP+Vwq9UDDgv89c6OdCj/m3C9iZtH1h0r6SkG8drC1pKuOaJZXz+Bbb/0GFSrkLIdj5eGr3gGVHeFAdteEPkUjqjawCxKv5TgoG/H83n94PLPVqvoz6TqlDaJN42ozXPA64LWn78cCdpbzwjCisHFnooQjsSTOVrl5cuSqgxY7AIo8CaMUUIENb44ztSfocFFh2jIe4BV+MRCIpPrk0kLuBSUP5faYRJNNtpyhXQUWzGvANwHe9mu8lM4z3QtORf22priuEyNAPPfuUt/UoKW/VojZBw0wTZNkohQBRLQbyFrMXyI7HUx3/XetdeBbYiA8W7RISiSQPcgmQdUn/rynDWPBqvs2mMJhcnTab5eN/Ewz4P2Fu+xxwBfCAWSX4OeCMYMC/rVTjigLxpIJyqlkLKxvp5qvVFTRfFbsC7yRWFYtihfFGhnR6X46mbFtx3NwCASQSydzIKkCCAf/2pKefDwb8F6Qf49V8rcA1mXI2CiEY8K+zcEwU+Kz5KAszG0nZsoZmCjHTgb6mkuarEvg/yMMHUiwFZOeT4ZRAgMaFNhasllnPEkklyelE92q+BWZy3ye9mu/qDCasDcB7iiVAqpVMAiQbg6MwEpp+m+w2wfKFNeb/EALbZh3bXmOibGb6OYExxVrTh80NSlHqffVtTvVzrDi2Ia/8ComkVlFtsPhQd8FVhEv5M5ktCutc4GrTYvF6hv2K6WCva0aN1EXYlcOBvmV36r7lXQJ7BVtuFaKBOP6ZwLEpd0XYmMUuc3vyvvrs2D0Kiw+toFNJIikjLcsc2F3VkyibTE4BEgz4f+rVfDeb60Cmvufjpg+irhkT1jWQrT1p5qsy17yaQZ4J5+oOfVbhUWlkqQ3JfMHuUmheUr3l8GcVa2aG+GFmSO8TwYD/7+b//wKeDgb81b3aFIF0DSRbKXfDgO17Uhe2VYvL5ECPCJQ+I+Wh7tVRLPahAFDGBa6Hqjsk1tWqsvKEhkoPQyIpCwtWOVCquKOnVdEWMyOkvgLcbm77OHC+V/O9PRjwZzJv1Q0zfSCZ5W53v0I0Pv1hN7gEi9oyHlp01F4DdXgOwsoQOB+MoSTVAhAKxI92IFyph7oVGw3K7F8dpx2WtBbvy29zqrSvdWB3V6c6L5EUE1eLSkNH9Wof5CFAfgw8Dvw9adtNwL5mFNbbSzS+qmBshg8kswaSHn21arEoT8MoQ6COzk3TcTyXwNaTeo74RjuJg2Z+RWyKA5eFOlgtHoUlXXKxl0jyRVGgbZWz0sOYFasC5HhgSXKtqmDA3+/VfJ8HZi/nWOOMzvCBZF4U0/0f5cr/UEZExmgpq6jdOvZnUy2R+lKVxCGZvx5W62BVseYtKQONXTZs7QrtC10Wji49QghC/TqhPmsBIJWkodNWE71YrAoQHWgF0osdLmROS1dtkK6BZHKiR+Owq68y+R/KsMXrhAWO5xPYh0C1TSfl2XqMlPhs4YHoSc6sEsBqDkgpeoFIagNPm432fZz071HwtFUwDDGNhnY7sSUGQ9tjROZi8i0hqg1aV9ZGjpNVAXIH8Cev5vtfYIsZvrse+JK5r64ZTfeBZDBhbd+jpPQ8b28RtJSjZa0uUMcs/BCEwBWMYuudFDaZXyMwhUdDdiFRDf3QJdWLs1GlYz9n1ebpOJtUFm5wExnSGdoWJxaqLkHSvNSB3VkbPx6rAuQC0w/yJzNySzG1kt+WMyO8UqSH8boymLC2pPk/Vpcp+koZFpZKtas7jSThkZ3EYXaMZbnvGC1nodfGb0BSROxOha71LtSKNcWyjnuBjUWtKnrcmgbv6lHoyNBXo9jYLHavrAas9kQfAz7m1XwXAGvNzW8GA/7R0g6v8kQNg+RSUgrgzCBAts4o314e85XVyCvH87NHW+vLVeKHz/6VsGqQKHYvEEl1o9qg6wBXTeXoKIqC3eJ4bU6lZjSDcpFPR0IVOAJYHQz4bzK3NQQD/tDsr65dBhOpC2+mOlh9wzAwMr1NUQQrF5kCRBemzlaCH1VcWMo0V3sNbLtTBU3seAfCPT0m4QZjkWrJ861IE5YkDUWBznUuHA3yQ59PWO1IuAr4K7C/abq6yav5VgNPeDXfacGA/4XSD7UypAuQdPOVbsBdj6Xeky/rFLhMH5g6YEACjCXFdyRaNV/ZN8VTnscXQ+KAwuLLrfo/kAKk5rG7FNr3cVq691EdCg6P/MDnG1Y/8R8CTwCdk97XYMC/Fbje3Fe3zNBA0hzoj76gsrs/9W3cuL95ty8EyoBA7TdQShDxYcV8pYwY2LamHhfZMIdr5qFJFbMXiKS82N0KCw904W614WqZ/SGFx/zE6qd+HPBZs6xJ8j3vd4GjSzS2qmAonnr3npwD0t2n8OgLqW/h/isMDlg18RYpowLFdNDZunUoZl+OqLBUadf+fCJFZzDaFRJLCr+sVQc6Moy3ZnF4JoRHtRbwk1QPVr8hzVnK8jnL1Y2wUswwYZkaSCwB//eoLSV0t9EtOPNofUrlVweS7vx1sO3QwSiOELHkPA8L7K+lJk3FD7bPqTN9PiYsqYDUHs6GiRBX6SyWWMGqIfwJs3Xsdyc3eDVfU5Jpq27J5EQHeOAZlcHR1BVSO1afbl0bFShjqcJCiQjUXQbGirnLXCvJg46XEiS37TAaFfS1NkjTqvIhn2WlHD4Qm13B7plY+KoFQxfocYGorvSCWXE2qhNRVDUURiqpLFYFyBeAu72a71OAy6v5ngP2Mcu5n1niMVaUmQJE5fVdCs++lioEDt9PZ99lSW1vk7QPFQWbomBDwTaiYB+wYc9QJE1MPQRiKtVPoKJMP5SJJlF6XM25mou4IPJyauEA58EuGuxuItEEHrWw8hK5Wvkmo6qglkEFaV5mx6WqdJYhPj9fDF1gJARGHIRFzdO+V6GjQqU/HI1qTeRvSKoHq3kgz3k1377Ah8xILAO4Dril3nNB0gWIqtv46+OpwmNRs8J/HdmIy/zxCUMQHYki1MyLhrIX1FCuH2ruH7GIgZFkOTTCBrFtMUSSj8UYSKT4XBSXQvP6BhQUFFQ8JbY8lmsdcjaoxNIL7FQJqk2ZWJDzkAfOkIKrpa6twpI6wnIsp5lMeF1ph1N9DKUJkN69NsYj06ujqsCn3urElaT260M6IkcfDmGAPlKcgm5GzGDkjmGMWarxug5wo5TRNFGuLHRHozqzQptEIikLWQWIV/MFgwG/1/z/oVnOI4A+4EfBgH+2Y2uKgTQBMjaS+padts7GPp1puSH95av2GXs1OqvwwAbuA3ObeJYsUIqqNZSjja/NqUh7vURSQXJpIFuS/n/DwrnWAjcDK4owrqoh3YQ1niZAVrWnCg9j3MCIlM97Gn1j9g6C7oM9qDmczKoKi5uV0mTLlxBnY/U4ziWS+UhWARIM+D+Z9P9HZzuRV/PZgJFiDq7SxA2DMT1VmxgdTl20OptSF93EQPk6/OojOvretDDjg9woSUO0ddpxrs3dmMZlK1GplRLjyFExWCKRlJ58amG9DXg3sNLsC7IduDkY8D/JhJDRgXIUMC8b6f4PFyq946kCpM05EfGEOhFaYBTJt2GF2OvRlOf2xXYaj8v/I3DVqBlIaiASSWWx9Av0ar7/NmthHQ2ETJ/HycBjXs33idIPszLMrINlYyycVDQRaNwRI/JKhMhLESKvRMoW+y+EIJomQJz7FBb+6arutstZkQJEIqks+fQD+WAw4P998kav5jsP+Drwi9IMr7KkCxC7kbpgtToqV65D79cxkrPRFWY1VWXDVRvNz1JQbWB3SwEikVQSqwJkCXB7hu2/B35e5DFVDTNyQOKpoUXtFex5H3sjVftwrHCgFrigumuwcYcsG16dxONxhoaGpp5HYgl6e3srOqZiUU9zAQhHosTjcRyOwu8grQqQx4FDgafTth8E/LPgq1c56QJExFIFSEeFBIgwxIzoq0LNVwDuGtRApPmq+ojH4/T397Nw4UJUMxEoHo/hcFTwTquI1NNcAKItzfT399PR0VGwEMmVB3Ji0tPfAL/yar5fAq+YPUEOAD4KfKegK9cA6QJEj1SHBpLoSSDGk8xXdnCuKmwwDlttll2XGkj1MTQ0lCI8JNWNqqosXLiQvr4+Fi5cWNA5cmkgD2bYdmWGbTebpqy6Iz0KKzZaHRpIuvnKudpZcJa5dKBLiokUHrWFqqozOqzmQ648EKsRWjW6BM1OugYSHUnTQCpg+hG6ILaleOarWgzhVRSZAyKRVAP55IG0AmvMEN43zNpYBAP+8mXOlZkz29pY43bz6tAgu0IqLw6mqhyVMGHFd8ZTiiYqbgXH8sIlWS36PxweFaUGzW4SSb0xqwDxar4lwE+Bd5rNoxQg5tV8t5tdCvuKOSCv5lsD/BI4CVhjts5N3r8VWGb6YZI5JBjwv1rMsZzW1sZpbW08EY+x6bUGHu1NrSdVCRNWevKgc61zToupuwb1R6l9SCTVQc7lw9Q6HgeGgf8EXjKFyAbg88CjXs23cVIbmStezecDfgbcPcuhnwgG/DcV45pWiA/A0DgYSWXWG21mCZA80Ud0Qk+GMIYKy1jXh1NfNxfzFTVqwpL+j9ri3pcqY6Q4Y0MN3h3VGLO9wxcDm4CzgwF/co71E17N92vgz8BFwNeKNJ524ESzIOOHi3TOOWOEYSiSutAWon0IQzB2zyh6gcIjHbVJxb6o8B+JqhYmBCuNQwoQSYm48OJL2fT8i1z+9S9z3DFHzdj/+S9+hedffIkvfv4zXH3Nz6a267qOEAK7ffr3+Ln/+TTe004G4NXX3uDW2/08/+JLjI2N43a7WL1qJdqZXk475aSp19wT/Bvfv+qalLBat8vFqlUr+OAHzuGoIw4v4ezzZ7bV52zgA2nCA8zaV17Nd6kZhVUUARIM+G9gQhOZraLvOV7NdzGwFHgNuCwY8N+Z6wUDvT0YemF1RnRdp3c0DkybsFptccLj+TWiSLypF014AKgrIRLKX/nTDYPw+CguO4wM1VjfVcA9qqSUlEkk4vT1dFd0TMWilucSiSWIx9OqQwtBQi+8hfJciMfz/24LIWhrW8BdgXs4cuOhKfu6u3ezs3vis+lob+OO2387te+HP7qW7t09fP9/L08bQ4xHHnuC7/3gGs5591n850fPo6OjnZGRUf7+j0e4+prr2LZtBx86930A6PqEtvanP/wKm23i7i4UCnPX3ffy1cu+zZXf/Qbr1+1XwLuRcbLE4zEi4XDO71zn4qVZ980mQJYHA/7nc+zfZLV8uxmt1ZRtfzDgH8q2L8M13wA+CYwCnwX+4tV8bwkG/I9le1F712KLp5+J7c2tjKW1levyOPA0WvdAC10w/ILVKVoYU7uN5qNaUJz5342Hx0fxNDazoEGhpa227ubtToWFyz0p2/p6unN+yWuJWp5Lb2/vjES7eDyG3VaZSA2HI3/tXFEUjj/2aO4J/o3hkTE6O9qn9t17/4Mce/SR/PWe+7DbHSlzVcxw2PT5h0JhfvyT6znrHWfy0Y+cN7W9o6ODd//bWSxftozhkZGp19lsdnPszikB0trq5IPvP4fgfQ/y+JNPc/BBBxbwbsxkMjHS7fHQ2dVV0Dlme4cVr+ZzBAP+bLcQjgzO7GycDASz7fRqPk8w4J/1lj4Y8J+Vtulyr+Y72xQoWQXIXBAChmNzM2FFX41ijCXdEanQrLWguPL3QSg2BbUlNX5b9aiozTOFgYgIjDE9Y5HHWswBkeYrSalpb2vj4IM2cO99f+OD738vmFaI+x94iEu+8Fn+es99ls/19DPPMTo2xnvffXbG/UcfdYTlcxmGgd1WXTbn2ZaQV8xoqGzv2OmApcinYMB/36zNvgvndbNeV0nQDRiOpS5c+YTwioQg/Gw4ZZtrvQvHkuLdmdm77NhaM3+5hCEwQgbGqDEhxMKgqOB2KVO9Q8pVRXiuOJukAJGUnjPPOJ2bfn0z//6+96AoCv985jkcDgeHHnJQXufZtXs3Ho+bzs6OgscyNjbOHXcG6O3r5+QTTyj4PKVgNgHyO+Bqr+Z7WzDg35W8w6v59gV+BFxV2iGmXHON6bT/UprJ60DggVJdV2duGkj0lUhq6REbeA5rKNr4FBsZtY+p/aqCrcmGrWlCwESHbLgXeFi92sYCMyQ21J+g/7UYInsr96pAhvBKysEJbzmWn1x3Pc/+63k2HnYI99x7P6efelLeWdt2mw3DMBBCTL12cHCIc/9jql8fuq7zve9+g0MPnhZO73r3v0/97/G4Wbt6FVd8+zLWrFlVlPkVi9kEyDXAWcBmr+b7HfCy+ZqDgPcB9wPXlWmsAD3Au4AWr+b7DBADvgDsB7ynVBfVdRiOp35xrGogIi4IP5eqfbg3uFGLaIpRW2wF5YI0Jrl1GjrsIKD/9eoWIjKEV1IOnA4Hp51yEn+9J8i+a1fzxFNP858fPc/CK1NZsXwZ0WiMXd27Wb5swrfV1raAwB23Th3j1XwT6dlJ/N+ffjflA6lmcv4azSzzM4Bvms2kvgV8BVhvLtzvCgb8RVtuvJpvs1fzRYCAuWmzV/NFvJrvF+Z4wqbZrMmMvtpu+lZODgb8m4s1jnSGoypxY3qBdqkTeSBWiLwYQYST3iI7uA/15HpJ3tgW5P9Fc9jBYUsVOg2ddtr3dVZtd1vVBnaXFCCS8qC9zcvjjz/Fvfc9wMEHbaCrqzPvc2w8/FDa29u4+Xe3ZdxvGDViO87CrG5U04F+hfkoKcGAf52FY14xw4vLRl94pv/DyiIrYgaRTWnax0EeVE/xFkHFoRSkzTRm0aAaOyc0kYE3qk8Tkf4PSTlZs2YVq1at4JY/3M7/fPpTBZ3D4XBwyRc+y9e+8R08HjfnvPtslixZTDgS4YUXX+Z3f7idzo4OFi0qrBpupanBOJzy0xsqzIEeeSGSWrfKoeA+2J3zNflia7UVVE2z0Zn9NY1ddoQpRKoJWcK9NqnljPC3v83LDTf9huOPP4YZdiaLHH7YIfzkR1dy2x//zBcu+RrDI8PY7XZWrljO8ccezbvecSaNjY1FH3s5UES13WaWjoIn+t839PDH16Y/4BM74YOzZL/EtscYC45CkobqOcKDZ2PxnOcArn1deWs0I0P9HLmui9UduV8XDxuI4uU9zhmbU8GWQfDVcu5EOrU8l97eXrrS8gnqqQlTPc2FpPlk+tzSyHq3Wbu3BmWkP5xfGffYthhj96UKD8Wl4D6ouNqH6lIKNodlM2El4yiiqU0ikdQfUoBYYCCSupDmCuGNbYkydv/YDH2n4bjGgrLGc6EW4DyfpLGABEaJRCJJxmrTqGezbG/3ar43iz6qKqM/Ys0HEnszi/A4oRHXfnOrmpuJbImDs6Eq4KnBPiASiaS6mK2c+2HARmCDV/N9NIMtbH+gNsMH8mAwTYC0jScIbY4hIgKREKALRFwQ3xGfITwa39qIa31xTVcAaoOKWmBIq9vOnNpYSiQSCRZMWMuAT5s1r27IsD9kZqPXLeNRQSgxvVAviugQGCZiocVB40mNuPYvvvCgwNyPSRoc8yZwQiKRlJCcAiQY8N8F3OXVfDuCAb+lqrv1xs60cuen7g3DbMJDgcaTmkpitpo8f6HmK4CG+gkkkUgkFcSSDSQY8K/war4Fk8+9mq/Rq/nO8mq+DSUdXRWwc3D6bt2lG6zvi+Y8Hhs0nlJC4QHYmlQUe+EmKKmBSCSSYmApCsssl/5roNWr+Zxmm9uVgNOr+T4UDPhvL/1QK0OyBnLoQAxHcmhug0LDEQ1gV1DsCoodbO121FkS3hQbJfGLWMUjBYhEIikCVsN4v2b6QgDeCzSb3QCPBr4P1K8ASdJAjupNbVfiWucuSBAobjVj8cNy+bUbZASWRCIpAlYFyH5maXeAdwC3BgP+ca/mexDYp4TjqziTGsiy8QTLQqlp2a51hZmpVHeqhqKqsLZTZU2HUpboqL6ekl9CIpnioaHideLMhxMXLLBwlGQuWI0DjQEOr+ZTgVOBe83t7rmUCKkFdg5OCJB07cOxwoGtuTBHtuKZFhKNLjh6tY21naoMrZVI5iFezcd9f3uw0sMoCKsayKNm3w/dFDp/N7efD+TqmV7z7BwSOHXBoQOpzvO5+DAmNZDlbQrrFqnYCujlIZFIis+FF1/KCy++PNWLw2G309nZwWmnnsR7fe+ydI7evj6efuY5zjzj9BKPtvJYFSD/YwqQxcD7ggF/3Kv5OoGvmyatuiSWEOwZFRw5EMWV5jx3rCzMkaCoYG9UOHSZSleOLoISiaQynHLSCVzyxc+B2S3wmWf/xWXfuoIGj5t/O+uds77+kUef4MGHHpYCZJJgwL8VeHvatj6v5lsaDPhDJRtdhekeFggBR2dwnhfSARDA5lE5YqWdNtmaVSKpemw2G0cduZHly5ayY8dEV+8dO3dx3c9v4JXNr6EbBvusWc1/fepj7LfvPtzwy99w6x//jBAC7ez38cPvfYv16/bn7nvv5/e3/pHevn4WLeri3A+cw2mnnDR1nXA4wneu+CFPPPlPXG4XZ73j7Zz3wfdVcObWsHwL7NV8q72a7zKv5rsxafPBpRlWdbBz0GBpMZ3nKmxYLYWHRFIrRKNRHvz7w+zu6eHEtx4PwOXf/h5ut5ubf3U9t958I4sXL+Qb35rot/fxj36I0049iQ0HrCNwx62sX7c/m55/kR//9Of896c/yV/+eAuf+NhH+N4Pfsym51+cus6f/3IX79Tehv+23/LBD5zDr377O7Zs3VaxeVvFah7Iiabj/AWzH/rHvJpvNfCAV/OdFwz4/1T6oZafnUNihvZRqPN8ItJKobNTmq0kkmrmgb8/zEMPPwZAIpHAbrfzoQ++nwPW7w/Aj6+6AlVRcLkmbiRPOvEEgvc/yMDAIO3tbTPO9+f/u4ujjjicIzceBsBxxxzF179yEQsWtE4dc+wxR3HIwQcC8LbTT+Gn1/2C7dt3smb1qrLMuVCs+kC+DXw2GPD/zKv5wphmLa/mO9fMEalPAdKTKIrzXFVhTYdCs1vFWUD7WYlEUj6SfSCJRIJt23fw45/+nM2vvsZlX72ETZte4Obf38bOnd1EolEmm/LF4vGM59vVvZvDD0k11hx/3DEpz5cuWTz1v9M5UWsoEp2l6kUVYHU1OzCpmGJy2O4dZo5IXRJ6OpTiPI+783eeK8qE8GjxqCiKbMsqkdQSdrudfdau4RMf+wiPPPYEO3bu4hvfuoINB6znNzf9nMAdt/LNy74y63lmy3Wo1RB+q6uZAFoybF8DVL+YLJDmF8Ipz8Nr8neeNzihxezsZ3crqLba/KJIJBJ47PEniScSfPjcD9DYMNGe+vXX38j5mmVLl7Bjx86UbcH7H0zxgdQqVgVIALjeq/nWMOETafVqvlOAPwB3lXaIlSE2brBy0bSvQwAtG/J3nnsc0wJDmq8kktpCCMGu7t388tc3s2rVCg4+aMJP8exzm9B1nYcefpQn//kMAHv39gLgdrno7x9gZGSESCTKWe94O888t4mHH30cXdd5+pnnuOpHP8UwjJzXrgWs+kAuAG4GJkXtgNlc6h7gcyUcX8VwNqq85ydLGNoW4y/XdpMYstPenr/zPLnznxQgkvlIrZUUSXaiK4pCe9sCjj7qCD5wjo+uri4++P738sMfTwiAE44/lm9+/ctcetm3+drl3+EbX/sSp596Eo88+gQf/vh/cdGFF3D8sUfzP//vU/zixl/z3e9dxcKuTj53wac57NDaD2JVJh1AVvBqvvXAOsAAXg0G/JtLOrriUnDJld/fvZ3IUCNtSv6NNPZbpNJk9h9fuMGFew59PIpFX083nYuXVnoYRaOe5lPLc+nt7aWrqytlWzwew+GojwY09TQXkuaT6XNLI6vdPa9b4mDA/0ow4L8DeBlwezXfvDHoF6o7SA1EIpHUK7OuaF7N9ymv5rvaq/mOMZ/fBrwKPAM8a5Y0qXts2YVwVpx2pupc2V0K6hyaQEkkEkm1kVOAeDXfl4CrgJOBe72a72KzD8gJwInAIPDV8g23cqgFhNk1OKUDXSKR1C+zrWrnAb5gwH8Y8EmzeOL5wYD/0WDA/wjwCWD26mJ1gFqABuJKClFwSAEikUjqjNlWtWVA0Pz/DsAFvDS5Mxjwv25W6K17CjFheZL8bVIDkUgk9cZsq5ozGPAbTAiLCBANBvx62jHzwrBfiAbSIHNAJBJJHSNXNYvk+0ap6rQJy+ZUsDnnhZyVSCTziNkSCZ1ezffrHM8BCuusVEMogJKnBuJ2mIWwAKesfyWRSOqQ2QTIw8CKpOf/SHs+eUxR8Gq+RcAVwJmAB3gR+HIw4H8w6RgPcCVwjlmf60XgomDA/7dijSOdgvwfSeYrR6PUPiQSSf2RU4AEA/6TyzcUMB31g8BhwJAZ9XWnV/PtHwz4u81jrgWOA04Btpl92e/yar5DggH/a6UYlD2HAFHsCopTQXEoKHYFfVRHxIRMIJRITLY/VpmmpSuPa6jIdQvll7+6mfsf+Du/ven6Sg/FMlZrYZUcr+ab1CauDAb8Pea2K4BLgGOBP3k1X7sZWvzeYMA/GQ32A7MvyfnAhaUYW5NDMJ62zbHIjq3TPqM6r13YMUYNWh0CYhPF0qQAkUhqgwsvvpQXXnwZm2265JDDbmfZsqX821kaZ5x+akXHV21UjQAJBvwjwMfTNq81/05qHxvNMT+VdtyTppDJykBvD4ZeWPXLTneCWGKEkei0sIgpKspIds2kcbGOEhOE3MW5CAAAFEBJREFU+wVDQ9UlQBKJOH093RaOrA3qaT61PJdILEE8HkvdKAR6IlGR8cwYiwWEEJz01uP54uc/M7UtGo3x8COP8YOrf4rD4eCE44/JeY5C0Q0dUeC4C0II4vEYkXA453cuV222sgkQr+azA03Z9gcD/qG041uAXwJ3BQP+x83NC82//Wkv75stH6W9q/B0ld6tOzlg9QI27zGIxkFtUHF1ZS/t7nLAkmXmW7um4MuWjFou2JeJeppPLc+lt7d3RrHBeDyGzV6Z+9RCCh8qioKqqimvdTicnPk2Lw8+9AiPPPoEp5z0Vl56+RV+ceOv2bJ1G4qicMD6dXzmvz7BErOz4Ac+9HHe955/Y/uOnTz0j0dBgZNPPIHPfPqTKIqCYRj8+re/557g3wiFw7zluKNpaWlBSRr3nj17ue4XN/Lyy68ST8RZu2Y1n/jYh1m3/0QPvwsu/BIbDlhHLBbjvvsfxOly8rGPnMeK5Uv50U9+Rk/PXvbddy1fvvjzdHXOrDg1WUzR7fHQmbuYYlbKeWt8sunfyPjwar6pXrFezbcKeMQUDP9u4dzKXKrtzoZdmahptbpDRVXB1pK7om6zSzrNJZJ6Ix6PoygK8Xicr37jO+y7z1puveUmfvvLn6MndK686pqpY+02G7f98Q6OOfpIbvvdTVx6yRf4v7vu5smnngbg/gce4rY/3cHFX7iA2393E8cdezR333vf1Ot1Xeeir1yG3Wbn+muv5uabrueAdftz4cWXTvUdsdtt3Hf/Axx84Ab++Idf82/vegfX/vwG/vTnO7nyf7/Jzb/+BaFQmNv+eEfJ3pOy3RoEA/77rCQdejXfUcCdgB/4TDDgT2403GP+7QKSW3wtTNpXdCabCDY4FZa1KuxtyS13m/Jvmy6RSKqUcDhM8P4HeeGll/nWZZficDj4zY0/x+Gw43A4cDocvOX4Y/jZL36Z8roNB6zjuGOOAmDj4YfS3NzE1m07OOboI3nwoYc56ojDp3qCvPUtx3H3vfezbdt2AJ765zN0d+/mh9/7Fq2tE81gP3zeB/i/wN08+NDDvO+9PgCWLl3CySedAMAJbzmWm35zC2e98+0saG0F4MiNh7Fl67aSvTdV4wNhQngcBNwNXB4M+H+U4ZCngZgZhXVb0vbjTaFTcpYusmPvtNEznF3hkRqIRFK7JDeUwtQ89tt3H75yyYUcdeRGAP7xyGP477iT3T17iMfjGIaBrqcW6Vi6dEnKc5fTRTQ60QF8795ejjj80JT9K5YtnRIg3bt7aGpqpKO9fWq/w+Fg8aJFdO+evldetHDh9PldLnNbV8q2aKx0PpWqESBezWcDfgVcm0V4EAz4h72a7wbgu17N95IZxnshsMoM7y05ng4bGxarjEZ0xrN0g292SwEikdQqp5x0Apd8caLRqmEYfO6LX6G5qXFKm3jhxZf5/lXXcP4nPso7tbfhcrm466/3cvU116WcJ1cF73g8PpVoPIme1uI2U7M/IQRK0utUdeY1FLV8nolqCg86zoyyusir+SJpj18kHfc5U9t4AOg1kw7PCAb8pdPTkmjosGG3KRyyzEamz0lVobF+mpZJJPMaVVX54uf+m+c2PU/g7om6si+/spnm5ibe4ztr6q7/tdffmOVMqXR1dbJnz96Ubdt3TFvlly9byvh4iL6+6XihWCxGz569LF9WPUEWVaOBBAP+h634SIIBfxT4rPkoKw6PgsMzITWa3Qr7dKq8tjf1rqHRScodgkQiqW2WL1/GRz98Lr+48TccsfFwFi7sYnw8xOZXX2eftau566/38uaWrWCaphYunD2i6bhjjuLGX/2W5194ifXr9uPRx57k1ddep7FhIvnxiI2HsWL5Mq67/kYu+Mz52FSVX9/8B4Apn0c1UDUCpBZo6Eh9u1Z3KPSNKwyOT6ua0nwlkaRSaxnhmfCd/U7+8chjXHHl1fzgym9zxumnctGXv47TYeeM00/lm1//ChdefCnnf+bzXHPV92Y939nv0ujr7+db3/0+kUiEY485inef/S7uuvteAGw2G5d/7Utce/2NnPuRT+J0Oth/v325+vvfSfGLVBolk52tTil4om8+uRO73s7iQ9wzssrDccGjb+pM+s/WLVJZ1VFNlsGZ1HKuQSbqaT61PJfe3l660vIJJnMN6oF6mgtJ88n0uaWR9a64ule6KsLuVjKWJPE4FA5YPL29MXt+oUQikdQVUoBYpKEje/Lg0laVhS0TQrpFmrAkEsk8QfpALNLQnvutOnCJSjim47RLASKRSOYHUgOxgM2l4GzK/VY5bAqHr8hd4kQikUjqCSlALOBaYO04t0NqHxKJZP4gBYgF7LI0iURiCcMorGWCpDIYhpEx490qUoBIJJKisGDBAvbu3SuFSI1gGAZ79+6lra2t4HNIJ7pEIikKDoeDjo4O+vr6pqoxRMJh3B5PpYdWFOppLgDh8TGWLFuOw+GwcHRmpACRSCRFw+FwsDCpQmxfT3fBzYqqjXqaC0CfHp+T8ECasCQSiURSKFKASCQSiaQgpACRSCQSSUFIASKRSCSSgpACRCKRSCQFIQWIRCKRSApiPvUDkUgkEkkRkRqIRCKRSApCChCJRCKRFIQUIBKJRCIpCClAJBKJRFIQUoBIJBKJpCCkAJFIJBJJQUgBIpFIJJKCkOXcs+DVfB7gSuAcoAV4EbgoGPD/rdJjs4pX860BfgmcBKwJBvxbk/bVzPy8mm8RcAVwJuAxx/rlYMD/IDU2FybGezDwHeA4wAlsBr4dDPj/TA3OJxmv5nsL8BDwzWDAfxk1Nh+v5tsKLAP0tF2HBAP+V2tpLpN4Nd/HgIuBVUA3cE0w4L+KInw2UgPJzrXA6cApQCfwO+Aur+bbr9IDs4JX8/mAx4FtWQ6ppfndASwCDjP//h2406v5lpr7a2YuXs3XBDwAvA6sAbqAPwO3ezXfBvOwmplPMuZi9EtgLG1Xrc3nE8GA3532eNXcV1Nz8Wq+9wNfAz4MtAKfAc73ar6jzEPmNB+pgWTAq/nagfOA9wYD/pfMzT/war5zgfOBCys8RCu0AycCK8wvzxS1ND+v5pu8K7oyGPD3mNuuAC4BjvVqvgdrZS4mHnPstwQD/hAT87kG+BZwkFfz9dTYfJL5DvCKeZcLNfZdm40ancvXgS8GA/4nzOd3mY+izEcKkMxsNN+bp9K2PwkcW6Ex5UUw4L+BiS/Jigy7a2Z+wYB/BPh42ua15t/uWprL/2/vzIOlKq44/D3RxLiVBKVcotESg0RMxaUqcY2WtkqLSyfRlIlWNCVKFWIEVFziGiHGuEYNKpRgqQE02hGhg7ZbYkBjKRK1lE1cINEoCK6oGMgf/EYut2bemzc84I053z8zr/sufe7069N9Tt9zWCHPO8Coyt/Ohy2A84D5wKPNJk8F58N+wInAbprFVmhGeY51PgwFtgFmA5fkFCc2myzOh62BXkAX58MzQE9grsyld3eEPGbCqk4lJ+fCUvkCYKt10J6Opmnl04pkNDApp/hUk8vyKfCOfFQup7igGeVxPmyk3+TMnOKbpepmk+d5YJbMOtsBE4AJzoe9m1CW7fXZHzhebbwNGO98+EFHyGMrkPbRAnyZo092avmcD98EJgJv6x+iNTq1LKxYjXxVK5AzgKnOh9ZmfZ1ZnuHASznFO9txTqeUJ6d4VKnoMufD0cCpQK5xWqeUpTC+X5pTnK3v18tEdTLwUI3z6pbHViDVeUufW5bKuxfqmpmmk09Ov6eBKcDhOcUPVNV0shTJKS7IKV4E/EczxaaSR6arnwKn1TikqeSpwRxg6yaUZYE+F5XK53aUPKZAqvMs8Jm2WRbZRwNYs9NU8jkfegOTgeE5xf45xaWF6maT5Qjnwzznw8alqhbg82aTR/6pzYAXnQ8LnA8LgH2Bc5wP05pJHufDjs6HEc6HzUtVu8oX0jSyiDlSIt8rlfcAXu0IeSwfSA2cD38ADgWO1lbYIcDZwK45xVpbYzsdzodDtPQuvwfSFPI5H7po5ZFyihfWOKYpZGFFW7sBL2knzBBgiWbvVwP75RSfajJ5ugJlZXgP8CRwZU7xrWaRR9uQZ2ub+EANrmdpk8N3coozm0WWCs6H8yTLMfLv9AOuA/bKKT63uvKYD6Q2g/Ty2mPApsB04NDO2Emq4XyYqReHKqvMmc6H5cAdOcV+TSTf3tot0tv5cHaprtlkIae40Png5DeYpRcJZwBBmwJoMnkWlU0k2hzwfmXbdbPIk1NcognXb6VIWjToHphTnKnDmkKWAldoDPgT0E197cic4nOqXy15bAViGIZhNIT5QAzDMIyGMAViGIZhNIQpEMMwDKMhTIEYhmEYDWEKxDAMw2gIUyCGYRhGQ9h7IEanwflwIPBYTrGlE7SlJ3AvsBPwo5xiWtdtqgfnwydA/5zimHXdljWF8+EAxXH6dk5x7rpuz/8zpkCMVVB+jQOA/XOKU0p1Y1jxwtVJ66yBa49+SsCzBfBxudL5cJIi0H5a5dzFOcW1Ep3V+XACMLUykOYUN1wL91wfGAD8DNhFL9zNA+5T3pb31uT9c4p/A9a4nEbbmAIxqrEAuNX5sHtO8bN13ZhGcT60AOvlFMvpSeuhG/B6TvGjNo7bJKf4eYNNXC0k37WKTLxWZuLOhw2ApLSvg4DHgaXKAzIMmO582KdKWPcOu38pFpqxDjEFYlRjlGLjnAdcWu0A58MOCsjmcooPq6yHQkAclFN83PkwRTGRNlRWxCXA+coBfrNSuk4Djs8pzi9c+xDgemAHhfs4M6f4V1bGK7pSOZw31v2G5RTvVf0lQF/F/zpDcjxcpf0HAL9RoLyPFP9osGI3JeAwoEUmoWNzig+09yGqLafkFL9RKLscOCGnuIPShs7Svc5W2JZ3gYtziqNZOWAPV7KmTYDngMGKp/WuQqEk58PknOJRClfTL6c4SuefBpyuZ/0mcDdwWU7xU4VUeUjB9m4AegP/AgblFCfVEOuXCpa4S07xjUL5PxX2fLrSpAbdv9ye9aVwTq6Y2ZwPA6SMtgXeAO4ErsgpLq2YNYGfK17Yzc6HR1S2c05xTh19opvkO1jPcB5wdU5xZHt/U2NVzIluVOMzmXDOdT70Wo3rLJXieEIz+hukGM5UDubtFMn1rNJ5AzWodte5k5Q3A+AaYE9lTOuqVLDjFFa8QiUGWFdl+VsFKbpHZHLZRtfbEsjOh5acogfukGlow0aURzueD8CvNYBuBowBRijdKFLix8is2BX4O/Ag0EUZ5gB8lTwWFTPbVQqQ11UD7Il6hsX7XwIcB2yuKKyjtbqpxgnA2JLygBWmpf/qfn0VZLFNlLP74oKC/AlwCjC0dOiRwM46tkxbfWKYTJE9Fe9pIHBtIQe90SC2AjGqklOc6nwYDYx0PuyfU2w0aNqcnOJ4VgwW92mwvEmpXXE+PCjzR5FhlRWJ8+FizaAPcz5MkGI7rBBZ+D6Vn6rBFeWDH9aK+a0/8EpO8Wr9/bHz4QLgH8BeVVJ8rmluzym+yAp57wEuVMjtpzXYDcspzmLlCuZ5YIM6rns6cFdOsZI4aLrz4UbgV86HgYXjbqwEz9NvdJIU6ttVrtlTK4RavKRxZccqeSiqMRi4Jaf4ZKGNV2lFdnnhuNtziovVxi8KnQ+b1tEntgKWAZ/kFJdporDpavRpQ5gCMVrjXOBlDbgjGrzGa4XvFWf066Wyr5XOebnyJae4yPmwWOk5d9LMO8k0UmE9mcoqLFQu9Vr0KN5DVKKt7tROBfJhcUATU3KKB7fjGnMK35focyPnQ8WJ/4V/Qz6ZsawcPFujh1ZSRWZqFt69UFb1/jWu+Xkb40YXfdY7tvQE9ihFWm5hhXxfKZTV8vHU0ycuBO4H3nI+PKrcMuOA1vqIUQemQIya5BTfdz6cDozRjK4tqplEl9VZVqTs9G4BPimct3dOcVor59fj+C+baCptb++stL1O9HqfEYU2NrqteXmdcrb1exSZI19JLXrperNq1JflXwYMzSleU+3ggnKu9Zu22Sdyii/I37SPcl8MAi5yPny/6Hsz2o/5QIxWySlG+RFuLFVVZqrFWeL2HXTbL/wucoBuLufqXCmX3YsHOx+2l3O2XmYCZft35Z61Br5GWFJ6PrTnGclks0BbZUGzcufDEOfDjnVcYpY2CRTpBSyuYZ6qh7HAcc6Hb5UrlPxrCDCxYm6S4m+tj8yq8nt2dz5sUmd72uwTyjC4Xk7xCSUl662V74/rvIdRA1uBGPUwQCafDwo7mt4GFgJ9ZD7YWMd1BBdo5fMecJls6ZNzih85H0bJhj9NvoB9gah7j6vz+jcDg5wPZwE3ycE/HHi6kGinI3gZ2NL5sFdO8Rnnwx7AIRpU6+UmYIB2hs0AzpHf4LbC/+8uzodnldypyO+BW+RXeQz4rp7TyJzi8iqmt3q4Dvgh8BfnwxnqD8VtvF8Hjig9g8OdDyNkahoqM1jxerc7H/4MTNDGivFKt9q/rcbkFD9srU84H8bLJPmA8+FSma12k2lwdiMPwFiJrUCMNskp/lv+kG0LZcuVD7uP8+E17Wq6QdWNTkw20Kx9pFY972hnTd/C+xiDlQ52srbfjgQuyinWqzzIKb6q7b3Hayvsk8ArgG+w3bWYCNwKTHQ+zJDp5Jp2Pp/hyib3sBRpH6BPTnGRNiLcBfxONv5VyCnepV1Lt2jgvFMryfMbFUgbEw4C/qh3UN6TApkEzAf2LGWzGyiH+jxtUrhfK6D1db1xcphfAXwop/dU7dSrl5p9Qv30GK04X9UkaKzqa21VNurEMhIahtEwCvkyAzhqDW53NjoppkAMw1gtnA+T9NJnX2C+vSn+/4OZsAzDWF1+IWf2C6Ut2saXHFuBGIZhGA1hKxDDMAyjIUyBGIZhGA1hCsQwDMNoCFMghmEYRkOYAjEMwzAa4n+uQdAMGEtt/wAAAABJRU5ErkJggg==\n"
-     },
-     "metadata": {
-      "bento_obj_id": "139939791511408",
-      "needs_background": "light"
-     }
-    }
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "originalKey": "49c62bed-cab5-44f9-82b0-90ca2c2f598d",
-    "customOutput": null,
-    "collapsed": false,
-    "requestMsgId": "b2ac13f5-29a6-4287-b521-59bcdcf9f737",
-    "executionStartTime": 1668658418086,
-    "executionStopTime": 1668658418094
-   },
-   "source": [
-    ""
-   ],
-   "execution_count": 13,
-   "outputs": []
-  }
- ]
+  ]
 }


### PR DESCRIPTION
Summary:
Speed up composite mtbo tutorial to run in standard mode within 30 mins.

- Set number of contexts from 20 to 6
- reduce number of initial points and number of steps from 20 to 10
- reduce num_samples from 128 to 64

Differential Revision: D44120017

