### PR TITLE
SampleReducingMCAcquisitionFunction

### DIFF
--- a/botorch/acquisition/acquisition.py
+++ b/botorch/acquisition/acquisition.py
@@ -140,6 +140,14 @@ class MCSamplerMixin(ABC):
             )
         return self.sampler(posterior=posterior)
 
+    @property
+    def sample_shape(self) -> torch.Size:
+        return (
+            self.sampler.sample_shape
+            if self.sampler is not None
+            else self._default_sample_shape
+        )
+
 
 class MultiModelAcquisitionFunction(AcquisitionFunction, ABC):
     r"""Abstract base class for acquisition functions that require

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -425,7 +425,7 @@ class GenericMCObjective(MCAcquisitionObjective):
             self.objective = objective
 
     def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
-        r"""Evaluate the feasibility-weigthed objective on the samples.
+        r"""Evaluate the objective on the samples.
 
         Args:
             samples: A `sample_shape x batch_shape x q x m`-dim Tensors of
@@ -434,8 +434,7 @@ class GenericMCObjective(MCAcquisitionObjective):
                 the objective depends on the inputs explicitly.
 
         Returns:
-            A `sample_shape x batch_shape x q`-dim Tensor of objective values
-            weighted by feasibility (assuming maximization).
+            A `sample_shape x batch_shape x q`-dim Tensor of objective values.
         """
         return self.objective(samples, X=X)
 
@@ -462,6 +461,9 @@ class ConstrainedMCObjective(GenericMCObjective):
         >>> constrained_objective = ConstrainedMCObjective(objective, [constraint])
         >>> samples = sampler(posterior)
         >>> objective = constrained_objective(samples)
+
+    TODO: Deprecate this as default way to handle constraints with MC acquisition
+    functions once we have data on how well SampleReducingMCAcquisitionFunction works.
     """
 
     def __init__(

--- a/botorch/utils/objective.py
+++ b/botorch/utils/objective.py
@@ -87,20 +87,50 @@ def apply_constraints_nonnegative_soft(
     Returns:
         A `n_samples x b x q (x m')`-dim tensor of feasibility-weighted objectives.
     """
+    w = compute_smoothed_constraint_indicator(
+        constraints=constraints, samples=samples, eta=eta
+    )
+    if obj.dim() == samples.dim():
+        w = w.unsqueeze(-1)  # Need to unsqueeze to accommodate the outcome dimension.
+    return obj.clamp_min(0).mul(w)  # Enforce non-negativity of obj, apply constraints.
+
+
+def compute_smoothed_constraint_indicator(
+    constraints: List[Callable[[Tensor], Tensor]],
+    samples: Tensor,
+    eta: Union[Tensor, float],
+) -> Tensor:
+    r"""Computes the feasibility indicator of a list of constraints given posterior
+    samples, using a sigmoid to smoothly approximate the feasibility indicator
+    of each individual constraint to ensure differentiability and high gradient signal.
+
+    Args:
+        constraints: A list of callables, each mapping a Tensor of size `b x q x m`
+            to a Tensor of size `b x q`, where negative values imply feasibility.
+            This callable must support broadcasting. Only relevant for multi-
+            output models (`m` > 1).
+        samples: A `n_samples x b x q x m` Tensor of samples drawn from the posterior.
+        eta: The temperature parameter for the sigmoid function. Can be either a float
+            or a 1-dim tensor. In case of a float the same eta is used for every
+            constraint in constraints. In case of a tensor the length of the tensor
+            must match the number of provided constraints. The i-th constraint is
+            then estimated with the i-th eta value.
+
+    Returns:
+        A `n_samples x b x q`-dim tensor of feasibility indicator values.
+    """
     if type(eta) != Tensor:
         eta = torch.full((len(constraints),), eta)
     if len(eta) != len(constraints):
         raise ValueError(
             "Number of provided constraints and number of provided etas do not match."
         )
-    obj = obj.clamp_min(0)  # Enforce non-negativity with constraints
+    is_feasible = torch.ones_like(samples[..., 0])
     for constraint, e in zip(constraints, eta):
