### PR TITLE
Remove special error handling for indices of wrong dtype in constraints

### DIFF
--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -793,24 +793,10 @@ def get_polytope_samples(
     """
     # create tensors representing linear inequality constraints
     # of the form Ax >= b.
-    # TODO: remove this error handling functionality in a few releases.
-    # Context: BoTorch inadvertently supported indices with unusual dtypes.
-    # This is now not supported.
-    index_dtype_error = (
-        "Normalizing {var_name} failed. Check that the first "
-        "element of {var_name} is the correct dtype following "
-        "the previous IndexError."
-    )
     if inequality_constraints:
         # normalize_linear_constraints is called to solve this issue:
         # https://github.com/pytorch/botorch/issues/1225
-        try:
-            # non-standard dtypes used to be supported for indices in constraints;
-            # this is no longer true
-            constraints = normalize_linear_constraints(bounds, inequality_constraints)
-        except IndexError as e:
-            msg = index_dtype_error.format(var_name="`inequality_constraints`")
-            raise ValueError(msg) from e
+        constraints = normalize_linear_constraints(bounds, inequality_constraints)
 
         A, b = sparse_to_dense_constraints(
             d=bounds.shape[-1],
@@ -823,16 +809,7 @@ def get_polytope_samples(
     else:
         dense_inequality_constraints = None
     if equality_constraints:
-        try:
-            # non-standard dtypes used to be supported for indices in constraints;
-            # this is no longer true
-            constraints = normalize_linear_constraints(bounds, equality_constraints)
-        except IndexError as e:
-            msg = index_dtype_error.format(var_name="`equality_constraints`")
-            raise ValueError(msg) from e
-
-        # normalize_linear_constraints is called to solve this issue:
-        # https://github.com/pytorch/botorch/issues/1225
+        constraints = normalize_linear_constraints(bounds, equality_constraints)
         dense_equality_constraints = sparse_to_dense_constraints(
             d=bounds.shape[-1], constraints=constraints
         )

--- a/test/utils/test_sampling.py
+++ b/test/utils/test_sampling.py
@@ -222,64 +222,6 @@ class TestSampleUtils(BotorchTestCase):
         x = find_interior_point(A=A, b=b)
         self.assertAlmostEqual(x.item(), 5.0, places=4)
 
-    def test_get_polytope_samples_wrong_inequality_constraints_dtype(self):
-        for dtype in (torch.float, torch.double):
-            with self.subTest(dtype=dtype):
-                tkwargs = {"device": self.device, "dtype": dtype}
-                bounds = torch.zeros(2, 4, **tkwargs)
-                inequality_constraints = [
-                    (
-                        torch.tensor([3], dtype=torch.float, device=self.device),
-                        torch.tensor([-4], **tkwargs),
-                        -3,
-                    )
-                ]
-
-                msg = (
-                    "Normalizing `inequality_constraints` failed. Check that the first "
-                    "element of `inequality_constraints` is the correct dtype following"
-                    " the previous IndexError."
-                )
-                msg_orig = "tensors used as indices must be long, byte or bool tensors"
-
-                with self.assertRaisesRegex(ValueError, msg), self.assertRaisesRegex(
-                    IndexError, msg_orig
-                ):
-                    get_polytope_samples(
-                        n=5,
-                        bounds=bounds,
-                        inequality_constraints=inequality_constraints,
-                    )
-
-    def test_get_polytope_samples_wrong_equality_constraints_dtype(self):
-        for dtype in (torch.float, torch.double):
-            with self.subTest(dtype=dtype):
-                tkwargs = {"device": self.device, "dtype": dtype}
-                bounds = torch.zeros(2, 4, **tkwargs)
-
-                equality_constraints = [
-                    (
-                        torch.tensor([0], dtype=torch.float, device=self.device),
-                        torch.tensor([1], **tkwargs),
-                        0.5,
-                    )
-                ]
-                msg = (
-                    "Normalizing `equality_constraints` failed. Check that the first "
-                    "element of `equality_constraints` is the correct dtype following "
-                    "the previous IndexError."
-                )
-                msg_orig = "tensors used as indices must be long, byte or bool tensors"
-
-                with self.assertRaisesRegex(ValueError, msg), self.assertRaisesRegex(
-                    IndexError, msg_orig
-                ):
-                    get_polytope_samples(
-                        n=5,
-                        bounds=bounds,
-                        equality_constraints=equality_constraints,
-                    )
-
     def test_get_polytope_samples(self):
         tkwargs = {"device": self.device}
         for dtype in (torch.float, torch.double):


### PR DESCRIPTION
Summary:
- BoTorch used to accommodate indices of non-int dtypes in `get_polytope_samples`
- Last year we introduced a minor break to backward compatibilty by not allowing non-integer indices, and added some fancy error handling to explain what has gone wrong in case someone did try to pass non-int indices. We wrote a TODO that this should be removed in a few releases, so that a regular old IndexError will be raised
- this PR removes the fancy error handling, as planned

Differential Revision: D46331239

