### PR TITLE
Fix warning in `test_normalize`

### DIFF
--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -603,7 +603,7 @@ class Normalize(AffineInputTransform):
         r"""Get the arguments necessary to construct an exact copy of the transform."""
         return {
             "d": self._d,
-            "indices": getattr(self, "indices", None),
+            "indices": list(self.indices) if hasattr(self, "indices") else  None,
             "bounds": self.bounds,
             "batch_shape": self.batch_shape,
             "transform_on_train": self.transform_on_train,

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -501,7 +501,7 @@ class Normalize(AffineInputTransform):
     def __init__(
         self,
         d: int,
-        indices: Optional[List[int]] = None,
+        indices: Optional[Union[List[int], Tensor]] = None,
         bounds: Optional[Tensor] = None,
         batch_shape: torch.Size = torch.Size(),  # noqa: B008
         transform_on_train: bool = True,
@@ -629,7 +629,7 @@ class InputStandardize(AffineInputTransform):
     def __init__(
         self,
         d: int,
-        indices: Optional[List[int]] = None,
+        indices: Optional[Union[List[int], Tensor]] = None,
         batch_shape: torch.Size = torch.Size(),  # noqa: B008
         transform_on_train: bool = True,
         transform_on_eval: bool = True,

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -603,7 +603,7 @@ class Normalize(AffineInputTransform):
         r"""Get the arguments necessary to construct an exact copy of the transform."""
         return {
             "d": self._d,
-            "indices": list(self.indices) if hasattr(self, "indices") else  None,
+            "indices": list(self.indices) if hasattr(self, "indices") else None,
             "bounds": self.bounds,
             "batch_shape": self.batch_shape,
             "transform_on_train": self.transform_on_train,

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -360,7 +360,9 @@ class AffineInputTransform(ReversibleInputTransform, Module):
         if (indices is not None) and (len(indices) == 0):
             raise ValueError("`indices` list is empty!")
         if (indices is not None) and (len(indices) > 0):
-            indices = torch.as_tensor(indices, dtype=torch.long, device=coefficient.device)
+            indices = torch.as_tensor(
+                indices, dtype=torch.long, device=coefficient.device
+            )
             if len(indices) > d:
                 raise ValueError("Can provide at most `d` indices!")
             if (indices > d - 1).any():


### PR DESCRIPTION
Return the proper type of `indices` in `get_init_args()` for `Normalize`. This would cause the following warning: 

```
botorch/models/transforms/input.py:362: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
    indices = torch.tensor(indices, dtype=torch.long)
```