### PR TITLE
make synthetic constrained test functions subclass from SyntheticTestFunction

### DIFF
--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -802,7 +802,7 @@ class ThreeHumpCamel(SyntheticTestFunction):
 #  ------------ Constrained synthetic test functions ----------- #
 
 
-class ConstrainedGramacy(ConstrainedBaseTestProblem):
+class ConstrainedGramacy(ConstrainedBaseTestProblem, SyntheticTestFunction):
     r"""Constrained Gramacy test function.
 
     This problem comes from [Gramacy2016]_. The problem is defined

--- a/test/test_functions/test_synthetic.py
+++ b/test/test_functions/test_synthetic.py
@@ -324,6 +324,7 @@ class TestConstrainedGramacy(
     BotorchTestCase,
     BaseTestProblemTestCaseMixIn,
     ConstrainedTestProblemTestCaseMixin,
+    SyntheticTestFunctionTestCaseMixin,
 ):
 
     functions = [
@@ -334,6 +335,7 @@ class TestConstrainedGramacy(
 class TestConstrainedHartmann(
     BotorchTestCase,
     BaseTestProblemTestCaseMixIn,
+    SyntheticTestFunctionTestCaseMixin,
     ConstrainedTestProblemTestCaseMixin,
 ):
 
@@ -345,6 +347,7 @@ class TestConstrainedHartmann(
 class TestConstrainedHartmannSmooth(
     BotorchTestCase,
     BaseTestProblemTestCaseMixIn,
+    SyntheticTestFunctionTestCaseMixin,
     ConstrainedTestProblemTestCaseMixin,
 ):
 


### PR DESCRIPTION
Summary: This is required to inherit `optimal_value` and `optimizers`.

Differential Revision: D49689060


