### PR TITLE
Don't raise specious warning about input transforms with approximate GPs

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import copy
 import warnings
 
-from typing import Optional, Type, Union
+from typing import Optional, Type, TypeVar, Union
 
 import torch
 from botorch.models.gpytorch import GPyTorchModel
@@ -64,9 +64,13 @@ from gpytorch.variational import (
     VariationalStrategy,
 )
 from torch import Tensor
+from torch.nn import Module
 
 
 MIN_INFERRED_NOISE_LEVEL = 1e-4
+
+
+TApproxModel = TypeVar("TApproxModel", bound="ApproximateGPyTorchModel")
 
 
 class ApproximateGPyTorchModel(GPyTorchModel):
@@ -119,6 +123,19 @@ class ApproximateGPyTorchModel(GPyTorchModel):
     @property
     def num_outputs(self):
         return self._desired_num_outputs
+
+    def eval(self: TApproxModel) -> TApproxModel:
+        r"""Puts the model in `eval` mode."""
+        return Module.eval(self)
+
+    def train(self: TApproxModel, mode: bool = True) -> TApproxModel:
+        r"""Put the model in `train` mode.
+
+        Args:
+            mode: A boolean denoting whether to put in `train` or `eval` mode.
+                If `False`, model is put in `eval` mode.
+        """
+        return Module.train(self, mode=mode)
 
     def posterior(
         self, X, output_indices=None, observation_noise=False, *args, **kwargs

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -209,11 +209,12 @@ class Model(Module, ABC):
                 self.set_train_data(X_tf, strict=False)
                 self._has_transformed_inputs = True
             else:
-                raise RuntimeError(
+                warnings.warn(
                     "Could not update `train_inputs` with transformed inputs "
                     f"since {self.__class__.__name__} does not have a `train_inputs` "
                     "attribute. Make sure that the `input_transform` is applied to "
                     "both the train inputs and test inputs.",
+                    RuntimeWarning,
                 )
 
     def _revert_to_original_inputs(self) -> None:

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -209,12 +209,11 @@ class Model(Module, ABC):
                 self.set_train_data(X_tf, strict=False)
                 self._has_transformed_inputs = True
             else:
-                warnings.warn(
+                raise RuntimeError(
                     "Could not update `train_inputs` with transformed inputs "
                     f"since {self.__class__.__name__} does not have a `train_inputs` "
                     "attribute. Make sure that the `input_transform` is applied to "
                     "both the train inputs and test inputs.",
-                    RuntimeWarning,
                 )
 
     def _revert_to_original_inputs(self) -> None:


### PR DESCRIPTION
## Motivation

The BoTorch base `Model` class warns if an input transform has been provided, the `eval` method is called, and the object has no `train_inputs` attribute. This is not appropriate for `ApproximateGPyTorchModel`s; see #1824 . This PR gives `ApproximateGPyTorchModel` the `train` and `eval` modes from `torch.nn.Module`, which is the same as the methods it had been inheriting from `Model` but without the irrelevant input transform logic.

A nicer fix would be to remove the input transform logic from `Model` and have it only in subclasses that it applies to, so that subclasses like `ApproximateGPyTorchModel` would not need to do anything special to avoid inheriting that.

I think this all applies to `EnsembleModel`s as well as `ApproximateGPyTorchModel`s --looking into this now.

## Test Plan

Added a unit test to make sure transforms are applied appropriately