### PR TITLE
Release notes for 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 The release log for BoTorch.
 
-## [0.9.0] - July 31, 2023
+## [0.9.1] - Aug 1, 2023
+
+* Require linear_operator == 0.5.1 (#1963).
+
+
+## [0.9.0] - Aug 1, 2023
 
 #### Compatibility
 * Require Python >= 3.9.0 (#1924).


### PR DESCRIPTION
0.9.1 is the same as 0.9.0 apart from a version bump to linear_operator that was required since the pinned 0.5.0 version had a bug.