### PR TITLE
Remove deprecated usage of `torch.norm`

### DIFF
--- a/botorch/acquisition/penalized.py
+++ b/botorch/acquisition/penalized.py
@@ -44,7 +44,8 @@ class L2Penalty(torch.nn.Module):
             A tensor of size "batch_shape" representing the acqfn for each q-batch.
         """
         regularization_term = (
-            torch.norm((X - self.init_point), p=2, dim=-1).max(dim=-1).values ** 2
+            torch.linalg.norm((X - self.init_point), ord=2, dim=-1).max(dim=-1).values
+            ** 2
         )
         return regularization_term
 
@@ -72,7 +73,7 @@ class L1Penalty(torch.nn.Module):
             A tensor of size "batch_shape" representing the acqfn for each q-batch.
         """
         regularization_term = (
-            torch.norm((X - self.init_point), p=1, dim=-1).max(dim=-1).values
+            torch.linalg.norm((X - self.init_point), ord=1, dim=-1).max(dim=-1).values
         )
         return regularization_term
 
@@ -101,7 +102,7 @@ class GaussianPenalty(torch.nn.Module):
         Returns:
             A tensor of size "batch_shape" representing the acqfn for each q-batch.
         """
-        sq_diff = torch.norm((X - self.init_point), p=2, dim=-1) ** 2
+        sq_diff = torch.linalg.norm((X - self.init_point), ord=2, dim=-1) ** 2
         pdf = torch.exp(sq_diff / 2 / self.sigma**2)
         regularization_term = pdf.max(dim=-1).values
         return regularization_term
@@ -257,7 +258,10 @@ def group_lasso_regularizer(X: Tensor, groups: List[List[int]]) -> Tensor:
     """
     return torch.sum(
         torch.stack(
-            [math.sqrt(len(g)) * torch.norm(X[..., g], p=2, dim=-1) for g in groups],
+            [
+                math.sqrt(len(g)) * torch.linalg.norm(X[..., g], ord=2, dim=-1)
+                for g in groups
+            ],
             dim=-1,
         ),
         dim=-1,
@@ -289,7 +293,7 @@ class L1PenaltyObjective(torch.nn.Module):
             A "1 x batch_shape x q" tensor representing the penalty for each point.
             The first dimension corresponds to the dimension of MC samples.
         """
-        return torch.norm((X - self.init_point), p=1, dim=-1).unsqueeze(dim=0)
+        return torch.linalg.norm((X - self.init_point), ord=1, dim=-1).unsqueeze(dim=0)
 
 
 class PenalizedMCObjective(GenericMCObjective):

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -354,7 +354,7 @@ class HeteroskedasticSingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP):
     Example:
         >>> train_X = torch.rand(20, 2)
         >>> train_Y = torch.sin(train_X).sum(dim=1, keepdim=True)
-        >>> se = torch.norm(train_X, dim=1, keepdim=True)
+        >>> se = torch.linalg.norm(train_X, dim=1, keepdim=True)
         >>> train_Yvar = 0.1 + se * torch.rand_like(train_Y)
         >>> model = HeteroskedasticSingleTaskGP(train_X, train_Y, train_Yvar)
     """

--- a/botorch/models/pairwise_gp.py
+++ b/botorch/models/pairwise_gp.py
@@ -671,7 +671,7 @@ class PairwiseGP(Model, GP, FantasizeMixin):
             cov_g = covar @ g.unsqueeze(-1)
             x_update = torch.linalg.solve(cov_hl, cov_g).squeeze(-1)
             x_next = x - x_update
-            diff = torch.norm(x - x_next)
+            diff = torch.linalg.norm(x - x_next)
             x = x_next
             i += 1
 

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -139,7 +139,7 @@ class Ackley(SyntheticTestFunction):
 
     def evaluate_true(self, X: Tensor) -> Tensor:
         a, b, c = self.a, self.b, self.c
-        part1 = -a * torch.exp(-b / math.sqrt(self.dim) * torch.norm(X, dim=-1))
+        part1 = -a * torch.exp(-b / math.sqrt(self.dim) * torch.linalg.norm(X, dim=-1))
         part2 = -(torch.exp(torch.mean(torch.cos(c * X), dim=-1)))
         return part1 + part2 + a + math.e
 
@@ -231,7 +231,7 @@ class DropWave(SyntheticTestFunction):
     _check_grad_at_opt = False
 
     def evaluate_true(self, X: Tensor) -> Tensor:
-        norm = torch.norm(X, dim=-1)
+        norm = torch.linalg.norm(X, dim=-1)
         part1 = 1.0 + torch.cos(12.0 * norm)
         part2 = 0.5 * norm.pow(2) + 2.0
         return -part1 / part2
@@ -455,7 +455,7 @@ class HolderTable(SyntheticTestFunction):
     ]
 
     def evaluate_true(self, X: Tensor) -> Tensor:
