### PR TITLE
Add `batch_shape` property to `SingleTaskVariationalGP`

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -426,6 +426,17 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
 
         self.to(train_X)
 
+    @property
+    def batch_shape(self) -> torch.Size:
+        r"""The batch shape of the model.
+
+        This is a batch shape from an I/O perspective. For a model with `m`
+        outputs, a `test_batch_shape x q x d`-shaped input `X` to the `posterior`
+        method returns a Posterior object over an output of shape
+        `broadcast(test_batch_shape, model.batch_shape) x q x m`.
+        """
+        return self._input_batch_shape
+
     def init_inducing_points(
         self,
         inputs: Tensor,

--- a/test/models/test_approximate_gp.py
+++ b/test/models/test_approximate_gp.py
@@ -97,6 +97,8 @@ class TestSingleTaskVariationalGP(BotorchTestCase):
                 model = SingleTaskVariationalGP(tx, ty, inducing_points=tx)
                 posterior = model.posterior(test)
                 self.assertIsInstance(posterior, GPyTorchPosterior)
+                # test batch_shape property
+                self.assertEqual(model.batch_shape, tx.shape[:-2])
 
     def test_variational_setUp(self):
         for dtype in [torch.float, torch.double]:


### PR DESCRIPTION
This enables the use of `SingleTaskVariationalGP` with certain botorch features (e.g. with entropy-based acquistion functions as requested in https://github.com/pytorch/botorch/discussions/1795).

This is a bit of a band-aid, the proper thing to do here is to fix up the PR upstreaming this to gpytorch (https://github.com/cornellius-gp/gpytorch/pull/2307) to enable support for `batch_shape` on all approximate gpytorch models, and then just call that on the `model` in `ApproximateGPyTorchModel`.