### PR TITLE
Raise ValueError when m<2 in qNoisyExpectedHypervolumeImprovement

### DIFF
--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -442,6 +442,11 @@ class qNoisyExpectedHypervolumeImprovement(
             cache_root: A boolean indicating whether to cache the root
                 decomposition over `X_baseline` and use low-rank updates.
         """
+        if len(ref_point) < 2:
+            raise ValueError(
+                "qNoisyExpectedHypervolumeImprovement supports m>=2 outcomes "
+                f"but ref_point has length {len(ref_point)}, which is smaller than 2."
+            )
         ref_point = torch.as_tensor(
             ref_point, dtype=X_baseline.dtype, device=X_baseline.device
         )

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -624,7 +624,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
         tkwargs = {"device": self.device}
         for dtype, m in product(
             (torch.float, torch.double),
-            (2, 3),
+            (1, 2, 3),
         ):
             tkwargs["dtype"] = dtype
             ref_point = self.ref_point[:m]
@@ -641,6 +641,19 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             X = torch.zeros(1, 1, **tkwargs)
             # basic test
             sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+
+            # test error is raised if m == 1
+            if m == 1:
+                with self.assertRaises(ValueError):
+                    acqf = qNoisyExpectedHypervolumeImprovement(
+                        model=mm,
+                        ref_point=ref_point,
+                        X_baseline=X_baseline,
+                        sampler=sampler,
+                        cache_root=False,
+                    )
+                continue
+
             acqf = qNoisyExpectedHypervolumeImprovement(
                 model=mm,
                 ref_point=ref_point,

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -644,7 +644,10 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
 
             # test error is raised if m == 1
             if m == 1:
-                with self.assertRaises(ValueError):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "qNoisyExpectedHypervolumeImprovement supports m>=2 outcomes "
+                ):
                     acqf = qNoisyExpectedHypervolumeImprovement(
                         model=mm,
                         ref_point=ref_point,

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -646,7 +646,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             if m == 1:
                 with self.assertRaisesRegex(
                     ValueError,
-                    "qNoisyExpectedHypervolumeImprovement supports m>=2 outcomes "
+                    "qNoisyExpectedHypervolumeImprovement supports m>=2 outcomes ",
                 ):
                     acqf = qNoisyExpectedHypervolumeImprovement(
                         model=mm,


### PR DESCRIPTION
Raise more informative message when qNoistyExpectedHypervolumeImprovement cannot handle single objective input as discussed in #1880 