### PR TITLE
Stop some warnings in unit tests

### DIFF
--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -43,25 +43,31 @@ class BotorchTestCase(TestCase):
 
     device = torch.device("cpu")
 
-    def setUp(self):
+    def setUp(self, suppress_input_warnings: bool = True) -> None:
         warnings.resetwarnings()
         settings.debug._set_state(False)
         warnings.simplefilter("always", append=True)
-        warnings.filterwarnings(
-            "ignore",
-            message="The model inputs are of type",
-            category=UserWarning,
-        )
-        warnings.filterwarnings(
-            "ignore",
-            message="Non-strict enforcement of botorch tensor conventions.",
-            category=BotorchTensorDimensionWarning,
-        )
-        warnings.filterwarnings(
-            "ignore",
-            message="Input data is not standardized.",
-            category=InputDataWarning,
-        )
+        if suppress_input_warnings:
+            warnings.filterwarnings(
+                "ignore",
+                message="The model inputs are of type",
+                category=UserWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message="Non-strict enforcement of botorch tensor conventions.",
+                category=BotorchTensorDimensionWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message="Input data is not standardized.",
+                category=InputDataWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message="Input data is not contained to the unit cube.",
+                category=InputDataWarning,
+            )
 
     def assertAllClose(
         self,

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -97,6 +97,7 @@ class DummyAcquisitionFunction(AcquisitionFunction):
 
 class InputConstructorBaseTestCase:
     def setUp(self) -> None:
+        super().setUp()
         self.mock_model = MockModel(
             posterior=MockPosterior(mean=None, variance=None, base_shape=(1,))
         )

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -556,7 +556,7 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
             "prune_baseline": False,
             "cache_root": True,
             "posterior_transform": ScalarizedPosteriorTransform(weights=torch.ones(m)),
-            "sampler": SobolQMCNormalSampler(5),
+            "sampler": SobolQMCNormalSampler(sample_shape=torch.Size([5])),
         }
         acqf = qNoisyExpectedImprovement(**nei_args)
         X = torch.randn_like(X_baseline)

