### PR TITLE
compare types with "is" so flake8 passes

### DIFF
--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -136,7 +136,7 @@ class MultiObjectiveMCAcquisitionFunction(AcquisitionFunction, MCSamplerMixin, A
         self.add_module("objective", objective)
         self.constraints = constraints
         if constraints:
-            if type(eta) != Tensor:
+            if type(eta) is not Tensor:
                 eta = torch.full((len(constraints),), eta)
             self.register_buffer("eta", eta)
         self.X_pending = None

--- a/botorch/acquisition/objective.py
+++ b/botorch/acquisition/objective.py
@@ -494,7 +494,7 @@ class ConstrainedMCObjective(GenericMCObjective):
         """
         super().__init__(objective=objective)
         self.constraints = constraints
-        if type(eta) != Tensor:
+        if type(eta) is not Tensor:
             eta = torch.full((len(constraints),), eta)
         self.register_buffer("eta", eta)
         self.register_buffer("infeasible_cost", torch.as_tensor(infeasible_cost))

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -64,11 +64,11 @@ _sqrt5 = math.sqrt(5)
 
 
 def _handle_torch_linalg(exception: Exception) -> bool:
-    return type(exception) == torch.linalg.LinAlgError
+    return type(exception) is torch.linalg.LinAlgError
 
 
 def _handle_valerr_in_dist_init(exception: Exception) -> bool:
-    if not type(exception) == ValueError:
+    if type(exception) is not ValueError:
         return False
     return "satisfy the constraint PositiveDefinite()" in str(exception)
 

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -118,7 +118,7 @@ class InputTransform(ABC):
         """
         other_state_dict = other.state_dict()
         return (
-            type(self) == type(other)
+            type(self) is type(other)
             and (self.transform_on_train == other.transform_on_train)
             and (self.transform_on_eval == other.transform_on_eval)
             and (self.transform_on_fantasize == other.transform_on_fantasize)
@@ -1547,7 +1547,7 @@ class OneHotToNumeric(InputTransform, Module):
             A boolean indicating if the other transform is equivalent.
         """
         return (
-            type(self) == type(other)
+            type(self) is type(other)
             and (self.transform_on_train == other.transform_on_train)
             and (self.transform_on_eval == other.transform_on_eval)
             and (self.transform_on_fantasize == other.transform_on_fantasize)

--- a/botorch/utils/objective.py
+++ b/botorch/utils/objective.py
@@ -152,7 +152,7 @@ def compute_smoothed_feasibility_indicator(
     Returns:
         A `n_samples x b x q`-dim tensor of feasibility indicator values.
     """
-    if type(eta) != Tensor:
+    if type(eta) is not Tensor:
         eta = torch.full((len(constraints),), eta)
     if len(eta) != len(constraints):
         raise ValueError(

--- a/botorch/utils/probability/linalg.py
+++ b/botorch/utils/probability/linalg.py
@@ -189,7 +189,7 @@ class PivotedCholesky:
         for name in ("tril", "perm", "diag"):
             a = getattr(self, name)
             b = getattr(other, name)
-            if type(a) != type(b):
+            if type(a) is not type(b):
                 raise NotImplementedError(f"Types of field {name} do not match.")
 
             if a is not None:

--- a/botorch/utils/probability/mvnxpb.py
+++ b/botorch/utils/probability/mvnxpb.py
@@ -302,7 +302,7 @@ class MVNXPB:
             if _self is None and _other is None:
                 continue
 
-            if type(_self) != type(_other):
+            if type(_self) is not type(_other):
                 raise TypeError(
                     f"Concatenation failed: `self.{key}` has type {type(_self)}, "
                     f"but `other.{key}` is of type {type(_self)}."

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -702,7 +702,7 @@ class TestPyroCatchNumericalErrors(BotorchTestCase):
 
         # But once we register this specific error then it should
         def catch_runtime_error(e):
-            return type(e) == RuntimeError and "foo" in str(e)
+            return type(e) is RuntimeError and "foo" in str(e)
 
         register_exception_handler("foo_runtime", catch_runtime_error)
         _, val = potential_grad(potential_fn_rterr_foo, z)

--- a/test/optim/closures/test_model_closures.py
+++ b/test/optim/closures/test_model_closures.py
@@ -65,7 +65,7 @@ class TestLossClosures(BotorchTestCase):
 
     def test_data_loader(self):
         for mll in self.mlls.values():
-            if type(mll) != ExactMarginalLogLikelihood:
+            if type(mll) is not ExactMarginalLogLikelihood:
                 continue
 
             dataset = TensorDataset(*mll.model.train_inputs, mll.model.train_targets)

--- a/test/utils/test_dispatcher.py
+++ b/test/utils/test_dispatcher.py
@@ -63,8 +63,8 @@ class TestDispatcher(BotorchTestCase):
                 self.assertEqual(self.dispatcher[args], _pow)
 
                 retval = self.dispatcher(*args)
-                test_type = float if (type_a == float or type_b == float) else int
-                self.assertTrue(type(retval) == test_type)
+                test_type = float if (type_a is float or type_b is float) else int
+                self.assertIs(type(retval), test_type)
                 self.assertEqual(retval, test_type(8))
 
     def test_notImplemented(self):


### PR DESCRIPTION
## Motivation

Flake8 is failing in the CI because it now requires comparing types with "is" rather than "==".

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Units, flake8
