### PR TITLE
Fix warnings from acquisition function tests

### DIFF
--- a/botorch/acquisition/cached_cholesky.py
+++ b/botorch/acquisition/cached_cholesky.py
@@ -48,6 +48,16 @@ def supports_cache_root(model: Model) -> bool:
     return True
 
 
+def _get_cache_root_not_supported_message(model_cls: type) -> str:
+    msg = (
+        "`cache_root` is only supported for GPyTorchModels that "
+        "are not MultiTask models and don't produce a "
+        f"TransformedPosterior. Got a model of type {model_cls}. Setting "
+        "`cache_root = False`."
+    )
+    return msg
+
+
 class CachedCholeskyMCAcquisitionFunction(ABC):
     r"""Abstract class for acquisition functions using a cached Cholesky.
 
@@ -72,10 +82,7 @@ class CachedCholeskyMCAcquisitionFunction(ABC):
         """
         if cache_root and not supports_cache_root(model):
             warnings.warn(
-                "`cache_root` is only supported for GPyTorchModels (with "
-                "the exception of MultiTask models & models producing a "
-                f"TransformedPosterior). Got model={model}. Setting "
-                "`cache_root = False",
+                _get_cache_root_not_supported_message(type(model)),
                 RuntimeWarning,
             )
             cache_root = False

