### PR TITLE
Enabling candidate generation with both `non_linear_constraints` and `fixed_features`

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -114,15 +114,11 @@ def gen_candidates_scipy(
     # if there are fixed features we may optimize over a domain of lower dimension
     reduced_domain = False
     if fixed_features:
-        # TODO: We can support fixed features, see Max's comment on D33551393. We can
-        # consider adding this at a later point.
+        # if nonlinear constraints are present we opimize over the complete domain
         if nonlinear_inequality_constraints:
-            raise NotImplementedError(
-                "Fixed features are not supported when non-linear inequality "
-                "constraints are given."
-            )
-        # if there are no constraints things are straightforward
-        if not (inequality_constraints or equality_constraints):
+            reduced_domain = False
+        # if there are no constraints, things are straightforward
+        elif not (inequality_constraints or equality_constraints):
             reduced_domain = True
         # if there are we need to make sure features are fixed to specific values
         else:

--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -341,6 +341,7 @@ def gen_candidates_torch(
             upper_bounds=upper_bounds,
             inequality_constraints=None,
             equality_constraints=None,
+            nonlinear_inequality_constraints=None,
         )
 
         # call the routine with no fixed_features

--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -114,11 +114,12 @@ def gen_candidates_scipy(
     # if there are fixed features we may optimize over a domain of lower dimension
     reduced_domain = False
     if fixed_features:
-        # if nonlinear constraints are present we opimize over the complete domain
-        if nonlinear_inequality_constraints:
-            reduced_domain = False
         # if there are no constraints, things are straightforward
-        elif not (inequality_constraints or equality_constraints):
+        if not (
+            inequality_constraints
+            or equality_constraints
+            or nonlinear_inequality_constraints
+        ):
             reduced_domain = True
         # if there are we need to make sure features are fixed to specific values
         else:
@@ -133,6 +134,7 @@ def gen_candidates_scipy(
             upper_bounds=upper_bounds,
             inequality_constraints=inequality_constraints,
             equality_constraints=equality_constraints,
+            nonlinear_inequality_constraints=nonlinear_inequality_constraints,
         )
         # call the routine with no fixed_features
         clamped_candidates, batch_acquisition = gen_candidates_scipy(
@@ -142,6 +144,7 @@ def gen_candidates_scipy(
             upper_bounds=_no_fixed_features.upper_bounds,
             inequality_constraints=_no_fixed_features.inequality_constraints,
             equality_constraints=_no_fixed_features.equality_constraints,
+            nonlinear_inequality_constraints=_no_fixed_features.nonlinear_inequality_constraints,
             options=options,
             fixed_features=None,
             timeout_sec=timeout_sec,

--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -144,7 +144,7 @@ def gen_candidates_scipy(
             upper_bounds=_no_fixed_features.upper_bounds,
             inequality_constraints=_no_fixed_features.inequality_constraints,
             equality_constraints=_no_fixed_features.equality_constraints,
-            nonlinear_inequality_constraints=_no_fixed_features.nonlinear_inequality_constraints,
+            nonlinear_inequality_constraints=_no_fixed_features.nonlinear_inequality_constraints,  # noqa: E501
             options=options,
             fixed_features=None,
             timeout_sec=timeout_sec,

--- a/botorch/generation/utils.py
+++ b/botorch/generation/utils.py
@@ -66,7 +66,7 @@ class _NoFixedFeatures:
     upper_bounds: Optional[Union[float, Tensor]]
     inequality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]]
     equality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]]
-    nonlinear_inequality_constraints: Optional[List[Callable]]
+    nonlinear_inequality_constraints: Optional[List[Callable[[Tensor], Tensor]
 
 
 def _remove_fixed_features_from_optimization(
@@ -77,7 +77,7 @@ def _remove_fixed_features_from_optimization(
     upper_bounds: Optional[Union[float, Tensor]],
     inequality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]],
     equality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]],
-    nonlinear_inequality_constraints: Optional[List[Callable]],
+    nonlinear_inequality_constraints: Optional[List[Callable[[Tensor], Tensor],
 ) -> _NoFixedFeatures:
     """
     Given a set of non-empty fixed features, this function effectively reduces the

--- a/botorch/generation/utils.py
+++ b/botorch/generation/utils.py
@@ -66,7 +66,7 @@ class _NoFixedFeatures:
     upper_bounds: Optional[Union[float, Tensor]]
     inequality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]]
     equality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]]
-    nonlinear_inequality_constraints: Optional[List[Callable[[Tensor], Tensor]
+    nonlinear_inequality_constraints: Optional[List[Callable[[Tensor], Tensor]]]
 
 
 def _remove_fixed_features_from_optimization(
@@ -77,7 +77,7 @@ def _remove_fixed_features_from_optimization(
     upper_bounds: Optional[Union[float, Tensor]],
     inequality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]],
     equality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]],
-    nonlinear_inequality_constraints: Optional[List[Callable[[Tensor], Tensor],
+    nonlinear_inequality_constraints: Optional[List[Callable[[Tensor], Tensor]]],
 ) -> _NoFixedFeatures:
     """
     Given a set of non-empty fixed features, this function effectively reduces the
@@ -103,6 +103,11 @@ def _remove_fixed_features_from_optimization(
         equality constraints: A list of tuples (indices, coefficients, rhs),
             with each tuple encoding an inequality constraint of the form
             `sum_i (X[indices[i]] * coefficients[i]) = rhs`.
+        nonlinear_inequality_constraints: A list of callables with that represent
+            non-linear inequality constraints of the form `callable(x) >= 0`. Each
+            callable is expected to take a `(num_restarts) x q x d`-dim tensor as
+            an input and return a `(num_restarts) x q`-dim tensor with the
+            constraint values.
 
     Returns:
         _NoFixedFeatures dataclass object.

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -333,8 +333,6 @@ def _generate_unfixed_nonlin_constraints(
 
     values = torch.tensor(list(fixed_features.values()), dtype=torch.double)
 
-    new_constraints = []
-
     def _wrap_nlc(nlc: Callable) -> Callable:
         def new_nlc(X: Tensor) -> Tensor:
             ivalues = values.to(X).expand(*X.shape[:-1], len(fixed_features))

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -313,10 +313,10 @@ def _make_linear_constraints(
 
 
 def _generate_unfixed_nonlin_constraints(
-    constraints: Optional[List[Callable[[Tensor], Tensor]],
+    constraints: Optional[List[Callable[[Tensor], Tensor]]],
     fixed_features: Dict[int, float],
     dimension: int,
-) -> Optional[List[Callable[[Tensor], Tensor]]:
+) -> Optional[List[Callable[[Tensor], Tensor]]]:
     # If constraints is None or an empty list, then return itself
     if not constraints:
         return constraints
@@ -333,7 +333,9 @@ def _generate_unfixed_nonlin_constraints(
 
     values = torch.tensor(list(fixed_features.values()), dtype=torch.double)
 
-    def _wrap_nonlin_constraint(constraint: Callable[[Tensor], Tensor]) -> Callable[[Tensor], Tensor]:
+    def _wrap_nonlin_constraint(
+        constraint: Callable[[Tensor], Tensor]
+    ) -> Callable[[Tensor], Tensor]:
         def new_nonlin_constraint(X: Tensor) -> Tensor:
             ivalues = values.to(X).expand(*X.shape[:-1], len(fixed_features))
             X_perm = torch.cat([X, ivalues], dim=-1)
@@ -341,7 +343,9 @@ def _generate_unfixed_nonlin_constraints(
 
         return new_nonlin_constraint
 
-    return [_wrap_nonlin_constraint(constraint=constraint) for constraint in constraints]
+    return [
+        _wrap_nonlin_constraint(constraint=constraint) for constraint in constraints
+    ]
 
 
 def _generate_unfixed_lin_constraints(

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -331,7 +331,7 @@ def _generate_unfixed_nonlin_constraints(
             selector.append(idx_X)
             idx_X += 1
 
-    values = torch.tensor([v for v in fixed_features.values()], dtype=torch.double)
+    values = torch.tensor(list(fixed_features.values()), dtype=torch.double)
 
     new_constraints = []
 
@@ -343,9 +343,7 @@ def _generate_unfixed_nonlin_constraints(
 
         return new_nlc
 
-    for nlc in constraints:
-        new_constraints.append(_wrap_nlc(nlc=nlc))
-    return new_constraints
+    return [_wrap_nlc(nlc=nlc) for nlc in constraints]
 
 
 def _generate_unfixed_lin_constraints(

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -317,7 +317,10 @@ def _generate_unfixed_nonlin_constraints(
     fixed_features: Dict[int, float],
     dimension: int,
 ) -> Optional[List[Callable[[Tensor], Tensor]]]:
-    # If constraints is None or an empty list, then return itself
+    """Given a dictionary of fixed features, returns a list of callables for
+    nonlinear inequality constraints expecting only a tensor with the non-fixed
+    features as input.
+    """
     if not constraints:
         return constraints
 

--- a/test/generation/test_utils.py
+++ b/test/generation/test_utils.py
@@ -105,6 +105,7 @@ class TestGenerationUtils(BotorchTestCase):
                 upper_bounds=upper_bounds,
                 inequality_constraints=inequality_constraints,
                 equality_constraints=equality_constraints,
+                nonlinear_inequality_constraints=None,
             )
             self.assertIsInstance(
                 _no_ff.acquisition_function, FixedFeatureAcquisitionFunction

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -862,24 +862,30 @@ class TestOptimizeAcqf(BotorchTestCase):
                 torch.allclose(acq_value, torch.tensor(2.45, **tkwargs), atol=1e-3)
             )
 
+            with torch.random.fork_rng():
+                torch.manual_seed(0)
+                batch_initial_conditions = torch.rand(num_restarts, 1, 3, **tkwargs)
+                batch_initial_conditions[..., 0] = 2
+
             # test with fixed features
             candidates, acq_value = optimize_acqf(
                 acq_function=mock_acq_function,
                 bounds=bounds,
                 q=1,
-                nonlinear_inequality_constraints=[nlc1, nlc2, nlc3, nlc4],
+                nonlinear_inequality_constraints=[nlc1, nlc2],
                 batch_initial_conditions=batch_initial_conditions,
                 num_restarts=num_restarts,
                 fixed_features={0: 2},
             )
+            self.assertEqual(candidates[0, 0], 2.0)
             self.assertTrue(
                 torch.allclose(
-                    candidates,
-                    torch.tensor([[2, 1, 1]], **tkwargs),
+                    torch.sort(candidates).values,
+                    torch.tensor([[0, 2, 2]], **tkwargs),
                 )
             )
             self.assertTrue(
-                torch.allclose(acq_value, torch.tensor(2.45, **tkwargs), atol=1e-3)
+                torch.allclose(acq_value, torch.tensor(2.8284, **tkwargs), atol=1e-3)
             )
 
             # Test that an ic_generator object with the same API as

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -879,22 +879,6 @@ class TestOptimizeAcqf(BotorchTestCase):
                 )
                 self.assertEqual(candidates.size(), torch.Size([1, 3]))
 
-            # Make sure fixed features aren't supported
-            with self.assertRaisesRegex(
-                NotImplementedError,
-                "Fixed features are not supported when non-linear inequality "
-                "constraints are given.",
-            ):
-                optimize_acqf(
-                    acq_function=mock_acq_function,
-                    bounds=bounds,
-                    q=1,
-                    nonlinear_inequality_constraints=[nlc1, nlc2, nlc3, nlc4],
-                    batch_initial_conditions=batch_initial_conditions,
-                    num_restarts=num_restarts,
-                    fixed_features={0: 0.1},
-                )
-
             # Constraints must be passed in as lists
             with self.assertRaisesRegex(
                 ValueError,

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -862,6 +862,26 @@ class TestOptimizeAcqf(BotorchTestCase):
                 torch.allclose(acq_value, torch.tensor(2.45, **tkwargs), atol=1e-3)
             )
 
+            # test with fixed features
+            candidates, acq_value = optimize_acqf(
+                acq_function=mock_acq_function,
+                bounds=bounds,
+                q=1,
+                nonlinear_inequality_constraints=[nlc1, nlc2, nlc3, nlc4],
+                batch_initial_conditions=batch_initial_conditions,
+                num_restarts=num_restarts,
+                fixed_features={0: 2},
+            )
+            self.assertTrue(
+                torch.allclose(
+                    candidates,
+                    torch.tensor([[2, 1, 1]], **tkwargs),
+                )
+            )
+            self.assertTrue(
+                torch.allclose(acq_value, torch.tensor(2.45, **tkwargs), atol=1e-3)
+            )
+
             # Test that an ic_generator object with the same API as
             # gen_batch_initial_conditions returns candidates of the
             # required shape.

--- a/test/optim/test_parameter_constraints.py
+++ b/test/optim/test_parameter_constraints.py
@@ -224,32 +224,32 @@ class TestParameterConstraints(BotorchTestCase):
             return x[..., 0] - 1
 
         # first test with one constraint
-        new_constraints = _generate_unfixed_nonlin_constraints(
+        new_nlc1,  = _generate_unfixed_nonlin_constraints(
             constraints=[nlc1], fixed_features={1: 2.0}, dimension=3
         )
         self.assertAllClose(
             nlc1(torch.tensor([[4.0, 2.0, 2.0]], device=self.device)),
-            new_constraints[0](torch.tensor([[4.0, 2.0]], device=self.device)),
+            new_nlc1(torch.tensor([[4.0, 2.0]], device=self.device)),
         )
         # test with several constraints
         constraints = [nlc1, nlc2]
         new_constraints = _generate_unfixed_nonlin_constraints(
             constraints=constraints, fixed_features={1: 2.0}, dimension=3
         )
-        for i in range(2):
+        for nlc, new_nlc in zip(constraints, new_constraints):
             self.assertAllClose(
-                constraints[i](torch.tensor([[4.0, 2.0, 2.0]], device=self.device)),
-                new_constraints[i](torch.tensor([[4.0, 2.0]], device=self.device)),
+               nlc(torch.tensor([[4.0, 2.0, 2.0]], device=self.device)),
+                new_nlc(torch.tensor([[4.0, 2.0]], device=self.device)),
             )
         # test with several constraints and two fixes
         constraints = [nlc1, nlc2]
         new_constraints = _generate_unfixed_nonlin_constraints(
             constraints=constraints, fixed_features={1: 2.0, 2: 1.0}, dimension=3
         )
-        for i in range(2):
+        for nlc, new_nlc in zip(constraints, new_constraints):
             self.assertAllClose(
-                constraints[i](torch.tensor([[4.0, 2.0, 1.0]], device=self.device)),
-                new_constraints[i](torch.tensor([[4.0]], device=self.device)),
+                nlc(torch.tensor([[4.0, 2.0, 1.0]], device=self.device)),
+                new_nlc(torch.tensor([[4.0]], device=self.device)),
             )
 
     def test_generate_unfixed_lin_constraints(self):

--- a/test/optim/test_parameter_constraints.py
+++ b/test/optim/test_parameter_constraints.py
@@ -224,7 +224,7 @@ class TestParameterConstraints(BotorchTestCase):
             return x[..., 0] - 1
 
         # first test with one constraint
-        new_nlc1,  = _generate_unfixed_nonlin_constraints(
+        (new_nlc1,) = _generate_unfixed_nonlin_constraints(
             constraints=[nlc1], fixed_features={1: 2.0}, dimension=3
         )
         self.assertAllClose(
@@ -238,7 +238,7 @@ class TestParameterConstraints(BotorchTestCase):
         )
         for nlc, new_nlc in zip(constraints, new_constraints):
             self.assertAllClose(
-               nlc(torch.tensor([[4.0, 2.0, 2.0]], device=self.device)),
+                nlc(torch.tensor([[4.0, 2.0, 2.0]], device=self.device)),
                 new_nlc(torch.tensor([[4.0, 2.0]], device=self.device)),
             )
         # test with several constraints and two fixes

--- a/test/optim/test_parameter_constraints.py
+++ b/test/optim/test_parameter_constraints.py
@@ -12,6 +12,7 @@ from botorch.exceptions.errors import CandidateGenerationError, UnsupportedError
 from botorch.optim.parameter_constraints import (
     _arrayify,
     _generate_unfixed_lin_constraints,
+    _generate_unfixed_nonlin_constraints,
     _make_linear_constraints,
     eval_lin_constraint,
     lin_constraint_jac,
@@ -213,6 +214,42 @@ class TestParameterConstraints(BotorchTestCase):
                 shapeX=shapeX,
                 inequality_constraints=[(indices, coefficients, 1.0)],
                 equality_constraints=[(indices, coefficients, 1.0)],
+            )
+
+    def test_generate_unfixed_nonlin_constraints(self):
+        def nlc1(x):
+            return 4 - x.sum(dim=-1)
+
+        def nlc2(x):
+            return x[..., 0] - 1
+
+        # first test with one constraint
+        new_constraints = _generate_unfixed_nonlin_constraints(
+            constraints=[nlc1], fixed_features={1: 2.0}, dimension=3
+        )
+        self.assertAllClose(
+            nlc1(torch.tensor([[4.0, 2.0, 2.0]], device=self.device)),
+            new_constraints[0](torch.tensor([[4.0, 2.0]], device=self.device)),
+        )
+        # test with several constraints
+        constraints = [nlc1, nlc2]
+        new_constraints = _generate_unfixed_nonlin_constraints(
+            constraints=constraints, fixed_features={1: 2.0}, dimension=3
+        )
+        for i in range(2):
+            self.assertAllClose(
+                constraints[i](torch.tensor([[4.0, 2.0, 2.0]], device=self.device)),
+                new_constraints[i](torch.tensor([[4.0, 2.0]], device=self.device)),
+            )
+        # test with several constraints and two fixes
+        constraints = [nlc1, nlc2]
+        new_constraints = _generate_unfixed_nonlin_constraints(
+            constraints=constraints, fixed_features={1: 2.0, 2: 1.0}, dimension=3
+        )
+        for i in range(2):
+            self.assertAllClose(
+                constraints[i](torch.tensor([[4.0, 2.0, 1.0]], device=self.device)),
+                new_constraints[i](torch.tensor([[4.0]], device=self.device)),
             )
 
     def test_generate_unfixed_lin_constraints(self):


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR adds the possibility to use `fixed_features` in combination with `nonlinear_inequality_constraints` as discussed in issue https://github.com/pytorch/botorch/issues/1904.

@Balandat: concerning the solution that you suggested: I think it is much easier as the `f_np_wrapper` is also used for the nonlinear constraints: https://github.com/pytorch/botorch/blob/38e20275188f4cb2b99c8631bb91450b59140308/botorch/generation/gen.py#L224 and `fix_features` is already applied there: https://github.com/pytorch/botorch/blob/38e20275188f4cb2b99c8631bb91450b59140308/botorch/generation/gen.py#L189

So no need for another wrapper, or?

A wrapper function would be only needed if one wants to have the possibility to use the nonlinear constraints also with the reduced domain, then one would need a method, which takes the reduced X as input and augments it with the fixed features. 

Here is some example code, that shows that it works:

``` python
import torch
from botorch.models import SingleTaskGP
from botorch.fit import fit_gpytorch_mll
from botorch.utils import standardize
from gpytorch.mlls import ExactMarginalLogLikelihood
from botorch.utils.sampling import get_polytope_samples

def constraint(X):
    return torch.sum(X[...,:3], dim=-1) -1.80

train_X = torch.rand(10, 3)
Y = 1 - torch.norm(train_X[:,:2] - 0.5, dim=-1, keepdim=True)
Y = Y + 0.1 * torch.randn_like(Y)  # add some noise
train_Y = standardize(Y)

gp = SingleTaskGP(train_X, train_Y)
mll = ExactMarginalLogLikelihood(gp.likelihood, gp)
fit_gpytorch_mll(mll)

from botorch.acquisition import UpperConfidenceBound

UCB = UpperConfidenceBound(gp, beta=0.1)

from botorch.optim import optimize_acqf


bounds = torch.stack([torch.zeros(3), torch.ones(3)])

batch_initial_conditions = get_polytope_samples(
    n=5,
    bounds=bounds,
    inequality_constraints=[(torch.tensor([0,1,2]),torch.tensor([1.,1.,1.]),1.8)],
    n_burnin=1000
).unsqueeze(-2)

candidate, acq_value = optimize_acqf(
    UCB, 
    bounds=bounds, 
    q=1, 
    num_restarts=5, 
    raw_samples=20,
    fixed_features={2:0.5}, 
    nonlinear_inequality_constraints = [constraint],
    batch_initial_conditions = batch_initial_conditions
)
print(candidate)  # tensor([0.4887, 0.5063])
print(candidate.sum())
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests. 


