### PR TITLE
Import OptimzeResult from scipy.optimize to remove DeprecationWarning

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -31,7 +31,7 @@ from botorch.optim.parameter_constraints import (
 from botorch.optim.stopping import ExpMAStoppingCriterion
 from botorch.optim.utils import _filter_kwargs, columnwise_clamp, fix_features
 from botorch.optim.utils.timeout import minimize_with_timeout
-from scipy.optimize.optimize import OptimizeResult
+from scipy.optimize import OptimizeResult
 from torch import Tensor
 from torch.optim import Optimizer
 


### PR DESCRIPTION
Getting rid of 

> /botorch/botorch/generation/gen.py:34: DeprecationWarning: Please use `OptimizeResult` from the `scipy.optimize` namespace, the `scipy.optimize.optimize` namespace is deprecated.
>   from scipy.optimize.optimize import OptimizeResult