### PR TITLE
Remove deprecated `_get_extra_mll_args` from BoTorch

### DIFF
--- a/botorch/optim/utils/__init__.py
+++ b/botorch/optim/utils/__init__.py
@@ -15,7 +15,6 @@ from botorch.optim.utils.common import (
     _warning_handler_template,
 )
 from botorch.optim.utils.model_utils import (
-    _get_extra_mll_args,
     get_data_loader,
     get_name_filter,
     get_parameters,
@@ -33,7 +32,6 @@ from botorch.optim.utils.timeout import minimize_with_timeout
 
 __all__ = [
     "_filter_kwargs",
-    "_get_extra_mll_args",
     "_handle_numerical_errors",
     "_warning_handler_template",
     "as_ndarray",

--- a/botorch/optim/utils/model_utils.py
+++ b/botorch/optim/utils/model_utils.py
@@ -9,25 +9,12 @@ r"""Utilities for fitting and manipulating models."""
 from __future__ import annotations
 
 from re import Pattern
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    NamedTuple,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Dict, Iterator, NamedTuple, Optional, Tuple, Union
 from warnings import warn
 
 import torch
 from botorch.exceptions.warnings import BotorchWarning
 from botorch.models.gpytorch import GPyTorchModel
-from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
-from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
-from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
 from torch import Tensor
 from torch.nn import Module
 from torch.utils.data import DataLoader, TensorDataset
@@ -37,29 +24,6 @@ class TorchAttr(NamedTuple):
     shape: torch.Size
     dtype: torch.dtype
     device: torch.device
-
-
-def _get_extra_mll_args(
-    mll: MarginalLogLikelihood,
-) -> Union[List[Tensor], List[List[Tensor]]]:
-    r"""Obtain extra arguments for MarginalLogLikelihood objects.
-
-    Get extra arguments (beyond the model output and training targets) required
-    for the particular type of MarginalLogLikelihood for a forward pass.
-
-    Args:
-        mll: The MarginalLogLikelihood module.
-
-    Returns:
-        Extra arguments for the MarginalLogLikelihood.
-        Returns an empty list if the mll type is unknown.
-    """
-    warn("`_get_extra_mll_args` is marked for deprecation.", DeprecationWarning)
-    if isinstance(mll, ExactMarginalLogLikelihood):
-        return list(mll.model.train_inputs)
-    elif isinstance(mll, SumMarginalLogLikelihood):
-        return [list(x) for x in mll.model.train_inputs]
-    return []
 
 
 def get_data_loader(

--- a/test/optim/utils/test_model_utils.py
+++ b/test/optim/utils/test_model_utils.py
@@ -16,7 +16,6 @@ import torch
 from botorch import settings
 from botorch.models import ModelListGP, SingleTaskGP
 from botorch.optim.utils import (
-    _get_extra_mll_args,
     get_data_loader,
     get_name_filter,
     get_parameters,
@@ -49,38 +48,6 @@ class DummyPriorRuntimeError(Prior):
 
     def rsample(self, sample_shape=torch.Size()):  # noqa: B008
         raise RuntimeError("Another runtime error.")
-
-
-class TestGetExtraMllArgs(BotorchTestCase):
-    def test_get_extra_mll_args(self):
-        train_X = torch.rand(3, 5)
-        train_Y = torch.rand(3, 1)
-        model = SingleTaskGP(train_X=train_X, train_Y=train_Y)
-
-        # test ExactMarginalLogLikelihood
-        exact_mll = ExactMarginalLogLikelihood(model.likelihood, model)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            exact_extra_args = _get_extra_mll_args(mll=exact_mll)
-        self.assertEqual(len(exact_extra_args), 1)
-        self.assertTrue(torch.equal(exact_extra_args[0], train_X))
-
-        # test SumMarginalLogLikelihood
-        model2 = ModelListGP(model)
-        sum_mll = SumMarginalLogLikelihood(model2.likelihood, model2)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            sum_mll_extra_args = _get_extra_mll_args(mll=sum_mll)
-        self.assertEqual(len(sum_mll_extra_args), 1)
-        self.assertEqual(len(sum_mll_extra_args[0]), 1)
-        self.assertTrue(torch.equal(sum_mll_extra_args[0][0], train_X))
-
-        # test unsupported MarginalLogLikelihood type
-        unsupported_mll = MarginalLogLikelihood(model.likelihood, model)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            unsupported_mll_extra_args = _get_extra_mll_args(mll=unsupported_mll)
-        self.assertEqual(unsupported_mll_extra_args, [])
 
 
 class TestGetDataLoader(BotorchTestCase):


### PR DESCRIPTION
Summary: This completes removing everything deprecated in the closures refactor, along with D48738275.

Reviewed By: saitcakmak

Differential Revision: D50207579

