### PR TITLE
UnstandardizePosteriorTransform test coverage

### DIFF
--- a/botorch/acquisition/multi_objective/objective.py
+++ b/botorch/acquisition/multi_objective/objective.py
@@ -309,6 +309,3 @@ class UnstandardizeAnalyticMultiOutputObjective(
             DeprecationWarning,
         )
         super().__init__(Y_mean=Y_mean, Y_std=Y_std)
-
-    def forward(self, posterior: GPyTorchPosterior) -> Tensor:
-        return self.outcome_transform.untransform_posterior(posterior)

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -291,7 +291,7 @@ class UnstandardizePosteriorTransform(PosteriorTransform):
         self.outcome_transform.eval()
 
     def evaluate(self, Y: Tensor) -> Tensor:
-        return self.outcome_transform(Y)
+        return self.outcome_transform.untransform(Y)[0]
 
     def forward(self, posterior: GPyTorchPosterior) -> Tensor:
         return self.outcome_transform.untransform_posterior(posterior)


### PR DESCRIPTION
Summary: This commit adds test coverage for `UnstandardizePosteriorTransform`'s `forward` and `evaluate`.

Differential Revision: D44772259

