### PR TITLE
Update publish_site to gracefully exit if there are no changes

### DIFF
--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -144,7 +144,7 @@ if [[ $VERSION == false ]]; then
   cd botorch-gh-pages || exit
   git add .
   # Exit gracefully if there's nothing to commit.
-  [[ -z $(git diff --cached --exit-code) ]] && exit 0
+  [[ -z $(git diff --cached --exit-code) ]] && echo "Nothing to commit"; exit 0
   # Commit & push if there's something to commit.
   git commit -m 'Update latest version of site'
   git push
@@ -224,7 +224,7 @@ else
   cd botorch-gh-pages || exit
   git add --all
   # Exit gracefully if there's nothing to commit.
-  [[ -z $(git diff --cached --exit-code) ]] && exit 0
+  [[ -z $(git diff --cached --exit-code) ]] && echo "Nothing to commit"; exit 0
   # Commit & push if there's something to commit.
   git commit -m "Publish version ${VERSION} of site"
   git push

--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -143,6 +143,9 @@ if [[ $VERSION == false ]]; then
   # Push changes to gh-pages
   cd botorch-gh-pages || exit
   git add .
+  # Exit gracefully if there's nothing to commit.
+  [[ -z $(git diff --cached --exit-code) ]] && exit 0
+  # Commit & push if there's something to commit.
   git commit -m 'Update latest version of site'
   git push
 
@@ -220,6 +223,9 @@ else
   rsync -avh ./new-site/ ./botorch-gh-pages/
   cd botorch-gh-pages || exit
   git add --all
+  # Exit gracefully if there's nothing to commit.
+  [[ -z $(git diff --cached --exit-code) ]] && exit 0
+  # Commit & push if there's something to commit.
   git commit -m "Publish version ${VERSION} of site"
   git push
 


### PR DESCRIPTION
https://github.com/pytorch/botorch/actions/runs/4957898093/jobs/8870503024 failed with `nothing to commit, working tree clean` message, presumably due to `git commit ...` returning a non-zero exit code with this. This solution checks if there are changes to be committed and exists with 0 if there's nothing to commit.

The solution is adapted from https://stackoverflow.com/a/5139672