### PR TITLE
Make X, Y, Yvar into properties in datasets

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -141,7 +141,10 @@ def _field_is_shared(
         obj = getattr(dataset, fieldname)
         if base is None:
             base = obj
-        elif base != obj:
+        elif isinstance(base, Tensor):
+            if not torch.equal(base, obj):
+                return False
+        elif base != obj:  # pragma: no cover
             return False
 
     return True
@@ -414,7 +417,7 @@ def construct_inputs_noisy_ei(
     X = _get_dataset_field(training_data, "X", first_only=True, assert_shared=True)
     return {
         "model": model,
-        "X_observed": X(),
+        "X_observed": X,
         "num_fantasies": num_fantasies,
         "maximize": maximize,
     }
@@ -624,7 +627,6 @@ def construct_inputs_qNEI(
         X_baseline = _get_dataset_field(
             training_data,
             fieldname="X",
-            transform=lambda field: field(),
             assert_shared=True,
             first_only=True,
         )
@@ -845,7 +847,6 @@ def construct_inputs_EHVI(
     X = _get_dataset_field(
         training_data,
         fieldname="X",
-        transform=lambda field: field(),
         first_only=True,
         assert_shared=True,
     )
@@ -908,7 +909,6 @@ def construct_inputs_qEHVI(
     X = _get_dataset_field(
         training_data,
         fieldname="X",
-        transform=lambda field: field(),
         first_only=True,
         assert_shared=True,
     )
@@ -974,7 +974,6 @@ def construct_inputs_qNEHVI(
         X_baseline = _get_dataset_field(
             training_data,
             fieldname="X",
-            transform=lambda field: field(),
             first_only=True,
             assert_shared=True,
         )
@@ -1245,7 +1244,6 @@ def get_best_f_analytic(
     Y = _get_dataset_field(
         training_data,
         fieldname="Y",
-        transform=lambda field: field(),
         join_rule=lambda field_tensors: torch.cat(field_tensors, dim=-1),
     )
 
@@ -1274,7 +1272,6 @@ def get_best_f_mc(
     X_baseline = _get_dataset_field(
         training_data,
         fieldname="X",
-        transform=lambda field: field(),
         assert_shared=True,
         first_only=True,
     )
@@ -1282,7 +1279,6 @@ def get_best_f_mc(
     Y = _get_dataset_field(
         training_data,
         fieldname="Y",
-        transform=lambda field: field(),
         join_rule=lambda field_tensors: torch.cat(field_tensors, dim=-1),
     )  # batch_shape x n x d
 

--- a/botorch/models/utils/parse_training_data.py
+++ b/botorch/models/utils/parse_training_data.py
@@ -51,9 +51,9 @@ def parse_training_data(
 def _parse_model_supervised(
     consumer: Model, dataset: SupervisedDataset, **ignore: Any
 ) -> Dict[str, Tensor]:
-    parsed_data = {"train_X": dataset.X(), "train_Y": dataset.Y()}
+    parsed_data = {"train_X": dataset.X, "train_Y": dataset.Y}
     if dataset.Yvar is not None:
-        parsed_data["train_Yvar"] = dataset.Yvar()
+        parsed_data["train_Yvar"] = dataset.Yvar
     return parsed_data
 
 
@@ -61,9 +61,11 @@ def _parse_model_supervised(
 def _parse_pairwiseGP_ranking(
     consumer: PairwiseGP, dataset: RankingDataset, **ignore: Any
 ) -> Dict[str, Tensor]:
-    datapoints = dataset.X.values
-    comparisons = dataset.X.indices
-    comp_order = dataset.Y()
+    # TODO: [T163045056] Not sure what the point of the special container is if we have
+    # to further process it here. We should move this logic into RankingDataset.
+    datapoints = dataset._X.values
+    comparisons = dataset._X.indices
+    comp_order = dataset.Y
     comparisons = torch.gather(input=comparisons, dim=-1, index=comp_order)
 
     return {

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import math
-
 from typing import Any, Callable, Sequence, Type
 from unittest import mock
 from unittest.mock import MagicMock
@@ -132,7 +131,7 @@ class TestInputConstructorUtils(InputConstructorBaseTestCase):
         best_f = get_best_f_analytic(training_data=self.blockX_blockY)
         self.assertEqual(best_f, get_best_f_analytic(self.blockX_blockY[0]))
 
-        best_f_expected = self.blockX_blockY[0].Y().squeeze().max()
+        best_f_expected = self.blockX_blockY[0].Y.squeeze().max()
         self.assertEqual(best_f, best_f_expected)
         with self.assertRaisesRegex(
             NotImplementedError,
@@ -147,7 +146,7 @@ class TestInputConstructorUtils(InputConstructorBaseTestCase):
             training_data=self.blockX_multiY, posterior_transform=post_tf
         )
 
-        multi_Y = torch.cat([d.Y() for d in self.blockX_multiY.values()], dim=-1)
+        multi_Y = torch.cat([d.Y for d in self.blockX_multiY.values()], dim=-1)
         best_f_expected = post_tf.evaluate(multi_Y).max()
         self.assertEqual(best_f_tf, best_f_expected)
 
@@ -160,14 +159,14 @@ class TestInputConstructorUtils(InputConstructorBaseTestCase):
         best_f = get_best_f_mc(training_data=self.blockX_blockY)
         self.assertEqual(best_f, get_best_f_mc(self.blockX_blockY[0]))
 
-        best_f_expected = self.blockX_blockY[0].Y().max(dim=0).values
+        best_f_expected = self.blockX_blockY[0].Y.max(dim=0).values
         self.assertAllClose(best_f, best_f_expected)
         with self.assertRaisesRegex(UnsupportedError, "require an objective"):
             get_best_f_mc(training_data=self.blockX_multiY)
         obj = LinearMCObjective(weights=torch.rand(2))
         best_f = get_best_f_mc(training_data=self.blockX_multiY, objective=obj)
 
-        multi_Y = torch.cat([d.Y() for d in self.blockX_multiY.values()], dim=-1)
+        multi_Y = torch.cat([d.Y for d in self.blockX_multiY.values()], dim=-1)
         best_f_expected = (multi_Y @ obj.weights).amax(dim=-1, keepdim=True)
         self.assertAllClose(best_f, best_f_expected)
         post_tf = ScalarizedPosteriorTransform(weights=torch.ones(2))
@@ -295,7 +294,7 @@ class TestAnalyticAcquisitionFunctionInputConstructors(InputConstructorBaseTestC
                 kwargs = c(
                     model=mock_model, training_data=self.blockX_blockY, maximize=False
                 )
-                best_f_expected = self.blockX_blockY[0].Y().squeeze().max()
+                best_f_expected = self.blockX_blockY[0].Y.squeeze().max()
                 self.assertIs(kwargs["model"], mock_model)
                 self.assertIsNone(kwargs["posterior_transform"])
                 self.assertEqual(kwargs["best_f"], best_f_expected)
@@ -346,7 +345,7 @@ class TestAnalyticAcquisitionFunctionInputConstructors(InputConstructorBaseTestC
                 kwargs = c(model=mock_model, training_data=self.blockX_blockY)
                 self.assertEqual(kwargs["model"], mock_model)
                 self.assertTrue(
-                    torch.equal(kwargs["X_observed"], self.blockX_blockY[0].X())
+                    torch.equal(kwargs["X_observed"], self.blockX_blockY[0].X)
                 )
                 self.assertEqual(kwargs["num_fantasies"], 20)
                 self.assertTrue(kwargs["maximize"])
@@ -361,7 +360,7 @@ class TestAnalyticAcquisitionFunctionInputConstructors(InputConstructorBaseTestC
                 )
                 self.assertEqual(kwargs["model"], mock_model)
                 self.assertTrue(
-                    torch.equal(kwargs["X_observed"], self.blockX_blockY[0].X())
+                    torch.equal(kwargs["X_observed"], self.blockX_blockY[0].X)
                 )
                 self.assertEqual(kwargs["num_fantasies"], 10)
                 self.assertFalse(kwargs["maximize"])
@@ -484,7 +483,7 @@ class TestMCAcquisitionFunctionInputConstructors(InputConstructorBaseTestCase):
         acqf = qExpectedImprovement(**kwargs)
         self.assertIs(acqf.model, mock_model)
 
-        multi_Y = torch.cat([d.Y() for d in self.blockX_multiY.values()], dim=-1)
+        multi_Y = torch.cat([d.Y for d in self.blockX_multiY.values()], dim=-1)
         best_f_expected = objective(multi_Y).max()
         self.assertEqual(kwargs["best_f"], best_f_expected)
         # Check explicitly specifying `best_f`.
@@ -551,7 +550,7 @@ class TestMCAcquisitionFunctionInputConstructors(InputConstructorBaseTestCase):
         self.assertIsNone(kwargs["X_pending"])
         self.assertIsNone(kwargs["sampler"])
         self.assertTrue(kwargs["prune_baseline"])
-        self.assertTrue(torch.equal(kwargs["X_baseline"], self.blockX_blockY[0].X()))
+        self.assertTrue(torch.equal(kwargs["X_baseline"], self.blockX_blockY[0].X))
         self.assertIsNone(kwargs["constraints"])
         self.assertIsInstance(kwargs["eta"], float)
         self.assertLess(kwargs["eta"], 1)
@@ -637,7 +636,7 @@ class TestMCAcquisitionFunctionInputConstructors(InputConstructorBaseTestCase):
         self.assertEqual(kwargs["tau"], 1e-2)
         self.assertIsInstance(kwargs["eta"], float)
         self.assertLess(kwargs["eta"], 1)
-        multi_Y = torch.cat([d.Y() for d in self.blockX_multiY.values()], dim=-1)
+        multi_Y = torch.cat([d.Y for d in self.blockX_multiY.values()], dim=-1)
         best_f_expected = objective(multi_Y).max()
         self.assertEqual(kwargs["best_f"], best_f_expected)
         acqf = qProbabilityOfImprovement(**kwargs)
@@ -816,7 +815,7 @@ class TestMultiObjectiveAcquisitionFunctionInputConstructors(
 
         # Test defaults
         mm = SingleTaskGP(torch.rand(1, 2), torch.rand(1, 2))
-        mean = mm.posterior(self.blockX_blockY[0].X()).mean
+        mean = mm.posterior(self.blockX_blockY[0].X).mean
         kwargs = c(
             model=mm,
             training_data=self.blockX_blockY,
@@ -920,7 +919,7 @@ class TestMultiObjectiveAcquisitionFunctionInputConstructors(
         )
         ref_point_expected = objective_thresholds
         self.assertTrue(torch.equal(kwargs["ref_point"], ref_point_expected))
-        self.assertTrue(torch.equal(kwargs["X_baseline"], self.blockX_blockY[0].X()))
+        self.assertTrue(torch.equal(kwargs["X_baseline"], self.blockX_blockY[0].X))
         self.assertIsInstance(kwargs["sampler"], SobolQMCNormalSampler)
         self.assertEqual(kwargs["sampler"].sample_shape, torch.Size([128]))
         self.assertIsInstance(kwargs["objective"], IdentityMCMultiOutputObjective)
@@ -1196,7 +1195,7 @@ class TestMultiObjectiveAcquisitionFunctionInputConstructors(
         func = get_acqf_input_constructor(qJointEntropySearch)
         # we need to run optimize_posterior_samples, so we sort of need
         # a real model as there is no other (apparent) option
-        model = SingleTaskGP(self.blockX_blockY[0].X(), self.blockX_blockY[0].Y())
+        model = SingleTaskGP(self.blockX_blockY[0].X, self.blockX_blockY[0].Y)
 
         kwargs = func(
             model=model,
@@ -1208,9 +1207,7 @@ class TestMultiObjectiveAcquisitionFunctionInputConstructors(
         )
 
         self.assertFalse(kwargs["maximize"])
-        self.assertEqual(
-            self.blockX_blockY[0].X().dtype, kwargs["optimal_inputs"].dtype
-        )
+        self.assertEqual(self.blockX_blockY[0].X.dtype, kwargs["optimal_inputs"].dtype)
         self.assertEqual(len(kwargs["optimal_inputs"]), 17)
         self.assertEqual(len(kwargs["optimal_outputs"]), 17)
         # asserting that, for the non-batch case, the optimal inputs are
@@ -1315,7 +1312,7 @@ class TestInstantiationFromInputConstructor(InputConstructorBaseTestCase):
         )
 
     def test_qjes(self) -> None:
-        model = SingleTaskGP(self.blockX_blockY[0].X(), self.blockX_blockY[0].Y())
+        model = SingleTaskGP(self.blockX_blockY[0].X, self.blockX_blockY[0].Y)
         self._test_constructor_base(
             classes=[qJointEntropySearch],
             model=model,


### PR DESCRIPTION
Summary:
Since the primary use case of the datasets is to house a couple tensors, this simplifies the process by making dataset.X/Y/Yvar into a tensor rather than a callable.

This also eliminates the need to make tensors into containers, eliminating a step in the process.

Differential Revision: D48926544


