### PR TITLE
Update google analytics ID

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -33,7 +33,7 @@ const siteConfig = {
   projectName: 'botorch',
 
   // Google analytics
-  gaTrackingId: 'UA-139570076-2',
+  gaTrackingId: 'G-CXN3PGE3CC',
 
   // links that will be used in the header navigation bar
   headerLinks: [


### PR DESCRIPTION
Google Analytics is deprecating the old way of doing things and requires us to set up a new Google Analytics 4 property. Updating the ID in the site config to (hopefully) track site engagement under the new property. Not sure if this will work with docusaurus v1 but probably easiest to just try (it didn't complain during a local build).