-        term = torch.abs(1 - torch.norm(X, dim=-1) / math.pi)
+        term = torch.abs(1 - torch.linalg.norm(X, dim=-1) / math.pi)
         return -(
             torch.abs(torch.sin(X[..., 0]) * torch.cos(X[..., 1]) * torch.exp(term))
         )

--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -166,7 +166,7 @@ def sample_hypersphere(
     else:
         with manual_seed(seed=seed):
             rnd = torch.randn(n, d, dtype=dtype)
-    samples = rnd / torch.norm(rnd, dim=-1, keepdim=True)
+    samples = rnd / torch.linalg.norm(rnd, dim=-1, keepdim=True)
     if device is not None:
         samples = samples.to(device)
     return samples

--- a/docs/objectives.md
+++ b/docs/objectives.md
@@ -47,7 +47,7 @@ to optimize a $obj(y) = 1 - \\|y - y_0\\|_2$, where $y_0 \in \mathbb{R}^2$.
 For this you would use the following custom objective (here we can ignore the
 inputs $X$ as the objective does not depend on it):
 ```python
-obj = lambda xi, X: 1 - torch.norm(xi - y_0, dim=-1)
+obj = lambda xi, X: 1 - torch.linalg.norm(xi - y_0, dim=-1)
 mc_objective = GenericMCObjective(obj)
 ```
 
@@ -66,7 +66,7 @@ A custom objective module of the above example would be
 class MyCustomObjective(MCAcquisitionObjective):
 
     def forward(self, samples, X=None):
-      return 1 - torch.norm(samples - y_0, dim=-1)
+      return 1 - torch.linalg.norm(samples - y_0, dim=-1)
 ```
 
 

--- a/test/acquisition/test_penalized.py
+++ b/test/acquisition/test_penalized.py
@@ -41,7 +41,7 @@ class TestL2Penalty(BotorchTestCase):
             sample_point = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **tkwargs)
 
             diff_norm_squared = (
-                torch.norm((sample_point - init_point), p=2, dim=-1) ** 2
+                torch.linalg.norm((sample_point - init_point), ord=2, dim=-1) ** 2
             )
             real_value = diff_norm_squared.max(dim=-1).values
             computed_value = l2_module(sample_point)
@@ -59,7 +59,7 @@ class TestL1Penalty(BotorchTestCase):
                 [[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], device=self.device, dtype=dtype
             )
 
-            diff_l1_norm = torch.norm((sample_point - init_point), p=1, dim=-1)
+            diff_l1_norm = torch.linalg.norm((sample_point - init_point), ord=1, dim=-1)
             real_value = diff_l1_norm.max(dim=-1).values
             computed_value = l1_module(sample_point)
             self.assertEqual(computed_value.item(), real_value.item())
@@ -77,7 +77,7 @@ class TestGaussianPenalty(BotorchTestCase):
             sample_point = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **tkwargs)
 
             diff_norm_squared = (
-                torch.norm((sample_point - init_point), p=2, dim=-1) ** 2
+                torch.linalg.norm((sample_point - init_point), ord=2, dim=-1) ** 2
             )
             max_l2_distance = diff_norm_squared.max(dim=-1).values
             real_value = torch.exp(max_l2_distance / 2 / sigma**2)
@@ -266,8 +266,8 @@ class TestL1PenaltyObjective(BotorchTestCase):
                 [[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], device=self.device, dtype=dtype
             )
 
-            real_values = torch.norm(
-                (sample_point - init_point), p=1, dim=-1
+            real_values = torch.linalg.norm(
+                (sample_point - init_point), ord=1, dim=-1
             ).unsqueeze(dim=0)
             computed_values = l1_module(sample_point)
             self.assertTrue(torch.equal(real_values, computed_values))

--- a/test/models/kernels/test_categorical.py
+++ b/test/models/kernels/test_categorical.py
@@ -27,14 +27,14 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
         kernel = CategoricalKernel()
         kernel.initialize(lengthscale=1)
         actual_value = torch.tensor(1.0).view_as(kernel.lengthscale)
-        self.assertLess(torch.norm(kernel.lengthscale - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.lengthscale - actual_value), 1e-5)
 
     def test_initialize_lengthscale_batch(self):
         kernel = CategoricalKernel(batch_shape=torch.Size([2]))
         ls_init = torch.tensor([1.0, 2.0])
         kernel.initialize(lengthscale=ls_init)
         actual_value = ls_init.view_as(kernel.lengthscale)
-        self.assertLess(torch.norm(kernel.lengthscale - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.lengthscale - actual_value), 1e-5)
 
     def test_forward(self):
         x1 = torch.tensor([[4, 2], [3, 1], [8, 5], [7, 6]], dtype=torch.float)

--- a/test/models/kernels/test_contextual.py
+++ b/test/models/kernels/test_contextual.py
@@ -33,7 +33,7 @@ class ContextualKernelTest(BotorchTestCase):
         x2 = torch.rand(5, 4)
         res = kernel(x1, x2).to_dense()
         res_diag = kernel(x1, x2, diag=True)
-        self.assertLess(torch.norm(res_diag - res.diag()), 1e-4)
+        self.assertLess(torch.linalg.norm(res_diag - res.diag()), 1e-4)
 
         # test raise of ValueError
         with self.assertRaises(ValueError):
@@ -61,7 +61,7 @@ class ContextualKernelTest(BotorchTestCase):
         # test set_outputscale_list
         kernel.initialize(outputscale_list=[0.5, 0.5])
         actual_value = torch.tensor([0.5, 0.5]).view_as(kernel.outputscale_list)
-        self.assertLess(torch.norm(kernel.outputscale_list - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.outputscale_list - actual_value), 1e-5)
 
         self.assertTrue(kernel.train_embedding)
         self.assertEqual(kernel.num_contexts, num_contexts)

--- a/test/models/kernels/test_downsampling.py
+++ b/test/models/kernels/test_downsampling.py
@@ -48,7 +48,7 @@ class TestDownsamplingKernel(BotorchTestCase, BaseKernelTestCase):
         actual = offset + diff.pow(1 + power)
         res = kernel(a, b).to_dense()
 
-        self.assertLess(torch.norm(res - actual), 1e-5)
+        self.assertLess(torch.linalg.norm(res - actual), 1e-5)
 
     def test_computes_downsampling_function(self):
         a = torch.tensor([0.1, 0.2]).view(2, 1)
@@ -64,7 +64,7 @@ class TestDownsamplingKernel(BotorchTestCase, BaseKernelTestCase):
         actual = offset + diff.pow(1 + power)
         res = kernel(a, b).to_dense()
 
-        self.assertLess(torch.norm(res - actual), 1e-5)
+        self.assertLess(torch.linalg.norm(res - actual), 1e-5)
 
     def test_subset_computes_active_downsampling_function_batch(self):
         a = torch.tensor([[0.1, 0.2, 0.2], [0.3, 0.4, 0.2], [0.5, 0.5, 0.5]]).view(
@@ -96,7 +96,7 @@ class TestDownsamplingKernel(BotorchTestCase, BaseKernelTestCase):
 
         diff = torch.tensor([[0.2, 0.2, 0.25], [0.2, 0.2, 0.25], [0.2, 0.2, 0.25]])
         actual[2, :, :] = offset + diff.pow(1 + power)
-        self.assertLess(torch.norm(res - actual), 1e-5)
+        self.assertLess(torch.linalg.norm(res - actual), 1e-5)
 
     def test_computes_downsampling_function_batch(self):
         a = torch.tensor([[0.1, 0.2], [0.3, 0.4], [0.5, 0.5]]).view(3, 2, 1)
@@ -119,33 +119,33 @@ class TestDownsamplingKernel(BotorchTestCase, BaseKernelTestCase):
 
         diff = torch.tensor([[0.2, 0.2], [0.2, 0.2]])
         actual[2, :, :] = offset + diff.pow(1 + power)
-        self.assertLess(torch.norm(res - actual), 1e-5)
+        self.assertLess(torch.linalg.norm(res - actual), 1e-5)
 
     def test_initialize_offset(self):
         kernel = DownsamplingKernel()
         kernel.initialize(offset=1)
         actual_value = torch.tensor(1.0).view_as(kernel.offset)
-        self.assertLess(torch.norm(kernel.offset - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.offset - actual_value), 1e-5)
 
     def test_initialize_offset_batch(self):
         kernel = DownsamplingKernel(batch_shape=torch.Size([2]))
         off_init = torch.tensor([1.0, 2.0])
         kernel.initialize(offset=off_init)
         actual_value = off_init.view_as(kernel.offset)
-        self.assertLess(torch.norm(kernel.offset - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.offset - actual_value), 1e-5)
 
     def test_initialize_power(self):
         kernel = DownsamplingKernel()
         kernel.initialize(power=1)
         actual_value = torch.tensor(1.0).view_as(kernel.power)
-        self.assertLess(torch.norm(kernel.power - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.power - actual_value), 1e-5)
 
     def test_initialize_power_batch(self):
         kernel = DownsamplingKernel(batch_shape=torch.Size([2]))
         power_init = torch.tensor([1.0, 2.0])
         kernel.initialize(power=power_init)
         actual_value = power_init.view_as(kernel.power)
-        self.assertLess(torch.norm(kernel.power - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.power - actual_value), 1e-5)
 
     def test_last_dim_is_batch(self):
         a = (
@@ -176,7 +176,7 @@ class TestDownsamplingKernel(BotorchTestCase, BaseKernelTestCase):
 
         diff = torch.tensor([[0.2, 0.2], [0.2, 0.2]])
         actual[2, :, :] = offset + diff.pow(1 + power)
-        self.assertLess(torch.norm(res - actual), 1e-5)
+        self.assertLess(torch.linalg.norm(res - actual), 1e-5)
 
     def test_diag_calculation(self):
         a = torch.tensor([0.1, 0.2]).view(2, 1)
@@ -192,7 +192,7 @@ class TestDownsamplingKernel(BotorchTestCase, BaseKernelTestCase):
         actual = offset + diff.pow(1 + power)
         res = kernel(a, b, diag=True)
 
-        self.assertLess(torch.norm(res - torch.diag(actual)), 1e-5)
+        self.assertLess(torch.linalg.norm(res - torch.diag(actual)), 1e-5)
 
     def test_initialize_power_prior(self):
         kernel = DownsamplingKernel()

--- a/test/models/kernels/test_exponential_decay.py
+++ b/test/models/kernels/test_exponential_decay.py
@@ -32,7 +32,7 @@ class TestExponentialDecayKernel(BotorchTestCase, BaseKernelTestCase):
         actual = offset + diff.pow(-power)
         res = kernel(a, b).to_dense()
 
-        self.assertLess(torch.norm(res - actual), 1e-5)
+        self.assertLess(torch.linalg.norm(res - actual), 1e-5)
 
     def test_computes_exponential_decay_function(self):
         a = torch.tensor([1.0, 2.0]).view(2, 1)
@@ -49,7 +49,7 @@ class TestExponentialDecayKernel(BotorchTestCase, BaseKernelTestCase):
         actual = offset + torch.tensor([1.0]).div(diff.pow(power))
         res = kernel(a, b).to_dense()
 
-        self.assertLess(torch.norm(res - actual), 1e-5)
+        self.assertLess(torch.linalg.norm(res - actual), 1e-5)
 
     def test_subset_active_exponential_decay_function_batch(self):
         a = torch.tensor([[1.0, 0.0], [2.0, 0.0], [3.0, 0.0], [4.0, 0.0]]).view(2, 2, 2)
@@ -71,7 +71,7 @@ class TestExponentialDecayKernel(BotorchTestCase, BaseKernelTestCase):
         actual[1, :, :] = offset + torch.tensor([1.0]).div(diff.pow(power))
 
         res = kernel(a, b).to_dense()
-        self.assertLess(torch.norm(res - actual), 1e-5)
+        self.assertLess(torch.linalg.norm(res - actual), 1e-5)
 
     def test_computes_exponential_decay_function_batch(self):
         a = torch.tensor([[1.0, 2.0], [3.0, 4.0]]).view(2, 2, 1)
@@ -93,46 +93,46 @@ class TestExponentialDecayKernel(BotorchTestCase, BaseKernelTestCase):
         actual[1, :, :] = offset + diff.pow(-power)
 
         res = kernel(a, b).to_dense()
-        self.assertLess(torch.norm(res - actual), 1e-5)
+        self.assertLess(torch.linalg.norm(res - actual), 1e-5)
 
     def test_initialize_lengthscale(self):
         kernel = ExponentialDecayKernel()
         kernel.initialize(lengthscale=1)
         actual_value = torch.tensor(1.0).view_as(kernel.lengthscale)
-        self.assertLess(torch.norm(kernel.lengthscale - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.lengthscale - actual_value), 1e-5)
 
     def test_initialize_lengthscale_batch(self):
         kernel = ExponentialDecayKernel(batch_shape=torch.Size([2]))
         ls_init = torch.tensor([1.0, 2.0])
         kernel.initialize(lengthscale=ls_init)
         actual_value = ls_init.view_as(kernel.lengthscale)
-        self.assertLess(torch.norm(kernel.lengthscale - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.lengthscale - actual_value), 1e-5)
 
     def test_initialize_offset(self):
         kernel = ExponentialDecayKernel()
         kernel.initialize(offset=1)
         actual_value = torch.tensor(1.0).view_as(kernel.offset)
-        self.assertLess(torch.norm(kernel.offset - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.offset - actual_value), 1e-5)
 
     def test_initialize_offset_batch(self):
         kernel = ExponentialDecayKernel(batch_shape=torch.Size([2]))
         off_init = torch.tensor([1.0, 2.0])
         kernel.initialize(offset=off_init)
         actual_value = off_init.view_as(kernel.offset)
-        self.assertLess(torch.norm(kernel.offset - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.offset - actual_value), 1e-5)
 
     def test_initialize_power(self):
         kernel = ExponentialDecayKernel()
         kernel.initialize(power=1)
         actual_value = torch.tensor(1.0).view_as(kernel.power)
-        self.assertLess(torch.norm(kernel.power - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.power - actual_value), 1e-5)
 
     def test_initialize_power_batch(self):
         kernel = ExponentialDecayKernel(batch_shape=torch.Size([2]))
         power_init = torch.tensor([1.0, 2.0])
         kernel.initialize(power=power_init)
         actual_value = power_init.view_as(kernel.power)
-        self.assertLess(torch.norm(kernel.power - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.power - actual_value), 1e-5)
 
     def test_initialize_power_prior(self):
         kernel = ExponentialDecayKernel()

--- a/test/models/kernels/test_linear_truncated_fidelity.py
+++ b/test/models/kernels/test_linear_truncated_fidelity.py
@@ -56,10 +56,10 @@ class TestLinearTruncatedFidelityKernel(BotorchTestCase, BaseKernelTestCase):
             matern_term = matern_ker(x1, x2).to_dense()
             actual = t * matern_term
             res = kernel(x1, x2).to_dense()
-            self.assertLess(torch.norm(res - actual), 1e-4)
+            self.assertLess(torch.linalg.norm(res - actual), 1e-4)
             # test diagonal mode
             res_diag = kernel(x1, x2, diag=True)
-            self.assertLess(torch.norm(res_diag - actual.diag()), 1e-4)
+            self.assertLess(torch.linalg.norm(res_diag - actual.diag()), 1e-4)
         # make sure that we error out if last_dim_is_batch=True
         with self.assertRaises(NotImplementedError):
             kernel(x1, x2, diag=True, last_dim_is_batch=True)
@@ -105,11 +105,12 @@ class TestLinearTruncatedFidelityKernel(BotorchTestCase, BaseKernelTestCase):
             matern_term = matern_ker(x1, x2).to_dense()
             actual = t * matern_term
             res = kernel(x1, x2).to_dense()
-            self.assertLess(torch.norm(res - actual), 1e-4)
+            self.assertLess(torch.linalg.norm(res - actual), 1e-4)
             # test diagonal mode
             res_diag = kernel(x1, x2, diag=True)
             self.assertLess(
-                torch.norm(res_diag - torch.diagonal(actual, dim1=-1, dim2=-2)), 1e-4
+                torch.linalg.norm(res_diag - torch.diagonal(actual, dim1=-1, dim2=-2)),
+                1e-4,
             )
         # make sure that we error out if last_dim_is_batch=True
         with self.assertRaises(NotImplementedError):
@@ -150,7 +151,7 @@ class TestLinearTruncatedFidelityKernel(BotorchTestCase, BaseKernelTestCase):
         kernel = LinearTruncatedFidelityKernel(fidelity_dims=[1, 2], dimension=3)
         kernel.initialize(power=1)
         actual_value = torch.tensor(1, dtype=torch.float).view_as(kernel.power)
-        self.assertLess(torch.norm(kernel.power - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.power - actual_value), 1e-5)
 
     def test_initialize_power_batch(self):
         kernel = LinearTruncatedFidelityKernel(
@@ -159,7 +160,7 @@ class TestLinearTruncatedFidelityKernel(BotorchTestCase, BaseKernelTestCase):
         power_init = torch.tensor([1, 2], dtype=torch.float)
         kernel.initialize(power=power_init)
         actual_value = power_init.view_as(kernel.power)
-        self.assertLess(torch.norm(kernel.power - actual_value), 1e-5)
+        self.assertLess(torch.linalg.norm(kernel.power - actual_value), 1e-5)
 
     def test_raise_init_errors(self):
         with self.assertRaises(UnsupportedError):
@@ -180,7 +181,8 @@ class TestLinearTruncatedFidelityKernel(BotorchTestCase, BaseKernelTestCase):
         kernel_basic = LinearTruncatedFidelityKernel(fidelity_dims=[1, 2], dimension=4)
         covar_mat_actual = kernel_basic(x[:, [0, 2, 4, 6]]).evaluate_kernel().to_dense()
         self.assertLess(
-            torch.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(), 1e-4
+            torch.linalg.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(),
+            1e-4,
         )
 
     def test_active_dims_range(self):
@@ -193,7 +195,8 @@ class TestLinearTruncatedFidelityKernel(BotorchTestCase, BaseKernelTestCase):
         kernel_basic = LinearTruncatedFidelityKernel(fidelity_dims=[1, 2], dimension=6)
         covar_mat_actual = kernel_basic(x[:, active_dims]).evaluate_kernel().to_dense()
         self.assertLess(
-            torch.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(), 1e-4
+            torch.linalg.norm(covar_mat - covar_mat_actual) / covar_mat_actual.norm(),
+            1e-4,
         )
 
     def test_error_on_fidelity_only(self):

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -66,7 +66,7 @@ class SquaredAcquisitionFunction(AcquisitionFunction):
         super().__init__(model=model)
 
     def forward(self, X):
-        return torch.norm(X, dim=-1).squeeze(-1)
+        return torch.linalg.norm(X, dim=-1).squeeze(-1)
 
 
 class MockOneShotEvaluateAcquisitionFunction(MockOneShotAcquisitionFunction):

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -119,7 +119,7 @@ from botorch.utils import standardize
 from gpytorch.mlls import ExactMarginalLogLikelihood
 
 train_X = torch.rand(10, 2)
-Y = 1 - torch.norm(train_X - 0.5, dim=-1, keepdim=True)
+Y = 1 - torch.linalg.norm(train_X - 0.5, dim=-1, keepdim=True)
 Y = Y + 0.1 * torch.randn_like(Y)  # add some noise
 train_Y = standardize(Y)
 


### PR DESCRIPTION
See title

Addresses #2001

Differential Revision: D48923425


