### PR TITLE
Update min req linear_operator to 0.5.1

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   run:
     - pytorch >=1.13.1
     - gpytorch ==1.11
-    - linear_operator ==0.5.0
+    - linear_operator ==0.5.1
     - scipy
     - multipledispatch
     - pyro-ppl >=1.8.4

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Optimization simply use Ax.
 - Python >= 3.9
 - PyTorch >= 1.13.1
 - gpytorch == 1.11
-- linear_operator == 0.5.0
+- linear_operator == 0.5.1
 - pyro-ppl >= 1.8.4
 - scipy
 - multiple-dispatch

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - pytorch>=1.13.1
   - gpytorch==1.11
-  - linear_operator==0.5.0
+  - linear_operator==0.5.1
   - scipy
   - multipledispatch
   - pyro-ppl>=1.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ scipy
 torch>=1.13.1
 pyro-ppl>=1.8.4
 gpytorch==1.11
-linear_operator==0.5.0
+linear_operator==0.5.1


### PR DESCRIPTION
linear_operator 0.5.0 had a bug that causes some things in botorch to raise errors. This bumps things to the newly released 0.5.1 that fixes these issues.