### PR TITLE
Exit publish_site.sh script on error

### DIFF
--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+set -e
+
 usage() {
   echo "Usage: $0 [-d] [-v VERSION]"
   echo ""


### PR DESCRIPTION
Adds `set -e` to the publish_site.sh script to exit the script if any command has non-zero exit code. This avoids silent failures in the automated website deployment on GHA.