### PR TITLE
Set `gaGtag` to true in website siteConfig.js

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -35,6 +35,9 @@ const siteConfig = {
   // Google analytics
   gaTrackingId: 'G-CXN3PGE3CC',
 
+  // Use global site tags (gtag.js) to be compatible with Google Analytics 4
+  gaGtag: true,
+
   // links that will be used in the header navigation bar
   headerLinks: [
     {doc: 'introduction', label: 'Docs'},


### PR DESCRIPTION
With Google Analytics 4 we need to use Google Tag Manager, so this should be required now.