### PR TITLE
Fix minimize test due to issue with rounding np array element

### DIFF
--- a/test/optim/utils/test_timeout.py
+++ b/test/optim/utils/test_timeout.py
@@ -30,14 +30,14 @@ class TestMinimizeWithTimeout(BotorchTestCase):
             res = minimize_with_timeout(**base_kwargs)
             self.assertTrue(res.success)
             self.assertAlmostEqual(res.fun, 0.0)
-            self.assertAlmostEqual(res.x, 0.0)
+            self.assertAlmostEqual(res.x.item(), 0.0)
             self.assertEqual(res.nit, 2)  # quadratic approx. is exact
 
         with self.subTest("test w/ non-binding timeout"):
             res = minimize_with_timeout(**base_kwargs, timeout_sec=1.0)
             self.assertTrue(res.success)
             self.assertAlmostEqual(res.fun, 0.0)
-            self.assertAlmostEqual(res.x, 0.0)
+            self.assertAlmostEqual(res.x.item(), 0.0)
             self.assertEqual(res.nit, 2)  # quadratic approx. is exact
 
         with self.subTest("test w/ binding timeout"):


### PR DESCRIPTION
When running tests locally I ran into the following error: 

self = <test.optim.utils.test_timeout.TestMinimizeWithTimeout testMethod=test_minimize_with_timeout>

    def test_minimize_with_timeout(self):
        def f_and_g(x: np.ndarray, sleep_sec: float = 0.0):
            time.sleep(sleep_sec)
            return x**2, 2 * x

        base_kwargs = {
            "fun": f_and_g,
            "x0": np.array([1.0]),
            "method": "L-BFGS-B",
            "jac": True,
            "bounds": [(-2.0, 2.0)],
        }

        with self.subTest("test w/o timeout"):
            res = minimize_with_timeout(**base_kwargs)
            self.assertTrue(res.success)
            self.assertAlmostEqual(res.fun, 0.0)
            self.assertAlmostEqual(res.x, 0.0)
            TypeError: type numpy.ndarray doesn't define __round__ method
            

This adds an `item()` to the single-element arrays to return a python `float` instead. Not sure why this doesn't fail in the CI, presumably it's a scipy/numpy versioning issue? Probably not worth digging deep here if this works both locally and on the CI. 