### PR TITLE
Fix fantasization with FixedNoiseGP and outcome transforms and use FantasizeMixin

### DIFF
--- a/botorch/acquisition/active_learning.py
+++ b/botorch/acquisition/active_learning.py
@@ -93,7 +93,8 @@ class qNegIntegratedPosteriorVariance(AnalyticAcquisitionFunction):
         # Construct the fantasy model (we actually do not use the full model,
         # this is just a convenient way of computing fast posterior covariances
         fantasy_model = self.model.fantasize(
-            X=X, sampler=self.sampler, observation_noise=True
+            X=X,
+            sampler=self.sampler,
         )
 
         bdims = tuple(1 for _ in X.shape[:-2])

--- a/botorch/acquisition/knowledge_gradient.py
+++ b/botorch/acquisition/knowledge_gradient.py
@@ -184,7 +184,8 @@ class qKnowledgeGradient(MCAcquisitionFunction, OneShotAcquisitionFunction):
 
         # construct the fantasy model of shape `num_fantasies x b`
         fantasy_model = self.model.fantasize(
-            X=X_actual, sampler=self.sampler, observation_noise=True
+            X=X_actual,
+            sampler=self.sampler,
         )
 
         # get the value function
@@ -233,7 +234,8 @@ class qKnowledgeGradient(MCAcquisitionFunction, OneShotAcquisitionFunction):
 
         # construct the fantasy model of shape `num_fantasies x b`
         fantasy_model = self.model.fantasize(
-            X=X, sampler=self.sampler, observation_noise=True
+            X=X,
+            sampler=self.sampler,
         )
 
         # get the value function