--- a/test/acquisition/test_preference.py
+++ b/test/acquisition/test_preference.py
@@ -18,7 +18,8 @@ from botorch.utils.testing import BotorchTestCase
 
 
 class TestPreferenceAcquisitionFunctions(BotorchTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
+        super().setUp()
         self.twargs = {"dtype": torch.double}
         self.X_dim = 3
         self.Y_dim = 2

--- a/test/acquisition/test_prior_guided.py
+++ b/test/acquisition/test_prior_guided.py
@@ -39,6 +39,7 @@ def get_weighted_val(ei_val, prob, exponent, use_log):
 
 class TestPriorGuidedAcquisitionFunction(BotorchTestCase):
     def setUp(self):
+        super().setUp()
         self.prior = DummyPrior()
         self.train_X = torch.rand(5, 3, dtype=torch.double, device=self.device)
         self.train_Y = self.train_X.norm(dim=-1, keepdim=True)

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -296,7 +296,7 @@ class TestGPyTorchModel(BotorchTestCase):
         self.assertFalse(model.last_fantasize_flag)
         model.posterior(test_X)
         self.assertFalse(model.last_fantasize_flag)
-        model.fantasize(test_X, SobolQMCNormalSampler(2))
+        model.fantasize(test_X, SobolQMCNormalSampler(sample_shape=torch.Size([2])))
         self.assertTrue(model.last_fantasize_flag)
         model.last_fantasize_flag = False
         with fantasize():

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -382,7 +382,9 @@ class TestModelListGP(BotorchTestCase):
         m1 = SingleTaskGP(torch.rand(5, 2), torch.rand(5, 1)).eval()
         m2 = SingleTaskGP(torch.rand(5, 2), torch.rand(5, 1)).eval()
         modellist = ModelListGP(m1, m2)
-        fm = modellist.fantasize(torch.rand(3, 2), sampler=IIDNormalSampler(2))
+        fm = modellist.fantasize(
+            torch.rand(3, 2), sampler=IIDNormalSampler(sample_shape=torch.Size([2]))
+        )
         self.assertIsInstance(fm, ModelListGP)
         for i in range(2):
             fm_i = fm.models[i]
@@ -391,8 +393,8 @@ class TestModelListGP(BotorchTestCase):
             self.assertEqual(fm_i.train_targets.shape, torch.Size([2, 8]))
 
         # test decoupled
-        sampler1 = IIDNormalSampler(2)
-        sampler2 = IIDNormalSampler(2)
+        sampler1 = IIDNormalSampler(sample_shape=torch.Size([2]))
+        sampler2 = IIDNormalSampler(sample_shape=torch.Size([2]))
         eval_mask = torch.tensor(
             [[1, 0], [0, 1], [1, 0]],
             dtype=torch.bool,
@@ -457,7 +459,7 @@ class TestModelListGP(BotorchTestCase):
                     return fant.posterior(target_x).mean.mean(dim=(-2, -3))
 
                 # ~0
-                sampler = IIDNormalSampler(10, seed=0)
+                sampler = IIDNormalSampler(sample_shape=torch.Size([10]), seed=0)
                 fant_mean_with_manual_transform = _get_fant_mean(
                     model_manually_transformed, sampler=sampler
                 )
@@ -490,8 +492,8 @@ class TestModelListGP(BotorchTestCase):
                 )
                 # test decoupled
                 sampler = ListSampler(
-                    IIDNormalSampler(10, seed=0),
-                    IIDNormalSampler(10, seed=0),
+                    IIDNormalSampler(sample_shape=torch.Size([10]), seed=0),
+                    IIDNormalSampler(sample_shape=torch.Size([10]), seed=0),
                 )
                 fant_mean_with_manual_transform = _get_fant_mean(
                     model_manually_transformed,
@@ -539,7 +541,7 @@ class TestModelListGP(BotorchTestCase):
         100 at x=0. If transforms are not properly applied, we'll get answers
         on the order of ~1. Answers between 99 and 101 are acceptable.
         """
-        n_fants = 20
+        n_fants = torch.Size([20])
         y_at_low_x = 100.0
         y_at_high_x = -40.0
 

--- a/test/models/utils/test_assorted.py
+++ b/test/models/utils/test_assorted.py
@@ -72,6 +72,11 @@ class TestAddOutputDim(BotorchTestCase):
 
 
 class TestInputDataChecks(BotorchTestCase):
+    def setUp(self) -> None:
+        # The super class usually disables input data warnings in unit tests.
+        # Don't do that here.
+        super().setUp(suppress_input_warnings=False)
+
     def test_check_no_nans(self):
         check_no_nans(torch.tensor([1.0, 2.0]))
         with self.assertRaises(InputDataError):
@@ -87,12 +92,10 @@ class TestInputDataChecks(BotorchTestCase):
                     any(issubclass(w.category, InputDataWarning) for w in ws)
                 )
             check_min_max_scaling(X=X, raise_on_fail=True)
-            with warnings.catch_warnings(record=True) as ws:
+            with self.assertWarnsRegex(
+                expected_warning=InputDataWarning, expected_regex="not scaled"
+            ):
                 check_min_max_scaling(X=X, strict=True)
-                self.assertTrue(
-                    any(issubclass(w.category, InputDataWarning) for w in ws)
-                )
-                self.assertTrue(any("not scaled" in str(w.message) for w in ws))
             with self.assertRaises(InputDataError):
                 check_min_max_scaling(X=X, strict=True, raise_on_fail=True)
             # check proper input

--- a/test/optim/test_fit.py
+++ b/test/optim/test_fit.py
@@ -25,7 +25,8 @@ from scipy.optimize import OptimizeResult
 
 
 class TestFitGPyTorchMLLScipy(BotorchTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
+        super().setUp()
         self.mlls = {}
         with torch.random.fork_rng():
             torch.manual_seed(0)
@@ -172,7 +173,8 @@ class TestFitGPyTorchMLLScipy(BotorchTestCase):
 
 
 class TestFitGPyTorchMLLTorch(BotorchTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
+        super().setUp()
         self.mlls = {}
         with torch.random.fork_rng():
             torch.manual_seed(0)
@@ -236,7 +238,8 @@ class TestFitGPyTorchMLLTorch(BotorchTestCase):
 
 
 class TestFitGPyTorchScipy(BotorchTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
+        super().setUp()
         self.mlls = {}
         with torch.random.fork_rng():
             torch.manual_seed(0)
@@ -372,6 +375,7 @@ class TestFitGPyTorchScipy(BotorchTestCase):
 
 class TestFitGPyTorchTorch(BotorchTestCase):
     def setUp(self):
+        super().setUp()
         self.mlls = {}
         with torch.random.fork_rng():
             torch.manual_seed(0)

--- a/test/optim/test_numpy_converter.py
+++ b/test/optim/test_numpy_converter.py
@@ -230,7 +230,8 @@ class TestSetParamsWithArray(BotorchTestCase):
 
 
 class TestScipyObjectiveAndGrad(BotorchTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
+        super().setUp()
         with torch.random.fork_rng():
             torch.manual_seed(0)
             train_X = torch.linspace(0, 1, 10).unsqueeze(-1)

--- a/test/optim/utils/test_model_utils.py
+++ b/test/optim/utils/test_model_utils.py
@@ -116,6 +116,7 @@ class TestGetDataLoader(BotorchTestCase):
 
 class TestGetParameters(BotorchTestCase):
     def setUp(self):
+        super().setUp()
         self.module = GaussianLikelihood(
             noise_constraint=GreaterThan(1e-6, initial_value=0.123),
         )
@@ -124,7 +125,7 @@ class TestGetParameters(BotorchTestCase):
         self.assertEqual(0, len(get_parameters(self.module, requires_grad=False)))
 
         params = get_parameters(self.module)
-        self.assertTrue(1 == len(params))
+        self.assertEqual(1, len(params))
         self.assertEqual(next(iter(params)), "noise_covar.raw_noise")
         self.assertTrue(
             self.module.noise_covar.raw_noise.equal(next(iter(params.values())))

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -69,7 +69,8 @@ class MockOptimizer:
 class TestFitAPI(BotorchTestCase):
     r"""Unit tests for general fitting API"""
 
-    def setUp(self):
+    def setUp(self) -> None:
+        super().setUp()
         with torch.random.fork_rng():
             torch.manual_seed(0)
             train_X = torch.linspace(0, 1, 10).unsqueeze(-1)
@@ -172,7 +173,8 @@ class TestFitAPI(BotorchTestCase):
 
 
 class TestFitFallback(BotorchTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
+        super().setUp()
         with torch.random.fork_rng():
             torch.manual_seed(0)
             train_X = torch.linspace(0, 1, 10).unsqueeze(-1)
@@ -377,7 +379,8 @@ class TestFitFallback(BotorchTestCase):
 
 
 class TestFitFallbackAppoximate(BotorchTestCase):
-    def setUp(self):
+    def setUp(self) -> None:
+        super().setUp()
         with torch.random.fork_rng():
             torch.manual_seed(0)
             train_X = torch.linspace(0, 1, 10).unsqueeze(-1)

--- a/test/utils/multi_objective/box_decompositions/test_box_decomposition.py
+++ b/test/utils/multi_objective/box_decompositions/test_box_decomposition.py
@@ -49,6 +49,7 @@ class DummyFastPartitioning(FastPartitioning, DummyBoxDecomposition):
 
 class TestBoxDecomposition(BotorchTestCase):
     def setUp(self):
+        super().setUp()
         self.ref_point_raw = torch.zeros(3, device=self.device)
         self.Y_raw = torch.tensor(
             [

--- a/test/utils/multi_objective/box_decompositions/test_utils.py
+++ b/test/utils/multi_objective/box_decompositions/test_utils.py
@@ -269,6 +269,7 @@ class TestFastPartitioningUtils(BotorchTestCase):
     """
 
     def setUp(self):
+        super().setUp()
         self.ref_point = -torch.tensor([10.0, 10.0, 10.0], device=self.device)
         self.U = -self.ref_point.clone().view(1, -1)
         self.Z = torch.empty(1, 3, 3, device=self.device)

--- a/test/utils/probability/test_truncated_multivariate_normal.py
+++ b/test/utils/probability/test_truncated_multivariate_normal.py
@@ -28,7 +28,8 @@ class TestTruncatedMultivariateNormal(BotorchTestCase):
         upper_quantile_min: float = 0.1,  # MC methods will not produce any samples.
         num_log_probs: int = 4,
         seed: int = 1,
-    ):
+    ) -> None:
+        super().setUp()
         self.seed_generator = count(seed)
         self.num_log_probs = num_log_probs
 

