### PR TITLE
Polytope sampling for linear constraints along the q-dimension

### DIFF
--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -70,10 +70,13 @@ def transform_constraints(
     d dimensional state.
 
     Args:
-        constraints (Union[List[Tuple[Tensor, Tensor, float]], None]): Constraints
-            to transform.
-        q (int): Size of the q-batch.
-        d (int): Dimensionality of the problem.
+        constraints: A list of tuples (indices, coefficients, rhs), with each tuple encoding an
+            (in-)equality constraint of the form `\sum_i (X[indices[i]] * coefficients[i]) (>)= rhs`.
+            If `indices` is a 2-d Tensor, this supports specifying constraints across the points
+            in the `q`-batch (inter-point constraints). If `None`, this function is a nullop and
+            simply returns `None`.
+        q: Size of the `q`-batch.
+        d: Dimensionality of the problem.
 
     Returns:
         List[Tuple[Tensor, Tensor, float]]: List of transformed constraints.

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -196,17 +196,11 @@ def sample_q_batches_from_polytope(
     """
 
     # check if inter-point constraints are present
-    inter_point = False
-    if inequality_constraints is not None:
-        for c in inequality_constraints:
-            if len(c[0].shape) > 1:
-                inter_point = True
-                break
-    if inter_point is False and equality_constraints is not None:
-        for c in equality_constraints:
-            if len(c[0].shape) > 1:
-                inter_point = True
-                break
+    inter_point = any(
+        indices.shape > 1
+        for constraints in (inequality_constraints or [], equality_constraints or [])
+        for indices, _, _ in constraints
+    )
 
     if inter_point:
         return (

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -182,7 +182,8 @@ def sample_q_batches_from_polytope(
         q: Number of samples per q-batch
         bounds: A `2 x d` tensor of lower and upper bounds for each column of `X`.
         n_burnin: The number of burn-in samples for the Markov chain sampler.
-        thinning: The amount of thinning (number of steps to take between returning samples).
+            thinning: The amount of thinning (number of steps to take between
+            returning samples).
         seed: The random seed.
         inequality constraints: A list of tuples (indices, coefficients, rhs),
             with each tuple encoding an inequality constraint of the form
@@ -197,7 +198,7 @@ def sample_q_batches_from_polytope(
 
     # check if inter-point constraints are present
     inter_point = any(
-        indices.shape > 1
+        len(indices.shape) > 1
         for constraints in (inequality_constraints or [], equality_constraints or [])
         for indices, _, _ in constraints
     )

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -114,7 +114,7 @@ def transform_intra_point_constraint(
     """
     indices, coefficients, rhs = constraint
     if indices.max() >= d:
-        raise ValueError("d has to be larger than the largest index in the constraint.")
+        raise ValueError(f"Constraint indices cannot exceed the problem dimension {d=}.")
     return [
         (
             torch.tensor([i * d + j for j in indices], dtype=torch.int64),

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -66,6 +66,18 @@ TGenInitialConditions = Callable[
 def transform_constraints(
     constraints: Union[List[Tuple[Tensor, Tensor, float]], None], q: int, d: int
 ) -> List[Tuple[Tensor, Tensor, float]]:
+    """Transform constraints to sample from a d*q dimensional space instead of a
+    d dimensional state.
+
+    Args:
+        constraints (Union[List[Tuple[Tensor, Tensor, float]], None]): Constraints
+            to transform.
+        q (int): Size of the q-batch.
+        d (int): Dimensionality of the problem.
+
+    Returns:
+        List[Tuple[Tensor, Tensor, float]]: List of transformed constraints.
+    """
     if constraints is None:
         return None
     transformed = []
@@ -80,22 +92,25 @@ def transform_constraints(
 def transform_intra_point_constraint(
     constraint: Tuple[Tensor, Tensor, float], d: int, q: int
 ) -> List[Tuple[Tensor, Tensor, float]]:
-    """_summary_
+    """Transforms an intra-point/pointwise constraint from
+    d-dimensional space to a d*q dimesional space.
 
     Args:
-        constraint (Tuple[Tensor, Tensor, float]): _description_
-        d (int): _description_
-        q (int): _description_
+        constraint (Tuple[Tensor, Tensor, float]): Constraints
+            to transform.
+        d (int): Size of the q-batch.
+        q (int): Dimensionality of the problem.
 
     Raises:
-        ValueError: _description_
+        ValueError: If indices in the constraints are larger than the
+            dimensionality d of the problem.
 
     Returns:
-        List[Tuple[Tensor, Tensor, float]]: _description_
+        List[Tuple[Tensor, Tensor, float]]: List of transformed constraints.
     """
     indices, coefficients, rhs = constraint
     if indices.max() >= d:
-        raise ValueError()
+        raise ValueError("d has to be larger than the largest index in the constraint.")
     return [
         (
             torch.tensor([i * d + j for j in indices], dtype=torch.int64),
@@ -109,22 +124,25 @@ def transform_intra_point_constraint(
 def transform_inter_point_constraint(
     constraint: Tuple[Tensor, Tensor, float], d: int
 ) -> Tuple[Tensor, Tensor, float]:
-    """_summary_
+    """Transforms an inter-point constraint from
+    d-dimensional space to a d*q dimesional space.
 
     Args:
-        constraint (Tuple[Tensor, Tensor, float]): _description_
-        d (int): _description_
+        constraint (Tuple[Tensor, Tensor, float]): Constraint
+            to transform.
+        d (int): Size of the q-batch.
+        q (int): Dimensionality of the problem.
 
     Raises:
-        ValueError: _description_
-        ValueError: _description_
+        ValueError: If indices in the constraints are larger than the
+            dimensionality d of the problem.
 
     Returns:
-        Tuple[Tensor, Tensor, float]: _description_
+        List[Tuple[Tensor, Tensor, float]]: Transformed constraint.
     """
     indices, coefficients, rhs = constraint
     if indices[:, 1].max() >= d:
-        raise ValueError()
+        raise ValueError("d has to be larger than the largest index in the constraint.")
     return (
         torch.tensor([r[0] * d + r[1] for r in indices], dtype=torch.int64),
         coefficients,

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -203,25 +203,21 @@ def sample_q_batches_from_polytope(
     )
 
     if inter_point:
-        return (
-            get_polytope_samples(
-                n=n,
-                bounds=torch.hstack([bounds for _ in range(q)]),
-                inequality_constraints=transform_constraints(
-                    constraints=inequality_constraints, q=q, d=bounds.shape[1]
-                ),
-                equality_constraints=transform_constraints(
-                    constraints=equality_constraints, q=q, d=bounds.shape[1]
-                ),
-                seed=seed,
-                n_burnin=n_burnin,
-                thinning=thinning * q,
-            )
-            .view(n, q, -1)
-            .cpu()
+        samples = get_polytope_samples(
+            n=n,
+            bounds=torch.hstack([bounds for _ in range(q)]),
+            inequality_constraints=transform_constraints(
+                constraints=inequality_constraints, q=q, d=bounds.shape[1]
+            ),
+            equality_constraints=transform_constraints(
+                constraints=equality_constraints, q=q, d=bounds.shape[1]
+            ),
+            seed=seed,
+            n_burnin=n_burnin,
+            thinning=thinning * q,
         )
-    return (
-        get_polytope_samples(
+    else:
+        samples = get_polytope_samples(
             n=n * q,
             bounds=bounds,
             inequality_constraints=inequality_constraints,
@@ -230,9 +226,7 @@ def sample_q_batches_from_polytope(
             n_burnin=n_burnin,
             thinning=thinning,
         )
-        .view(n, q, -1)
-        .cpu()
-    )
+    return samples.view(n, q, -1).cpu()
 
 
 def gen_batch_initial_conditions(

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -149,7 +149,7 @@ def transform_inter_point_constraint(
     """
     indices, coefficients, rhs = constraint
     if indices[:, 1].max() >= d:
-        raise ValueError("d has to be larger than the largest index in the constraint.")
+        raise ValueError(f"Constraint indices cannot exceed the problem dimension {d=}.")
     return (
         torch.tensor([r[0] * d + r[1] for r in indices], dtype=torch.int64),
         coefficients,

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -159,7 +159,7 @@ def transform_inter_point_constraint(
             f"Constraint indices cannot exceed the problem dimension {d=}."
         )
     return (
-        torch.tensor([r[0] * d + r[1] for r in indices], dtype=torch.int64),
+        torch.tensor([r[0] * d + r[1] for r in indices], dtype=torch.int64, device=indices.device),
         coefficients,
         rhs,
     )

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -236,10 +236,18 @@ def gen_batch_initial_conditions(
             else:
                 X_rnd = (
                     get_polytope_samples(
-                        n=n * q,
-                        bounds=bounds,
-                        inequality_constraints=inequality_constraints,
-                        equality_constraints=equality_constraints,
+                        n=n,
+                        bounds=torch.hstack([bounds for _ in range(q)]),
+                        inequality_constraints=transform_constraints(
+                            constraints=inequality_constraints, q=q, d=bounds.shape[1]
+                        )
+                        if inequality_constraints is not None
+                        else None,
+                        equality_constraints=transform_constraints(
+                            constraints=equality_constraints, q=q, d=bounds.shape[1]
+                        )
+                        if equality_constraints is not None
+                        else None,
                         seed=seed,
                         n_burnin=options.get("n_burnin", 10000),
                         thinning=options.get("thinning", 32),

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -124,7 +124,9 @@ def transform_intra_point_constraint(
         )
     return [
         (
-            torch.tensor([i * d + j for j in indices], dtype=torch.int64, device=indices.device),
+            torch.tensor(
+                [i * d + j for j in indices], dtype=torch.int64, device=indices.device
+            ),
             coefficients,
             rhs,
         )
@@ -159,7 +161,9 @@ def transform_inter_point_constraint(
             f"Constraint indices cannot exceed the problem dimension {d=}."
         )
     return (
-        torch.tensor([r[0] * d + r[1] for r in indices], dtype=torch.int64, device=indices.device),
+        torch.tensor(
+            [r[0] * d + r[1] for r in indices], dtype=torch.int64, device=indices.device
+        ),
         coefficients,
         rhs,
     )

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -96,7 +96,7 @@ def transform_intra_point_constraint(
     constraint: Tuple[Tensor, Tensor, float], d: int, q: int
 ) -> List[Tuple[Tensor, Tensor, float]]:
     """Transforms an intra-point/pointwise constraint from
-    d-dimensional space to a d*q dimesional space.
+    d-dimensional space to a d*q-dimesional space.
 
     Args:
         constraint (Tuple[Tensor, Tensor, float]): Constraints

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -266,7 +266,7 @@ def gen_batch_initial_conditions(
                         ),
                         seed=seed,
                         n_burnin=options.get("n_burnin", 10000),
-                        thinning=options.get("thinning", 32) * q,
+                        thinning=options.get("thinning", 32 * q),
                     )
                     .view(n, q, -1)
                     .cpu()

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -66,8 +66,11 @@ TGenInitialConditions = Callable[
 def transform_constraints(
     constraints: Union[List[Tuple[Tensor, Tensor, float]], None], q: int, d: int
 ) -> List[Tuple[Tensor, Tensor, float]]:
-    """Transform constraints to sample from a d*q dimensional space instead of a
-    d dimensional state.
+    """Transform constraints to sample from a d*q-dimensional space instead of a
+    d-dimensional state.
+    
+    This function assumes that constraints are the same for each input batch,
+    and broadcasts the constraints accordingly to the input batch shape.
 
     Args:
         constraints: A list of tuples (indices, coefficients, rhs), with each tuple encoding an

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -124,7 +124,7 @@ def transform_intra_point_constraint(
         )
     return [
         (
-            torch.tensor([i * d + j for j in indices], dtype=torch.int64),
+            torch.tensor([i * d + j for j in indices], dtype=torch.int64, device=indices.device),
             coefficients,
             rhs,
         )

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -139,10 +139,11 @@ def transform_inter_point_constraint(
     d-dimensional space to a d*q dimesional space.
 
     Args:
-        constraint (Tuple[Tensor, Tensor, float]): Constraint
-            to transform.
-        d (int): Size of the q-batch.
-        q (int): Dimensionality of the problem.
+        constraints: A list of tuples (indices, coefficients, rhs), with each tuple encoding an
+            (in-)equality constraint of the form `\sum_i (X[indices[i]] * coefficients[i]) (>)= rhs`.
+            `indices` must be a 2-d Tensor, where in each row `indices[i] = (k_i, l_i)` the first index
+            `k_i` corresponds to the `k_i`-th element of the `q`-batch and the second index `l_i`
+            corresponds to the `l_i`-th feature of that element.
 
     Raises:
         ValueError: If indices in the constraints are larger than the

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -139,11 +139,12 @@ def transform_inter_point_constraint(
     d-dimensional space to a d*q dimesional space.
 
     Args:
-        constraints: A list of tuples (indices, coefficients, rhs), with each tuple encoding an
-            (in-)equality constraint of the form `\sum_i (X[indices[i]] * coefficients[i]) (>)= rhs`.
-            `indices` must be a 2-d Tensor, where in each row `indices[i] = (k_i, l_i)` the first index
-            `k_i` corresponds to the `k_i`-th element of the `q`-batch and the second index `l_i`
-            corresponds to the `l_i`-th feature of that element.
+        constraints: A list of tuples (indices, coefficients, rhs), with each tuple
+            encoding an (in-)equality constraint of the form
+            `\sum_i (X[indices[i]] * coefficients[i]) (>)= rhs`. `indices` must be a
+            2-d Tensor, where in each row `indices[i] = (k_i, l_i)` the first index
+            `k_i` corresponds to the `k_i`-th element of the `q`-batch and the second
+            index `l_i` corresponds to the `l_i`-th feature of that element.
 
     Raises:
         ValueError: If indices in the constraints are larger than the

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -68,16 +68,17 @@ def transform_constraints(
 ) -> List[Tuple[Tensor, Tensor, float]]:
     """Transform constraints to sample from a d*q-dimensional space instead of a
     d-dimensional state.
-    
+
     This function assumes that constraints are the same for each input batch,
     and broadcasts the constraints accordingly to the input batch shape.
 
     Args:
-        constraints: A list of tuples (indices, coefficients, rhs), with each tuple encoding an
-            (in-)equality constraint of the form `\sum_i (X[indices[i]] * coefficients[i]) (>)= rhs`.
-            If `indices` is a 2-d Tensor, this supports specifying constraints across the points
-            in the `q`-batch (inter-point constraints). If `None`, this function is a nullop and
-            simply returns `None`.
+        constraints: A list of tuples (indices, coefficients, rhs), with each tuple
+            encoding an (in-)equality constraint of the form
+            `\sum_i (X[indices[i]] * coefficients[i]) (>)= rhs`.
+            If `indices` is a 2-d Tensor, this supports specifying constraints across
+            the points in the `q`-batch (inter-point constraints). If `None`, this
+            function is a nullop and simply returns `None`.
         q: Size of the `q`-batch.
         d: Dimensionality of the problem.
 
@@ -102,10 +103,11 @@ def transform_intra_point_constraint(
     d-dimensional space to a d*q-dimesional space.
 
     Args:
-        constraints: A list of tuples (indices, coefficients, rhs), with each tuple encoding an
-            (in-)equality constraint of the form `\sum_i (X[indices[i]] * coefficients[i]) (>)= rhs`.
-            Here `indices` must be one-dimensional, and the constraint is applied to all points
-            within the `q`-batch.
+        constraints: A list of tuples (indices, coefficients, rhs), with each tuple
+            encoding an (in-)equality constraint of the form
+            `\sum_i (X[indices[i]] * coefficients[i]) (>)= rhs`. Here `indices` must
+            be one-dimensional, and the constraint is applied to all points within the
+            `q`-batch.
         d: Dimensionality of the problem.
 
     Raises:
@@ -117,7 +119,9 @@ def transform_intra_point_constraint(
     """
     indices, coefficients, rhs = constraint
     if indices.max() >= d:
-        raise ValueError(f"Constraint indices cannot exceed the problem dimension {d=}.")
+        raise ValueError(
+            f"Constraint indices cannot exceed the problem dimension {d=}."
+        )
     return [
         (
             torch.tensor([i * d + j for j in indices], dtype=torch.int64),
@@ -149,7 +153,9 @@ def transform_inter_point_constraint(
     """
     indices, coefficients, rhs = constraint
     if indices[:, 1].max() >= d:
-        raise ValueError(f"Constraint indices cannot exceed the problem dimension {d=}.")
+        raise ValueError(
+            f"Constraint indices cannot exceed the problem dimension {d=}."
+        )
     return (
         torch.tensor([r[0] * d + r[1] for r in indices], dtype=torch.int64),
         coefficients,

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -99,10 +99,11 @@ def transform_intra_point_constraint(
     d-dimensional space to a d*q-dimesional space.
 
     Args:
-        constraint (Tuple[Tensor, Tensor, float]): Constraints
-            to transform.
-        d (int): Size of the q-batch.
-        q (int): Dimensionality of the problem.
+        constraints: A list of tuples (indices, coefficients, rhs), with each tuple encoding an
+            (in-)equality constraint of the form `\sum_i (X[indices[i]] * coefficients[i]) (>)= rhs`.
+            Here `indices` must be one-dimensional, and the constraint is applied to all points
+            within the `q`-batch.
+        d: Dimensionality of the problem.
 
     Raises:
         ValueError: If indices in the constraints are larger than the

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -182,7 +182,7 @@ def sample_q_batches_from_polytope(
         q: Number of samples per q-batch
         bounds: A `2 x d` tensor of lower and upper bounds for each column of `X`.
         n_burnin: The number of burn-in samples for the Markov chain sampler.
-        thinning: The amount of thinning.
+        thinning: The amount of thinning (number of steps to take between returning samples).
         seed: The random seed.
         inequality constraints: A list of tuples (indices, coefficients, rhs),
             with each tuple encoding an inequality constraint of the form

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -97,6 +97,22 @@ class OptimizeAcqfInputs:
                 "bounds should be a `2 x d` tensor, current shape: "
                 f"{list(self.bounds.shape)}."
             )
+        # validate that linear constraints across the q-dim and
+        # self.sequential are not present together
+        if self.inequality_constraints is not None and self.sequential is True:
+            for constraint in self.inequality_constraints:
+                if len(constraint[0].shape) > 1:
+                    raise UnsupportedError(
+                        "Linear inequality constraints across the q-dimension are not "
+                        "supported for sequential optimization."
+                    )
+        if self.equality_constraints is not None and self.sequential is True:
+            for constraint in self.equality_constraints:
+                if len(constraint[0].shape) > 1:
+                    raise UnsupportedError(
+                        "Linear equality constraints across the q-dimension are not "
+                        "supported for sequential optimization."
+                    )
 
         # TODO: Validate constraints if provided:
         # https://github.com/pytorch/botorch/pull/1231

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -341,7 +341,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
             constraints = [
                 (
                     torch.tensor([0, 1], dtype=torch.int64, device=self.device),
-                    torch.tensor([-1.0, -1.0]).to(dtype=dtype, device=self.device),
+                    torch.tensor([-1.0, -1.0], dtype=dtype, device=self.device),
                     -1.0,
                 ),
                 (

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -307,7 +307,10 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                 torch.tensor([-1.0, -1.0], dtype=dtype),
                 0,
             )
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(
+                ValueError,
+                "d has to be larger than the largest index in the constraint.",
+            ):
                 transform_intra_point_constraint(constraint=constraint, d=3, q=2)
 
     def test_gen_batch_intial_conditions_transform_inter_point_constraint(self):
@@ -333,7 +336,10 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                 torch.tensor([1.0, -1.0], dtype=dtype, device=self.device),
                 0,
             )
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(
+                ValueError,
+                "d has to be larger than the largest index in the constraint.",
+            ):
                 transform_inter_point_constraint(constraint=constraint, d=3)
 
     def test_gen_batch_initial_conditions_transform_constraints(self):

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -28,15 +28,15 @@ from botorch.exceptions.warnings import BotorchWarning
 from botorch.models import SingleTaskGP
 from botorch.optim import initialize_q_batch, initialize_q_batch_nonneg
 from botorch.optim.initializers import (
-    transform_constraints,
-    transform_horizontal_constraint,
-    transform_vertical_constraint,
     gen_batch_initial_conditions,
     gen_one_shot_kg_initial_conditions,
     gen_value_function_initial_conditions,
     sample_perturbed_subset_dims,
     sample_points_around_best,
     sample_truncated_normal_perturbations,
+    transform_constraints,
+    transform_horizontal_constraint,
+    transform_vertical_constraint,
 )
 from botorch.sampling.normal import IIDNormalSampler
 from botorch.utils.sampling import draw_sobol_samples

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -309,7 +309,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
             )
             with self.assertRaisesRegex(
                 ValueError,
-                "d has to be larger than the largest index in the constraint.",
+                "Constraint indices cannot exceed the problem dimension d=3.",
             ):
                 transform_intra_point_constraint(constraint=constraint, d=3, q=2)
 
@@ -338,7 +338,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
             )
             with self.assertRaisesRegex(
                 ValueError,
-                "d has to be larger than the largest index in the constraint.",
+                "Constraint indices cannot exceed the problem dimension d=3.",
             ):
                 transform_inter_point_constraint(constraint=constraint, d=3)
 

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -276,8 +276,8 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
     def test_gen_batch_initial_conditions_transform_horizontal_constraint(self):
         for dtype in (torch.float, torch.double):
             constraint = (
-                torch.tensor([0, 1], dtype=torch.int64),
-                torch.tensor([-1, -1]).to(dtype=dtype),
+                torch.tensor([0, 1], dtype=torch.int64, device=self.device),
+                torch.tensor([-1, -1]).to(dtype=dtype, device=self.device),
                 -1.0,
             )
             constraints = transform_horizontal_constraint(
@@ -285,13 +285,16 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
             )
             self.assertEqual(len(constraints), 3)
             self.assertAllClose(
-                constraints[0][0], torch.tensor([0, 1], dtype=torch.int64)
+                constraints[0][0],
+                torch.tensor([0, 1], dtype=torch.int64, device=self.device),
             )
             self.assertAllClose(
-                constraints[1][0], torch.tensor([3, 4], dtype=torch.int64)
+                constraints[1][0],
+                torch.tensor([3, 4], dtype=torch.int64, device=self.device),
             )
             self.assertAllClose(
-                constraints[2][0], torch.tensor([6, 7], dtype=torch.int64)
+                constraints[2][0],
+                torch.tensor([6, 7], dtype=torch.int64, device=self.device),
             )
             for constraint in constraints:
                 self.assertAllClose(
@@ -310,20 +313,24 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
     def test_gen_batch_intial_conditions_transform_vertical_constraint(self):
         for dtype in (torch.float, torch.double):
             constraint = (
-                torch.tensor([[0, 1], [1, 1]]),
-                torch.tensor([1.0, -1.0], dtype=dtype),
+                torch.tensor([[0, 1], [1, 1]], dtype=torch.int64, device=self.device),
+                torch.tensor([1.0, -1.0], dtype=dtype, device=self.device),
                 0,
             )
             transformed = transform_vertical_constraint(constraint=constraint, d=3)
-            self.assertAllClose(transformed[0], torch.tensor([1, 4]))
             self.assertAllClose(
-                transformed[1], torch.tensor([1.0, -1.0]).to(dtype=dtype)
+                transformed[0],
+                torch.tensor([1, 4], dtype=torch.int64, device=self.device),
+            )
+            self.assertAllClose(
+                transformed[1],
+                torch.tensor([1.0, -1.0]).to(dtype=dtype, device=self.device),
             )
             self.assertEqual(constraint[2], 0.0)
             # test failure on invalid d
             constraint = (
-                torch.tensor([[0, 1], [1, 3]]),
-                torch.tensor([1.0, -1.0], dtype=dtype),
+                torch.tensor([[0, 1], [1, 3]], dtype=torch.int64, device=self.device),
+                torch.tensor([1.0, -1.0], dtype=dtype, device=self.device),
                 0,
             )
             with self.assertRaises(ValueError):
@@ -333,35 +340,45 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
         for dtype in (torch.float, torch.double):
             constraints = [
                 (
-                    torch.tensor([0, 1], dtype=torch.int64),
-                    torch.tensor([-1.0, -1.0]).to(dtype=dtype),
+                    torch.tensor([0, 1], dtype=torch.int64, device=self.device),
+                    torch.tensor([-1.0, -1.0]).to(dtype=dtype, device=self.device),
                     -1.0,
                 ),
                 (
-                    torch.tensor([[0, 1], [1, 1]]),
-                    torch.tensor([1.0, -1.0], dtype=dtype),
+                    torch.tensor(
+                        [[0, 1], [1, 1]], device=self.device, dtype=torch.int64
+                    ),
+                    torch.tensor([1.0, -1.0], dtype=dtype, device=self.device),
                     0,
                 ),
             ]
             transformed = transform_constraints(constraints=constraints, d=3, q=3)
             self.assertEqual(len(transformed), 4)
             self.assertAllClose(
-                transformed[0][0], torch.tensor([0, 1], dtype=torch.int64)
+                transformed[0][0],
+                torch.tensor([0, 1], dtype=torch.int64, device=self.device),
             )
             self.assertAllClose(
-                transformed[1][0], torch.tensor([3, 4], dtype=torch.int64)
+                transformed[1][0],
+                torch.tensor([3, 4], dtype=torch.int64, device=self.device),
             )
             self.assertAllClose(
-                transformed[2][0], torch.tensor([6, 7], dtype=torch.int64)
+                transformed[2][0],
+                torch.tensor([6, 7], dtype=torch.int64, device=self.device),
             )
             for constraint in transformed[:3]:
                 self.assertAllClose(
-                    torch.tensor([-1, -1]).to(dtype=dtype), constraint[1]
+                    torch.tensor([-1, -1], dtype=dtype, device=self.device),
+                    constraint[1],
                 )
                 self.assertEqual(constraint[2], -1.0)
-            self.assertAllClose(transformed[-1][0], torch.tensor([1, 4]))
             self.assertAllClose(
-                transformed[-1][1], torch.tensor([1.0, -1.0]).to(dtype=dtype)
+                transformed[-1][0],
+                torch.tensor([1, 4], dtype=torch.int64, device=self.device),
+            )
+            self.assertAllClose(
+                transformed[-1][1],
+                torch.tensor([1.0, -1.0], dtype=dtype, device=self.device),
             )
             self.assertEqual(transformed[-1][2], 0.0)
 
@@ -433,6 +450,77 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                             self.assertTrue(
                                 torch.all(batch_initial_conditions[..., idx] == val)
                             )
+
+    def test_gen_batch_initial_conditions_vertical_constraints(self):
+        for dtype in (torch.float, torch.double):
+            bounds = torch.tensor([[0, 0], [1, 1]], device=self.device, dtype=dtype)
+            inequality_constraints = [
+                (
+                    torch.tensor([0, 1], device=self.device, dtype=torch.int64),
+                    torch.tensor([-1, -1.0], device=self.device, dtype=dtype),
+                    torch.tensor(-1.0, device=self.device, dtype=dtype),
+                )
+            ]
+            equality_constraints = [
+                (
+                    torch.tensor(
+                        [[0, 0], [1, 0]], device=self.device, dtype=torch.int64
+                    ),
+                    torch.tensor([1.0, -1.0], device=self.device, dtype=dtype),
+                    0,
+                ),
+                (
+                    torch.tensor(
+                        [[0, 0], [2, 0]], device=self.device, dtype=torch.int64
+                    ),
+                    torch.tensor([1.0, -1.0], device=self.device, dtype=dtype),
+                    0,
+                ),
+            ]
+
+            for nonnegative, seed in product([True, False], [None, 1234]):
+                mock_acqf = MockAcquisitionFunction()
+                with mock.patch.object(
+                    MockAcquisitionFunction,
+                    "__call__",
+                    wraps=mock_acqf.__call__,
+                ):
+                    batch_initial_conditions = gen_batch_initial_conditions(
+                        acq_function=mock_acqf,
+                        bounds=bounds,
+                        q=3,
+                        num_restarts=2,
+                        raw_samples=10,
+                        options={
+                            "nonnegative": nonnegative,
+                            "eta": 0.01,
+                            "alpha": 0.1,
+                            "seed": seed,
+                            "init_batch_limit": None,
+                            "thinning": 2,
+                            "n_burnin": 3,
+                        },
+                        inequality_constraints=inequality_constraints,
+                        equality_constraints=equality_constraints,
+                    )
+                    expected_shape = torch.Size([2, 3, 2])
+                    self.assertEqual(batch_initial_conditions.shape, expected_shape)
+                    self.assertEqual(batch_initial_conditions.device, bounds.device)
+                    self.assertEqual(batch_initial_conditions.dtype, bounds.dtype)
+
+                    self.assertTrue((batch_initial_conditions.sum(dim=-1) <= 1).all())
+
+                    self.assertAllClose(
+                        batch_initial_conditions[0, 0, 0],
+                        batch_initial_conditions[0, 1, 0],
+                        batch_initial_conditions[0, 2, 0],
+                    )
+
+                    self.assertAllClose(
+                        batch_initial_conditions[1, 0, 0],
+                        batch_initial_conditions[1, 1, 0],
+                        batch_initial_conditions[1, 2, 0],
+                    )
 
     def test_error_equality_constraints_with_sample_around_best(self):
         tkwargs = {"device": self.device, "dtype": torch.double}

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -346,7 +346,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
     def test_gen_batch_initial_conditions_transform_constraints(self):
         for dtype in (torch.float, torch.double):
             # test with None
-            self.assertTrue(transform_constraints(constraints=None, d=3, q=3) is None)
+            self.assertIsNone(transform_constraints(constraints=None, d=3, q=3))
             constraints = [
                 (
                     torch.tensor([0, 1], dtype=torch.int64, device=self.device),

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -379,6 +379,51 @@ class TestOptimizeAcqf(BotorchTestCase):
                 sequential=True,
             )
 
+    def test_optimize_acqf_sequential_q_constraint_notimplemented(self):
+        # Sequential acquisition function not supported with q-constraints
+        with self.assertRaises(UnsupportedError):
+            optimize_acqf(
+                acq_function=MockAcquisitionFunction(),
+                bounds=torch.stack([torch.zeros(3), 4 * torch.ones(3)]),
+                equality_constraints=[
+                    (
+                        torch.tensor(
+                            [[0, 0], [1, 0]], device=self.device, dtype=torch.int64
+                        ),
+                        torch.tensor(
+                            [1.0, -1.0], device=self.device, dtype=torch.float64
+                        ),
+                        0,
+                    ),
+                ],
+                q=3,
+                num_restarts=2,
+                raw_samples=10,
+                return_best_only=True,
+                sequential=True,
+            )
+        with self.assertRaises(UnsupportedError):
+            optimize_acqf(
+                acq_function=MockAcquisitionFunction(),
+                bounds=torch.stack([torch.zeros(3), 4 * torch.ones(3)]),
+                inequality_constraints=[
+                    (
+                        torch.tensor(
+                            [[0, 0], [1, 0]], device=self.device, dtype=torch.int64
+                        ),
+                        torch.tensor(
+                            [1.0, -1.0], device=self.device, dtype=torch.float64
+                        ),
+                        0,
+                    ),
+                ],
+                q=3,
+                num_restarts=2,
+                raw_samples=10,
+                return_best_only=True,
+                sequential=True,
+            )
+
     def test_optimize_acqf_batch_limit(self) -> None:
         num_restarts = 3
         raw_samples = 5


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR adds polytope sampling for linear constraints along the q-dimension for acqf optimization in this case without the need for providing batch initial conditions explicitly. The provided solution is discussed in issue https://github.com/pytorch/botorch/issues/1737.

The PR is to 95% complete, but I am not sure with some naming things, so I named the two types of constraints in the method names often `horizontal` and `vertical`. I feel that there is better naming. So it would be nice if @Balandat or @saitcakmak  could just have a look and give some hints, so that I can finish it. From the functionality perspective, it should be complete.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.
