### PR TITLE
Adding `get_monotonicity_constraints`

### DIFF
--- a/test/utils/probability/test_lin_ess.py
+++ b/test/utils/probability/test_lin_ess.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 import torch
 from botorch.exceptions.errors import BotorchError
+from botorch.utils.constraints import get_monotonicity_constraints
 from botorch.utils.probability.lin_ess import LinearEllipticalSliceSampler
 from botorch.utils.testing import BotorchTestCase
 from torch import Tensor
@@ -414,15 +415,9 @@ class TestLinearEllipticalSliceSampler(BotorchTestCase):
                 )
 
             # high dimensional test case
+            # Encodes order constraints on all d variables: Ax < b <-> x[i] < x[i + 1]
             d = 128
-            # this encodes order constraints on all d variables: Ax < b
-            # x[i] < x[i + 1]
-            A = torch.zeros(d - 1, d, **tkwargs)
-            for i in range(d - 1):
-                A[i, i] = 1
-                A[i, i + 1] = -1
-            b = torch.zeros(d - 1, 1, **tkwargs)
-
+            A, b = get_monotonicity_constraints(d=d, **tkwargs)
             interior_point = torch.arange(d, **tkwargs).unsqueeze(-1) / d - 1 / 2
             sampler = LinearEllipticalSliceSampler(
                 inequality_constraints=(A, b),

--- a/test/utils/probability/test_lin_ess.py
+++ b/test/utils/probability/test_lin_ess.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import itertools
+
 import math
 
 from unittest.mock import patch
@@ -14,6 +16,7 @@ import torch
 from botorch.exceptions.errors import BotorchError
 from botorch.utils.probability.lin_ess import LinearEllipticalSliceSampler
 from botorch.utils.testing import BotorchTestCase
+from torch import Tensor
 
 
 class TestLinearEllipticalSliceSampler(BotorchTestCase):
@@ -162,8 +165,8 @@ class TestLinearEllipticalSliceSampler(BotorchTestCase):
             self.assertFalse(torch.equal(sampler._x, sampler.x0))
 
     def test_multivariate(self):
-        for dtype in (torch.float, torch.double):
-            d = 3
+        for dtype, atol in zip((torch.float, torch.double), (1e-6, 1e-12)):
+            d = 5
             tkwargs = {"device": self.device, "dtype": dtype}
             # special case: N(0, I) truncated to greater than lower_bound
             A = -torch.eye(d, **tkwargs)
@@ -207,30 +210,58 @@ class TestLinearEllipticalSliceSampler(BotorchTestCase):
             # normalizing to maximal unit variance so that sem math below applies
             cov_matrix /= cov_matrix.max()
             interior_point = torch.ones_like(mean)
-            for mean_i, cov_i in [
+            means_and_covs = [
                 (None, None),
                 (mean, None),
                 (None, cov_matrix),
                 (mean, cov_matrix),
-            ]:
-                with self.subTest(mean=mean_i, cov=cov_i):
+            ]
+            fixed_indices = [None, [1, 3]]
+            for (mean_i, cov_i), ff_i in itertools.product(
+                means_and_covs,
+                fixed_indices,
+            ):
+                with self.subTest(mean=mean_i, cov=cov_i, fixed_indices=ff_i):
                     sampler = LinearEllipticalSliceSampler(
                         inequality_constraints=(A, b),
                         interior_point=interior_point,
                         check_feasibility=True,
                         mean=mean_i,
                         covariance_matrix=cov_i,
+                        fixed_indices=ff_i,
                     )
                     # checking standardized system of constraints
-                    mean_i = torch.zeros_like(mean) if mean_i is None else mean_i
-                    cov_root_i = (
-                        torch.eye(d, **tkwargs)
-                        if cov_i is None
-                        else torch.linalg.cholesky_ex(cov_i)[0]
-                    )
-                    self.assertAllClose(sampler._Az, A @ cov_root_i)
-                    self.assertAllClose(sampler._bz, b - A @ mean_i)
+                    mean_i = torch.zeros(d, 1, **tkwargs) if mean_i is None else mean_i
+                    cov_i = torch.eye(d, **tkwargs) if cov_i is None else cov_i
 
+                    # Transform the system to incorporate equality constraints and non-
+                    # standard mean and covariance.
+                    Az_i, bz_i = A, b
+                    if ff_i is None:
+                        is_fixed = []
+                        not_fixed = range(d)
+                    else:
+                        is_fixed = sampler._is_fixed
+                        not_fixed = sampler._not_fixed
+                        self.assertIsInstance(is_fixed, Tensor)
+                        self.assertIsInstance(not_fixed, Tensor)
+                        self.assertEqual(is_fixed.shape, (len(ff_i),))
+                        self.assertEqual(not_fixed.shape, (d - len(ff_i),))
+                        self.assertTrue(all(i in ff_i for i in is_fixed))
+                        self.assertFalse(any(i in ff_i for i in not_fixed))
+                        # Modifications to constraint system
+                        Az_i = A[:, not_fixed]
+                        bz_i = b - A[:, is_fixed] @ interior_point[is_fixed]
+                        mean_i = mean_i[not_fixed]
+                        cov_i = cov_i[not_fixed.unsqueeze(-1), not_fixed.unsqueeze(0)]
+
+                    cov_root_i = torch.linalg.cholesky_ex(cov_i)[0]
+                    bz_i = bz_i - Az_i @ mean_i
+                    Az_i = Az_i @ cov_root_i
+                    self.assertAllClose(sampler._Az, Az_i, atol=atol)
+                    self.assertAllClose(sampler._bz, bz_i, atol=atol)
+
+                    # testing standardization of non-fixed elements
                     x = torch.randn_like(mean_i)
                     z = sampler._standardize(x)
                     self.assertAllClose(
@@ -238,8 +269,22 @@ class TestLinearEllipticalSliceSampler(BotorchTestCase):
                         torch.linalg.solve_triangular(
                             cov_root_i, x - mean_i, upper=False
                         ),
+                        atol=atol,
                     )
-                    self.assertAllClose(sampler._unstandardize(z), x)
+                    self.assertAllClose(sampler._unstandardize(z), x, atol=atol)
+
+                    # testing transformation
+                    x = torch.randn(d, 1, **tkwargs)
+                    x[is_fixed] = interior_point[is_fixed]  # fixed dimensions
+                    z = sampler._transform(x)
+                    self.assertAllClose(
+                        z,
+                        torch.linalg.solve_triangular(
+                            cov_root_i, x[not_fixed] - mean_i, upper=False
+                        ),
+                        atol=atol,
+                    )
+                    self.assertAllClose(sampler._untransform(z), x, atol=atol)
 
                     # checking rejection-free property
                     num_samples = 32
@@ -252,22 +297,27 @@ class TestLinearEllipticalSliceSampler(BotorchTestCase):
                     # of 5 sigma is 1 in 1.76 million.
                     # sem ~ 0.7 -> can differentiate from zero mean
                     sem = 5 / math.sqrt(num_samples)
-                    sample_mean = samples.mean(dim=0)
-                    self.assertAllClose(sample_mean, mean_i.squeeze(-1), atol=sem)
+                    sample_mean = samples.mean(dim=0).unsqueeze(-1)
+                    self.assertAllClose(sample_mean[not_fixed], mean_i, atol=sem)
+                    # testing the samples have correctly fixed features
+                    self.assertTrue(
+                        torch.equal(sample_mean[is_fixed], interior_point[is_fixed])
+                    )
 
-                    # checking that standardization does not change feasibility values
+                    # checking that transformation does not change feasibility values
                     X_test = 3 * torch.randn(d, num_samples, **tkwargs)
+                    X_test[is_fixed] = interior_point[is_fixed]
                     self.assertAllClose(
-                        sampler._Az @ sampler._standardize(X_test) - sampler._bz,
+                        sampler._Az @ sampler._transform(X_test) - sampler._bz,
                         A @ X_test - b,
-                        atol=1e-5,
+                        atol=atol,
                     )
                     self.assertAllClose(
                         sampler._is_feasible(
-                            sampler._standardize(X_test), standardized=True
+                            sampler._transform(X_test), transformed=True
                         ),
-                        sampler._is_feasible(X_test, standardized=False),
-                        atol=1e-5,
+                        sampler._is_feasible(X_test, transformed=False),
+                        atol=atol,
                     )
 
             # thining and burn-in tests
@@ -311,7 +361,7 @@ class TestLinearEllipticalSliceSampler(BotorchTestCase):
             rot_angle, slices = sampler._find_rotated_intersections(nu)
             self.assertEqual(rot_angle, 0.0)
             self.assertAllClose(
-                slices, torch.tensor([[0.0, 2 * torch.pi]], **tkwargs), atol=1e-6
+                slices, torch.tensor([[0.0, 2 * torch.pi]], **tkwargs), atol=atol
             )
 
             # 2) testing tangential intersection of ellipse with constraint
@@ -341,6 +391,27 @@ class TestLinearEllipticalSliceSampler(BotorchTestCase):
                         RuntimeError, "Sampling resulted in infeasible point"
                     ):
                         sampler.step()
