### PR TITLE
Add outcome and feature names to datasets

### DIFF
--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -108,10 +108,30 @@ class InputConstructorBaseTestCase(BotorchTestCase):
         X2 = torch.rand(3, 2)
         Y1 = torch.rand(3, 1)
         Y2 = torch.rand(3, 1)
+        feature_names = ["X1", "X2"]
+        outcome_names = ["Y"]
 
-        self.blockX_blockY = SupervisedDataset.dict_from_iter(X1, Y1)
-        self.blockX_multiY = SupervisedDataset.dict_from_iter(X1, (Y1, Y2))
-        self.multiX_multiY = SupervisedDataset.dict_from_iter((X1, X2), (Y1, Y2))
+        self.blockX_blockY = {
+            0: SupervisedDataset(
+                X1, Y1, feature_names=feature_names, outcome_names=outcome_names
+            )
+        }
+        self.blockX_multiY = {
+            0: SupervisedDataset(
+                X1, Y1, feature_names=feature_names, outcome_names=outcome_names
+            ),
+            1: SupervisedDataset(
+                X1, Y2, feature_names=feature_names, outcome_names=outcome_names
+            ),
+        }
+        self.multiX_multiY = {
+            0: SupervisedDataset(
+                X1, Y1, feature_names=feature_names, outcome_names=outcome_names
+            ),
+            1: SupervisedDataset(
+                X2, Y2, feature_names=feature_names, outcome_names=outcome_names
+            ),
+        }
         self.bounds = 2 * [(0.0, 1.0)]
 
 

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -550,7 +550,9 @@ class TestFullyBayesianSingleTaskGP(BotorchTestCase):
             X, Y, Yvar, model = self._get_data_and_model(
                 infer_noise=infer_noise, **tkwargs
             )
-            training_data = SupervisedDataset(X, Y, Yvar)
+            training_data = SupervisedDataset(
+                X, Y, Yvar=Yvar, feature_names=["1", "2", "3", "4"], outcome_names=["1"]
+            )
 
             data_dict = model.construct_inputs(training_data)
             self.assertTrue(X.equal(data_dict["train_X"]))

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -566,14 +566,9 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
         for dtype, infer_noise in [(torch.float, False), (torch.double, True)]:
             tkwargs = {"device": self.device, "dtype": dtype}
             task_feature = 0
-
-            if infer_noise:
-                datasets, (train_X, train_Y) = _gen_datasets(yvar=None, **tkwargs)
-                train_Yvar = None
-            else:
-                datasets, (train_X, train_Y, train_Yvar) = _gen_datasets(
-                    yvar=0.05, **tkwargs
-                )
+            datasets, (train_X, train_Y, train_Yvar) = _gen_datasets(
+                yvar=None if infer_noise else 0.05, **tkwargs
+            )
 
             model = SaasFullyBayesianMultiTaskGP(
                 train_X=train_X,

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -374,7 +374,12 @@ class TestSingleTaskGP(BotorchTestCase):
             )
             X = model_kwargs["train_X"]
             Y = model_kwargs["train_Y"]
-            training_data = SupervisedDataset(X, Y)
+            training_data = SupervisedDataset(
+                X,
+                Y,
+                feature_names=[f"x{i}" for i in range(X.shape[-1])],
+                outcome_names=["y"],
+            )
             data_dict = model.construct_inputs(training_data)
             self.assertTrue(X.equal(data_dict["train_X"]))
             self.assertTrue(Y.equal(data_dict["train_Y"]))
@@ -448,7 +453,13 @@ class TestFixedNoiseGP(TestSingleTaskGP):
             X = model_kwargs["train_X"]
             Y = model_kwargs["train_Y"]
             Yvar = model_kwargs["train_Yvar"]
-            training_data = SupervisedDataset(X, Y, Yvar)
+            training_data = SupervisedDataset(
+                X,
+                Y,
+                Yvar=Yvar,
+                feature_names=[f"x{i}" for i in range(X.shape[-1])],
+                outcome_names=["y"],
+            )
             data_dict = model.construct_inputs(training_data)
             self.assertTrue(X.equal(data_dict["train_X"]))
             self.assertTrue(Y.equal(data_dict["train_Y"]))

--- a/test/models/test_gp_regression_fidelity.py
+++ b/test/models/test_gp_regression_fidelity.py
@@ -414,7 +414,14 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
                     lin_truncated=lin_trunc,
                     **tkwargs,
                 )
