### PR TITLE
JES input constructor `bounds` type annotation

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -1247,7 +1247,7 @@ def optimize_objective(
 def construct_inputs_qJES(
     model: Model,
     training_data: MaybeDict[SupervisedDataset],
-    bounds: Tensor,
+    bounds: List[Tuple[float, float]],
     num_optima: int = 64,
     maximize: bool = True,
     condition_noiseless: bool = True,


### PR DESCRIPTION
Summary: Changing type annotation for `bounds` to `List[Tuple[float, float]]`, as in the input constructors for other acquisition functions like `qKnowledgeGradient` and `qMaxValueEntropy`. Since `bounds=torch.as_tensor(bounds, dtype=dtype).T` is passed to `get_optimal_samples` this would only be correct for a `Tensor` if `bounds` was `d x 2`.

Differential Revision: D45620960

