### PR TITLE
Re-enable vae_mnist tutorial

### DIFF
--- a/tutorials/vae_mnist.ipynb
+++ b/tutorials/vae_mnist.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "dtype = torch.double\n",
-    "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")"
+    "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\", False)"
    ]
   },
   {
@@ -73,48 +73,30 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We next instantiate the CNN for digit recognition and load a pre-trained model.\n",
-    "\n",
-    "Here, you may have to change `PRETRAINED_LOCATION` to the location of the `pretrained_models` folder on your machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'tutorials'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "os.path.basename(os.getcwd())"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_pretrained_dir():\n",
+    "def get_pretrained_dir() -> str:\n",
+    "    \"\"\"\n",
+    "    Get the directory of pretrained models, which are in the BoTorch repo.\n",
+    "\n",
+    "    Returns the location specified by PRETRAINED_LOCATION if that env\n",
+    "    var is set; otherwise checks if we are in a likely part of the BoTorch\n",
+    "    repo (botorch/botorch or botorch/tutorials) and returns the right path.\n",
+    "    \"\"\"\n",
+    "    if \"PRETRAINED_LOCATION\" in os.environ.keys():\n",
+    "        return os.environ[\"PRETRAINED_LOCATION\"]\n",
     "    cwd = os.getcwd()\n",
     "    folder = os.path.basename(cwd)\n",
-    "    # automated tests run from botorch/botorch folder\n",
+    "    # automated tests run from botorch folder\n",
     "    if folder == \"botorch\":  \n",
     "        return os.path.join(cwd, \"tutorials/pretrained_models/\")\n",
     "    # typical case (running from tutorial folder)\n",
-    "    return os.path.join(cwd, \"pretrained_models/\")"
+    "    elif folder == \"tutorials\":\n",
+    "        return os.path.join(cwd, \"pretrained_models/\")\n",
+    "    raise FileNotFoundError(\"Could not figure out location of pretrained models.\")\n"
    ]
   },
   {


### PR DESCRIPTION
Summary:
* Use PRETRAINED_LOCATION as an env var to tell where the pretrained models are if the tutorial is being run from somewhere weird


Differential Revision: D44543440

