### PR TITLE
Adding central moments to standardization warning

### DIFF
--- a/botorch/models/utils/assorted.py
+++ b/botorch/models/utils/assorted.py
@@ -193,8 +193,8 @@ def check_standardization(
         Ymean, Ystd = torch.mean(Y, dim=-2), torch.std(Y, dim=-2)
         if torch.abs(Ymean).max() > atol_mean or torch.abs(Ystd - 1).max() > atol_std:
             msg = (
-                "Input data is not standardized. Please consider scaling the "
-                "input to zero mean and unit variance."
+                f"Input data is not standardized (mean = {Ymean}, std = {Ystd}). "
+                "Please consider scaling the input to zero mean and unit variance."
             )
             if raise_on_fail:
                 raise InputDataError(msg)


### PR DESCRIPTION
Summary:
This commit adds the mean and std of the outcome data to the standardization warning.

Reason:

I got a standardization warning even though I passed a `Standardize` transform, which turned out to be caused by an upstream data processing bug that made the output data constant (std = 0). Understanding and resolving this would have been quicker if the warning would have given me the first two central moments right away.

Reviewed By: sdaulton

Differential Revision: D47190582