-                training_data = SupervisedDataset(kwargs["train_X"], kwargs["train_Y"])
+
+                X = kwargs["train_X"]
+                training_data = SupervisedDataset(
+                    X=X,
+                    Y=kwargs["train_Y"],
+                    feature_names=[f"x{i}" for i in range(X.shape[-1])],
+                    outcome_names=["y"],
+                )
 
                 # missing fidelity features
                 with self.assertRaisesRegex(TypeError, "argument: 'fidelity_features'"):
@@ -523,7 +530,13 @@ class TestFixedNoiseMultiFidelityGP(TestSingleTaskMultiFidelityGP):
                     lin_truncated=lin_trunc,
                     **tkwargs,
                 )
-                training_data = SupervisedDataset(kwargs["train_X"], kwargs["train_Y"])
+                X = kwargs["train_X"]
+                training_data = SupervisedDataset(
+                    X=X,
+                    Y=kwargs["train_Y"],
+                    feature_names=[f"x{i}" for i in range(X.shape[-1])],
+                    outcome_names=["y"],
+                )
                 data_dict = model.construct_inputs(training_data, fidelity_features=[1])
                 self.assertTrue("train_Yvar" not in data_dict)
 
@@ -532,6 +545,8 @@ class TestFixedNoiseMultiFidelityGP(TestSingleTaskMultiFidelityGP):
                     X=kwargs["train_X"],
                     Y=kwargs["train_Y"],
                     Yvar=torch.full(kwargs["train_Y"].shape[:-1] + (1,), 0.1),
+                    feature_names=[f"x{i}" for i in range(X.shape[-1])],
+                    outcome_names=["y"],
                 )
 
                 # missing fidelity features

--- a/test/models/test_gp_regression_mixed.py
+++ b/test/models/test_gp_regression_mixed.py
@@ -273,7 +273,12 @@ class TestMixedSingleTaskGP(BotorchTestCase):
             tkwargs = {"device": self.device, "dtype": dtype}
             X, Y = _get_random_data(batch_shape=batch_shape, m=1, d=d, **tkwargs)
             cat_dims = list(range(ncat))
-            training_data = SupervisedDataset(X, Y)
+            training_data = SupervisedDataset(
+                X,
+                Y,
+                feature_names=[f"x{i}" for i in range(d)],
+                outcome_names=["y"],
+            )
             model_kwargs = MixedSingleTaskGP.construct_inputs(
                 training_data, categorical_features=cat_dims
             )
@@ -283,7 +288,13 @@ class TestMixedSingleTaskGP(BotorchTestCase):
             self.assertIsNone(model_kwargs["likelihood"])
 
         # With train_Yvar.
