### PR TITLE
add utility for printing shapes as strings

### DIFF
--- a/botorch/logging.py
+++ b/botorch/logging.py
@@ -6,6 +6,7 @@
 
 import logging
 
+import torch
 
 LOG_LEVEL_DEFAULT = logging.CRITICAL
 
@@ -34,6 +35,10 @@ def _get_logger(
     logger.addHandler(console)
     logger.propagate = False
     return logger
+
+
+def shape_to_str(shape: torch.Size) -> str:
+    return f"`{' x '.join(str(i) for i in shape)}`"
 
 
 logger = _get_logger()

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -33,6 +33,7 @@ import numpy as np
 import torch
 from botorch import settings
 from botorch.exceptions.errors import BotorchTensorDimensionError, InputDataError
+from botorch.logging import shape_to_str
 from botorch.models.utils.assorted import fantasize as fantasize_flag
 from botorch.posteriors import Posterior, PosteriorList
 from botorch.sampling.base import MCSampler
@@ -581,8 +582,8 @@ class ModelList(Model):
             ):
                 raise BotorchTensorDimensionError(
                     f"Expected evaluation_mask of shape `{X.shape[0]} "
-                    f"x {self.num_outputs}`, but got `"
-                    f"{' x '.join(str(i) for i in evaluation_mask.shape)}`."
+                    f"x {self.num_outputs}`, but got "
+                    f"{shape_to_str(evaluation_mask.shape)}."
                 )
             if not isinstance(sampler, ListSampler):
                 raise ValueError("Decoupled fantasization requires a list of samplers.")

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -6,8 +6,10 @@
 
 import logging
 
+import torch
+
 from botorch import settings
-from botorch.logging import LOG_LEVEL_DEFAULT, logger
+from botorch.logging import LOG_LEVEL_DEFAULT, logger, shape_to_str
 from botorch.utils.testing import BotorchTestCase
 
 
@@ -31,3 +33,9 @@ class TestLogging(BotorchTestCase):
             self.assertEqual(logger.level, logging.INFO)
         # Finally, verify the original level is set again
         self.assertEqual(logger.level, LOG_LEVEL_DEFAULT)
+
+    def test_shape_to_str(self):
+        self.assertEqual("``", shape_to_str(torch.Size([])))
+        self.assertEqual("`1`", shape_to_str(torch.Size([1])))
+        self.assertEqual("`1 x 2`", shape_to_str(torch.Size([1, 2])))
+        self.assertEqual("`1 x 2 x 3`", shape_to_str(torch.Size([1, 2, 3])))


### PR DESCRIPTION
Summary: This is useful for printing exception messages in a nice format that is easily verified with `assertRaisesRegex`.

Reviewed By: Balandat

Differential Revision: D47710862

