### PR TITLE
Change batch range for FullyBayesianPosterior

### DIFF
--- a/botorch/posteriors/fully_bayesian.py
+++ b/botorch/posteriors/fully_bayesian.py
@@ -138,6 +138,6 @@ class FullyBayesianPosterior(GPyTorchPosterior):
         candidate produces same value regardless of its position on the t-batch.
         """
         if self._is_mt:
-            return (0, -3)
-        else:
             return (0, -2)
+        else:
+            return (0, -1)


### PR DESCRIPTION
Summary: Changes the batch range of FullyBayesianPosterior, which effectively means that we will regard the MC batch as a t-batch for the purposes of sampling.

Reviewed By: dme65

Differential Revision: D44599898

