### PR TITLE
Merge SupervisedDataset & FixedNoiseDataset

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -99,7 +99,7 @@ from botorch.sampling.base import MCSampler
 from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.constraints import get_outcome_constraint_transforms
 from botorch.utils.containers import BotorchContainer
-from botorch.utils.datasets import BotorchDataset, SupervisedDataset
+from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.multi_objective.box_decompositions.non_dominated import (
     FastNondominatedPartitioning,
     NondominatedPartitioning,
@@ -114,7 +114,7 @@ MaybeDict = Union[T, Dict[Hashable, T]]
 
 
 def _field_is_shared(
-    datasets: Union[Iterable[BotorchDataset], Dict[Hashable, BotorchDataset]],
+    datasets: Union[Iterable[SupervisedDataset], Dict[Hashable, SupervisedDataset]],
     fieldname: Hashable,
 ) -> bool:
     r"""Determines whether or not a given field is shared by all datasets."""
@@ -136,7 +136,7 @@ def _field_is_shared(
 
 
 def _get_dataset_field(
-    dataset: MaybeDict[BotorchDataset],
+    dataset: MaybeDict[SupervisedDataset],
     fieldname: str,
     transform: Optional[Callable[[BotorchContainer], Any]] = None,
     join_rule: Optional[Callable[[Sequence[Any]], Any]] = None,

--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -185,7 +185,7 @@ class MixedSingleTaskGP(SingleTaskGP):
         likelihood: Optional[Likelihood] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        r"""Construct `Model` keyword arguments from a dict of `BotorchDataset`.
+        r"""Construct `Model` keyword arguments from a dict of `SupervisedDataset`.
 
         Args:
             training_data: A `SupervisedDataset` containing the training data.

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -38,7 +38,7 @@ from botorch.models.utils.assorted import fantasize as fantasize_flag
 from botorch.posteriors import Posterior, PosteriorList
 from botorch.sampling.base import MCSampler
 from botorch.sampling.list_sampler import ListSampler
-from botorch.utils.datasets import BotorchDataset
+from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.transforms import is_fully_bayesian
 from torch import Tensor
 from torch.nn import Module, ModuleDict, ModuleList
@@ -169,10 +169,10 @@ class Model(Module, ABC):
     @classmethod
     def construct_inputs(
         cls,
-        training_data: Union[BotorchDataset, Dict[Hashable, BotorchDataset]],
+        training_data: Union[SupervisedDataset, Dict[Hashable, SupervisedDataset]],
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        r"""Construct `Model` keyword arguments from a dict of `BotorchDataset`."""
+        r"""Construct `Model` keyword arguments from a dict of `SupervisedDataset`."""
         from botorch.models.utils.parse_training_data import parse_training_data
 
         return parse_training_data(cls, training_data, **kwargs)

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -47,7 +47,7 @@ from botorch.models.fully_bayesian import (
 from botorch.models.transforms import Normalize, Standardize
 from botorch.posteriors.fully_bayesian import batched_bisect, FullyBayesianPosterior
 from botorch.sampling.get_sampler import get_sampler
-from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
+from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.multi_objective.box_decompositions.non_dominated import (
     NondominatedPartitioning,
 )
@@ -550,10 +550,7 @@ class TestFullyBayesianSingleTaskGP(BotorchTestCase):
             X, Y, Yvar, model = self._get_data_and_model(
                 infer_noise=infer_noise, **tkwargs
             )
-            if infer_noise:
-                training_data = SupervisedDataset(X, Y)
-            else:
-                training_data = FixedNoiseDataset(X, Y, Yvar)
+            training_data = SupervisedDataset(X, Y, Yvar)
 
             data_dict = model.construct_inputs(training_data)
             self.assertTrue(X.equal(data_dict["train_X"]))

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -20,7 +20,7 @@ from botorch.models.transforms.input import InputStandardize
 from botorch.models.utils import add_output_dim
 from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling import SobolQMCNormalSampler
-from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
+from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.sampling import manual_seed
 from botorch.utils.testing import _get_random_data, BotorchTestCase
 from gpytorch.kernels import MaternKernel, RBFKernel, ScaleKernel
@@ -450,7 +450,7 @@ class TestFixedNoiseGP(TestSingleTaskGP):
             X = model_kwargs["train_X"]
             Y = model_kwargs["train_Y"]
             Yvar = model_kwargs["train_Yvar"]
-            training_data = FixedNoiseDataset(X, Y, Yvar)
+            training_data = SupervisedDataset(X, Y, Yvar)
             data_dict = model.construct_inputs(training_data)
             self.assertTrue(X.equal(data_dict["train_X"]))
             self.assertTrue(Y.equal(data_dict["train_Y"]))

--- a/test/models/test_gp_regression_fidelity.py
+++ b/test/models/test_gp_regression_fidelity.py
@@ -20,7 +20,7 @@ from botorch.models.gp_regression_fidelity import (
 from botorch.models.transforms import Normalize, Standardize
 from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling import SobolQMCNormalSampler
-from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
+from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.testing import _get_random_data, BotorchTestCase
 from gpytorch.kernels.scale_kernel import ScaleKernel
 from gpytorch.likelihoods import FixedNoiseGaussianLikelihood
@@ -487,7 +487,7 @@ class TestFixedNoiseMultiFidelityGP(TestSingleTaskMultiFidelityGP):
                 self.assertTrue("train_Yvar" not in data_dict)
 
                 # len(Xs) == len(Ys) == 1
-                training_data = FixedNoiseDataset(
+                training_data = SupervisedDataset(
                     X=kwargs["train_X"],
                     Y=kwargs["train_Y"],
                     Yvar=torch.full(kwargs["train_Y"].shape[:-1] + (1,), 0.1),

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -22,7 +22,7 @@ from botorch.models.transforms.input import Normalize
 from botorch.models.transforms.outcome import Standardize
 from botorch.posteriors import GPyTorchPosterior
 from botorch.posteriors.transformed import TransformedPosterior
-from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
+from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
 from gpytorch.kernels import (
@@ -59,7 +59,7 @@ def _gen_datasets(yvar: Optional[float] = None, **tkwargs):
     Yvar1 = torch.full_like(Y1, yvar)
     Yvar2 = torch.full_like(Y2, yvar)
     train_Yvar = torch.cat([Yvar1, Yvar2])
-    datasets = {0: FixedNoiseDataset(X, Y1, Yvar1), 1: FixedNoiseDataset(X, Y2, Yvar2)}
+    datasets = {0: SupervisedDataset(X, Y1, Yvar1), 1: SupervisedDataset(X, Y2, Yvar2)}
     return datasets, (train_X, train_Y, train_Yvar)
 
 

--- a/test/models/utils/test_parse_training_data.py
+++ b/test/models/utils/test_parse_training_data.py
@@ -67,9 +67,9 @@ class TestParseTrainingData(BotorchTestCase):
         with self.assertRaisesRegex(UnsupportedError, "multiple datasets to single"):
             parse_training_data(Model, datasets)
 
+        _datasets = datasets.copy()
+        _datasets[m] = SupervisedDataset(rand(n, 2), rand(n, 1), rand(n, 1))
         with self.assertRaisesRegex(UnsupportedError, "Cannot combine .* hetero"):
-            _datasets = datasets.copy()
-            _datasets[m] = FixedNoiseDataset(rand(n, 2), rand(n, 1), rand(n, 1))
             parse_training_data(MultiTaskGP, _datasets)
 
         with self.assertRaisesRegex(ValueError, "Missing required term"):


### PR DESCRIPTION
Summary:
This diff deprecates `FixedNoiseDataset` and merges it into `SupervisedDataset` with Yvar becoming an optional field. This also simplifies the class hierarchy a bit, removing `SupervisedDatasetMeta` in favor of an `__init__` method.

I plan to follow up on this by adding optional metric names to datasets and introducing a MultiTaskDataset, which will simplify some of the planned work in Ax MBM.

Differential Revision: D47729430

