### PR TITLE
Only do checks for `_optimize_acqf_sequential_q` when it will be used

### DIFF
--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -358,7 +358,7 @@ class TestOptimizeAcqf(BotorchTestCase):
                     q=q,
                     num_restarts=num_restarts,
                     raw_samples=raw_samples,
-                    batch_initial_conditions=mock_gen_batch_initial_conditions,
+                    batch_initial_conditions=torch.zeros((1, 1, 3)),
                     sequential=True,
                 )
 


### PR DESCRIPTION
Summary:
`optimize_acqf` calls `_optimize_acqf_sequential_q` when `sequential=True` and `q > 1`. We had been doing input validation for `_optimize_acqf_sequential` even when it was not called, in the `q=1` case. This unnecessary check became a problem when `sequential=True` became a default for MBM in https://github.com/facebook/Ax/pull/1585 , breaking Ax benchmarks.

This PR moves checks for sequential optimization to `_optimize_acqf_sequential_q`, so they will only happen if `_optimize_acqf_sequential_q` is called.

Reviewed By: saitcakmak

Differential Revision: D45324522

