### PR TITLE
Move consolidate_duplicates to BoTorch and consolidate duplicates in PairwiseGP

### DIFF
--- a/botorch/models/utils/__init__.py
+++ b/botorch/models/utils/__init__.py
@@ -10,6 +10,8 @@ from botorch.models.utils.assorted import (
     check_min_max_scaling,
     check_no_nans,
     check_standardization,
+    consolidate_duplicates,
+    detect_duplicates,
     fantasize,
     gpt_posterior_settings,
     mod_batch_shape,
@@ -32,4 +34,6 @@ __all__ = [
     "multioutput_to_batch_mode_transform",
     "mod_batch_shape",
     "validate_input_scaling",
+    "detect_duplicates",
+    "consolidate_duplicates",
 ]


### PR DESCRIPTION
Summary:
# Context
One problem for GP models is that when evaluating points that are close, it is likely to trigger numerical issues resulted from non-PSD covariance matrix. The problem is particularly pronounced and hard to bypass when doing optimization (either BOPE or preferential BO) as we would need to repetitively compare points to the incumbent.

To improve preference learning stability, we can automatically consolidate the same (or numerically similar points) into the same point. For example, with training data `datapoints = [[1, 2], [3, 4], [1, 2], [5, 6]]` and `comparisons = [[0, 1], [2, 3]]` with be turned into the consolidated `datapoints = [[1, 2], [3, 4], [5, 6]]` and `comparisons = [[0, 1], [0, 2]]`. This shouldn't lead to any changes model fitting as the likelihood remains the same.

# Code changes
To implement this, following changes are made
- Upstreamed the `consolidate_duplicates` and related helper functions from `Ax` to `Botorch`.
- Implicitly replace `datapoint` and `comparisons` in `PairwiseGP` with the consolidated ones.
- Added `unconsolidated_datapoints`, `unconsolidated_comparisons`, and `unconsolidated_utility` in case the user would like to access the original data and the corresponding utility directly from the model.

Differential Revision: D44126864

