### PR TITLE
Fix memory leak in inducing point allocators

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -191,7 +191,7 @@ class _SingleTaskVariationalGP(ApproximateGP):
         Args:
             train_X: Training inputs (due to the ability of the SVGP to sub-sample
                 this does not have to be all of the training inputs).
-            train_Y: Training targets (optional).
+            train_Y: Not used.
             num_outputs: Number of output responses per input.
             covar_module: Kernel function. If omitted, uses a `MaternKernel`.
             mean_module: Mean of GP model. If omitted, uses a `ConstantMean`.
@@ -402,7 +402,6 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
 
         model = _SingleTaskVariationalGP(
             train_X=transformed_X,
-            train_Y=train_Y,
             num_outputs=num_outputs,
             learn_inducing_points=learn_inducing_points,
             covar_module=covar_module,


### PR DESCRIPTION
Fixes #1788 .
## Motivation

`allocate_inducing_points` leaks memory when passed a `kernel_matrix` with `requires_grad=True`. The memory leak happens due to a specific pattern of in-place torch operations in `_pivoted_cholesky_init`;  see [this comment](https://github.com/pytorch/botorch/issues/1788#issuecomment-1593893838) for more explanation. There is no need for `allocate_inducing_points` to support a `kernel_matrix` with `requires_grad=True`, because the output of `allocate_inducing_points` is not differentiable anyway (thanks to in-place operations).

[x] make `_pivoted_cholesky_init` raise an `UnsupportedError` when passed a `kernel_matrix` with `requires_grad=True`. That is mildly BC-breaking, but I think that is okay since the alternative is a memory leak.
[x] Evaluate kernels with `torch.no_grad()` where they are only used to be passed to `_pivoted_cholesky_init`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

[x] Unit test for memory leak
[x] Unit test for UnsupportedError