--- a/botorch/acquisition/multi_objective/max_value_entropy_search.py
+++ b/botorch/acquisition/multi_objective/max_value_entropy_search.py
@@ -114,7 +114,9 @@ class qMultiObjectiveMaxValueEntropy(
         self.model = batched_multi_output_to_single_output(
             batch_mo_model=batched_mo_model
         )
-        self.fantasies_sampler = SobolQMCNormalSampler(num_fantasies)
+        self.fantasies_sampler = SobolQMCNormalSampler(
+            sample_shape=torch.Size([num_fantasies])
+        )
         self.num_fantasies = num_fantasies
         # weight is used in _compute_information_gain
         self.maximize = True

--- a/botorch/acquisition/multi_objective/multi_output_risk_measures.py
+++ b/botorch/acquisition/multi_objective/multi_output_risk_measures.py
@@ -439,7 +439,9 @@ class MVaR(MultiOutputRiskMeasureMCObjective):
             y_grid = torch.stack(
                 [
                     torch.stack(
-                        torch.meshgrid([Y_sorted[b, :, i] for i in range(m)]),
+                        torch.meshgrid(
+                            [Y_sorted[b, :, i] for i in range(m)], indexing=None
+                        ),
                         dim=-1,
                     ).view(-1, m)
                     for b in range(batch)

--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -44,6 +44,16 @@ if TYPE_CHECKING:
     from gpytorch.likelihoods import Likelihood  # pragma: no cover
 
 
+def _get_single_precision_warning(dtype: torch.dtype) -> str:
+    msg = (
+        f"The model inputs are of type {dtype}. It is strongly recommended "
+        "to use double precision in BoTorch, as this improves both "
+        "precision and stability and can help avoid numerical errors. "
+        "See https://github.com/pytorch/botorch/discussions/1444"
+    )
+    return msg
+
+
 class GPyTorchModel(Model, ABC):
     r"""Abstract base class for models based on GPyTorch models.
 
@@ -116,13 +126,7 @@ class GPyTorchModel(Model, ABC):
             )
         if X.dtype != torch.float64:
             # NOTE: Not using a BotorchWarning since those get ignored.
-            warnings.warn(
-                f"The model inputs are of type {X.dtype}. It is strongly recommended "
-                "to use double precision in BoTorch, as this improves both "
-                "precision and stability and can help avoid numerical errors. "
-                "See https://github.com/pytorch/botorch/discussions/1444",
-                UserWarning,
-            )
+            warnings.warn(_get_single_precision_warning(X.dtype), UserWarning)
 
     @property
     def batch_shape(self) -> torch.Size:

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -549,7 +549,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
             train_noise = train_noise.detach()
 
         train_diff = self.train_targets - self.mean_module(train_x)
-        train_solve = (self.train_full_covar + train_noise).inv_matmul(
+        train_solve = (self.train_full_covar + train_noise).solve(
             train_diff.reshape(*train_diff.shape[:-2], -1)
         )
         if detach_test_caches.on():
@@ -673,7 +673,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
         # next the predictive variance, assume diagonal noise
         test_var_term = KroneckerProductLinearOperator(
             test_test_covar, task_covar
-        ).diag()
+        ).diagonal()
 
         if diagonal_noise:
             task_evals, task_evecs = self._task_covar_matrix.diagonalization()

--- a/botorch/models/utils/inducing_point_allocators.py
+++ b/botorch/models/utils/inducing_point_allocators.py
@@ -308,7 +308,7 @@ def _pivoted_cholesky_init(
     cis = torch.zeros(
         (max_length, item_size), device=kernel_matrix.device, dtype=kernel_matrix.dtype
     )
-    di2s = kernel_matrix.diag()
+    di2s = kernel_matrix.diagonal()
     scores = di2s * torch.square(quality_scores)
     selected_items = []
     selected_item = torch.argmax(scores)

--- a/botorch/posteriors/higher_order.py
+++ b/botorch/posteriors/higher_order.py
@@ -229,7 +229,7 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
 
         # K_{train, train}^{-1} (y - Y_x)
         # internally, this solve is done using Kronecker algebra and is fast.
-        kinv_rhs = self.train_train_covar.inv_matmul(train_rhs)
+        kinv_rhs = self.train_train_covar.solve(train_rhs)
         # multiply by cross-covariance
         test_updated_samples = self.test_train_covar.matmul(kinv_rhs)
 

--- a/botorch/posteriors/multitask.py
+++ b/botorch/posteriors/multitask.py
@@ -226,7 +226,7 @@ class MultitaskGPPosterior(GPyTorchPosterior):
             train_diff.reshape(*train_diff.shape[:-2], -1) - updated_obs_samples
         )
         train_covar_plus_noise = self.train_train_covar + self.train_noise
-        obs_solve = train_covar_plus_noise.inv_matmul(obs_minus_samples.unsqueeze(-1))
+        obs_solve = train_covar_plus_noise.solve(obs_minus_samples.unsqueeze(-1))
 
         # and multiply the test-observed matrix against the result of the solve
         updated_samples = self.test_train_covar.matmul(obs_solve).squeeze(-1)

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -619,6 +619,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             ],
             device=self.device,
         )
+        super().setUp()
 
     def test_q_noisy_expected_hypervolume_improvement(self):
         tkwargs = {"device": self.device}
@@ -1400,11 +1401,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                     *train_batch_shape, 3, 2, **tkwargs
                 )
                 train_Y = standardize(train_Y)
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        "ignore", message=_get_single_precision_warning(torch.float32)
-                    )
-                    model = SingleTaskGP(train_X, train_Y)
+                model = SingleTaskGP(train_X, train_Y)
                 if len(train_batch_shape) > 0:
                     X_baseline = train_X[0]
                 else:

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -36,7 +36,6 @@ from botorch.models import (
     MultiTaskGP,
 )
 from botorch.models.gp_regression import SingleTaskGP
-from botorch.models.gpytorch import _get_single_precision_warning
 from botorch.models.transforms.input import InputPerturbation
 from botorch.models.transforms.outcome import Standardize
 from botorch.posteriors.posterior_list import PosteriorList

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -12,6 +12,7 @@ from unittest import mock
 
 import torch
 from botorch import settings
+from botorch.acquisition.cached_cholesky import _get_cache_root_not_supported_message
 from botorch.acquisition.multi_objective.monte_carlo import (
     MultiObjectiveMCAcquisitionFunction,
     qExpectedHypervolumeImprovement,
@@ -35,6 +36,7 @@ from botorch.models import (
     MultiTaskGP,
 )
 from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.gpytorch import _get_single_precision_warning
 from botorch.models.transforms.input import InputPerturbation
 from botorch.models.transforms.outcome import Standardize
 from botorch.posteriors.posterior_list import PosteriorList
@@ -1364,8 +1366,8 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             "likelihood.noise_covar.raw_noise": torch.tensor(
                 [[0.0895], [0.2594]], dtype=torch.float64
             ),
-            "mean_module.constant": torch.tensor(
-                [[-0.4545], [-0.1285]], dtype=torch.float64
+            "mean_module.raw_constant": torch.tensor(
+                [-0.4545, -0.1285], dtype=torch.float64
             ),
             "covar_module.raw_outputscale": torch.tensor(
                 [1.4876, 1.4897], dtype=torch.float64
@@ -1374,6 +1376,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                 [[[-0.7202, -0.2868]], [[-0.8794, -1.2877]]], dtype=torch.float64
             ),
         }
+
         # test batched models (e.g. for MCMC)
         for train_batch_shape in (torch.Size([]), torch.Size([3])):
             if len(train_batch_shape) > 0:
@@ -1397,10 +1400,11 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                     *train_batch_shape, 3, 2, **tkwargs
                 )
                 train_Y = standardize(train_Y)
-                model = SingleTaskGP(
-                    train_X,
-                    train_Y,
-                )
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore", message=_get_single_precision_warning(torch.float32)
+                    )
+                    model = SingleTaskGP(train_X, train_Y)
                 if len(train_batch_shape) > 0:
                     X_baseline = train_X[0]
                 else:
@@ -1478,8 +1482,8 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
 
     def test_cache_root_w_standardize(self):
         # Test caching with standardize transform.
-        train_x = torch.rand(3, 2)
-        train_y = torch.randn(3, 2)
+        train_x = torch.rand(3, 2, dtype=torch.float64)
+        train_y = torch.randn(3, 2, dtype=torch.float64)
         model = SingleTaskGP(train_x, train_y, outcome_transform=Standardize(m=2))
         acqf = qNoisyExpectedHypervolumeImprovement(
             model=model,
@@ -1538,13 +1542,17 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
         for dtype, prune in ((torch.float, False), (torch.double, True)):
             tkwargs = {"device": self.device, "dtype": dtype}
             model = GenericDeterministicModel(f=lambda x: x, num_outputs=2)
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=model,
-                ref_point=torch.tensor([0.0, 0.0], **tkwargs),
-                X_baseline=torch.rand(5, 2, **tkwargs),
-                prune_baseline=prune,
-                cache_root=True,
-            )
+            with self.assertWarnsRegex(
+                RuntimeWarning,
+                _get_cache_root_not_supported_message(GenericDeterministicModel),
+            ):
+                acqf = qNoisyExpectedHypervolumeImprovement(
+                    model=model,
+                    ref_point=torch.tensor([0.0, 0.0], **tkwargs),
+                    X_baseline=torch.rand(5, 2, **tkwargs),
+                    prune_baseline=prune,
+                    cache_root=True,
+                )
             self.assertFalse(acqf._cache_root)
             self.assertEqual(
                 acqf(torch.rand(3, 2, 2, **tkwargs)).shape, torch.Size([3])
@@ -1566,7 +1574,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
         hogp_obj = GenericMCMultiOutputObjective(lambda Y, X: Y.mean(dim=-2))
         test_x = torch.rand(2, 3, 2, **tkwargs)
 
-        def get_acqf(model, matheron):
+        def get_acqf(model):
             return qNoisyExpectedHypervolumeImprovement(
                 model=model,
                 ref_point=torch.tensor([0.0, 0.0], **tkwargs),
@@ -1574,12 +1582,11 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                 sampler=IIDNormalSampler(sample_shape=torch.Size([2])),
                 objective=hogp_obj if isinstance(model, HigherOrderGP) else None,
                 prune_baseline=True,
-                cache_root=True,
+                cache_root=False,
             )
 
         for model in [mtgp, kmtgp, hogp]:
-            matheron = isinstance(model, (KroneckerMultiTaskGP, HigherOrderGP))
-            acqf = get_acqf(model, matheron)
+            acqf = get_acqf(model)
             posterior = model.posterior(acqf.X_baseline)
             base_evals = acqf.base_sampler(posterior)
             base_samples = acqf.base_sampler.base_samples

--- a/test/acquisition/multi_objective/test_objective.py
+++ b/test/acquisition/multi_objective/test_objective.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
+import warnings
 
 import torch
 from botorch.acquisition.multi_objective.multi_output_risk_measures import (
@@ -93,7 +94,12 @@ class TestFeasibilityWeightedMCMultiOutputObjective(BotorchTestCase):
             self.assertTrue(feas_obj._verify_output_shape)
 
             # With an objective.
-            dummy_obj = MultiOutputExpectation(n_w=1, weights=[2.0])
+            preprocessing_function = WeightedMCMultiOutputObjective(
+                weights=torch.tensor([2.0])
+            )
+            dummy_obj = MultiOutputExpectation(
+                n_w=1, preprocessing_function=preprocessing_function
+            )
             dummy_obj._verify_output_shape = False  # for testing
             feas_obj = FeasibilityWeightedMCMultiOutputObjective(
                 model=mm,
@@ -136,6 +142,13 @@ class TestFeasibilityWeightedMCMultiOutputObjective(BotorchTestCase):
 
 class TestUnstandardizeMultiOutputObjective(BotorchTestCase):
     def test_unstandardize_mo_objective(self):
+        warnings.filterwarnings(
+            "ignore",
+            message=(
+                "UnstandardizeAnalyticMultiOutputObjective is deprecated. "
+                "Use UnstandardizePosteriorTransform instead."
+            ),
+        )
         Y_mean = torch.ones(2)
         Y_std = torch.ones(2)
         with self.assertRaises(BotorchTensorDimensionError):

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import warnings
 from typing import List
 
 import torch
@@ -15,7 +14,7 @@ from botorch.acquisition.monte_carlo import qExpectedImprovement
 from botorch.acquisition.proximal import ProximalAcquisitionFunction
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models import ModelListGP, SingleTaskGP
-from botorch.models.gpytorch import _get_single_precision_warning, GPyTorchModel
+from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model import Model
 from botorch.models.transforms.input import Normalize
 from botorch.utils.testing import BotorchTestCase
@@ -56,15 +55,9 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                 # test with and without transformed weights
                 for transformed_weighting in [True, False]:
                     # test with single outcome model
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings(
-                            "ignore",
-                            message=_get_single_precision_warning(torch.float32),
-                        )
-
-                        model = SingleTaskGP(
-                            train_X, train_Y, input_transform=input_transform
-                        )
+                    model = SingleTaskGP(
+                        train_X, train_Y, input_transform=input_transform
+                    )
 
                     model = model.to(device=self.device, dtype=dtype).eval()
 

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List
 import warnings
+from typing import List
 
 import torch
 from botorch.acquisition import LinearMCObjective, ScalarizedPosteriorTransform
@@ -15,7 +15,7 @@ from botorch.acquisition.monte_carlo import qExpectedImprovement
 from botorch.acquisition.proximal import ProximalAcquisitionFunction
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models import ModelListGP, SingleTaskGP
-from botorch.models.gpytorch import GPyTorchModel, _get_single_precision_warning
+from botorch.models.gpytorch import _get_single_precision_warning, GPyTorchModel
 from botorch.models.model import Model
 from botorch.models.transforms.input import Normalize
 from botorch.utils.testing import BotorchTestCase

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -42,18 +42,16 @@ class NegativeAcquisitionFunction(AcquisitionFunction):
         return torch.ones(*X.shape[:-1]) * -1.0
 
 
-# TODO: parametrize
 class TestProximalAcquisitionFunction(BotorchTestCase):
     def test_proximal(self):
         for dtype in (torch.float, torch.double):
-            train_X = torch.rand(5, 3, device=self.device, dtype=dtype) * 2.0
-            train_Y = train_X.norm(dim=-1, keepdim=True)
-
             # test single point evaluation with and without input transform
             normalize = Normalize(
                 3, bounds=torch.tensor(((0.0, 0.0, 0.0), (2.0, 2.0, 2.0)))
             )
-            for input_transform in [None, normalize]:
+            for input_transform, x_scale in [(None, 1), (normalize, 2)]:
+                train_X = torch.rand(5, 3, device=self.device, dtype=dtype) * x_scale
+                train_Y = train_X.norm(dim=-1, keepdim=True)
 
                 # test with and without transformed weights
                 for transformed_weighting in [True, False]:
@@ -62,14 +60,6 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                         warnings.filterwarnings(
                             "ignore",
                             message=_get_single_precision_warning(torch.float32),
-                        )
-                        warnings.filterwarnings(
-                            "ignore",
-                            message=(
-                                "Input data is not contained to the unit cube. "
-                                "Please consider min-max scaling the input "
-                                "data.",
-                            ),
                         )
 
                         model = SingleTaskGP(

--- a/test/sampling/pathwise/test_update_strategies.py
+++ b/test/sampling/pathwise/test_update_strategies.py
@@ -26,7 +26,7 @@ from botorch.utils.context_managers import delattr_ctx
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.kernels import MaternKernel, RBFKernel, ScaleKernel
 from gpytorch.likelihoods import BernoulliLikelihood
-from gpytorch.utils.cholesky import psd_safe_cholesky
+from linear_operator.utils.cholesky import psd_safe_cholesky
 from linear_operator.operators import ZeroLinearOperator
 from torch import Size
 from torch.nn.functional import pad

--- a/test/sampling/pathwise/test_update_strategies.py
+++ b/test/sampling/pathwise/test_update_strategies.py
@@ -26,8 +26,8 @@ from botorch.utils.context_managers import delattr_ctx
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.kernels import MaternKernel, RBFKernel, ScaleKernel
 from gpytorch.likelihoods import BernoulliLikelihood
-from linear_operator.utils.cholesky import psd_safe_cholesky
 from linear_operator.operators import ZeroLinearOperator
+from linear_operator.utils.cholesky import psd_safe_cholesky
 from torch import Size
 from torch.nn.functional import pad
 


### PR DESCRIPTION
## Motivation

Lots of warnings are raised by tests. This is annoying. Also, sometimes these indicate a problem that needs to be fixed. For example, BoTorch is using some deprecated functionality.

This isn't all the warnings by any means; I fixed almost all of those stemming from test/acquisition/multi_objective and a few in test/acquisition.

* I replaced deprecated functionality with appropriate replacement
* I silenced some warnings when the test has intentionally done the thing the warning is complaining about. For example, using single precision
* Didn't do anything about numerical warnings

## Test Plan

Mostly changing tests.