### PR TITLE
Change how ModelListGP.posterior evaluates sub-models

### DIFF
--- a/botorch/acquisition/joint_entropy_search.py
+++ b/botorch/acquisition/joint_entropy_search.py
@@ -139,9 +139,9 @@ class qJointEntropySearch(AcquisitionFunction, MCSamplerMixin):
             warnings.filterwarnings("ignore")
             with fantasize_flag():
                 with settings.propagate_grads(False):
-                    # We must do a forward pass one before conditioning
+                    # We must do a forward pass one before conditioning.
                     self.initial_model.posterior(
-                        self.model.train_inputs[0], observation_noise=False
+                        self.optimal_inputs[:1], observation_noise=False
                     )
 
                 # This equates to the JES version proposed by Hvarfner et. al.

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -509,12 +509,14 @@ class TestModelListGPyTorchModel(BotorchTestCase):
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertEqual(posterior.mean.shape, torch.Size([2, 2]))
             posterior = model.posterior(
-                test_X, observation_noise=torch.rand(2, **tkwargs)
+                test_X, observation_noise=torch.rand(2, 2, **tkwargs)
             )
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertEqual(posterior.mean.shape, torch.Size([2, 2]))
             posterior = model.posterior(
-                test_X, output_indices=[0], observation_noise=torch.rand(2, **tkwargs)
+                test_X,
+                output_indices=[0],
+                observation_noise=torch.rand(2, 2, **tkwargs),
             )
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertEqual(posterior.mean.shape, torch.Size([2, 1]))


### PR DESCRIPTION
Summary:
Prior to this change, `ModelListGP.posterior` would call it's submodels directly and work with the returned MVNs, skipping any processing in the individual `posterior` methods. This was particularly consequential for the `MultiTaskGP` (and subclasses) where skipping the `posterior` meant changing the expected shape of the `X` required by the `posterior`.

With this change, `ModelListGP.posterior` evaluates the `posterior` methods for each of its submodels, and combines the MVNs into a single MVN where applicable. For `MultiTaskGP`, this makes it so that the `posterior` can be evaluated using the same inputs regardless of whether the mdoel is wrapped in a `ModelListGP` or not.

Differential Revision: D46364187

