### PR TITLE
Use `prune_baseline=True` as default for qNEI

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -510,7 +510,7 @@ def construct_inputs_qNEI(
     X_pending: Optional[Tensor] = None,
     sampler: Optional[MCSampler] = None,
     X_baseline: Optional[Tensor] = None,
-    prune_baseline: Optional[bool] = False,
+    prune_baseline: Optional[bool] = True,
     cache_root: Optional[bool] = True,
     **kwargs: Any,
 ) -> Dict[str, Any]:

--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -213,7 +213,7 @@ class qNoisyExpectedImprovement(
         objective: Optional[MCAcquisitionObjective] = None,
         posterior_transform: Optional[PosteriorTransform] = None,
         X_pending: Optional[Tensor] = None,
-        prune_baseline: bool = False,
+        prune_baseline: bool = True,
         cache_root: bool = True,
         **kwargs: Any,
     ) -> None:

--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -129,7 +129,7 @@ def get_acquisition_function(
             objective=objective,
             posterior_transform=posterior_transform,
             X_pending=X_pending,
-            prune_baseline=kwargs.get("prune_baseline", False),
+            prune_baseline=kwargs.get("prune_baseline", True),
             marginalize_dim=kwargs.get("marginalize_dim"),
             cache_root=kwargs.get("cache_root", True),
         )

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -396,7 +396,7 @@ class TestMCAcquisitionFunctionInputConstructors(
         self.assertIsNone(kwargs["objective"])
         self.assertIsNone(kwargs["X_pending"])
         self.assertIsNone(kwargs["sampler"])
-        self.assertFalse(kwargs["prune_baseline"])
+        self.assertTrue(kwargs["prune_baseline"])
         self.assertTrue(torch.equal(kwargs["X_baseline"], self.blockX_blockY[0].X()))
         with self.assertRaisesRegex(ValueError, "Field `X` must be shared"):
             c(model=mock_model, training_data=self.multiX_multiY)
@@ -405,13 +405,13 @@ class TestMCAcquisitionFunctionInputConstructors(
             model=mock_model,
             training_data=self.blockX_blockY,
             X_baseline=X_baseline,
-            prune_baseline=True,
+            prune_baseline=False,
         )
         self.assertEqual(kwargs["model"], mock_model)
         self.assertIsNone(kwargs["objective"])
         self.assertIsNone(kwargs["X_pending"])
         self.assertIsNone(kwargs["sampler"])
-        self.assertTrue(kwargs["prune_baseline"])
+        self.assertFalse(kwargs["prune_baseline"])
         self.assertTrue(torch.equal(kwargs["X_baseline"], X_baseline))
 
     def test_construct_inputs_qPI(self):

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -217,6 +217,7 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
                 model=mm_noisy,
                 X_baseline=X_baseline,
                 sampler=sampler,
+                prune_baseline=False,
                 cache_root=False,
             )
             res = acqf(X)
@@ -228,6 +229,7 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
                 model=mm_noisy,
                 X_baseline=X_baseline,
                 sampler=sampler,
+                prune_baseline=False,
                 cache_root=False,
             )
             res = acqf(X)
@@ -243,6 +245,7 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
                 model=mm_noisy,
                 X_baseline=X_baseline,
                 sampler=sampler,
+                prune_baseline=False,
                 cache_root=False,
             )
             res = acqf(X)
@@ -263,6 +266,7 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
                 model=mm_noisy_pending,
                 X_baseline=X_baseline,
                 sampler=sampler,
+                prune_baseline=False,
                 cache_root=False,
             )
             acqf.set_X_pending()
@@ -298,6 +302,7 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
                 model=mm_noisy,
                 X_baseline=X_baseline,
                 sampler=sampler,
+                prune_baseline=False,
                 cache_root=False,
             )
             res = acqf(X)
@@ -310,6 +315,7 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
                 model=mm_noisy,
                 X_baseline=X_baseline,
                 sampler=sampler,
+                prune_baseline=False,
                 cache_root=False,
             )
             res = acqf(X)  # 1-dim batch
@@ -334,6 +340,7 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
                 model=mm_noisy,
                 X_baseline=X_baseline,
                 sampler=sampler,
+                prune_baseline=False,
                 cache_root=False,
             )
             res = acqf(X)

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -953,7 +953,7 @@ class TestSampleAroundBest(BotorchTestCase):
             )
             # test NEI with X_baseline
             acqf = qNoisyExpectedImprovement(
-                model, X_baseline=X_train, cache_root=False
+                model, X_baseline=X_train, prune_baseline=False, cache_root=False
             )
             with mock.patch(
                 "botorch.optim.initializers.sample_perturbed_subset_dims"
@@ -975,7 +975,7 @@ class TestSampleAroundBest(BotorchTestCase):
                 )
             )
             acqf = qNoisyExpectedImprovement(
-                model, X_baseline=X_train, cache_root=False
+                model, X_baseline=X_train, prune_baseline=False, cache_root=False
             )
             X_rnd = sample_points_around_best(
                 acq_function=acqf,
@@ -1100,7 +1100,7 @@ class TestSampleAroundBest(BotorchTestCase):
             bounds[1] = 2
             # test NEI with X_baseline
             acqf = qNoisyExpectedImprovement(
-                model, X_baseline=X_train, cache_root=False
+                model, X_baseline=X_train, prune_baseline=False, cache_root=False
             )
             with mock.patch(
                 "botorch.optim.initializers.sample_perturbed_subset_dims",

--- a/test/optim/utils/test_acquisition_utils.py
+++ b/test/optim/utils/test_acquisition_utils.py
@@ -156,7 +156,7 @@ class TestGetXBaseline(BotorchTestCase):
             )
             # test NEI with X_baseline
             acqf = qNoisyExpectedImprovement(
-                model, X_baseline=X_train[:2], cache_root=False
+                model, X_baseline=X_train[:2], prune_baseline=False, cache_root=False
             )
             X = get_X_baseline(acq_function=acqf)
             self.assertTrue(torch.equal(X, acqf.X_baseline))

--- a/tutorials/meta_learning_with_rgpe.ipynb
+++ b/tutorials/meta_learning_with_rgpe.ipynb
@@ -779,6 +779,7 @@
     "            model=rgpe_model,\n",
     "            X_baseline=train_x,\n",
     "            sampler=sampler_qnei,\n",
+    "            prune_baseline=False,\n",
     "        )\n",
     "\n",
     "        # optimize\n",


### PR DESCRIPTION
Summary: Without prune baseline, we waste a lot of compute in the forward pass since we need to compute the posterior for joint q-batch over X and X_baseline.

Reviewed By: dme65, Balandat

Differential Revision: D45054740

