### PR TITLE
Make some tensors buffers in pathwise sampling code

### DIFF
--- a/botorch/sampling/pathwise/features/maps.py
+++ b/botorch/sampling/pathwise/features/maps.py
@@ -109,6 +109,8 @@ class KernelFeatureMap(FeatureMap):
         """
         super().__init__()
         self.kernel = kernel
+        self.register_buffer("weight", weight)
+        self.register_buffer("bias", bias)
         self.weight = weight
         self.bias = bias
         self.input_transform = input_transform

--- a/botorch/sampling/pathwise/paths.py
+++ b/botorch/sampling/pathwise/paths.py
@@ -174,6 +174,8 @@ class GeneralizedLinearPath(SamplePath):
         """
         super().__init__()
         self.feature_map = feature_map
+        if not isinstance(weight, Parameter):
+            self.register_buffer("weight", weight)
         self.weight = weight
         self.bias_module = bias_module
         self.input_transform = input_transform

--- a/test/sampling/pathwise/test_prior_samplers.py
+++ b/test/sampling/pathwise/test_prior_samplers.py
@@ -138,16 +138,19 @@ class TestPriorSamplers(BotorchTestCase):
         with self.subTest("test_initialization"):
             model = self.models[SingleTaskGP][0]
             sample_shape = torch.Size([16])
-            weight_generator = MagicMock()
+            expected_weight_shape = (
+                sample_shape + model.covar_module.batch_shape + (self.num_features,)
+            )
+            weight_generator = MagicMock(
+                side_effect=lambda _: torch.rand(expected_weight_shape)
+            )
             draw_kernel_feature_paths(
                 model=model,
                 sample_shape=sample_shape,
                 num_features=self.num_features,
                 weight_generator=weight_generator,
             )
-            weight_generator.assert_called_once_with(
-                sample_shape + model.covar_module.batch_shape + (self.num_features,)
-            )
+            weight_generator.assert_called_once_with(expected_weight_shape)
 
     def _test_draw_kernel_feature_paths(self, model, paths, sample_shape, atol=3):
         (train_X,) = get_train_inputs(model, transformed=False)


### PR DESCRIPTION
Fixes an issue when moving a SamplePath from GPU to GPU.

I wasn't super thorough to go through all of the code and every eventuality, but this at least makes the issue reported in https://github.com/pytorch/botorch/issues/1820 go away. 
