### PR TITLE
`compute_best_feasible_f` utility

### DIFF
--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -32,6 +32,7 @@ from botorch.utils.multi_objective.box_decompositions.non_dominated import (
     FastNondominatedPartitioning,
     NondominatedPartitioning,
 )
+from botorch.utils.objective import compute_feasibility_indicator
 from botorch.utils.sampling import optimize_posterior_samples
 from botorch.utils.transforms import is_fully_bayesian
 from torch import Tensor
@@ -210,6 +211,113 @@ def get_acquisition_function(
         )
     raise NotImplementedError(
         f"Unknown acquisition function {acquisition_function_name}"
+    )
+
+
+def compute_best_feasible_objective(
+    samples: Tensor,
+    obj: Tensor,
+    constraints: Optional[List[Callable[[Tensor], Tensor]]],
+    model: Optional[Model] = None,
+    objective: Optional[MCAcquisitionObjective] = None,
+    posterior_transform: Optional[PosteriorTransform] = None,
+    X_baseline: Optional[Tensor] = None,
+    infeasible_obj: Optional[Tensor] = None,
+) -> Tensor:
+    """Computes the largest `obj` value that is feasible under the `constraints`. If
+    `constraints` is None, returns the best unconstrained objective value.
+
+    When no feasible observations exist and `infeasible_obj` is not `None`, returns
+    `infeasible_obj` (potentially reshaped). When no feasible observations exist and
+    `infeasible_obj` is `None`, uses `model`, `objective`, `posterior_transform`, and
+    `X_baseline` to infer and return an `infeasible_obj` `M` s.t. `M < min_x f(x)`.
+
+    Args:
+        samples: `(sample_shape) x batch_shape x q x m`-dim posterior samples.
+        obj: A `(sample_shape) x batch_shape x q`-dim Tensor of MC objective values.
+        constraints: A list of constraint callables which map posterior samples to
+            a scalar. The associated constraint is considered satisfied if this
+            scalar is less than zero.
+        model: A Model, only required when there are no feasible observations.
+        objective: An MCAcquisitionObjective, only optionally used when there are no
+            feasible observations.
+        posterior_transform: A PosteriorTransform, only optionally used when there are
+            no feasible observations.
+        X_baseline: A `batch_shape x d`-dim Tensor of baseline points, only required
+            when there are no feasible observations.
+        infeasible_obj: A Tensor to be returned when no feasible points exist.
+
+    Returns:
+        A `(sample_shape) x batch_shape x 1`-dim Tensor of best feasible objectives.
+    """
+    if constraints is None:  # unconstrained case
+        # we don't need to differentiate through X_baseline for now, so taking
+        # the regular max over the n points to get best_f is fine
+        with torch.no_grad():
+            return obj.amax(dim=-1, keepdim=True)
+
+    is_feasible = compute_feasibility_indicator(
+        constraints=constraints, samples=samples
+    )  # sample_shape x batch_shape x q
+    if is_feasible.any():
+        obj = torch.where(is_feasible, obj, -torch.inf)
+        with torch.no_grad():
+            return obj.amax(dim=-1, keepdim=True)
+
+    elif infeasible_obj is not None:
+        return infeasible_obj.expand(*obj.shape[:-1], 1)
+
+    else:
+        if model is None:
+            raise ValueError(
+                "Must specify `model` when no feasible observation exists."
+            )
+        if X_baseline is None:
+            raise ValueError(
+                "Must specify `X_baseline` when no feasible observation exists."
+            )
+        return _estimate_objective_lower_bound(
+            model=model,
+            objective=objective,
+            posterior_transform=posterior_transform,
+            X=X_baseline,
+        ).expand(*obj.shape[:-1], 1)
+
+
+def _estimate_objective_lower_bound(
+    model: Model,
+    objective: Optional[MCAcquisitionObjective],
+    posterior_transform: Optional[PosteriorTransform],
+    X: Tensor,
+) -> Tensor:
+    """Estimates a lower bound on the objective values by evaluating the model at convex
+    combinations of `X`, returning the 6-sigma lower bound of the computed statistics.
+
+    Args:
+        model: A fitted model.
+        objective: An MCAcquisitionObjective with `m` outputs.
+        posterior_transform: A PosteriorTransform.
+        X: A `n x d`-dim Tensor of design points from which to draw convex combinations.
+
+    Returns:
+        A `m`-dimensional Tensor of lower bounds of the objectives.
+    """
+    convex_weights = torch.rand(
+        32,
+        X.shape[-2],
+        dtype=X.dtype,
+        device=X.device,
+    )
+    weights_sum = convex_weights.sum(dim=0, keepdim=True)
+    convex_weights = convex_weights / weights_sum
+    # infeasible cost M is such that -M < min_x f(x), thus
+    # 0 < min_x f(x) - (-M), so we should take -M as a lower
+    # bound on the best feasible objective
+    return -get_infeasible_cost(
+        X=convex_weights @ X,
+        model=model,
+        objective=objective,
+        posterior_transform=posterior_transform,
     )
 
 