-        training_data = SupervisedDataset(X, Y, Y)
+        training_data = SupervisedDataset(
+            X,
+            Y,
+            Yvar=Y,
+            feature_names=[f"x{i}" for i in range(d)],
+            outcome_names=["y"],
+        )
         with self.assertWarnsRegex(InputDataWarning, "train_Yvar"):
             model_kwargs = MixedSingleTaskGP.construct_inputs(
                 training_data, categorical_features=cat_dims

--- a/test/utils/test_datasets.py
+++ b/test/utils/test_datasets.py
@@ -14,45 +14,72 @@ from torch import rand, randperm, Size, stack, Tensor, tensor
 class TestDatasets(BotorchTestCase):
     def test_supervised(self):
         # Generate some data
-        Xs = rand(4, 3, 2)
-        Ys = rand(4, 3, 1)
+        X = rand(3, 2)
+        Y = rand(3, 1)
+        feature_names = ["x1", "x2"]
+        outcome_names = ["y"]
 
         # Test `__init__`
-        dataset = SupervisedDataset(X=Xs[0], Y=Ys[0])
+        dataset = SupervisedDataset(
+            X=X, Y=Y, feature_names=feature_names, outcome_names=outcome_names
+        )
         self.assertIsInstance(dataset.X, Tensor)
         self.assertIsInstance(dataset._X, Tensor)
         self.assertIsInstance(dataset.Y, Tensor)
         self.assertIsInstance(dataset._Y, Tensor)
+        self.assertEqual(dataset.feature_names, feature_names)
+        self.assertEqual(dataset.outcome_names, outcome_names)
 
-        dataset = SupervisedDataset(
-            X=DenseContainer(Xs[0], Xs[0].shape[-1:]),
-            Y=DenseContainer(Ys[0], Ys[0].shape[-1:]),
+        dataset2 = SupervisedDataset(
+            X=DenseContainer(X, X.shape[-1:]),
+            Y=DenseContainer(Y, Y.shape[-1:]),
+            feature_names=feature_names,
+            outcome_names=outcome_names,
         )
-        self.assertIsInstance(dataset.X, Tensor)
-        self.assertIsInstance(dataset._X, DenseContainer)
-        self.assertIsInstance(dataset.Y, Tensor)
-        self.assertIsInstance(dataset._Y, DenseContainer)
+        self.assertIsInstance(dataset2.X, Tensor)
+        self.assertIsInstance(dataset2._X, DenseContainer)
+        self.assertIsInstance(dataset2.Y, Tensor)
+        self.assertIsInstance(dataset2._Y, DenseContainer)
+        self.assertEqual(dataset, dataset2)
 
         # Test `_validate`
         with self.assertRaisesRegex(ValueError, "Batch dimensions .* incompatible."):
-            SupervisedDataset(X=rand(1, 2), Y=rand(2, 1))
-
-        # Test `dict_from_iter` and `__eq__`
-        datasets = SupervisedDataset.dict_from_iter(X=Xs.unbind(), Y=Ys.unbind())
-        self.assertIsInstance(datasets, dict)
-        self.assertEqual(tuple(datasets.keys()), tuple(range(len(Xs))))
-        for i, dataset in datasets.items():
-            self.assertEqual(dataset, SupervisedDataset(Xs[i], Ys[i]))
-        self.assertNotEqual(datasets[0], datasets)
-
-        datasets = SupervisedDataset.dict_from_iter(X=Xs[0], Y=Ys.unbind())
-        self.assertEqual(len(datasets), len(Xs))
-        for i in range(1, len(Xs)):
-            self.assertTrue(torch.equal(datasets[0].X, datasets[i].X))
+            SupervisedDataset(
+                X=rand(1, 2),
+                Y=rand(2, 1),
+                feature_names=feature_names,
+                outcome_names=outcome_names,
+            )
+        with self.assertRaisesRegex(ValueError, "`Y` and `Yvar`"):
+            SupervisedDataset(
+                X=rand(2, 2),
+                Y=rand(2, 1),
+                Yvar=rand(2),
+                feature_names=feature_names,
+                outcome_names=outcome_names,
+            )
+        with self.assertRaisesRegex(ValueError, "feature_names"):
+            SupervisedDataset(
+                X=rand(2, 2),
+                Y=rand(2, 1),
+                feature_names=[],
+                outcome_names=outcome_names,
+            )
+        with self.assertRaisesRegex(ValueError, "outcome_names"):
+            SupervisedDataset(
+                X=rand(2, 2),
+                Y=rand(2, 1),
+                feature_names=feature_names,
+                outcome_names=[],
+            )
 
         # Test with Yvar.
         dataset = SupervisedDataset(
-            X=Xs[0], Y=Ys[0], Yvar=DenseContainer(Ys[0], Ys[0].shape[-1:])
+            X=X,
+            Y=Y,
+            Yvar=DenseContainer(Y, Y.shape[-1:]),
+            feature_names=feature_names,
+            outcome_names=outcome_names,
         )
         self.assertIsInstance(dataset.X, Tensor)
         self.assertIsInstance(dataset._X, Tensor)
@@ -63,54 +90,103 @@ class TestDatasets(BotorchTestCase):
 
     def test_fixedNoise(self):
         # Generate some data
-        Xs = rand(4, 3, 2)
-        Ys = rand(4, 3, 1)
-        Ys_var = rand(4, 3, 1)
-
-        # Test `dict_from_iter`
-        datasets = FixedNoiseDataset.dict_from_iter(
-            X=Xs.unbind(),
-            Y=Ys.unbind(),
-            Yvar=Ys_var.unbind(),
+        X = rand(3, 2)
+        Y = rand(3, 1)
+        Yvar = rand(3, 1)
+        feature_names = ["x1", "x2"]
+        outcome_names = ["y"]
+        dataset = FixedNoiseDataset(
+            X=X,
+            Y=Y,
+            Yvar=Yvar,
+            feature_names=feature_names,
+            outcome_names=outcome_names,
         )
-        for i, dataset in datasets.items():
-            self.assertTrue(dataset.X.equal(Xs[i]))
-            self.assertTrue(dataset.Y.equal(Ys[i]))
-            self.assertTrue(dataset.Yvar.equal(Ys_var[i]))
-
-        # Test handling of Tensor-valued arguments to `dict_from_iter`
-        datasets = FixedNoiseDataset.dict_from_iter(
-            X=Xs[0],
-            Y=Ys[1],
-            Yvar=Ys_var.unbind(),
-        )
-        for dataset in datasets.values():
-            self.assertTrue(Xs[0].equal(dataset.X))
-            self.assertTrue(Ys[1].equal(dataset.Y))
+        self.assertTrue(torch.equal(dataset.X, X))
+        self.assertTrue(torch.equal(dataset.Y, Y))
+        self.assertTrue(torch.equal(dataset.Yvar, Yvar))
+        self.assertEqual(dataset.feature_names, feature_names)
+        self.assertEqual(dataset.outcome_names, outcome_names)
 
         with self.assertRaisesRegex(
             ValueError, "`Y` and `Yvar`"
         ), self.assertWarnsRegex(DeprecationWarning, "SupervisedDataset"):
-            FixedNoiseDataset(X=Xs, Y=Ys, Yvar=Ys_var[0])
+            FixedNoiseDataset(
+                X=X,
+                Y=Y,
+                Yvar=Yvar.squeeze(),
+                feature_names=feature_names,
+                outcome_names=outcome_names,
+            )
 
     def test_ranking(self):
         # Test `_validate`
         X_val = rand(16, 2)
         X_idx = stack([randperm(len(X_val))[:3] for _ in range(1)])
         X = SliceContainer(X_val, X_idx, event_shape=Size([3 * X_val.shape[-1]]))
+        feature_names = ["x1", "x2"]
+        outcome_names = ["ranking indices"]
+
+        with self.assertRaisesRegex(ValueError, "The `values` field of `X`"):
+            RankingDataset(
+                X=X,
+                Y=tensor([[-1, 0, 1]]),
+                feature_names=feature_names[:1],
+                outcome_names=outcome_names,
+            )
 
         with self.assertRaisesRegex(ValueError, "out-of-bounds"):
-            RankingDataset(X=X, Y=tensor([[-1, 0, 1]]))
-        RankingDataset(X=X, Y=tensor([[2, 0, 1]]))
+            RankingDataset(
+                X=X,
+                Y=tensor([[-1, 0, 1]]),
+                feature_names=feature_names,
+                outcome_names=outcome_names,
+            )
+        RankingDataset(
+            X=X,
+            Y=tensor([[2, 0, 1]]),
+            feature_names=feature_names,
+            outcome_names=outcome_names,
+        )
 
         with self.assertRaisesRegex(ValueError, "out-of-bounds"):
-            RankingDataset(X=X, Y=tensor([[0, 1, 3]]))
-        RankingDataset(X=X, Y=tensor([[0, 1, 2]]))
+            RankingDataset(
+                X=X,
+                Y=tensor([[0, 1, 3]]),
+                feature_names=feature_names,
+                outcome_names=outcome_names,
+            )
+        RankingDataset(
+            X=X,
+            Y=tensor([[0, 1, 2]]),
+            feature_names=feature_names,
+            outcome_names=outcome_names,
+        )
 
         with self.assertRaisesRegex(ValueError, "missing zero-th rank."):
-            RankingDataset(X=X, Y=tensor([[1, 2, 2]]))
-        RankingDataset(X=X, Y=tensor([[0, 1, 1]]))
+            RankingDataset(
+                X=X,
+                Y=tensor([[1, 2, 2]]),
+                feature_names=feature_names,
+                outcome_names=outcome_names,
+            )
+        RankingDataset(
+            X=X,
+            Y=tensor([[0, 1, 1]]),
+            feature_names=feature_names,
+            outcome_names=outcome_names,
+        )
 
         with self.assertRaisesRegex(ValueError, "ranks not skipped after ties."):
-            RankingDataset(X=X, Y=tensor([[0, 0, 1]]))
-        RankingDataset(X=X, Y=tensor([[0, 0, 2]]))
+            RankingDataset(
+                X=X,
+                Y=tensor([[0, 0, 1]]),
+                feature_names=feature_names,
+                outcome_names=outcome_names,
+            )
+        RankingDataset(
+            X=X,
+            Y=tensor([[0, 0, 2]]),
+            feature_names=feature_names,
+            outcome_names=outcome_names,
+        )


### PR DESCRIPTION
Summary:
This will help us while passing data around in Ax by offering more granular information on what each dataset represents.

Also hard-deprecates `dict_from_iter` method that was unused outside of tests.

Differential Revision: D48926319