+
+            # testing error for fixed features with no interior point
+            with self.assertRaisesRegex(
+                ValueError,
+                ".*an interior point must also be provided in order to infer feasible ",
+            ):
+                LinearEllipticalSliceSampler(
+                    inequality_constraints=(A, b),
+                    fixed_indices=[0],
+                )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "Provide either covariance_root or fixed_indices, not both.",
+            ):
+                LinearEllipticalSliceSampler(
+                    inequality_constraints=(A, b),
+                    interior_point=interior_point,
+                    fixed_indices=[0],
+                    covariance_root=torch.eye(d, **tkwargs),
+                )
 
             # high dimensional test case
             d = 128

--- a/test/utils/test_constraints.py
+++ b/test/utils/test_constraints.py
@@ -6,10 +6,11 @@
 
 import torch
 from botorch.utils import get_outcome_constraint_transforms
+from botorch.utils.constraints import get_monotonicity_constraints
 from botorch.utils.testing import BotorchTestCase
 
 
-class TestGetOutcomeConstraintTransform(BotorchTestCase):
+class TestConstraintUtils(BotorchTestCase):
     def setUp(self):
         super().setUp()
         self.A = torch.tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
@@ -17,28 +18,65 @@ class TestGetOutcomeConstraintTransform(BotorchTestCase):
         self.Ys = torch.tensor([[0.75, 1.0, 0.5], [0.25, 1.5, 1.0]]).unsqueeze(0)
         self.results = torch.tensor([[-0.25, 0.5], [0.25, 1.5]]).view(1, 2, 2)
 
