### PR TITLE
Fix buffer issue with hypercell bounds in FastPartitioning

### DIFF
--- a/botorch/utils/multi_objective/box_decompositions/box_decomposition.py
+++ b/botorch/utils/multi_objective/box_decompositions/box_decomposition.py
@@ -54,6 +54,7 @@ class BoxDecomposition(Module, ABC):
         self._neg_ref_point = -ref_point
         self.sort = torch.tensor(sort, dtype=torch.bool)
         self.num_outcomes = ref_point.shape[-1]
+        self.register_buffer("hypercell_bounds", None)
 
         if Y is not None:
             if Y.isnan().any():

--- a/botorch/utils/multi_objective/box_decompositions/dominated.py
+++ b/botorch/utils/multi_objective/box_decompositions/dominated.py
@@ -46,7 +46,7 @@ class DominatedPartitioning(FastPartitioning):
             Z=self._Z, U=self._U, ref_point=self._neg_ref_point.view(-1)
         )
         cell_bounds = -minimization_cell_bounds.flip(0)
-        self.register_buffer("hypercell_bounds", cell_bounds)
+        self.hypercell_bounds = cell_bounds
 
     def _compute_hypervolume_if_y_has_data(self) -> Tensor:
         r"""Compute hypervolume that is dominated by the Pareto Frontier.

--- a/test/utils/multi_objective/box_decompositions/test_dominated.py
+++ b/test/utils/multi_objective/box_decompositions/test_dominated.py
@@ -151,3 +151,13 @@ class TestDominatedPartitioning(BotorchTestCase):
                 torch.Size([2, 1, pareto_Y.shape[-1]]),
             )
             self.assertEqual(partitioning.compute_hypervolume().item(), 0)
+
+        # Test that updating the partitioning does not lead to a buffer error.
+        partitioning = DominatedPartitioning(
+            ref_point=torch.zeros(3), Y=-torch.ones(1, 3)
+        )
+        self.assertTrue(
+            torch.equal(partitioning.hypercell_bounds, torch.zeros(2, 1, 3))
+        )
+        partitioning.update(Y=torch.ones(1, 3))
+        self.assertEqual(partitioning.compute_hypervolume().item(), 1)


### PR DESCRIPTION
Summary:
This helps avoid errors like the following which can happen if hypercell bounds are first set as regular attributes then we attempt to register them as buffers. Setting them as buffers from the beginning should avoid this.

```
  File "/mnt/xarfuse/uid-199974/b1f6ec7b-seed-e7e3112a-f647-4904-9044-f34920839d65-ns-4026532820/ax/service/utils/best_point_mixin.py", line 472, in _get_trace
    partitioning.update(Y=Yi)
  File "/mnt/xarfuse/uid-199974/b1f6ec7b-seed-e7e3112a-f647-4904-9044-f34920839d65-ns-4026532820/botorch/utils/multi_objective/box_decompositions/box_decomposition.py", line 290, in update
    self.reset()
  File "/mnt/xarfuse/uid-199974/b1f6ec7b-seed-e7e3112a-f647-4904-9044-f34920839d65-ns-4026532820/botorch/utils/multi_objective/box_decompositions/box_decomposition.py", line 225, in reset
    self.partition_space()
  File "/mnt/xarfuse/uid-199974/b1f6ec7b-seed-e7e3112a-f647-4904-9044-f34920839d65-ns-4026532820/botorch/utils/multi_objective/box_decompositions/box_decomposition.py", line 325, in partition_space
    super().partition_space()
  File "/mnt/xarfuse/uid-199974/b1f6ec7b-seed-e7e3112a-f647-4904-9044-f34920839d65-ns-4026532820/botorch/utils/multi_objective/box_decompositions/box_decomposition.py", line 151, in partition_space
    self._partition_space()
  File "/mnt/xarfuse/uid-199974/b1f6ec7b-seed-e7e3112a-f647-4904-9044-f34920839d65-ns-4026532820/botorch/utils/multi_objective/box_decompositions/box_decomposition.py", line 363, in _partition_space
    self._get_partitioning()
  File "/mnt/xarfuse/uid-199974/b1f6ec7b-seed-e7e3112a-f647-4904-9044-f34920839d65-ns-4026532820/botorch/utils/multi_objective/box_decompositions/dominated.py", line 49, in _get_partitioning
    self.register_buffer("hypercell_bounds", cell_bounds)
  File "/mnt/xarfuse/uid-199974/b1f6ec7b-seed-e7e3112a-f647-4904-9044-f34920839d65-ns-4026532820/torch/nn/modules/module.py", line 527, in register_buffer
    raise KeyError("attribute '{}' already exists".format(name))
KeyError: "attribute 'hypercell_bounds' already exists"
```

Reviewed By: Balandat

Differential Revision: D45683232