-        constraint_eval = soft_eval_constraint(constraint(samples), eta=e)
-        if obj.dim() == samples.dim():
-            # Need to unsqueeze to accommodate the outcome dimension.
-            constraint_eval = constraint_eval.unsqueeze(-1)
-        obj = obj.mul(constraint_eval)
-    return obj
+        w = soft_eval_constraint(constraint(samples), eta=e)
+        is_feasible = is_feasible.mul(w)  # TODO: add log version.
+
+    return is_feasible
 
 
 def soft_eval_constraint(lhs: Tensor, eta: float = 1e-3) -> Tensor:
@@ -158,6 +188,9 @@ def apply_constraints(
     # obj has dimensions n_samples x b x q (x m')
     obj = obj.add(infeasible_cost)  # now it is nonnegative
     obj = apply_constraints_nonnegative_soft(
-        obj=obj, constraints=constraints, samples=samples, eta=eta
+        obj=obj,
+        constraints=constraints,
+        samples=samples,
+        eta=eta,
     )
     return obj.add(-infeasible_cost)

--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -27,13 +27,19 @@ constraints, but still generate candidates subject to those constraints.
 ### Outcome Constraints
 
 In the context of Bayesian Optimization, outcome constraints usually mean
-constraints on some (black-box) outcome that needs to be modeled, just like
+constraints on a (black-box) outcome that needs to be modeled, just like
 the objective function is modeled by a surrogate model. Various approaches
-for handling these types of constraints have been proposed, a popular one that
-is also adopted by BoTorch (and available in the form of `ConstrainedMCObjective`)
-is to use variant of expected improvement in which the improvement in the objective
-is weighted by the probability of feasibility under the (modeled) outcome
-constraint ([^Gardner2014], [^Letham2017]).
+for handling these types of constraints have been proposed. A popular one that
+is also adopted by BoTorch for Monte Carlo acquistion functions is to multiply
+the acquisition utility by the feasibility indicator of the modeled outcome
+([^Gardner2014], [^Letham2017]). The approach can be utilized by passing
+`constraints` to the constructors of compatible acquisition functions,
+e.g. any `SampleReducingMCAcqquisitionFunction` with a positive acquisition utility,
+like expected improvement.
+Notably, if the constraint and objective models are statistically independent,
+the constrained expected improvement variant is mathematically equivalent to the
+unconstrained expected improvement of the objective, multiplied by the probability of
+feasibility under the modeled outcome constraint.
 
 See the [Closed-Loop Optimization](../tutorials/closed_loop_botorch_only)
 tutorial for an example of using outcome constraints in BoTorch.

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -6,6 +6,7 @@
 
 import warnings
 from copy import deepcopy
+from functools import partial
 from itertools import product
 from math import pi
 from unittest import mock
@@ -19,9 +20,12 @@ from botorch.acquisition.monte_carlo import (
     qProbabilityOfImprovement,
     qSimpleRegret,
     qUpperConfidenceBound,
+    SampleReducingMCAcquisitionFunction,
 )
 from botorch.acquisition.objective import (
+    ConstrainedMCObjective,
     GenericMCObjective,
+    IdentityMCObjective,
     PosteriorTransform,
     ScalarizedPosteriorTransform,
 )
@@ -31,10 +35,16 @@ from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.low_rank import sample_cached_cholesky
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
 from botorch.utils.transforms import standardize
+from torch import Tensor
 
 
 class DummyMCAcquisitionFunction(MCAcquisitionFunction):
     def forward(self, X):
+        pass
+
+
+class DummyReducingMCAcquisitionFunction(SampleReducingMCAcquisitionFunction):
+    def _sample_forward(self, X):
         pass
 
 
@@ -48,26 +58,40 @@ class DummyNonScalarizingPosteriorTransform(PosteriorTransform):
         pass  # pragma: no cover
 
 
+def infeasible_con(samples: Tensor) -> Tensor:
+    return torch.ones_like(samples[..., 0])
+
+
+def feasible_con(samples: Tensor) -> Tensor:
+    return -torch.ones_like(samples[..., 0])
+
+
 class TestMCAcquisitionFunction(BotorchTestCase):
     def test_abstract_raises(self):
-        with self.assertRaises(TypeError):
-            MCAcquisitionFunction()
+        for acqf_class in (MCAcquisitionFunction, SampleReducingMCAcquisitionFunction):
+            with self.assertRaises(TypeError):
+                acqf_class()
+
         # raise if model is multi-output, but no outcome transform or objective
         # are given
         no = "botorch.utils.testing.MockModel.num_outputs"
         with mock.patch(no, new_callable=mock.PropertyMock) as mock_num_outputs:
             mock_num_outputs.return_value = 2
             mm = MockModel(MockPosterior())
-            with self.assertRaises(UnsupportedError):
-                DummyMCAcquisitionFunction(model=mm)
-        # raise if model is multi-output, but outcome transform does not
-        # scalarize and no objetive is given
-        with mock.patch(no, new_callable=mock.PropertyMock) as mock_num_outputs:
-            mock_num_outputs.return_value = 2
-            mm = MockModel(MockPosterior())
-            ptf = DummyNonScalarizingPosteriorTransform()
-            with self.assertRaises(UnsupportedError):
-                DummyMCAcquisitionFunction(model=mm, posterior_transform=ptf)
+            for dummy in (
+                DummyMCAcquisitionFunction,
+                DummyReducingMCAcquisitionFunction,
+            ):
+                with self.assertRaises(UnsupportedError):
+                    dummy(model=mm)
+                # raise if model is multi-output, but outcome transform does not
+                # scalarize and no objetive is given
+                with mock.patch(no, new_callable=mock.PropertyMock) as mock_num_outputs:
+                    mock_num_outputs.return_value = 2
+                    mm = MockModel(MockPosterior())
+                    ptf = DummyNonScalarizingPosteriorTransform()
+                    with self.assertRaises(UnsupportedError):
+                        dummy(model=mm, posterior_transform=ptf)
 
 
 class TestQExpectedImprovement(BotorchTestCase):
@@ -487,7 +511,7 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
                 ) as mock_sample_cached:
                     torch.manual_seed(0)
                     val2 = acqf_no_cache(test_X2)