@@ -451,7 +453,8 @@ class qMultiFidelityKnowledgeGradient(qKnowledgeGradient):
         # construct the fantasy model of shape `num_fantasies x b`
         # expand X (to potentially add trace observations)
         fantasy_model = self.model.fantasize(
-            X=self.expand(X_eval), sampler=self.sampler, observation_noise=True
+            X=self.expand(X_eval),
+            sampler=self.sampler,
         )
         # get the value function
         value_function = _get_value_function(

--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -389,7 +389,8 @@ class qMaxValueEntropy(DiscreteMaxValueBase, MCSamplerMixin):
         if X_pending is not None:
             # fantasize the model and use this as the new model
             self.model = init_model.fantasize(
-                X=X_pending, sampler=self.fantasies_sampler, observation_noise=True
+                X=X_pending,
+                sampler=self.fantasies_sampler,
             )
         else:
             self.model = init_model

--- a/botorch/acquisition/multi_objective/max_value_entropy_search.py
+++ b/botorch/acquisition/multi_objective/max_value_entropy_search.py
@@ -146,7 +146,8 @@ class qMultiObjectiveMaxValueEntropy(
         if X_pending is not None:
             # fantasize the model
             fantasy_model = self._init_model.fantasize(
-                X=X_pending, sampler=self.fantasies_sampler, observation_noise=True
+                X=X_pending,
+                sampler=self.fantasies_sampler,
             )
             self.mo_model = fantasy_model
             # convert model to batched single outcome model.

--- a/botorch/acquisition/multi_step_lookahead.py
+++ b/botorch/acquisition/multi_step_lookahead.py
@@ -399,7 +399,7 @@ def _step(
     # construct fantasy model (with batch shape f_{j+1} x ... x f_1 x batch_shape)
     prop_grads = step_index > 0  # need to propagate gradients for steps > 0
     fantasy_model = model.fantasize(
-        X=X, sampler=samplers[0], observation_noise=True, propagate_grads=prop_grads
+        X=X, sampler=samplers[0], propagate_grads=prop_grads
     )
 
     # augment sample weights appropriately
@@ -585,7 +585,6 @@ def _get_induced_fantasy_model(
         fantasy_model = model.fantasize(
             X=Xs[0],
             sampler=samplers[0],
-            observation_noise=True,
         )
 
         return _get_induced_fantasy_model(

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -375,6 +375,7 @@ def _get_random_data(
         [torch.linspace(0, 0.95, n, **tkwargs) for _ in range(d)], dim=-1
     )
     train_x = train_x + 0.05 * torch.rand_like(train_x).repeat(rep_shape)
+    train_x[0] += 0.02  # modify the first batch
     train_y = torch.sin(train_x[..., :1] * (2 * math.pi))
     train_y = train_y + 0.2 * torch.randn(n, m, **tkwargs).repeat(rep_shape)
     return train_x, train_y

--- a/test/models/test_gp_regression_fidelity.py
+++ b/test/models/test_gp_regression_fidelity.py
@@ -362,8 +362,6 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
                 sampler = SobolQMCNormalSampler(sample_shape=torch.Size([3]))
                 fm = model.fantasize(X=X_f, sampler=sampler)
                 self.assertIsInstance(fm, model.__class__)
-                fm = model.fantasize(X=X_f, sampler=sampler, observation_noise=False)
-                self.assertIsInstance(fm, model.__class__)
 
     def test_subset_model(self):
         for (iteration_fidelity, data_fidelities) in self.FIDELITY_TEST_PAIRS:

--- a/test/models/test_gp_regression_mixed.py
+++ b/test/models/test_gp_regression_mixed.py
@@ -236,8 +236,6 @@ class TestMixedSingleTaskGP(BotorchTestCase):
             sampler = SobolQMCNormalSampler(sample_shape=torch.Size([3]))
             fm = model.fantasize(X=X_f, sampler=sampler)
             self.assertIsInstance(fm, model.__class__)
-            fm = model.fantasize(X=X_f, sampler=sampler, observation_noise=False)
-            self.assertIsInstance(fm, model.__class__)
 
     def test_subset_model(self):
         d, m = 3, 2

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -15,7 +15,7 @@ from botorch.exceptions import (
     BotorchTensorDimensionError,
     BotorchTensorDimensionWarning,
 )
-from botorch.exceptions.errors import InputDataError
+from botorch.exceptions.errors import DeprecationError, InputDataError
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.gpytorch import (
     BatchedMultiOutputGPyTorchModel,
@@ -209,17 +209,20 @@ class TestGPyTorchModel(BotorchTestCase):
             self.assertIsInstance(cm, SimpleGPyTorchModel)
             self.assertEqual(cm.train_targets.shape, torch.Size([2, 7]))
             cm = model.fantasize(
-                torch.rand(2, 1, **tkwargs), sampler=sampler, observation_noise=True
-            )
-            self.assertIsInstance(cm, SimpleGPyTorchModel)
-            self.assertEqual(cm.train_targets.shape, torch.Size([2, 7]))
-            cm = model.fantasize(
                 torch.rand(2, 1, **tkwargs),
                 sampler=sampler,
                 observation_noise=torch.rand(2, 1, **tkwargs),
             )
             self.assertIsInstance(cm, SimpleGPyTorchModel)
             self.assertEqual(cm.train_targets.shape, torch.Size([2, 7]))
+            # test that boolean observation noise is deprecated
+            msg = "`fantasize` no longer accepts a boolean for `observation_noise`."
+            with self.assertRaisesRegex(DeprecationError, msg):
+                model.fantasize(
+                    torch.rand(2, 1, **tkwargs),
+                    sampler=sampler,
+                    observation_noise=True,
+                )
 
     def test_validate_tensor_args(self) -> None:
         n, d = 3, 2
@@ -384,11 +387,6 @@ class TestBatchedMultiOutputGPyTorchModel(BotorchTestCase):
             # test fantasize
             sampler = SobolQMCNormalSampler(sample_shape=torch.Size([2]))
             cm = model.fantasize(torch.rand(2, 1, **tkwargs), sampler=sampler)
-            self.assertIsInstance(cm, SimpleBatchedMultiOutputGPyTorchModel)
-            self.assertEqual(cm.train_targets.shape, torch.Size([2, 2, 7]))
-            cm = model.fantasize(
-                torch.rand(2, 1, **tkwargs), sampler=sampler, observation_noise=True
-            )
             self.assertIsInstance(cm, SimpleBatchedMultiOutputGPyTorchModel)
             self.assertEqual(cm.train_targets.shape, torch.Size([2, 2, 7]))
             cm = model.fantasize(

--- a/test/models/test_pairwise_gp.py
+++ b/test/models/test_pairwise_gp.py
@@ -382,8 +382,6 @@ class TestPairwiseGP(BotorchTestCase):
             sampler = PairwiseSobolQMCNormalSampler(sample_shape=torch.Size([3]))
             fm = model.fantasize(X=X_f, sampler=sampler)
             self.assertIsInstance(fm, model.__class__)
-            fm = model.fantasize(X=X_f, sampler=sampler, observation_noise=False)
-            self.assertIsInstance(fm, model.__class__)
 
     def test_load_state_dict(self) -> None:
         model, _ = self._get_model_and_data(batch_shape=[])


### PR DESCRIPTION
Summary:
This fixes fantasization with FixedNoiseGP and outcome transforms where transformed `noise` was outcome-transformed again.

This also improves the fantasization for batched and batched multi-output models to use the average noise for each batch and output.

This also removes repeated code and uses the logic in `FantasizeMixin.fantasize` for handling `X` with size 0 on the -2 dimension.

Differential Revision: D49200325


