### PR TITLE
AnalyticExpectedUtilityOfBestOption input constructor uses pref_model.dim

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -1235,7 +1235,9 @@ def construct_inputs_analytic_eubo(
     # construct a deterministic fixed single sample model from `model`
     # i.e., performing EUBO-zeta by default as described
     # in https://arxiv.org/abs/2203.11382
-    w = torch.randn(model.num_outputs) * sample_multiplier
+    # using pref_model.dim instead of model.num_outputs here as MTGP's
+    # num_outputs could be tied to the number of tasks
+    w = torch.randn(pref_model.dim) * sample_multiplier
     one_sample_outcome_model = FixedSingleSampleModel(model=model, w=w)
 
     return {


### PR DESCRIPTION
Summary: Make AnalyticExpectedUtilityOfBestOption input constructor uses `pref_model.dim` instead of `model.num_outputs` as the latter may also depend on the number of tasks for MTGPs. And example is a model list of MTGPs will have `model.num_outputs = num_tasks * num_outcomes` while we only want `num_outcomes` here.

Differential Revision: D47826495

