### PR TITLE
Speed up composite_mtbo tutorial by running fewer trials in smoke test mode

### DIFF
--- a/tutorials/composite_mtbo.ipynb
+++ b/tutorials/composite_mtbo.ipynb
@@ -313,7 +313,7 @@
         "    n_steps = 1\n",
         "    batch_size = 2\n",
         "    num_samples = 4\n",
-        "    n_trials = 4\n",
+        "    n_trials = 2\n",
         "    verbose = False\n",
         "else:\n",
         "    n_init = 10\n",


### PR DESCRIPTION
## Motivation

This tutorial runs slowly in SMOKE_TEST mode because it runs 4 trials (compared to only 3 in non-smoke test mode).  This PR changes it to only run 2. On my laptop, this cut the runtime from 288s to 31s.

## Test Plan

Ran the tutorial
