### PR TITLE
Moving generic sample definition from GPyTorchPosterior to Posterior

### DIFF
--- a/botorch/posteriors/gpytorch.py
+++ b/botorch/posteriors/gpytorch.py
@@ -192,21 +192,6 @@ class GPyTorchPosterior(TorchPosterior):
             samples = samples.unsqueeze(-1)
         return samples
 
-    def sample(self, sample_shape: Optional[torch.Size] = None) -> Tensor:
-        r"""Sample from the posterior without gradients.
-
-        Args:
-            sample_shape: A `torch.Size` object specifying the sample shape. To
-                draw `n` samples, set to `torch.Size([n])`. To draw `b` batches
-                of `n` samples each, set to `torch.Size([b, n])`.
-
-        Returns:
-            Samples from the posterior, a tensor of shape
-            `self._extended_shape(sample_shape=sample_shape)`.
-        """
-        with torch.no_grad():
-            return self.rsample(sample_shape=sample_shape)
-
     @property
     def mean(self) -> Tensor:
         r"""The posterior mean."""

--- a/botorch/posteriors/posterior.py
+++ b/botorch/posteriors/posterior.py
@@ -69,6 +69,21 @@ class Posterior(ABC):
         """
         pass  # pragma: no cover
 
+    def sample(self, sample_shape: Optional[torch.Size] = None) -> Tensor:
+        r"""Sample from the posterior without gradients.
+
+        Args:
+            sample_shape: A `torch.Size` object specifying the sample shape. To
+                draw `n` samples, set to `torch.Size([n])`. To draw `b` batches
+                of `n` samples each, set to `torch.Size([b, n])`.
+
+        Returns:
+            Samples from the posterior, a tensor of shape
+            `self._extended_shape(sample_shape=sample_shape)`.
+        """
+        with torch.no_grad():
+            return self.rsample(sample_shape=sample_shape)
+
     @property
     def event_shape(self) -> torch.Size:
         r"""The event shape (i.e. the shape of a single sample)."""


### PR DESCRIPTION
Summary: This commit moves the non-differentiating `sample` method from `GPyTorchPosterior` to `Posterior`. The method is generic `sample` definition relies on `rsample`, which is already in the interface of `Posterior`. Doing this reduces Pyre warnings in Ax.

Differential Revision: D44712824

