### PR TITLE
Remove Fully Bayesian logic in low_rank

### DIFF
--- a/botorch/posteriors/fully_bayesian.py
+++ b/botorch/posteriors/fully_bayesian.py
@@ -138,6 +138,6 @@ class FullyBayesianPosterior(GPyTorchPosterior):
         candidate produces same value regardless of its position on the t-batch.
         """
         if self._is_mt:
-            return (0, -3)
-        else:
             return (0, -2)
+        else:
+            return (0, -1)

--- a/botorch/utils/low_rank.py
+++ b/botorch/utils/low_rank.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import torch
 from botorch.exceptions.errors import BotorchError
 from botorch.posteriors.base_samples import _reshape_base_samples_non_interleaved
-from botorch.posteriors.fully_bayesian import FullyBayesianPosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from gpytorch.distributions.multitask_multivariate_normal import (
     MultitaskMultivariateNormal,
@@ -62,12 +61,9 @@ def _reshape_base_samples(
     mvn = posterior.distribution
     loc = mvn.loc
     peshape = posterior._extended_shape()
-    is_fully_b = int(isinstance(posterior, FullyBayesianPosterior))
     base_samples = base_samples.view(
-        sample_shape
-        + torch.Size([1 for _ in range(loc.ndim - 1 - is_fully_b)])
-        + peshape[-2 - is_fully_b :]
-    ).expand(sample_shape + loc.shape[: -1 - is_fully_b] + peshape[-2 - is_fully_b :])
+        sample_shape + torch.Size([1] * (loc.ndim - 1)) + peshape[-2:]
+    ).expand(sample_shape + loc.shape[:-1] + peshape[-2:])
     if posterior._is_mt:
         base_samples = _reshape_base_samples_non_interleaved(
             mvn=posterior.distribution,


### PR DESCRIPTION
Changes the batch range of FullyBayesianPosterior, which effectively means that we will regard the MC batch as a t-batch for the purposes of sampling. Also remove the fully Bayesian specialty logic (previously necessary to deal with non-standard batch ranges).

Reviewed By: sdaulton

Differential Revision: D44634780

