### PR TITLE
Don't allow unused **kwargs in input_constructors except for a defined set of exceptions

### DIFF
--- a/botorch/acquisition/joint_entropy_search.py
+++ b/botorch/acquisition/joint_entropy_search.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import warnings
 from math import log, pi
 
-from typing import Any, Optional
+from typing import Optional
 
 import torch
 from botorch import settings
@@ -78,7 +78,6 @@ class qJointEntropySearch(AcquisitionFunction, MCSamplerMixin):
         estimation_type: str = "LB",
         maximize: bool = True,
         num_samples: int = 64,
-        **kwargs: Any,
     ) -> None:
         r"""Joint entropy search acquisition function.
 

--- a/botorch/acquisition/knowledge_gradient.py
+++ b/botorch/acquisition/knowledge_gradient.py
@@ -74,7 +74,6 @@ class qKnowledgeGradient(MCAcquisitionFunction, OneShotAcquisitionFunction):
         inner_sampler: Optional[MCSampler] = None,
         X_pending: Optional[Tensor] = None,
         current_value: Optional[Tensor] = None,
-        **kwargs: Any,
     ) -> None:
         r"""q-Knowledge Gradient (one-shot optimization).
 
@@ -330,7 +329,6 @@ class qMultiFidelityKnowledgeGradient(qKnowledgeGradient):
         expand: Callable[[Tensor], Tensor] = lambda X: X,
         valfunc_cls: Optional[Type[AcquisitionFunction]] = None,
         valfunc_argfac: Optional[Callable[[Model], Dict[str, Any]]] = None,
-        **kwargs: Any,
     ) -> None:
         r"""Multi-Fidelity q-Knowledge Gradient (one-shot optimization).
 

--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -326,7 +326,6 @@ class qMaxValueEntropy(DiscreteMaxValueBase, MCSamplerMixin):
         maximize: bool = True,
         X_pending: Optional[Tensor] = None,
         train_inputs: Optional[Tensor] = None,
-        **kwargs: Any,
     ) -> None:
         r"""Single-outcome max-value entropy search acquisition function.
 
@@ -697,7 +696,6 @@ class qMultiFidelityMaxValueEntropy(qMaxValueEntropy):
         cost_aware_utility: Optional[CostAwareUtility] = None,
         project: Callable[[Tensor], Tensor] = lambda X: X,
         expand: Callable[[Tensor], Tensor] = lambda X: X,
-        **kwargs: Any,
     ) -> None:
         r"""Single-outcome max-value entropy search acquisition function.
 

--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -24,7 +24,7 @@ import math
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from functools import partial
-from typing import Any, Callable, List, Optional, Protocol, Tuple, Union
+from typing import Callable, List, Optional, Protocol, Tuple, Union
 
 import torch
 from botorch.acquisition.acquisition import AcquisitionFunction, MCSamplerMixin
@@ -351,7 +351,6 @@ class qExpectedImprovement(SampleReducingMCAcquisitionFunction):
         X_pending: Optional[Tensor] = None,
         constraints: Optional[List[Callable[[Tensor], Tensor]]] = None,
         eta: Union[Tensor, float] = 1e-3,
-        **kwargs: Any,
     ) -> None:
         r"""q-Expected Improvement.
 
@@ -434,7 +433,7 @@ class qNoisyExpectedImprovement(
         cache_root: bool = True,
         constraints: Optional[List[Callable[[Tensor], Tensor]]] = None,
         eta: Union[Tensor, float] = 1e-3,
-        **kwargs: Any,
+        marginalize_dim: Optional[int] = None,
     ) -> None:
         r"""q-Noisy Expected Improvement.
 
@@ -469,6 +468,7 @@ class qNoisyExpectedImprovement(
             eta: Temperature parameter(s) governing the smoothness of the sigmoid
                 approximation to the constraint indicators. For more details, on this
                 parameter, see the docs of `compute_smoothed_feasibility_indicator`.
+            marginalize_dim: The dimension to marginalize over.
 
         TODO: similar to qNEHVI, when we are using sequential greedy candidate
         selection, we could incorporate pending points X_baseline and compute
@@ -491,7 +491,7 @@ class qNoisyExpectedImprovement(
                 X=X_baseline,
                 objective=objective,
                 posterior_transform=posterior_transform,
-                marginalize_dim=kwargs.get("marginalize_dim"),
+                marginalize_dim=marginalize_dim,
             )
         self.register_buffer("X_baseline", X_baseline)
         # registering buffers for _get_samples_and_objectives in the next `if` block

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -27,7 +27,7 @@ import warnings
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from itertools import combinations
-from typing import Any, Callable, List, Optional, Union
+from typing import Callable, List, Optional, Union
 
 import torch
 from botorch.acquisition.acquisition import AcquisitionFunction, MCSamplerMixin
@@ -373,7 +373,7 @@ class qNoisyExpectedHypervolumeImprovement(
         max_iep: int = 0,
         incremental_nehvi: bool = True,
         cache_root: bool = True,
-        **kwargs: Any,
+        marginalize_dim: Optional[int] = None,
     ) -> None:
         r"""q-Noisy Expected Hypervolume Improvement supporting m>=2 outcomes.
 
@@ -466,7 +466,7 @@ class qNoisyExpectedHypervolumeImprovement(
                 objective=objective,
                 constraints=constraints,
                 ref_point=ref_point,
-                marginalize_dim=kwargs.get("marginalize_dim"),
+                marginalize_dim=marginalize_dim,
             )
         self.register_buffer("ref_point", ref_point)
         self.alpha = alpha

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -14,6 +14,9 @@ from botorch.acquisition.multi_objective import (
     MCMultiOutputObjective,
     monte_carlo as moo_monte_carlo,
 )
+from botorch.acquisition.multi_objective.monte_carlo import (
+    qExpectedHypervolumeImprovement,
+)
 from botorch.acquisition.objective import (
     GenericMCObjective,
     MCAcquisitionObjective,
@@ -640,8 +643,11 @@ class TestGetAcquisitionFunction(BotorchTestCase):
         self.assertEqual(sampler.seed, 2)
         self.assertTrue(torch.equal(kwargs["X_pending"], self.X_pending))
 
-    @mock.patch(f"{moo_monte_carlo.__name__}.qExpectedHypervolumeImprovement")
-    def test_GetQEHVI(self, mock_acqf):
+    @mock.patch(
+        f"{moo_monte_carlo.__name__}.qExpectedHypervolumeImprovement",
+        wraps=qExpectedHypervolumeImprovement,
+    )
+    def test_GetQEHVI(self, mock_acqf) -> None:
         # make sure ref_point is specified
         with self.assertRaises(ValueError):
             acqf = get_acquisition_function(
@@ -690,7 +696,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
             ref_point=self.ref_point,
             Y=self.Y,
         )
-        self.assertEqual(acqf, mock_acqf.return_value)
+        self.assertIsInstance(acqf, qExpectedHypervolumeImprovement)
         mock_acqf.assert_called_once_with(
             constraints=None,
             eta=1e-3,


### PR DESCRIPTION
Summary:
[x] Remove unused arguments from input constructors and related functions. The idea is especially not to let unused keyword arguments disappear into `**kwargs` and be silently ignored
[x] add arguments to some input constructors so they don't need any `**kwargs`
[x] Add a decorator that ensures that each input constructor can accept a certain set of keyword arguments, even if those are not used are the constructor, while still erroring on
[ ] Prevent arguments from having different defaults in the input constructors as in acquisition functions

Reviewed By: SebastianAment

Differential Revision: D46519588

