### PR TITLE
Bump required pytorch version to 1.13.1

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - setuptools
     - setuptools_scm
   run:
-    - pytorch >=1.12
+    - pytorch >=1.13.1
     - gpytorch ==1.10
     - linear_operator ==0.4.0
     - scipy

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Optimization simply use Ax.
 
 **Installation Requirements**
 - Python >= 3.9
-- PyTorch >= 1.12
+- PyTorch >= 1.13.1
 - gpytorch == 1.10
 - linear_operator == 0.4.0
 - pyro-ppl >= 1.8.4

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - gpytorch
   - conda-forge
 dependencies:
-  - pytorch>=1.12
+  - pytorch>=1.13.1
   - gpytorch==1.10
   - linear_operator==0.4.0
   - scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 multipledispatch
 scipy
-torch>=1.12
+torch>=1.13.1
 pyro-ppl>=1.8.4
 gpytorch==1.10
 linear_operator==0.4.0


### PR DESCRIPTION
This has been out for a while now, and we can include it as part of our "major" 0.9.0 version bump.