### PR TITLE
Allow CI to pass when uploading to artifacts fails

### DIFF
--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -90,6 +90,8 @@ jobs:
         python scripts/run_tutorials.py -p "$(pwd)"
     - if: ${{ inputs.upload_artifact }}
       name: Upload performance data to artifacts branch
+      # Sometimes pushing to this branch doesn't work -- fix planned
+      continue-on-error: true
       # 1) Switch to artifacts branch
       # 2) Add the new CSV file
       # 3) Get .py and .ipynb files needed for analyzing tutorials data from main


### PR DESCRIPTION
## Motivation

This has been failing flakily, which is annoying. This is not an ideal fix but will stop the CI from failing when uploading performance data to the artifacts branch fails. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See if it breaks again after this is landed