### PR TITLE
Run the cleanup steps when publish site exits with no changes

### DIFF
--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -236,5 +236,6 @@ else
 fi
 
 # Clean up
+echo "Cleaning up temporary directories."
 cd "${SCRIPT_DIR}" || exit
 rm -rf "${WORK_DIR}"

--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -143,12 +143,14 @@ if [[ $VERSION == false ]]; then
   # Push changes to gh-pages
   cd botorch-gh-pages || exit
   git add .
-  # Exit gracefully if there's nothing to commit.
-  [[ -z $(git diff --cached --exit-code) ]] && echo "Nothing to commit"; exit 0
-  # Commit & push if there's something to commit.
-  git commit -m 'Update latest version of site'
-  git push
-
+  if [[ -z $(git diff --cached --exit-code) ]]; then
+    # Exit gracefully if there's nothing to commit.
+    echo "Nothing to commit"
+  else
+    # Commit & push if there's something to commit.
+    git commit -m 'Update latest version of site'
+    git push
+  fi
 else
   echo "-----------------------------------------"
   echo "Building new version ($VERSION) of site "
@@ -223,12 +225,14 @@ else
   rsync -avh ./new-site/ ./botorch-gh-pages/
   cd botorch-gh-pages || exit
   git add --all
-  # Exit gracefully if there's nothing to commit.
-  [[ -z $(git diff --cached --exit-code) ]] && echo "Nothing to commit"; exit 0
-  # Commit & push if there's something to commit.
-  git commit -m "Publish version ${VERSION} of site"
-  git push
-
+  if [[ -z $(git diff --cached --exit-code) ]]; then
+    # Exit gracefully if there's nothing to commit.
+    echo "Nothing to commit"
+  else
+    # Commit & push if there's something to commit.
+    git commit -m "Publish version ${VERSION} of site"
+    git push
+  fi
 fi
 
 # Clean up


### PR DESCRIPTION
This is a follow up to https://github.com/pytorch/botorch/pull/1830. The current setup doesn't perform the cleanup steps if we exit with nothing to commit.

Test: https://github.com/pytorch/botorch/actions/runs/5135512160/jobs/9241030759
![Screenshot 2023-05-31 at 9 53 34 AM](https://github.com/pytorch/botorch/assets/9263852/c8869c67-90a7-4b28-b365-5b9edd0f8bcb)

