### PR TITLE
Dont use a Sphinx version later than 7.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ if os.environ.get("ALLOW_LATEST_GPYTORCH_LINOP"):
 # Read in pinned versions of the formatting tools
 FMT_REQUIRES += read_deps_from_file("requirements-fmt.txt")
 # Dev is test + formatting + docs generation
-DEV_REQUIRES = TEST_REQUIRES + FMT_REQUIRES + ["sphinx"]
+DEV_REQUIRES = TEST_REQUIRES + FMT_REQUIRES + ["sphinx<=7.1.2"]
 
 # read in README.md as the long description
 with open(os.path.join(root_dir, "README.md"), "r") as fh:


### PR DESCRIPTION
Summary: Sphinx 7.2.0 or later leads to doc build failures.

Differential Revision: D48487417

