### PR TITLE
Require Python 3.9+, test for 3.9 and 3.11

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   host:
-    - python>=3.8
+    - python>=3.9
     - setuptools
     - setuptools_scm
   run:

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -29,7 +29,7 @@ jobs:
       run: |
         pytest -ra --cov=. --cov-report term-missing
     - name: Upload coverage
-      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.8 }}
+      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.9 }}
       run: |
         bash <(curl -s https://codecov.io/bash)
 
@@ -76,7 +76,7 @@ jobs:
       with:
         miniconda-version: "latest"
         activate-environment: test
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         # pin dependencies to match Meta-internal versions
@@ -40,7 +40,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         pip install flake8 flake8-docstrings

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -34,7 +34,7 @@ jobs:
       run: |
         pytest -ra --cov=. --cov-report term-missing
     - name: Upload coverage
-      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.8 }}
+      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.9 }}
       run: |
         bash <(curl -s https://codecov.io/bash)
 
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true
@@ -96,7 +96,7 @@ jobs:
       with:
         miniconda-version: "latest"
         activate-environment: test
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - name: Install dependencies

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Fetch all history for all tags and branches
       # We need to do this so setuptools_scm knows how to set the BoTorch version.
       run: git fetch --prune --unshallow

--- a/.github/workflows/reusable_website.yml
+++ b/.github/workflows/reusable_website.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - if: ${{ !inputs.publish_versioned_website }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -37,7 +37,7 @@ jobs:
       run: |
         pytest -ra --cov=. --cov-report term-missing
     - name: Upload coverage
-      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.8 }}
+      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.9 }}
       run: |
         bash <(curl -s https://codecov.io/bash)
 
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v2
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ run `flake8` as above to check.
 
 #### Type Hints
 
-BoTorch is fully typed using python 3.8+
+BoTorch is fully typed using python 3.9+
 [type hints](https://www.python.org/dev/peps/pep-0484/).
 We expect any contributions to also use proper type annotations. While we
 currently do not enforce full consistency of these in our continuous integration

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Optimization simply use Ax.
 ## Installation
 
 **Installation Requirements**
-- Python >= 3.8
+- Python >= 3.9
 - PyTorch >= 1.12
 - gpytorch == 1.10
 - linear_operator == 0.4.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 # Minimum required python version
 REQUIRED_MAJOR = 3
-REQUIRED_MINOR = 8
+REQUIRED_MINOR = 9
 
 # Requirements for testing, formatting, and tutorials
 TEST_REQUIRES = ["pytest", "pytest-cov"]
@@ -96,7 +96,7 @@ setup(
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     packages=find_packages(exclude=["test", "test.*"]),
     install_requires=install_requires,
     extras_require={


### PR DESCRIPTION
## Motivation

Python 3.11 was released over 8 months ago, so we should be testing for it. We can also drop support for Python 3.8, which was supplanted by 3.9 nearly 3 years ago.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manually running nightly cron: https://github.com/pytorch/botorch/actions/runs/5508340274
