### PR TITLE
Python 3.11 compliance for dataclasses: Don't use mutable defaults

### DIFF
--- a/botorch/utils/datasets.py
+++ b/botorch/utils/datasets.py
@@ -56,8 +56,8 @@ class SupervisedDatasetMeta(type):
                     value = DenseContainer(value, event_shape=value.shape[-1:])
                 elif not isinstance(value, BotorchContainer):
                     raise TypeError(
-                        f"Expected <BotorchContainer | Tensor> for field `{field.name}` "
-                        f"but was {type(value)}."
+                        "Expected <BotorchContainer | Tensor> for field "
+                        f"`{field.name}` but was {type(value)}."
                     )
             f_dict[field.name] = value
 

--- a/test/utils/test_datasets.py
+++ b/test/utils/test_datasets.py
@@ -30,14 +30,15 @@ class TestDatasets(BotorchTestCase):
     def test_supervised_meta(self):
         X = rand(3, 2)
         Y = rand(3, 1)
-        A = DenseContainer(rand(3, 5), event_shape=Size([5]))
+        t = rand(3, 5)
+        A = DenseContainer(t, event_shape=Size([5]))
         B = rand(2, 1)
 
         SupervisedDatasetWithDefaults = make_dataclass(
             cls_name="SupervisedDatasetWithDefaults",
             bases=(SupervisedDataset,),
             fields=[
-                ("default", DenseContainer, field(default=A)),
+                ("default", DenseContainer, field(default=t)),
                 ("factory", DenseContainer, field(default_factory=lambda: A)),
                 ("other", Tensor, field(default_factory=lambda: B)),
             ],
@@ -55,6 +56,7 @@ class TestDatasets(BotorchTestCase):
 
         # Check handling of default values and factories
         dataset = SupervisedDatasetWithDefaults(X=X, Y=Y)
+        self.assertIsInstance(dataset.default, DenseContainer)
         self.assertEqual(dataset.default, A)
         self.assertEqual(dataset.factory, A)
         self.assertTrue(dataset.other is B)


### PR DESCRIPTION
## Motivation

See error here: https://github.com/pytorch/botorch/actions/runs/5508336054/jobs/10039481686?pr=1924
* Tested with a tensor instead of a `DenseContainer` since we needed something non-mutable
* Added a test that the tensor is properly cast to a `DenseContainer`
* made code more readable (for me anyway)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Units

## Related PRs

Unblocks #1924 