### PR TITLE
Adding `sample_multiplier` in EUBO's acqf_input_constructor

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -1041,13 +1041,16 @@ def construct_inputs_analytic_eubo(
     model: Model,
     pref_model: Model,
     previous_winner: Optional[Tensor] = None,
+    sample_multiplier: Optional[float] = 1.0,
     **kwargs: Any,
 ) -> Dict[str, Any]:
     r"""Construct kwargs for the `AnalyticExpectedUtilityOfBestOption` constructor.
 
     Args:
         model: The outcome model to be used in the acquisition function.
-        pref_model: The preference model to be used in preference exploration
+        pref_model: The preference model to be used in preference exploration.
+        previous_winner: The previous winner of the best option.
+        sample_multiplier: The scale factor for the single-sample model.
 
     Returns:
         A dict mapping kwarg names of the constructor to values.
@@ -1055,7 +1058,8 @@ def construct_inputs_analytic_eubo(
     # construct a deterministic fixed single sample model from `model`
     # i.e., performing EUBO-zeta by default as described
     # in https://arxiv.org/abs/2203.11382
-    one_sample_outcome_model = FixedSingleSampleModel(model=model)
+    w = torch.randn(model.num_outputs) * sample_multiplier
+    one_sample_outcome_model = FixedSingleSampleModel(model=model, w=w)
 
     return {
         "pref_model": pref_model,

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -316,11 +316,14 @@ class TestAnalyticAcquisitionFunctionInputConstructors(
         mock_model.num_outputs = 3
         mock_model.train_inputs = [None]
         mock_pref_model = mock.Mock()
+
+        # test basic construction
         kwargs = c(model=mock_model, pref_model=mock_pref_model)
         self.assertTrue(isinstance(kwargs["outcome_model"], FixedSingleSampleModel))
         self.assertTrue(kwargs["pref_model"] is mock_pref_model)
         self.assertTrue(kwargs["previous_winner"] is None)
 
+        # test previous_winner
         previous_winner = torch.randn(3)
         kwargs = c(
             model=mock_model,
@@ -328,6 +331,16 @@ class TestAnalyticAcquisitionFunctionInputConstructors(
             previous_winner=previous_winner,
         )
         self.assertTrue(torch.equal(kwargs["previous_winner"], previous_winner))
+
+        # test sample_multiplier
+        torch.manual_seed(123)
+        kwargs = c(
+            model=mock_model,
+            pref_model=mock_pref_model,
+            sample_multiplier=1e6,
+        )
+        # w by default is drawn from std normal and very unlikely to be > 10.0
+        self.assertTrue((kwargs["outcome_model"].w.abs() > 10.0).all())
 
 
 class TestMCAcquisitionFunctionInputConstructors(


### PR DESCRIPTION
Summary: Adding `sample_multiplier` in  EUBO's acqf_input_constructor

Differential Revision: D45628367

