### PR TITLE
bump py version in deploy on release

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         pip install .[test]


### PR DESCRIPTION
Summary:
see title. Deploy on release failed due to running on py3.8

https://github.com/pytorch/botorch/actions/runs/5826595266/job/15801310995#step:6:37

Differential Revision: D48250526

