### PR TITLE
Fix codecov coverage

### DIFF
--- a/botorch/optim/utils/numpy_utils.py
+++ b/botorch/optim/utils/numpy_utils.py
@@ -159,10 +159,10 @@ def get_bounds_as_ndarray(
             lower, upper = bounds[name]
             lower = -inf if lower is None else lower
             upper = inf if upper is None else upper
-            if isinstance(lower, Tensor) and lower.device.type == "cuda":
-                lower = lower.cpu()  # pragma: no cover
-            if isinstance(upper, Tensor) and upper.device.type == "cuda":
-                upper = upper.cpu()  # pragma: no cover
+            if isinstance(lower, Tensor):
+                lower = lower.cpu()
+            if isinstance(upper, Tensor):
+                upper = upper.cpu()
             out[index : index + size, 0] = lower
             out[index : index + size, 1] = upper
         index = index + size

--- a/botorch/optim/utils/numpy_utils.py
+++ b/botorch/optim/utils/numpy_utils.py
@@ -160,9 +160,9 @@ def get_bounds_as_ndarray(
             lower = -inf if lower is None else lower
             upper = inf if upper is None else upper
             if isinstance(lower, Tensor) and lower.device.type == "cuda":
-                lower = lower.cpu()
+                lower = lower.cpu()  # pragma: no cover
             if isinstance(upper, Tensor) and upper.device.type == "cuda":
-                upper = upper.cpu()
+                upper = upper.cpu()  # pragma: no cover
             out[index : index + size, 0] = lower
             out[index : index + size, 1] = upper
         index = index + size


### PR DESCRIPTION
We measure the test coverage based on a CPU-only run of the test suite. These two lines were only executed for GPU tensors. Removing the condition will allow them to be executed always.