### PR TITLE
Refactor test function test utils

### DIFF
--- a/test/test_functions/test_multi_fidelity.py
+++ b/test/test_functions/test_multi_fidelity.py
@@ -9,10 +9,16 @@ from botorch.test_functions.multi_fidelity import (
     AugmentedHartmann,
     AugmentedRosenbrock,
 )
-from botorch.utils.testing import BotorchTestCase, SyntheticTestFunctionBaseTestCase
+from botorch.utils.testing import (
+    BaseTestProblemTestCaseMixIn,
+    BotorchTestCase,
+    SyntheticTestFunctionTestCaseMixin,
+)
 
 
-class TestAugmentedBranin(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestAugmentedBranin(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         AugmentedBranin(),
@@ -21,7 +27,9 @@ class TestAugmentedBranin(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
     ]
 
 
-class TestAugmentedHartmann(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestAugmentedHartmann(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         AugmentedHartmann(),
@@ -30,7 +38,9 @@ class TestAugmentedHartmann(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
     ]
 
 
-class TestAugmentedRosenbrock(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestAugmentedRosenbrock(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         AugmentedRosenbrock(),

--- a/test/test_functions/test_multi_objective.py
+++ b/test/test_functions/test_multi_objective.py
@@ -40,9 +40,10 @@ from botorch.test_functions.multi_objective import (
     ZDT3,
 )
 from botorch.utils.testing import (
+    BaseTestProblemTestCaseMixIn,
     BotorchTestCase,
-    ConstrainedMultiObjectiveTestProblemBaseTestCase,
-    MultiObjectiveTestProblemBaseTestCase,
+    ConstrainedTestProblemTestCaseMixin,
+    MultiObjectiveTestProblemTestCaseMixin,
 )
 
 
@@ -74,7 +75,11 @@ class TestBaseTestMultiObjectiveProblem(BotorchTestCase):
                     f.gen_pareto_front(1)
 
 
-class TestBraninCurrin(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
+class TestBraninCurrin(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+):
     functions = [BraninCurrin()]
 
     def test_init(self):
@@ -83,7 +88,11 @@ class TestBraninCurrin(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
             self.assertEqual(f.dim, 2)
 
 
-class TestDH(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
+class TestDH(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+):
     functions = [DH1(dim=2), DH2(dim=3), DH3(dim=4), DH4(dim=5)]
     dims = [2, 3, 4, 5]
     bounds = [
@@ -118,7 +127,11 @@ class TestDH(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
             self.assertAllClose(actual, expected)
 
 
-class TestDTLZ(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
+class TestDTLZ(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+):
     functions = [
         DTLZ1(dim=5, num_objectives=2),
         DTLZ2(dim=5, num_objectives=2),
@@ -180,7 +193,11 @@ class TestDTLZ(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
                             )
 
 
-class TestGMM(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
+class TestGMM(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+):
     functions = [GMM(num_objectives=4)]
 
     def test_init(self):
@@ -226,7 +243,12 @@ class TestGMM(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
             )
 
 
-class TestMW7(ConstrainedMultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
+class TestMW7(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+    ConstrainedTestProblemTestCaseMixin,
+):
     functions = [MW7(dim=3)]
 
     def test_init(self):
@@ -237,7 +259,11 @@ class TestMW7(ConstrainedMultiObjectiveTestProblemBaseTestCase, BotorchTestCase)
             self.assertEqual(f.dim, 3)
 
 
-class TestZDT(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
+class TestZDT(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+):
     functions = [
         ZDT1(dim=3, num_objectives=2),
         ZDT2(dim=3, num_objectives=2),
@@ -304,27 +330,119 @@ class TestZDT(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
                         )
 
 
-class TestMultiObjectiveProblems(
-    MultiObjectiveTestProblemBaseTestCase, BotorchTestCase
+# ------------------ Unconstrained Multi-objective test problems ------------------ #
+
+
+class TestCarSideImpact(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
 ):
-    functions = [CarSideImpact(), Penicillin(), ToyRobust(), VehicleSafety()]
+
+    functions = [CarSideImpact()]
 
 
-class TestConstrainedMultiObjectiveProblems(
-    ConstrainedMultiObjectiveTestProblemBaseTestCase, BotorchTestCase
+class TestPenicillin(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+):
+    functions = [Penicillin()]
+
+
+class TestToyRobust(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+):
+    functions = [ToyRobust()]
+
+
+class TestVehicleSafety(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+):
+    functions = [VehicleSafety()]
+
+
+# ------------------ Constrained Multi-objective test problems ------------------ #
+
+
+class TestBNH(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+    ConstrainedTestProblemTestCaseMixin,
+):
+    functions = [BNH()]
+
+
+class TestSRN(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+    ConstrainedTestProblemTestCaseMixin,
+):
+    functions = [SRN()]
+
+
+class TestCONSTR(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+    ConstrainedTestProblemTestCaseMixin,
+):
+    functions = [CONSTR()]
+
+
+class TestConstrainedBraninCurrin(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+    ConstrainedTestProblemTestCaseMixin,
 ):
     functions = [
-        BNH(),
-        SRN(),
-        CONSTR(),
         ConstrainedBraninCurrin(),
-        C2DTLZ2(dim=3, num_objectives=2),
-        DiscBrake(),
-        WeldedBeam(),
-        OSY(),
     ]
 
-    def test_c2dtlz2_batch_exception(self):
+
+class TestC2DTLZ2(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+    ConstrainedTestProblemTestCaseMixin,
+):
+    functions = [C2DTLZ2(dim=3, num_objectives=2)]
+
+    def test_batch_exception(self):
         f = C2DTLZ2(dim=3, num_objectives=2)
         with self.assertRaises(NotImplementedError):
             f.evaluate_slack_true(torch.empty(1, 1, 3))
+
+
+class TestDiscBrake(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+    ConstrainedTestProblemTestCaseMixin,
+):
+    functions = [DiscBrake()]
+
+
+class TestWeldedBeam(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+    ConstrainedTestProblemTestCaseMixin,
+):
+    functions = [WeldedBeam()]
+
+
+class TestOSY(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+    ConstrainedTestProblemTestCaseMixin,
+):
+    functions = [OSY()]

--- a/test/test_functions/test_multi_objective_multi_fidelity.py
+++ b/test/test_functions/test_multi_objective_multi_fidelity.py
@@ -8,10 +8,18 @@ from botorch.test_functions.multi_objective_multi_fidelity import (
     MOMFBraninCurrin,
     MOMFPark,
 )
-from botorch.utils.testing import BotorchTestCase, MultiObjectiveTestProblemBaseTestCase
+from botorch.utils.testing import (
+    BaseTestProblemTestCaseMixIn,
+    BotorchTestCase,
+    MultiObjectiveTestProblemTestCaseMixin,
+)
 
 
-class TestMOMFBraninCurrin(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
+class TestMOMFBraninCurrin(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+):
     functions = [MOMFBraninCurrin()]
     bounds = [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
 
@@ -24,7 +32,11 @@ class TestMOMFBraninCurrin(MultiObjectiveTestProblemBaseTestCase, BotorchTestCas
             )
 
 
-class TestMOMFPark(MultiObjectiveTestProblemBaseTestCase, BotorchTestCase):
+class TestMOMFPark(
+    BotorchTestCase,
+    BaseTestProblemTestCaseMixIn,
+    MultiObjectiveTestProblemTestCaseMixin,
+):
     functions = [MOMFPark()]
     bounds = [[0.0, 0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0, 1.0]]
 

--- a/test/test_functions/test_synthetic.py
+++ b/test/test_functions/test_synthetic.py
@@ -29,7 +29,11 @@ from botorch.test_functions.synthetic import (
     SyntheticTestFunction,
     ThreeHumpCamel,
 )
-from botorch.utils.testing import BotorchTestCase, SyntheticTestFunctionBaseTestCase
+from botorch.utils.testing import (
+    BaseTestProblemTestCaseMixIn,
+    BotorchTestCase,
+    SyntheticTestFunctionTestCaseMixin,
+)
 from torch import Tensor
 
 
@@ -46,7 +50,7 @@ class DummySyntheticTestFunctionWithOptimizers(DummySyntheticTestFunction):
     _optimizers = [(0, 0)]
 
 
-class TestSyntheticTestFunction(BotorchTestCase):
+class TestCustomBounds(BotorchTestCase):
     functions_with_custom_bounds = [  # Function name and the default dimension.
         (Ackley, 2),
         (Beale, 2),
@@ -100,37 +104,51 @@ class TestSyntheticTestFunction(BotorchTestCase):
             self.assertTrue(torch.allclose(func.bounds, bounds_tensor))
 
 
-class TestAckley(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestAckley(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [Ackley(), Ackley(negate=True), Ackley(noise_std=0.1), Ackley(dim=3)]
 
 
-class TestBeale(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestBeale(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [Beale(), Beale(negate=True), Beale(noise_std=0.1)]
 
 
-class TestBranin(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestBranin(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [Branin(), Branin(negate=True), Branin(noise_std=0.1)]
 
 
-class TestBukin(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestBukin(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [Bukin(), Bukin(negate=True), Bukin(noise_std=0.1)]
 
 
-class TestCosine8(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestCosine8(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [Cosine8(), Cosine8(negate=True), Cosine8(noise_std=0.1)]
 
 
-class TestDropWave(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestDropWave(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [DropWave(), DropWave(negate=True), DropWave(noise_std=0.1)]
 
 
-class TestDixonPrice(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestDixonPrice(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         DixonPrice(),
@@ -140,12 +158,16 @@ class TestDixonPrice(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
     ]
 
 
-class TestEggHolder(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestEggHolder(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [EggHolder(), EggHolder(negate=True), EggHolder(noise_std=0.1)]
 
 
-class TestGriewank(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestGriewank(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         Griewank(),
@@ -155,7 +177,9 @@ class TestGriewank(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
     ]
 
 
-class TestHartmann(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestHartmann(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         Hartmann(),
@@ -174,12 +198,16 @@ class TestHartmann(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
             Hartmann(dim=2)
 
 
-class TestHolderTable(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestHolderTable(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [HolderTable(), HolderTable(negate=True), HolderTable(noise_std=0.1)]
 
 
-class TestLevy(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestLevy(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         Levy(),
@@ -191,7 +219,9 @@ class TestLevy(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
     ]
 
 
-class TestMichalewicz(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestMichalewicz(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         Michalewicz(),
@@ -206,12 +236,16 @@ class TestMichalewicz(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
     ]
 
 
-class TestPowell(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestPowell(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [Powell(), Powell(negate=True), Powell(noise_std=0.1)]
 
 
-class TestRastrigin(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestRastrigin(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         Rastrigin(),
@@ -223,7 +257,9 @@ class TestRastrigin(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
     ]
 
 
-class TestRosenbrock(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestRosenbrock(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         Rosenbrock(),
@@ -235,17 +271,23 @@ class TestRosenbrock(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
     ]
 
 
-class TestShekel(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestShekel(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [Shekel(), Shekel(negate=True), Shekel(noise_std=0.1)]
 
 
-class TestSixHumpCamel(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestSixHumpCamel(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [SixHumpCamel(), SixHumpCamel(negate=True), SixHumpCamel(noise_std=0.1)]
 
 
-class TestStyblinskiTang(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestStyblinskiTang(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         StyblinskiTang(),
@@ -257,7 +299,9 @@ class TestStyblinskiTang(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
     ]
 
 
-class TestThreeHumpCamel(SyntheticTestFunctionBaseTestCase, BotorchTestCase):
+class TestThreeHumpCamel(
+    BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
+):
 
     functions = [
         ThreeHumpCamel(),


### PR DESCRIPTION
Summary:
Refactors the test utils for botorch test functions to make things more modular.

Instead of subclassing the base test cases, we now have class Mixins for synthetic, constrained, and multi-objective problems. This means we can mix-and-match the test case as needed.

Further, `BaseTestProblemTestCase` now subclasses `BotorchTestCase` so that we don't need to subclass from `BotorchTestCase` separately for every test.

Finally, this flattens the `TestMultiObjectiveProblems` and `TestConstrainedMultiObjectiveProblems` test collections (the idea behind the test design is that we have separate test cases for each problem (potentially with different arguments) to better identify and group the tests, so this reestablishes that.

Differential Revision: D45969036

