### PR TITLE
Remove cp for missing files from build_docs

### DIFF
--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -70,8 +70,6 @@ if [[ $ONLY_DOCUSAURUS == false ]]; then
 
   # move JS files from /sphinx/build/html/_static/*:
   cp "${SPHINX_JS_DIR}documentation_options.js" "${DOCUSAURUS_JS_DIR}documentation_options.js"
-  cp "${SPHINX_JS_DIR}jquery.js" "${DOCUSAURUS_JS_DIR}jquery.js"
-  cp "${SPHINX_JS_DIR}underscore.js" "${DOCUSAURUS_JS_DIR}underscore.js"
   cp "${SPHINX_JS_DIR}doctools.js" "${DOCUSAURUS_JS_DIR}doctools.js"
   cp "${SPHINX_JS_DIR}language_data.js" "${DOCUSAURUS_JS_DIR}language_data.js"
   cp "${SPHINX_JS_DIR}searchtools.js" "${DOCUSAURUS_JS_DIR}searchtools.js"


### PR DESCRIPTION
We're attempting to copy files that no longer exist (due to sphinx version changes), leading to error messages:
```
cp: cannot stat 'sphinx/build/html/_static/jquery.js': No such file or directory
cp: cannot stat 'sphinx/build/html/_static/underscore.js': No such file or directory
```
This removes those copy operations.