-                mock_sample_cached.assert_not_called()
+                    mock_sample_cached.assert_not_called()
                 self.assertAllClose(val, val2, **all_close_kwargs)
                 val2.sum().backward()
                 self.assertAllClose(X_grad, test_X2.grad, **all_close_kwargs)
@@ -522,7 +546,36 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
                 )
             )
 
-    # TODO: Test different objectives (incl. constraints)
+        # testing constraints
+        n, d, m = 8, 1, 3
+        X_baseline = torch.rand(n, d)
+        model = SingleTaskGP(X_baseline, torch.randn(n, m))  # batched model
+        nei_args = {
+            "model": model,
+            "X_baseline": X_baseline,
+            "prune_baseline": False,
+            "cache_root": True,
+            "posterior_transform": ScalarizedPosteriorTransform(weights=torch.ones(m)),
+            "sampler": SobolQMCNormalSampler(5),
+        }
+        acqf = qNoisyExpectedImprovement(**nei_args)
+        X = torch.randn_like(X_baseline)
+        for con in [feasible_con, infeasible_con]:
+            with self.subTest(con=con):
+                target = "botorch.acquisition.utils.get_infeasible_cost"
+                infcost = torch.tensor([3], device=self.device, dtype=dtype)
+                with mock.patch(target, return_value=infcost):
+                    cacqf = qNoisyExpectedImprovement(**nei_args, constraints=[con])
+
+                _, obj = cacqf._get_samples_and_objectives(X)
+                best_feas_f = cacqf.compute_best_f(obj)
+                if con is feasible_con:
+                    self.assertAllClose(best_feas_f, acqf.compute_best_f(obj))
+                else:
+                    self.assertAllClose(
+                        best_feas_f, torch.full_like(obj[..., [0]], -infcost.item())
+                    )
+        # TODO: Test different objectives (incl. constraints)
 
 
 class TestQProbabilityOfImprovement(BotorchTestCase):
@@ -863,3 +916,114 @@ class TestQUpperConfidenceBound(BotorchTestCase):
                 )
 
     # TODO: Test different objectives (incl. constraints)
