### PR TITLE
`compute_smoothed_constraint_indicator` -> `compute_smoothed_feasibility_indicator`

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -78,6 +78,7 @@ from botorch.acquisition.objective import (
 from botorch.acquisition.preference import AnalyticExpectedUtilityOfBestOption
 from botorch.acquisition.risk_measures import RiskMeasureMCObjective
 from botorch.acquisition.utils import (
+    compute_best_feasible_objective,
     expand_trace_observations,
     get_optimal_samples,
     project_to_target_fidelity,
@@ -457,7 +458,9 @@ def construct_inputs_qEI(
     X_pending: Optional[Tensor] = None,
     sampler: Optional[MCSampler] = None,
     best_f: Optional[Union[float, Tensor]] = None,
-    **kwargs: Any,
+    constraints: Optional[List[Callable[[Tensor], Tensor]]] = None,
+    eta: Union[Tensor, float] = 1e-3,
+    **ignored: Any,
 ) -> Dict[str, Any]:
     r"""Construct kwargs for the `qExpectedImprovement` constructor.
 
@@ -473,7 +476,15 @@ def construct_inputs_qEI(
         sampler: The sampler used to draw base samples. If omitted, uses
             the acquisition functions's default sampler.
         best_f: Threshold above (or below) which improvement is defined.
-        kwargs: Not used.
+        constraints: A list of constraint callables which map a Tensor of posterior
+            samples of dimension `sample_shape x batch-shape x q x m`-dim to a
+            `sample_shape x batch-shape x q`-dim Tensor. The associated constraints
+            are considered satisfied if the output is less than zero.
+        eta: Temperature parameter(s) governing the smoothness of the sigmoid
+            approximation to the constraint indicators. For more details, on this
+            parameter, see the docs of `compute_smoothed_constraint_indicator`.
+        ignored: Not used.
+
     Returns:
         A dict mapping kwarg names of the constructor to values.
     """
@@ -489,9 +500,11 @@ def construct_inputs_qEI(
             training_data=training_data,
             objective=objective,
             posterior_transform=posterior_transform,
+            constraints=constraints,
+            model=model,
         )
 
-    return {**base_inputs, "best_f": best_f}
+    return {**base_inputs, "best_f": best_f, "constraints": constraints, "eta": eta}
 
 
 @acqf_input_constructor(qNoisyExpectedImprovement)
@@ -505,7 +518,9 @@ def construct_inputs_qNEI(
     X_baseline: Optional[Tensor] = None,
     prune_baseline: Optional[bool] = True,
     cache_root: Optional[bool] = True,
-    **kwargs: Any,
+    constraints: Optional[List[Callable[[Tensor], Tensor]]] = None,
+    eta: Union[Tensor, float] = 1e-3,
+    **ignored: Any,
 ) -> Dict[str, Any]:
     r"""Construct kwargs for the `qNoisyExpectedImprovement` constructor.
 
@@ -527,7 +542,14 @@ def construct_inputs_qNEI(
         prune_baseline: If True, remove points in `X_baseline` that are
             highly unlikely to be the best point. This can significantly
             improve performance and is generally recommended.
-        kwargs: Not used.
+        constraints: A list of constraint callables which map a Tensor of posterior
+            samples of dimension `sample_shape x batch-shape x q x m`-dim to a
+            `sample_shape x batch-shape x q`-dim Tensor. The associated constraints
+            are considered satisfied if the output is less than zero.
+        eta: Temperature parameter(s) governing the smoothness of the sigmoid
+            approximation to the constraint indicators. For more details, on this
+            parameter, see the docs of `compute_smoothed_constraint_indicator`.
+        ignored: Not used.
 
     Returns:
         A dict mapping kwarg names of the constructor to values.
@@ -553,6 +575,8 @@ def construct_inputs_qNEI(
         "X_baseline": X_baseline,
         "prune_baseline": prune_baseline,
         "cache_root": cache_root,
+        "constraints": constraints,
+        "eta": eta,
     }
 
 
@@ -566,7 +590,9 @@ def construct_inputs_qPI(
     sampler: Optional[MCSampler] = None,
     tau: float = 1e-3,
     best_f: Optional[Union[float, Tensor]] = None,
-    **kwargs: Any,
+    constraints: Optional[List[Callable[[Tensor], Tensor]]] = None,
+    eta: Union[Tensor, float] = 1e-3,
+    **ignored: Any,
 ) -> Dict[str, Any]:
     r"""Construct kwargs for the `qProbabilityOfImprovement` constructor.
 
@@ -588,13 +614,26 @@ def construct_inputs_qPI(
         best_f: The best objective value observed so far (assumed noiseless). Can
             be a `batch_shape`-shaped tensor, which in case of a batched model
             specifies potentially different values for each element of the batch.
-        kwargs: Not used.
+        constraints: A list of constraint callables which map a Tensor of posterior
+            samples of dimension `sample_shape x batch-shape x q x m`-dim to a
+            `sample_shape x batch-shape x q`-dim Tensor. The associated constraints
+            are considered satisfied if the output is less than zero.
+        eta: Temperature parameter(s) governing the smoothness of the sigmoid
+            approximation to the constraint indicators. For more details, on this
+            parameter, see the docs of `compute_smoothed_constraint_indicator`.
+        ignored: Not used.
+
     Returns:
         A dict mapping kwarg names of the constructor to values.
     """
     if best_f is None:
-        best_f = get_best_f_mc(training_data=training_data, objective=objective)
-
+        best_f = get_best_f_mc(
+            training_data=training_data,
+            objective=objective,
+            posterior_transform=posterior_transform,
+            constraints=constraints,
+            model=model,
+        )
     base_inputs = _construct_inputs_mc_base(
         model=model,
         objective=objective,
@@ -603,7 +642,13 @@ def construct_inputs_qPI(
         X_pending=X_pending,
     )
 
-    return {**base_inputs, "tau": tau, "best_f": best_f}
+    return {
+        **base_inputs,
+        "tau": tau,
+        "best_f": best_f,
+        "constraints": constraints,
+        "eta": eta,
+    }
 
 
 @acqf_input_constructor(qUpperConfidenceBound)
@@ -615,7 +660,7 @@ def construct_inputs_qUCB(
     X_pending: Optional[Tensor] = None,
     sampler: Optional[MCSampler] = None,
     beta: float = 0.2,
-    **kwargs: Any,
+    **ignored: Any,
 ) -> Dict[str, Any]:
     r"""Construct kwargs for the `qUpperConfidenceBound` constructor.
 
@@ -631,7 +676,7 @@ def construct_inputs_qUCB(
         sampler: The sampler used to draw base samples. If omitted, uses
             the acquisition functions's default sampler.
         beta: Controls tradeoff between mean and standard deviation in UCB.
-        kwargs: Not used.
+        ignored: Not used.
 
     Returns:
         A dict mapping kwarg names of the constructor to values.
@@ -1083,18 +1128,28 @@ def get_best_f_mc(
     training_data: MaybeDict[SupervisedDataset],
     objective: Optional[MCAcquisitionObjective] = None,
     posterior_transform: Optional[PosteriorTransform] = None,
+    constraints: Optional[List[Callable[[Tensor], Tensor]]] = None,
+    model: Optional[Model] = None,
 ) -> Tensor:
     if isinstance(training_data, dict) and not _field_is_shared(
         training_data, fieldname="X"
     ):
         raise NotImplementedError("Currently only block designs are supported.")
 
+    X_baseline = _get_dataset_field(
+        training_data,
+        fieldname="X",
+        transform=lambda field: field(),
+        assert_shared=True,
+        first_only=True,
+    )
+
     Y = _get_dataset_field(
         training_data,
         fieldname="Y",
         transform=lambda field: field(),
         join_rule=lambda field_tensors: torch.cat(field_tensors, dim=-1),
-    )
+    )  # batch_shape x n x d
 
     if posterior_transform is not None:
         # retain the original tensor dimension since objective expects explicit
@@ -1111,7 +1166,16 @@ def get_best_f_mc(
                 "acquisition functions)."
             )
         objective = IdentityMCObjective()
-    return objective(Y).max(-1).values
+    obj = objective(Y, X=X_baseline)  # batch_shape x n
+    return compute_best_feasible_objective(
+        samples=Y,
+        obj=obj,
+        constraints=constraints,
+        model=model,
+        objective=objective,
+        posterior_transform=posterior_transform,
+        X_baseline=X_baseline,
+    )
 
 
 def optimize_objective(

--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -482,7 +482,7 @@ def construct_inputs_qEI(
             are considered satisfied if the output is less than zero.
         eta: Temperature parameter(s) governing the smoothness of the sigmoid
             approximation to the constraint indicators. For more details, on this
-            parameter, see the docs of `compute_smoothed_constraint_indicator`.
+            parameter, see the docs of `compute_smoothed_feasibility_indicator`.
         ignored: Not used.
 
     Returns:
@@ -548,7 +548,7 @@ def construct_inputs_qNEI(
             are considered satisfied if the output is less than zero.
         eta: Temperature parameter(s) governing the smoothness of the sigmoid
             approximation to the constraint indicators. For more details, on this
-            parameter, see the docs of `compute_smoothed_constraint_indicator`.
+            parameter, see the docs of `compute_smoothed_feasibility_indicator`.
         ignored: Not used.
 
     Returns:
@@ -620,7 +620,7 @@ def construct_inputs_qPI(
             are considered satisfied if the output is less than zero.
         eta: Temperature parameter(s) governing the smoothness of the sigmoid
             approximation to the constraint indicators. For more details, on this
-            parameter, see the docs of `compute_smoothed_constraint_indicator`.
+            parameter, see the docs of `compute_smoothed_feasibility_indicator`.
         ignored: Not used.
 
     Returns:

--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -42,7 +42,7 @@ from botorch.acquisition.utils import (
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.model import Model
 from botorch.sampling.base import MCSampler
-from botorch.utils.objective import compute_smoothed_constraint_indicator
+from botorch.utils.objective import compute_smoothed_feasibility_indicator
 from botorch.utils.transforms import (
     concatenate_pending_points,
     match_batch_shape,
@@ -215,7 +215,7 @@ class SampleReducingMCAcquisitionFunction(MCAcquisitionFunction):
                 acquistion utilities, e.g. all improvement-based acquisition functions.
             eta: Temperature parameter(s) governing the smoothness of the sigmoid
                 approximation to the constraint indicators. For more details, on this
-                parameter, see the docs of `compute_smoothed_constraint_indicator`.
+                parameter, see the docs of `compute_smoothed_feasibility_indicator`.
         """
         if constraints is not None and isinstance(objective, ConstrainedMCObjective):
             raise ValueError(
@@ -305,7 +305,7 @@ class SampleReducingMCAcquisitionFunction(MCAcquisitionFunction):
                     "Constraint-weighting requires unconstrained "
                     "acquisition values to be non-negative."
                 )
-            acqval = acqval * compute_smoothed_constraint_indicator(
+            acqval = acqval * compute_smoothed_feasibility_indicator(
                 constraints=self._constraints, samples=samples, eta=self._eta
             )
         return acqval
@@ -366,7 +366,7 @@ class qExpectedImprovement(SampleReducingMCAcquisitionFunction):
                 are considered satisfied if the output is less than zero.
             eta: Temperature parameter(s) governing the smoothness of the sigmoid
                 approximation to the constraint indicators. For more details, on this
-                parameter, see the docs of `compute_smoothed_constraint_indicator`.
+                parameter, see the docs of `compute_smoothed_feasibility_indicator`.
         """
         super().__init__(
             model=model,
@@ -457,7 +457,7 @@ class qNoisyExpectedImprovement(
                 are considered satisfied if the output is less than zero.
             eta: Temperature parameter(s) governing the smoothness of the sigmoid
                 approximation to the constraint indicators. For more details, on this
-                parameter, see the docs of `compute_smoothed_constraint_indicator`.
+                parameter, see the docs of `compute_smoothed_feasibility_indicator`.
 
         TODO: similar to qNEHVI, when we are using sequential greedy candidate
         selection, we could incorporate pending points X_baseline and compute
@@ -671,7 +671,7 @@ class qProbabilityOfImprovement(SampleReducingMCAcquisitionFunction):
                 scalar is less than zero.
             eta: Temperature parameter(s) governing the smoothness of the sigmoid
                 approximation to the constraint indicators. For more details, on this
-                parameter, see the docs of `compute_smoothed_constraint_indicator`.
+                parameter, see the docs of `compute_smoothed_feasibility_indicator`.
         """
         super().__init__(
             model=model,

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -57,7 +57,7 @@ from botorch.utils.multi_objective.box_decompositions.non_dominated import (
 from botorch.utils.multi_objective.box_decompositions.utils import (
     _pad_batch_pareto_frontier,
 )
-from botorch.utils.objective import compute_smoothed_constraint_indicator
+from botorch.utils.objective import compute_smoothed_feasibility_indicator
 from botorch.utils.torch import BufferDict
 from botorch.utils.transforms import (
     concatenate_pending_points,
@@ -279,7 +279,7 @@ class qExpectedHypervolumeImprovement(MultiObjectiveMCAcquisitionFunction):
         obj = self.objective(samples, X=X)
         q = obj.shape[-2]
         if self.constraints is not None:
-            feas_weights = compute_smoothed_constraint_indicator(
+            feas_weights = compute_smoothed_feasibility_indicator(
                 constraints=self.constraints, samples=samples, eta=self.eta
             )  # `sample_shape x batch-shape x q`
         self._cache_q_subset_indices(q_out=q)
@@ -414,7 +414,7 @@ class qNoisyExpectedHypervolumeImprovement(
                 tensor the length of the tensor must match the number of provided
                 constraints. The i-th constraint is then estimated with the i-th
                 eta value. For more details, on this parameter, see the docs of
-                `compute_smoothed_constraint_indicator`.
+                `compute_smoothed_feasibility_indicator`.
             prune_baseline: If True, remove points in `X_baseline` that are
                 highly unlikely to be the pareto optimal and better than the
                 reference point. This can significantly improve computation time and

--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -32,6 +32,7 @@ from botorch.utils.multi_objective.box_decompositions.non_dominated import (
     FastNondominatedPartitioning,
     NondominatedPartitioning,
 )
+from botorch.utils.objective import compute_feasibility_indicator
 from botorch.utils.sampling import optimize_posterior_samples
 from botorch.utils.transforms import is_fully_bayesian
 from torch import Tensor
@@ -210,6 +211,113 @@ def get_acquisition_function(
         )
     raise NotImplementedError(
         f"Unknown acquisition function {acquisition_function_name}"
+    )
+
+
+def compute_best_feasible_objective(
+    samples: Tensor,
+    obj: Tensor,
+    constraints: Optional[List[Callable[[Tensor], Tensor]]],
+    model: Optional[Model] = None,
+    objective: Optional[MCAcquisitionObjective] = None,
+    posterior_transform: Optional[PosteriorTransform] = None,
+    X_baseline: Optional[Tensor] = None,
+    infeasible_obj: Optional[Tensor] = None,
+) -> Tensor:
+    """Computes the largest `obj` value that is feasible under the `constraints`. If
+    `constraints` is None, returns the best unconstrained objective value.
+
+    When no feasible observations exist and `infeasible_obj` is not `None`, returns
+    `infeasible_obj` (potentially reshaped). When no feasible observations exist and
+    `infeasible_obj` is `None`, uses `model`, `objective`, `posterior_transform`, and
+    `X_baseline` to infer and return an `infeasible_obj` `M` s.t. `M < min_x f(x)`.
+
+    Args:
+        samples: `(sample_shape) x batch_shape x q x m`-dim posterior samples.
+        obj: A `(sample_shape) x batch_shape x q`-dim Tensor of MC objective values.
+        constraints: A list of constraint callables which map posterior samples to
+            a scalar. The associated constraint is considered satisfied if this
+            scalar is less than zero.
+        model: A Model, only required when there are no feasible observations.
+        objective: An MCAcquisitionObjective, only optionally used when there are no
+            feasible observations.
+        posterior_transform: A PosteriorTransform, only optionally used when there are
+            no feasible observations.
+        X_baseline: A `batch_shape x d`-dim Tensor of baseline points, only required
+            when there are no feasible observations.
+        infeasible_obj: A Tensor to be returned when no feasible points exist.
+
+    Returns:
+        A `(sample_shape) x batch_shape x 1`-dim Tensor of best feasible objectives.
+    """
+    if constraints is None:  # unconstrained case
+        # we don't need to differentiate through X_baseline for now, so taking
+        # the regular max over the n points to get best_f is fine
+        with torch.no_grad():
+            return obj.amax(dim=-1, keepdim=True)
+
+    is_feasible = compute_feasibility_indicator(
+        constraints=constraints, samples=samples
+    )  # sample_shape x batch_shape x q
+    if is_feasible.any():
+        obj = torch.where(is_feasible, obj, -torch.inf)
+        with torch.no_grad():
+            return obj.amax(dim=-1, keepdim=True)
+
+    elif infeasible_obj is not None:
+        return infeasible_obj.expand(*obj.shape[:-1], 1)
+
+    else:
+        if model is None:
+            raise ValueError(
+                "Must specify `model` when no feasible observation exists."
+            )
+        if X_baseline is None:
+            raise ValueError(
+                "Must specify `X_baseline` when no feasible observation exists."
+            )
+        return _estimate_objective_lower_bound(
+            model=model,
+            objective=objective,
+            posterior_transform=posterior_transform,
+            X=X_baseline,
+        ).expand(*obj.shape[:-1], 1)
+
+
+def _estimate_objective_lower_bound(
+    model: Model,
+    objective: Optional[MCAcquisitionObjective],
+    posterior_transform: Optional[PosteriorTransform],
+    X: Tensor,
+) -> Tensor:
+    """Estimates a lower bound on the objective values by evaluating the model at convex
+    combinations of `X`, returning the 6-sigma lower bound of the computed statistics.
+
+    Args:
+        model: A fitted model.
+        objective: An MCAcquisitionObjective with `m` outputs.
+        posterior_transform: A PosteriorTransform.
+        X: A `n x d`-dim Tensor of design points from which to draw convex combinations.
+
+    Returns:
+        A `m`-dimensional Tensor of lower bounds of the objectives.
+    """
+    convex_weights = torch.rand(
+        32,
+        X.shape[-2],
+        dtype=X.dtype,
+        device=X.device,
+    )
+    weights_sum = convex_weights.sum(dim=0, keepdim=True)
+    convex_weights = convex_weights / weights_sum
+    # infeasible cost M is such that -M < min_x f(x), thus
+    # 0 < min_x f(x) - (-M), so we should take -M as a lower
+    # bound on the best feasible objective
+    return -get_infeasible_cost(
+        X=convex_weights @ X,
+        model=model,
+        objective=objective,
+        posterior_transform=posterior_transform,
     )
 
 

--- a/botorch/utils/objective.py
+++ b/botorch/utils/objective.py
@@ -87,7 +87,7 @@ def apply_constraints_nonnegative_soft(
     Returns:
         A `n_samples x b x q (x m')`-dim tensor of feasibility-weighted objectives.
     """
-    w = compute_smoothed_constraint_indicator(
+    w = compute_smoothed_feasibility_indicator(
         constraints=constraints, samples=samples, eta=eta
     )
     if obj.dim() == samples.dim():
@@ -116,7 +116,7 @@ def compute_feasibility_indicator(
     return ind
 
 
-def compute_smoothed_constraint_indicator(
+def compute_smoothed_feasibility_indicator(
     constraints: List[Callable[[Tensor], Tensor]],
     samples: Tensor,
     eta: Union[Tensor, float],

--- a/test/utils/test_objective.py
+++ b/test/utils/test_objective.py
@@ -7,6 +7,10 @@
 
 import torch
 from botorch.utils import apply_constraints, get_objective_weights_transform
+from botorch.utils.objective import (
+    compute_feasibility_indicator,
+    compute_smoothed_constraint_indicator,
+)
 from botorch.utils.testing import BotorchTestCase
 from torch import Tensor
 
@@ -153,7 +157,7 @@ class TestApplyConstraints(BotorchTestCase):
             self.assertAllClose(obj, samples.clamp_min(-1.0) * 0.5 - 1.0)
             # nonnegative objective, one constraint, eta = 0
             obj = samples
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, "eta must be positive"):
                 apply_constraints(
                     obj=obj,
                     constraints=[zeros_f],
@@ -168,7 +172,7 @@ class TestApplyConstraints(BotorchTestCase):
             tkwargs["dtype"] = dtype
             samples = torch.rand(3, 2, **tkwargs)
             obj = samples.clone()
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, "Number of provided constraints"):
                 obj = apply_constraints(
                     obj=obj,
                     constraints=[zeros_f, zeros_f],
@@ -176,7 +180,7 @@ class TestApplyConstraints(BotorchTestCase):
                     infeasible_cost=0.0,
                     eta=torch.tensor([0.1]).to(**tkwargs),
                 )
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, "Number of provided constraints"):
                 obj = apply_constraints(
                     obj=obj,
                     constraints=[zeros_f, zeros_f],
@@ -184,6 +188,47 @@ class TestApplyConstraints(BotorchTestCase):
                     infeasible_cost=0.0,
                     eta=torch.tensor([0.1, 0.1, 0.3]).to(**tkwargs),
                 )
+
+    def test_constraint_indicators(self):
+        # nonnegative objective, one constraint
+        samples = torch.randn(1)
+        ind = compute_feasibility_indicator(constraints=[zeros_f], samples=samples)
+        self.assertAllClose(ind, torch.zeros_like(ind))
+        self.assertEqual(ind.dtype, torch.bool)
+
+        smoothed_ind = compute_smoothed_constraint_indicator(
+            constraints=[zeros_f], samples=samples, eta=1e-3
+        )
+        self.assertAllClose(smoothed_ind, ones_f(samples) / 2)
+
+        # two constraints
+        samples = torch.randn(1)
+        smoothed_ind = compute_smoothed_constraint_indicator(
+            constraints=[zeros_f, zeros_f],
+            samples=samples,
+            eta=1e-3,
+        )
+        self.assertAllClose(smoothed_ind, ones_f(samples) * 0.5 * 0.5)
+
+        # feasible
+        samples = torch.randn(1)
+        ind = compute_feasibility_indicator(
+            constraints=[minus_one_f],
+            samples=samples,
+        )
+        self.assertAllClose(ind, torch.ones_like(ind))
+
+        smoothed_ind = compute_smoothed_constraint_indicator(
+            constraints=[minus_one_f], samples=samples, eta=1e-3
+        )
+        self.assertTrue((smoothed_ind > 3 / 4).all())
+
+        with self.assertRaisesRegex(ValueError, "Number of provided constraints"):
+            compute_smoothed_constraint_indicator(
+                constraints=[zeros_f, zeros_f],
+                samples=samples,
+                eta=torch.tensor([0.1], device=self.device),
+            )
 
 
 class TestGetObjectiveWeightsTransform(BotorchTestCase):

--- a/test/utils/test_objective.py
+++ b/test/utils/test_objective.py
@@ -9,7 +9,7 @@ import torch
 from botorch.utils import apply_constraints, get_objective_weights_transform
 from botorch.utils.objective import (
     compute_feasibility_indicator,
-    compute_smoothed_constraint_indicator,
+    compute_smoothed_feasibility_indicator,
 )
 from botorch.utils.testing import BotorchTestCase
 from torch import Tensor
@@ -196,14 +196,14 @@ class TestApplyConstraints(BotorchTestCase):
         self.assertAllClose(ind, torch.zeros_like(ind))
         self.assertEqual(ind.dtype, torch.bool)
 
-        smoothed_ind = compute_smoothed_constraint_indicator(
+        smoothed_ind = compute_smoothed_feasibility_indicator(
             constraints=[zeros_f], samples=samples, eta=1e-3
         )
         self.assertAllClose(smoothed_ind, ones_f(samples) / 2)
 
         # two constraints
         samples = torch.randn(1)
-        smoothed_ind = compute_smoothed_constraint_indicator(
+        smoothed_ind = compute_smoothed_feasibility_indicator(
             constraints=[zeros_f, zeros_f],
             samples=samples,
             eta=1e-3,
@@ -218,13 +218,13 @@ class TestApplyConstraints(BotorchTestCase):
         )
         self.assertAllClose(ind, torch.ones_like(ind))
 
-        smoothed_ind = compute_smoothed_constraint_indicator(
+        smoothed_ind = compute_smoothed_feasibility_indicator(
             constraints=[minus_one_f], samples=samples, eta=1e-3
         )
         self.assertTrue((smoothed_ind > 3 / 4).all())
 
         with self.assertRaisesRegex(ValueError, "Number of provided constraints"):
-            compute_smoothed_constraint_indicator(
+            compute_smoothed_feasibility_indicator(
                 constraints=[zeros_f, zeros_f],
                 samples=samples,
                 eta=torch.tensor([0.1], device=self.device),


### PR DESCRIPTION
Summary: D47365085 introduced the aptly named `compute_feasibility_indicator`. This commit brings the smoothed counterpart in alignment with the naming convention.

Differential Revision: D47436246