--- a/test/utils/test_context_managers.py
+++ b/test/utils/test_context_managers.py
@@ -23,6 +23,7 @@ from torch.nn import Module, Parameter
 
 class TestContextManagers(BotorchTestCase):
     def setUp(self):
+        super().setUp()
         module = self.module = Module()
         for i, name in enumerate(ascii_lowercase[:3], start=1):
             values = torch.rand(2).to(torch.float16)

--- a/test/utils/test_dispatcher.py
+++ b/test/utils/test_dispatcher.py
@@ -23,6 +23,7 @@ def _helper_test_source(val):
 
 class TestDispatcher(BotorchTestCase):
     def setUp(self):
+        super().setUp()
         self.dispatcher = Dispatcher(name="test")
 
     def test_encoder(self):

--- a/test/utils/test_low_rank.py
+++ b/test/utils/test_low_rank.py
@@ -70,8 +70,8 @@ class TestSampleCachedCholesky(BotorchTestCase):
                             train_X,
                             train_Y[:, :m],
                         )
-                    sampler = IIDNormalSampler(3)
-                    base_sampler = IIDNormalSampler(3)
+                    sampler = IIDNormalSampler(sample_shape=torch.Size([3]))
+                    base_sampler = IIDNormalSampler(sample_shape=torch.Size([3]))
                     for q in (1, 3, 9):
                         # test batched baseline_L
                         for train_batch_shape in (

--- a/test/utils/test_sampling.py
+++ b/test/utils/test_sampling.py
@@ -310,6 +310,7 @@ class PolytopeSamplerTestBase:
     sampler_kwargs: Dict[str, Any] = {}
 
     def setUp(self):
+        super().setUp()
         self.bounds = torch.zeros(2, 3, device=self.device)
         self.bounds[1] = 1
         self.A = torch.tensor(


### PR DESCRIPTION
## Motivation

Warning output from unit tests sometimes indicates a serious problem and sometimes merely clutters the output so we can't notice the serious problems. These warnings are the latter:
*  InputDataWarning: Input data is not contained to the unit cube. Please consider min-max scaling the input data (occurred 194 times, now 0)
* BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly. (occurred 40 times, now 0)
*  The first positional argument of samplers, `num_samples`, has been deprecated and replaced with `sample_shape`, which expects a `torch.Size` object.' (occurred 35 times, now 0)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Units

## Related PRs

#1792, #1539