+
+
+class TestMCAcquisitionFunctionWithConstraints(BotorchTestCase):
+    def test_mc_acquisition_function_with_constraints(self):
+        for dtype in (torch.float, torch.double):
+            with self.subTest(dtype=dtype):
+                num_samples, n, q, d, m = 5, 4, 1, 3, 1
+                X = torch.randn(n, q, d, device=self.device, dtype=dtype)
+                samples = torch.randn(
+                    num_samples, n, q, m, device=self.device, dtype=dtype
+                )
+                mm = MockModel(MockPosterior(samples=samples))
+                nei_args = {
+                    "model": mm,
+                    "X_baseline": X,
+                    "prune_baseline": False,
+                }
+                for acqf_constructor in [
+                    partial(qProbabilityOfImprovement, model=mm, best_f=0.0),
+                    partial(qExpectedImprovement, model=mm, best_f=0.0),
+                    # cache_root=True not supported by MockModel, see test_cache_root
+                    partial(qNoisyExpectedImprovement, cache_root=False, **nei_args),
+                    partial(qNoisyExpectedImprovement, cache_root=True, **nei_args),
+                ]:
+                    acqf = acqf_constructor()
+                    mm._posterior._samples = (
+                        torch.cat((samples, samples), dim=-2)
+                        if isinstance(acqf, qNoisyExpectedImprovement)
+                        else samples
+                    )
+                    with self.subTest(acqf_class=type(acqf)):
+                        for con in [feasible_con, infeasible_con]:
+                            cacqf = acqf_constructor(constraints=[con])
+                            # for NEI test
+                            target = "botorch.acquisition.utils.get_infeasible_cost"
+                            inf_cost = torch.tensor(3, device=self.device, dtype=dtype)
+                            with mock.patch(target, return_value=inf_cost):
+                                vals = cacqf(X)
+                            # NOTE: this is only true for q = 1
+                            expected_vals = acqf(X) * (con(samples) < 0).squeeze()
+                            self.assertAllClose(vals, expected_vals)
+
+                        with self.assertRaisesRegex(
+                            ValueError,
+                            "ConstrainedMCObjective as well as constraints passed",
+                        ):
+                            acqf_constructor(
+                                constraints=[feasible_con],
+                                objective=ConstrainedMCObjective(
+                                    objective=IdentityMCObjective,
+                                    constraints=[feasible_con],
+                                ),
+                            )
+                # Forcing negative samples, which will throw an error with simple
+                # regret because the acquisition utility is negative.
+                samples = -torch.rand(n, q, m, device=self.device, dtype=dtype)
+                mm = MockModel(MockPosterior(samples=samples))
+                cacqf = qSimpleRegret(model=mm, constraints=[feasible_con])
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "Constraint-weighting requires unconstrained "
+                    "acquisition values to be non-negative",
+                ):
+                    cacqf(X)
+
+                # Test highlighting both common and different behavior of the old
+                # `ConstrainedMCObjective` and new `constraints` implementation.
+                # 1. Highlighting difference:
+                q = 1
+                samples = torch.randn(n, q, m, device=self.device, dtype=dtype)
+                mm = MockModel(MockPosterior(samples=samples))
+                constrained_objective = ConstrainedMCObjective(
+                    objective=IdentityMCObjective(),
+                    constraints=[infeasible_con],
+                    infeasible_cost=0.0,
+                )
+                # The old `ConstrainedMCObjective`-based implementation does not scale
+                # the best_f value by the feasibility indicator, while the new
+                # `constraints`-based implementation does. Therefore, the old version
+                # yields an acquisition value of 1, even though the constraint is not
+                # satisfied.
+                best_f = -1.0
+                old_acqf = qExpectedImprovement(
+                    model=mm, best_f=best_f, objective=constrained_objective
+                )
+                new_acqf = qExpectedImprovement(
+                    model=mm, best_f=best_f, constraints=[infeasible_con]
+                )
+                old_val = old_acqf(X)
+                self.assertAllClose(old_val, torch.ones_like(old_val))
+                new_val = new_acqf(X)
+                self.assertAllClose(new_val, torch.zeros_like(new_val))
+
+                # 2. Highlighting commonality:
+                # When best_f = 0 and infeasible_cost = 0, both implementations yield
+                # the same results.
+                constrained_objective = ConstrainedMCObjective(
+                    objective=IdentityMCObjective(),
+                    constraints=[feasible_con],
+                    infeasible_cost=0.0,
+                )
+                best_f = 0.0
+                old_acqf = qExpectedImprovement(
+                    model=mm, best_f=best_f, objective=constrained_objective
+                )
+                new_acqf = qExpectedImprovement(
+                    model=mm, best_f=best_f, constraints=[feasible_con]
+                )
+                old_val = old_acqf(X)
+                new_val = new_acqf(X)
+                self.assertAllClose(new_val, old_val)

