### PR TITLE
Bump req versions: gpytorch to 1.11 and linear_operator to 0.5.0

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -18,8 +18,8 @@ requirements:
     - setuptools_scm
   run:
     - pytorch >=1.12
-    - gpytorch ==1.10
-    - linear_operator ==0.4.0
+    - gpytorch ==1.11
+    - linear_operator ==0.5.0
     - scipy
     - multipledispatch
     - pyro-ppl >=1.8.4

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Optimization simply use Ax.
 **Installation Requirements**
 - Python >= 3.9
 - PyTorch >= 1.12
-- gpytorch == 1.10
-- linear_operator == 0.4.0
+- gpytorch == 1.11
+- linear_operator == 0.5.0
 - pyro-ppl >= 1.8.4
 - scipy
 - multiple-dispatch

--- a/environment.yml
+++ b/environment.yml
@@ -5,8 +5,8 @@ channels:
   - conda-forge
 dependencies:
   - pytorch>=1.12
-  - gpytorch==1.10
-  - linear_operator==0.4.0
+  - gpytorch==1.11
+  - linear_operator==0.5.0
   - scipy
   - multipledispatch
   - pyro-ppl>=1.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ multipledispatch
 scipy
 torch>=1.12
 pyro-ppl>=1.8.4
-gpytorch==1.10
-linear_operator==0.4.0
+gpytorch==1.11
+linear_operator==0.5.0


### PR DESCRIPTION
In preparation for 0.9.0 "major" release