--- a/test/utils/test_objective.py
+++ b/test/utils/test_objective.py
@@ -7,6 +7,10 @@
 
 import torch
 from botorch.utils import apply_constraints, get_objective_weights_transform
+from botorch.utils.objective import (
+    compute_feasibility_indicator,
+    compute_smoothed_constraint_indicator,
+)
 from botorch.utils.testing import BotorchTestCase
 from torch import Tensor
 
@@ -153,7 +157,7 @@ class TestApplyConstraints(BotorchTestCase):
             self.assertAllClose(obj, samples.clamp_min(-1.0) * 0.5 - 1.0)
             # nonnegative objective, one constraint, eta = 0
             obj = samples
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, "eta must be positive"):
                 apply_constraints(
                     obj=obj,
                     constraints=[zeros_f],
@@ -168,7 +172,7 @@ class TestApplyConstraints(BotorchTestCase):
             tkwargs["dtype"] = dtype
             samples = torch.rand(3, 2, **tkwargs)
             obj = samples.clone()
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, "Number of provided constraints"):
                 obj = apply_constraints(
                     obj=obj,
                     constraints=[zeros_f, zeros_f],
@@ -176,7 +180,7 @@ class TestApplyConstraints(BotorchTestCase):
                     infeasible_cost=0.0,
                     eta=torch.tensor([0.1]).to(**tkwargs),
                 )
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, "Number of provided constraints"):
                 obj = apply_constraints(
                     obj=obj,
                     constraints=[zeros_f, zeros_f],
@@ -184,6 +188,47 @@ class TestApplyConstraints(BotorchTestCase):
                     infeasible_cost=0.0,
                     eta=torch.tensor([0.1, 0.1, 0.3]).to(**tkwargs),
                 )
+
+    def test_constraint_indicators(self):
+        # nonnegative objective, one constraint
+        samples = torch.randn(1)
+        ind = compute_feasibility_indicator(constraints=[zeros_f], samples=samples)
+        self.assertAllClose(ind, torch.zeros_like(ind))
+        self.assertEqual(ind.dtype, torch.bool)
+
+        smoothed_ind = compute_smoothed_constraint_indicator(
+            constraints=[zeros_f], samples=samples, eta=1e-3
+        )
+        self.assertAllClose(smoothed_ind, ones_f(samples) / 2)
+
+        # two constraints
+        samples = torch.randn(1)
+        smoothed_ind = compute_smoothed_constraint_indicator(
+            constraints=[zeros_f, zeros_f],
+            samples=samples,
+            eta=1e-3,
+        )
+        self.assertAllClose(smoothed_ind, ones_f(samples) * 0.5 * 0.5)
+
+        # feasible
+        samples = torch.randn(1)
+        ind = compute_feasibility_indicator(
+            constraints=[minus_one_f],
+            samples=samples,
+        )
+        self.assertAllClose(ind, torch.ones_like(ind))
+
+        smoothed_ind = compute_smoothed_constraint_indicator(
+            constraints=[minus_one_f], samples=samples, eta=1e-3
+        )
+        self.assertTrue((smoothed_ind > 3 / 4).all())
+
+        with self.assertRaisesRegex(ValueError, "Number of provided constraints"):
+            compute_smoothed_constraint_indicator(
+                constraints=[zeros_f, zeros_f],
+                samples=samples,
+                eta=torch.tensor([0.1], device=self.device),
+            )
 
 
 class TestGetObjectiveWeightsTransform(BotorchTestCase):


### PR DESCRIPTION
Summary: This commit separates out the `compute_best_feasible_f` function from `qNEI` as a utility function in order to use it in the `input_constructors` and `get_acquisition_function` (follow-up).

Differential Revision: D47365085

