### PR TITLE
GPyTorch module constructors

### DIFF
--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -38,11 +38,11 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple
 import pyro
 import torch
 from botorch.acquisition.objective import PosteriorTransform
-from botorch.models.gp_regression import MIN_INFERRED_NOISE_LEVEL
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
 from botorch.models.utils import validate_input_scaling
+from botorch.models.utils.gpytorch_modules import MIN_INFERRED_NOISE_LEVEL
 from botorch.posteriors.fully_bayesian import FullyBayesianPosterior, MCMC_DIM
 from gpytorch.constraints import GreaterThan
 from gpytorch.distributions.multivariate_normal import MultivariateNormal

--- a/botorch/models/utils/gpytorch_modules.py
+++ b/botorch/models/utils/gpytorch_modules.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+from gpytorch.constraints.constraints import GreaterThan
+from gpytorch.kernels import MaternKernel, ScaleKernel
+from gpytorch.likelihoods.gaussian_likelihood import GaussianLikelihood
+from gpytorch.priors.torch_priors import GammaPrior
+
+MIN_INFERRED_NOISE_LEVEL = 1e-4
+
+
+def get_matern_kernel_with_gamma_prior(
+    ard_num_dims: int, batch_shape: Optional[torch.Size] = None
+) -> ScaleKernel:
+    r"""Constructs the Scale-Matern kernel that is used by default by
+    several models. This uses a Gamma(3.0, 6.0) prior for the lengthscale
+    and a Gamma(2.0, 0.15) prior for the output scale.
+    """
+    return ScaleKernel(
+        base_kernel=MaternKernel(
+            nu=2.5,
+            ard_num_dims=ard_num_dims,
+            batch_shape=batch_shape,
+            lengthscale_prior=GammaPrior(3.0, 6.0),
+        ),
+        batch_shape=batch_shape,
+        outputscale_prior=GammaPrior(2.0, 0.15),
+    )
+
+
+def get_gaussian_likelihood_with_gamma_prior(
+    batch_shape: Optional[torch.Size] = None,
+) -> GaussianLikelihood:
+    r"""Constructs the GaussianLikelihood that is used by default by
+    several models. This uses a Gamma(1.1, 0.05) prior and constrains the
+    noise level to be greater than MIN_INFERRED_NOISE_LEVEL (=1e-4).
+    """
+    batch_shape = torch.Size() if batch_shape is None else batch_shape
+    noise_prior = GammaPrior(1.1, 0.05)
+    noise_prior_mode = (noise_prior.concentration - 1) / noise_prior.rate
+    return GaussianLikelihood(
+        noise_prior=noise_prior,
+        batch_shape=batch_shape,
+        noise_constraint=GreaterThan(
+            MIN_INFERRED_NOISE_LEVEL,
+            transform=None,
+            initial_value=noise_prior_mode,
+        ),
+    )

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -163,6 +163,11 @@ Dataset Parsing
 .. automodule:: botorch.models.utils.parse_training_data
     :members:
 
+GPyTorch Module Constructors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.utils.gpytorch_modules
+    :members:
+
 Model Conversion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.models.converter

--- a/test/models/utils/test_gpytorch_modules.py
+++ b/test/models/utils/test_gpytorch_modules.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+from botorch.models.utils.gpytorch_modules import (
+    get_gaussian_likelihood_with_gamma_prior,
+    get_matern_kernel_with_gamma_prior,
+    MIN_INFERRED_NOISE_LEVEL,
+)
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.constraints.constraints import GreaterThan
+from gpytorch.kernels.matern_kernel import MaternKernel
+from gpytorch.kernels.scale_kernel import ScaleKernel
+from gpytorch.likelihoods.gaussian_likelihood import GaussianLikelihood
+from gpytorch.priors.torch_priors import GammaPrior
+
+
+class TestGPyTorchModules(BotorchTestCase):
+    def test_get_matern_kernel_with_gamma_prior(self):
+        for batch_shape in (None, torch.Size([2])):
+            kernel = get_matern_kernel_with_gamma_prior(
+                ard_num_dims=2, batch_shape=batch_shape
+            )
+            self.assertIsInstance(kernel, ScaleKernel)
+            self.assertEqual(kernel.batch_shape, batch_shape or torch.Size([]))
+            prior = kernel.outputscale_prior
+            self.assertIsInstance(prior, GammaPrior)
+            self.assertAllClose(prior.concentration.item(), 2.0)
+            self.assertAllClose(prior.rate.item(), 0.15)
+            base_kernel = kernel.base_kernel
+            self.assertIsInstance(base_kernel, MaternKernel)
+            self.assertEqual(base_kernel.batch_shape, batch_shape or torch.Size([]))
+            self.assertEqual(base_kernel.ard_num_dims, 2)
+            prior = base_kernel.lengthscale_prior
+            self.assertIsInstance(prior, GammaPrior)
+            self.assertAllClose(prior.concentration.item(), 3.0)
+            self.assertAllClose(prior.rate.item(), 6.0)
+
+    def test_get_gaussian_likelihood_with_gamma_prior(self):
+        for batch_shape in (None, torch.Size([2])):
+            likelihood = get_gaussian_likelihood_with_gamma_prior(
+                batch_shape=batch_shape
+            )
+            self.assertIsInstance(likelihood, GaussianLikelihood)
+            expected_shape = (batch_shape or torch.Size([])) + (1,)
+            self.assertEqual(likelihood.raw_noise.shape, expected_shape)
+            prior = likelihood.noise_covar.noise_prior
+            self.assertIsInstance(prior, GammaPrior)
+            self.assertAllClose(prior.concentration.item(), 1.1)
+            self.assertAllClose(prior.rate.item(), 0.05)
+            constraint = likelihood.noise_covar.raw_noise_constraint
+            self.assertIsInstance(constraint, GreaterThan)
+            self.assertAllClose(constraint.lower_bound.item(), MIN_INFERRED_NOISE_LEVEL)
+            self.assertIsNone(constraint._transform)
+            self.assertAllClose(constraint.initial_value.item(), 2.0)


### PR DESCRIPTION
Summary:
This is a proposal to use simple helpers to construct commonly used GPyTorch modules to avoid code duplication within the modeling stack.

This implements helpers for the default Matern kernel and the GaussianLikelihood. This can easily be extended for any other modules that are used in multiple places.

Reviewed By: Balandat

Differential Revision: D46613330