--- a/test/acquisition/test_objective.py
+++ b/test/acquisition/test_objective.py
@@ -289,9 +289,8 @@ class TestConstrainedMCObjective(BotorchTestCase):
                 objective=generic_obj, constraints=[feasible_con]
             )
             samples = torch.randn(1, device=self.device, dtype=dtype)
-            constrained_obj = generic_obj(samples)
             constrained_obj = apply_constraints(
-                obj=constrained_obj,
+                obj=generic_obj(samples),
                 constraints=[feasible_con],
                 samples=samples,
                 infeasible_cost=0.0,
@@ -302,9 +301,8 @@ class TestConstrainedMCObjective(BotorchTestCase):
                 objective=generic_obj, constraints=[infeasible_con]
             )
             samples = torch.randn(2, device=self.device, dtype=dtype)
-            constrained_obj = generic_obj(samples)
             constrained_obj = apply_constraints(
-                obj=constrained_obj,
+                obj=generic_obj(samples),
                 constraints=[infeasible_con],
                 samples=samples,
                 infeasible_cost=0.0,
@@ -315,9 +313,8 @@ class TestConstrainedMCObjective(BotorchTestCase):
                 objective=generic_obj, constraints=[feasible_con, infeasible_con]
             )
             samples = torch.randn(2, 1, device=self.device, dtype=dtype)
-            constrained_obj = generic_obj(samples)
             constrained_obj = apply_constraints(
-                obj=constrained_obj,
+                obj=generic_obj(samples),
                 constraints=[feasible_con, infeasible_con],
                 samples=samples,
                 infeasible_cost=torch.tensor([0.0], device=self.device, dtype=dtype),
@@ -329,9 +326,8 @@ class TestConstrainedMCObjective(BotorchTestCase):
                 eta=torch.tensor([1, 10]),
             )
             samples = torch.randn(2, 1, device=self.device, dtype=dtype)
-            constrained_obj = generic_obj(samples)
             constrained_obj = apply_constraints(
-                obj=constrained_obj,
+                obj=generic_obj(samples),
                 constraints=[feasible_con, infeasible_con],
                 samples=samples,
                 eta=torch.tensor([1, 10]),
@@ -345,9 +341,8 @@ class TestConstrainedMCObjective(BotorchTestCase):
                 infeasible_cost=5.0,
             )
             samples = torch.randn(3, 2, device=self.device, dtype=dtype)
-            constrained_obj = generic_obj(samples)
             constrained_obj = apply_constraints(
-                obj=constrained_obj,
+                obj=generic_obj(samples),
                 constraints=[feasible_con, infeasible_con],
                 samples=samples,
                 infeasible_cost=5.0,
@@ -361,9 +356,8 @@ class TestConstrainedMCObjective(BotorchTestCase):
                 eta=torch.tensor([1, 10]),
             )
             samples = torch.randn(3, 2, device=self.device, dtype=dtype)
-            constrained_obj = generic_obj(samples)
             constrained_obj = apply_constraints(
-                obj=constrained_obj,
+                obj=generic_obj(samples),
                 constraints=[feasible_con, infeasible_con],
                 samples=samples,
                 infeasible_cost=5.0,
@@ -377,9 +371,8 @@ class TestConstrainedMCObjective(BotorchTestCase):
                 infeasible_cost=torch.tensor([5.0], device=self.device, dtype=dtype),
             )
             samples = torch.randn(4, 3, 2, device=self.device, dtype=dtype)
-            constrained_obj = generic_obj(samples)
             constrained_obj = apply_constraints(
-                obj=constrained_obj,
+                obj=generic_obj(samples),
                 constraints=[feasible_con, infeasible_con],
                 samples=samples,
                 infeasible_cost=5.0,


### PR DESCRIPTION
Summary:
This primary purpose of this commit is to introduce `SampleReducingMCAcquisitionFunction`, which enables incorporating constraints to acquisition functions in a general and principled manner.
[See this overleaf doc](https://www.overleaf.com/read/zmkgyzcyffjs
) for context on how this differs to the current approach using `SampleReducingMCAcquisitionFunction` and why it could matter for BO performance.

In addition, the new approach leads to increased code sharing of existing `MCAcquisitionFunctions`.

Differential Revision: D43990659

