### PR TITLE
Fix test_compute_best_feasible_objective

### DIFF
--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -95,6 +95,10 @@ class TestConstraintUtils(BotorchTestCase):
                             **tkwargs,
                         ).view(-1, 1)
                         if len(batch_shape) > 0:
+                            # When `batch_shape = (b,)`, this expands `expected_best_f`
+                            # from shape (3, 1) to (3, 1, 1), then to 
+                            # (1, 1, ..., 1, 3, b, 1), where there are 
+                            # `len(sample_shape) - 1` leading ones.
                             expected_best_f = expected_best_f.unsqueeze(1).repeat(
                                 *[1] * len(sample_shape), *batch_shape, 1
                             )

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -98,7 +98,7 @@ class TestConstraintUtils(BotorchTestCase):
                             # When `batch_shape = (b,)`, this expands `expected_best_f`
                             # from shape (3, 1) to (3, 1, 1), then to
                             # (1, 1, ..., 1, 3, b, 1), where there are
-                            # `len(sample_shape)` leading ones.
+                            # `len(sample_shape) - 1` leading ones.
                             expected_best_f = expected_best_f.unsqueeze(1).repeat(
                                 *[1] * len(sample_shape), *batch_shape, 1
                             )

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -96,9 +96,9 @@ class TestConstraintUtils(BotorchTestCase):
                         ).view(-1, 1)
                         if len(batch_shape) > 0:
                             # When `batch_shape = (b,)`, this expands `expected_best_f`
-                            # from shape (3, 1) to (3, 1, 1), then to 
-                            # (1, 1, ..., 1, 3, b, 1), where there are 
-                            # `len(sample_shape) - 1` leading ones.
+                            # from shape (3, 1) to (3, 1, 1), then to
+                            # (1, 1, ..., 1, 3, b, 1), where there are
+                            # `len(sample_shape)` leading ones.
                             expected_best_f = expected_best_f.unsqueeze(1).repeat(
                                 *[1] * len(sample_shape), *batch_shape, 1
                             )

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -95,9 +95,8 @@ class TestConstraintUtils(BotorchTestCase):
                             **tkwargs,
                         ).view(-1, 1)
                         if len(batch_shape) > 0:
-                            expected_best_f = expected_best_f.unsqueeze(1)
-                            expected_best_f = expected_best_f.expand(
-                                *sample_shape, *batch_shape, 1
+                            expected_best_f = expected_best_f.unsqueeze(1).repeat(
+                                *[1] * len(sample_shape), *batch_shape, 1
                             )
                     else:
                         expected_best_f = torch.full(


### PR DESCRIPTION
Looks like PyTorch nightly made operations on expanded tensors a bit more restrictive and broke one of our unit tests. Fixes the failures in https://github.com/pytorch/botorch/actions/runs/6247371495/job/16959814099