### PR TITLE
Change the inheritance order of ModelListGPyTorchModel

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -527,7 +527,7 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
         return new_model
 
 
-class ModelListGPyTorchModel(GPyTorchModel, ModelList, ABC):
+class ModelListGPyTorchModel(ModelList, GPyTorchModel, ABC):
     r"""Abstract base class for models based on multi-output GPyTorch models.
 
     This is meant to be used with a gpytorch ModelList wrapper for independent

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -6,7 +6,7 @@
 
 
 import itertools
-from typing import Optional, List
+from typing import List, Optional
 
 import torch
 from botorch import fit_fully_bayesian_model_nuts

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -430,6 +430,9 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
         train_X, train_Y, train_Yvar, model = self._get_data_and_model(
             task_rank=1, **tkwargs
         )
+        # Make the model single-output.
+        model._output_tasks = [0]
+        model._num_outputs = 1
         fit_fully_bayesian_model_nuts(
             model, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
         )


### PR DESCRIPTION
A bunch of tests are currently failing as a result of https://github.com/cornellius-gp/gpytorch/pull/2360 removing `num_outputs` from `IndependentModelList`. This change lead to `ModelListGP.num_outputs` pointing to `GPyTorchModel.num_outputs`, which requires the model to define a `_num_outputs`. The correct behavior for `ModelListGP` is to use `ModelList.num_outputs`, which can be achieved by changing the inheritance order.