-    def test_None(self):
+    def test_get_outcome_constraint_transforms(self):
+        # test None
         self.assertIsNone(get_outcome_constraint_transforms(None))
 
-    def test_BasicEvaluation(self):
+        # test basic evaluation
         for dtype in (torch.float, torch.double):
-            A = self.A.to(dtype=dtype, device=self.device)
-            b = self.b.to(dtype=dtype, device=self.device)
-            Ys = self.Ys.to(dtype=dtype, device=self.device)
-            results = self.results.to(dtype=dtype, device=self.device)
+            tkwargs = {"dtype": dtype, "device": self.device}
+            A = self.A.to(**tkwargs)
+            b = self.b.to(**tkwargs)
+            Ys = self.Ys.to(**tkwargs)
+            results = self.results.to(**tkwargs)
             ocs = get_outcome_constraint_transforms((A, b))
             self.assertEqual(len(ocs), 2)
             for i in (0, 1):
                 for j in (0, 1):
                     self.assertTrue(torch.equal(ocs[j](Ys[:, i]), results[:, i, j]))
 
-    def test_BroadcastEvaluation(self):
-        k, t = 3, 4
-        mc_samples, b, q = 6, 4, 5
-        for dtype in (torch.float, torch.double):
-            A_ = torch.randn(k, t, dtype=dtype, device=self.device)
-            b_ = torch.randn(k, 1, dtype=dtype, device=self.device)
-            Y = torch.randn(mc_samples, b, q, t, dtype=dtype, device=self.device)
+            # test broadcasted evaluation
+            k, t = 3, 4
+            mc_samples, b, q = 6, 4, 5
+            A_ = torch.randn(k, t, **tkwargs)
+            b_ = torch.randn(k, 1, **tkwargs)
+            Y = torch.randn(mc_samples, b, q, t, **tkwargs)
             ocs = get_outcome_constraint_transforms((A_, b_))
             self.assertEqual(len(ocs), k)
             self.assertEqual(ocs[0](Y).shape, torch.Size([mc_samples, b, q]))
+
+    def test_get_monotonicity_constraints(self):
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"dtype": dtype, "device": self.device}
+            for d in (3, 17):
+                with self.subTest(dtype=dtype, d=d):
+                    A, b = get_monotonicity_constraints(d, **tkwargs)
+                    self.assertEqual(A.shape, (d - 1, d))
+                    self.assertEqual(A.dtype, dtype)
+                    self.assertEqual(A.device.type, self.device.type)
+
+                    self.assertEqual(b.shape, (d - 1, 1))
+                    self.assertEqual(b.dtype, dtype)
+                    self.assertEqual(b.device.type, self.device.type)
+
+                    unique_vals = torch.tensor([-1, 0, 1], **tkwargs)
+                    self.assertAllClose(A.unique(), unique_vals)
+                    self.assertAllClose(b, torch.zeros_like(b))
+                    self.assertTrue(
+                        torch.equal(A.sum(dim=-1), torch.zeros(d - 1, **tkwargs))
+                    )
+
+                    n_test = 3
+                    X_test = torch.randn(d, n_test, **tkwargs)
+
+                    X_diff_true = -X_test.diff(dim=0)  # x[i] - x[i+1] < 0
+                    X_diff = A @ X_test
+                    self.assertAllClose(X_diff, X_diff_true)
+
+                    is_monotonic_true = (X_diff_true < 0).all(dim=0)
+                    is_monotonic = (X_diff < b).all(dim=0)
+                    self.assertAllClose(is_monotonic, is_monotonic_true)
+
+                    Ad, bd = get_monotonicity_constraints(d, descending=True, **tkwargs)
+                    self.assertAllClose(Ad, -A)
+                    self.assertAllClose(bd, b)


### PR DESCRIPTION
Summary: This commit separates out a `get_monotonicity_constraints` helper function that returns a system of linear inequalities that encodes the monotonicity of a `d`-dimensional tensor.

Differential Revision: D46707577

