### PR TITLE
Fix missing secrets in website deployment

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -107,3 +107,4 @@ jobs:
     with:
       publish_versioned_website: true
       release_tag: ${{ github.event.release.tag_name }}
+    secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -119,7 +119,7 @@ jobs:
 
   publish-latest-website:
     name: Publish latest website
-    needs: [tests-and-coverage-nightly, package-test-deploy-pypi, package-conda]
+#     needs: [tests-and-coverage-nightly, package-test-deploy-pypi, package-conda]
     uses: ./.github/workflows/reusable_website.yml
     with:
       publish_versioned_website: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -119,7 +119,7 @@ jobs:
 
   publish-latest-website:
     name: Publish latest website
-#     needs: [tests-and-coverage-nightly, package-test-deploy-pypi, package-conda]
+    needs: [tests-and-coverage-nightly, package-test-deploy-pypi, package-conda]
     uses: ./.github/workflows/reusable_website.yml
     with:
       publish_versioned_website: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -123,6 +123,7 @@ jobs:
     uses: ./.github/workflows/reusable_website.yml
     with:
       publish_versioned_website: false
+    secrets: inherit
 
   run_tutorials:
     name: Run tutorials without smoke test on latest PyTorch / GPyTorch / Ax
@@ -132,4 +133,3 @@ jobs:
       use_stable_pytorch_gpytorch: false
       use_stable_ax: false
       upload_artifact: true
-    secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -132,3 +132,4 @@ jobs:
       use_stable_pytorch_gpytorch: false
       use_stable_ax: false
       upload_artifact: true
+    secrets: inherit


### PR DESCRIPTION
Website deployment didn't work when called from deploy on release or nightly workflows. This was due to missing secrets, which we now inherit from the parent workflow.

Website deployment works through nightly cron with this change: https://github.com/pytorch/botorch/actions/runs/4929215096/jobs/8808556629