### PR TITLE
Adding qLogNEHVI to acquisition factory

### DIFF
--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -15,7 +15,10 @@ import torch
 from botorch import settings
 from botorch.acquisition import AcquisitionFunction
 from botorch.acquisition.cached_cholesky import _get_cache_root_not_supported_message
-from botorch.acquisition.multi_objective.logei import qLogExpectedHypervolumeImprovement
+from botorch.acquisition.multi_objective.logei import (
+    qLogExpectedHypervolumeImprovement,
+    qLogNoisyExpectedHypervolumeImprovement,
+)
 from botorch.acquisition.multi_objective.monte_carlo import (
     MultiObjectiveMCAcquisitionFunction,
     qExpectedHypervolumeImprovement,
@@ -59,10 +62,14 @@ from botorch.utils.transforms import match_batch_shape, standardize
 from torch import Tensor
 
 
-def evaluate(acqf, X: Tensor) -> Tensor:
+def evaluate(acqf: MultiObjectiveMCAcquisitionFunction, X: Tensor) -> Tensor:
+    """On a high level, this test file abstracts away the acqf_class and executes
+    the respective tests for the LogEI, fat, and vanilla versions of the acquisition
+    functions separately, by converting all values to the same space via `evaluate`.
+    """
     return (
         acqf(X).exp()
-        if isinstance(acqf, qLogExpectedHypervolumeImprovement)
+        if isinstance(acqf, qLogExpectedHypervolumeImprovement)  # qLogNEHVI < qLogEHVI
         else acqf(X)
     )
 
@@ -714,148 +721,284 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
         super().setUp()
 
     def test_q_noisy_expected_hypervolume_improvement(self):
-        tkwargs = {"device": self.device}
         for dtype, m in product(
             (torch.float, torch.double),
             (1, 2, 3),
         ):
-            tkwargs["dtype"] = dtype
-            ref_point = self.ref_point[:m]
-            Y = self.Y_raw[:, :m].to(**tkwargs)
-            pareto_Y = self.pareto_Y_raw[:, :m].to(**tkwargs)
-            X_baseline = torch.rand(Y.shape[0], 1, **tkwargs)
-            # the event shape is `b x q + r x m` = 1 x 1 x 2
-            baseline_samples = Y
-            samples = torch.cat(
-                [baseline_samples.unsqueeze(0), torch.zeros(1, 1, m, **tkwargs)],
-                dim=1,
-            )
-            mm = MockModel(MockPosterior(samples=baseline_samples))
-            X = torch.zeros(1, 1, **tkwargs)
-            # basic test
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-
-            # test error is raised if m == 1
-            if m == 1:
-                with self.assertRaisesRegex(
-                    ValueError,
-                    "NoisyExpectedHypervolumeMixin supports m>=2 outcomes ",
-                ):
-                    acqf = qNoisyExpectedHypervolumeImprovement(
-                        model=mm,
-                        ref_point=ref_point,
-                        X_baseline=X_baseline,
-                        sampler=sampler,
-                        cache_root=False,
-                    )
-                continue
-
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm,
-                ref_point=ref_point,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                cache_root=False,
-            )
-            # set the MockPosterior to use samples over baseline points and new
-            # candidates
-            acqf.model._posterior._samples = samples
-            res = evaluate(acqf, X)
-            self.assertEqual(res.item(), 0.0)
-            # check ref point
-            self.assertTrue(
-                torch.equal(acqf.ref_point, torch.tensor(ref_point, **tkwargs))
-            )
-            # check cached indices
-            self.assertTrue(hasattr(acqf, "q_subset_indices"))
-            self.assertIn("q_choose_1", acqf.q_subset_indices)
-            self.assertTrue(
-                torch.equal(
-                    acqf.q_subset_indices["q_choose_1"],
-                    torch.tensor([[0]], device=self.device),
+            with self.subTest(dtype=dtype, m=m):
+                self._test_q_noisy_expected_hypervolume_improvement(
+                    qNoisyExpectedHypervolumeImprovement, dtype, m
                 )
-            )
 
-            # test q=2
-            X2 = torch.zeros(2, 1, **tkwargs)
-            samples2 = torch.cat(
-                [baseline_samples.unsqueeze(0), torch.zeros(1, 2, m, **tkwargs)],
-                dim=1,
-            )
-            mm2 = MockModel(MockPosterior(samples=baseline_samples))
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm2,
-                ref_point=ref_point,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                cache_root=False,
-            )
-            # set the MockPosterior to use samples over baseline points and new
-            # candidates
-            acqf.model._posterior._samples = samples2
-            res = evaluate(acqf, X2)
-            self.assertEqual(res.item(), 0.0)
-            # check cached indices
-            self.assertTrue(hasattr(acqf, "q_subset_indices"))
-            self.assertIn("q_choose_1", acqf.q_subset_indices)
-            self.assertTrue(
-                torch.equal(
-                    acqf.q_subset_indices["q_choose_1"],
-                    torch.tensor([[0], [1]], device=self.device),
+    def test_q_log_noisy_expected_hypervolume_improvement(self):
+        for dtype, m in product(
+            (torch.float, torch.double),
+            (1, 2, 3),
+        ):
+            with self.subTest(dtype=dtype, m=m):
+                self._test_q_noisy_expected_hypervolume_improvement(
+                    qLogNoisyExpectedHypervolumeImprovement, dtype, m
                 )
-            )
-            self.assertIn("q_choose_2", acqf.q_subset_indices)
-            self.assertTrue(
-                torch.equal(
-                    acqf.q_subset_indices["q_choose_2"],
-                    torch.tensor([[0, 1]], device=self.device),
-                )
-            )
-            self.assertNotIn("q_choose_3", acqf.q_subset_indices)
-            # now back to 1 and sure all caches were cleared
-            acqf.model = mm
-            res = evaluate(acqf, X)
-            self.assertNotIn("q_choose_2", acqf.q_subset_indices)
-            self.assertIn("q_choose_1", acqf.q_subset_indices)
-            self.assertTrue(
-                torch.equal(
-                    acqf.q_subset_indices["q_choose_1"],
-                    torch.tensor([[0]], device=self.device),
-                )
-            )
 
-            # test error is raised if X_baseline is batched
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            with self.assertRaises(UnsupportedError):
-                qNoisyExpectedHypervolumeImprovement(
-                    model=mm2,
+    def _test_q_noisy_expected_hypervolume_improvement(
+        self, acqf_class: Type[AcquisitionFunction], dtype: torch.dtype, m: int
+    ):
+        tkwargs = {"device": self.device}
+        tkwargs["dtype"] = dtype
+        ref_point = self.ref_point[:m]
+        Y = self.Y_raw[:, :m].to(**tkwargs)
+        pareto_Y = self.pareto_Y_raw[:, :m].to(**tkwargs)
+        X_baseline = torch.rand(Y.shape[0], 1, **tkwargs)
+        # the event shape is `b x q + r x m` = 1 x 1 x 2
+        baseline_samples = Y
+        samples = torch.cat(
+            [baseline_samples.unsqueeze(0), torch.zeros(1, 1, m, **tkwargs)],
+            dim=1,
+        )
+        mm = MockModel(MockPosterior(samples=baseline_samples))
+        X = torch.zeros(1, 1, **tkwargs)
+        # basic test
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+
+        # test error is raised if m == 1
+        if m == 1:
+            with self.assertRaisesRegex(
+                ValueError,
+                "NoisyExpectedHypervolumeMixin supports m>=2 outcomes ",
+            ):
+                acqf = acqf_class(
+                    model=mm,
                     ref_point=ref_point,
-                    X_baseline=X_baseline.unsqueeze(0),
+                    X_baseline=X_baseline,
                     sampler=sampler,
                     cache_root=False,
                 )
+            return
 
-            # test objective
-            # set the MockPosterior to use samples over baseline points
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            cache_root=False,
+        )
+        # set the MockPosterior to use samples over baseline points and new
+        # candidates
+        acqf.model._posterior._samples = samples
+        res = evaluate(acqf, X)
+        self.assertAlmostEqual(res.item(), 0.0)
+        # check ref point
+        self.assertTrue(torch.equal(acqf.ref_point, torch.tensor(ref_point, **tkwargs)))
+        # check cached indices
+        self.assertTrue(hasattr(acqf, "q_subset_indices"))
+        self.assertIn("q_choose_1", acqf.q_subset_indices)
+        self.assertTrue(
+            torch.equal(
+                acqf.q_subset_indices["q_choose_1"],
+                torch.tensor([[0]], device=self.device),
+            )
+        )
+
+        # test q=2
+        X2 = torch.zeros(2, 1, **tkwargs)
+        samples2 = torch.cat(
+            [baseline_samples.unsqueeze(0), torch.zeros(1, 2, m, **tkwargs)],
+            dim=1,
+        )
+        mm2 = MockModel(MockPosterior(samples=baseline_samples))
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        acqf = acqf_class(
+            model=mm2,
+            ref_point=ref_point,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            cache_root=False,
+        )
+        # set the MockPosterior to use samples over baseline points and new
+        # candidates
+        acqf.model._posterior._samples = samples2
+        res = evaluate(acqf, X2)
+        self.assertAlmostEqual(res.item(), 0.0)
+        # check cached indices
+        self.assertTrue(hasattr(acqf, "q_subset_indices"))
+        self.assertIn("q_choose_1", acqf.q_subset_indices)
+        self.assertTrue(
+            torch.equal(
+                acqf.q_subset_indices["q_choose_1"],
+                torch.tensor([[0], [1]], device=self.device),
+            )
+        )
+        self.assertIn("q_choose_2", acqf.q_subset_indices)
+        self.assertTrue(
+            torch.equal(
+                acqf.q_subset_indices["q_choose_2"],
+                torch.tensor([[0, 1]], device=self.device),
+            )
+        )
+        self.assertNotIn("q_choose_3", acqf.q_subset_indices)
+        # now back to 1 and sure all caches were cleared
+        acqf.model = mm
+        res = evaluate(acqf, X)
+        self.assertNotIn("q_choose_2", acqf.q_subset_indices)
+        self.assertIn("q_choose_1", acqf.q_subset_indices)
+        self.assertTrue(
+            torch.equal(
+                acqf.q_subset_indices["q_choose_1"],
+                torch.tensor([[0]], device=self.device),
+            )
+        )
+
+        # test error is raised if X_baseline is batched
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        with self.assertRaises(UnsupportedError):
+            acqf_class(
+                model=mm2,
+                ref_point=ref_point,
+                X_baseline=X_baseline.unsqueeze(0),
+                sampler=sampler,
+                cache_root=False,
+            )
+
+        # test objective
+        # set the MockPosterior to use samples over baseline points
+        mm._posterior._samples = baseline_samples
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            objective=IdentityMCMultiOutputObjective(),
+            cache_root=False,
+        )
+        # sample_shape x n x m
+        original_base_samples = sampler.base_samples.detach().clone()
+        # set the MockPosterior to use samples over baseline points and new
+        # candidates
+        mm._posterior._samples = samples
+        res = evaluate(acqf, X)
+        self.assertAlmostEqual(res.item(), 0.0)
+        # test that original base samples were retained
+        self.assertTrue(
+            torch.equal(
+                # sample_shape x batch_shape x n x m
+                sampler.base_samples[0, 0, : original_base_samples.shape[1], :],
+                original_base_samples[0],
+            )
+        )
+
+        # test that base_samples for X_baseline are fixed
+        # set the MockPosterior to use samples over baseline points
+        mm._posterior._samples = baseline_samples
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            cache_root=False,
+        )
+        orig_base_sampler = deepcopy(acqf.base_sampler)
+        # set the MockPosterior to use samples over baseline points and new
+        # candidates
+        mm._posterior._samples = samples
+        with torch.no_grad():
+            acqf(X)
+        self.assertTrue(
+            torch.equal(orig_base_sampler.base_samples, acqf.base_sampler.base_samples)
+        )
+        self.assertTrue(
+            torch.allclose(
+                acqf.base_sampler.base_samples,
+                acqf.sampler.base_samples[..., : X_baseline.shape[0], :],
+            )
+        )
+        mm._posterior._samples = baseline_samples
+        # test empty pareto set
+        ref_point2 = [15.0, 14.0, 16.0][:m]
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point2,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            objective=IdentityMCMultiOutputObjective(),
+            cache_root=False,
+        )
+        self.assertTrue((acqf.cell_lower_bounds[..., 0] == 15).all())
+        self.assertTrue((acqf.cell_lower_bounds[..., 1] == 14).all())
+        if m == 3:
+            self.assertTrue((acqf.cell_lower_bounds[..., 2] == 16).all())
+        self.assertTrue(torch.isinf(acqf.cell_upper_bounds).all())
+        for b in (acqf.cell_lower_bounds, acqf.cell_upper_bounds):
+            self.assertEqual(list(b.shape), [1, 1, m])
+            self.assertEqual(list(b.shape), [1, 1, m])
+
+        # test no baseline points
+        ref_point2 = [15.0, 14.0, 16.0][:m]
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point2,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            objective=IdentityMCMultiOutputObjective(),
+            prune_baseline=True,
+            cache_root=False,
+        )
+        self.assertTrue((acqf.cell_lower_bounds[..., 0] == 15).all())
+        self.assertTrue((acqf.cell_lower_bounds[..., 1] == 14).all())
+        if m == 3:
+            self.assertTrue((acqf.cell_lower_bounds[..., 2] == 16).all())
+        self.assertTrue(torch.isinf(acqf.cell_upper_bounds).all())
+        for b in (acqf.cell_lower_bounds, acqf.cell_upper_bounds):
+            self.assertEqual(list(b.shape), [1, 1, m])
+            self.assertEqual(list(b.shape), [1, 1, m])
+
+        # test X_pending with CBD
+        for incremental_nehvi in (False, True):
             mm._posterior._samples = baseline_samples
             sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
+            acqf = acqf_class(
                 model=mm,
                 ref_point=ref_point,
                 X_baseline=X_baseline,
                 sampler=sampler,
                 objective=IdentityMCMultiOutputObjective(),
+                incremental_nehvi=incremental_nehvi,
                 cache_root=False,
             )
-            # sample_shape x n x m
             original_base_samples = sampler.base_samples.detach().clone()
-            # set the MockPosterior to use samples over baseline points and new
-            # candidates
-            mm._posterior._samples = samples
-            res = evaluate(acqf, X)
-            self.assertEqual(res.item(), 0.0)
-            # test that original base samples were retained
+            # the box decomposition algorithm is faster on the CPU for m>2,
+            # so NEHVI runs it on the CPU
+            expected_pareto_Y = pareto_Y if m == 2 else pareto_Y.cpu()
+            self.assertTrue(
+                torch.equal(acqf.partitioning.pareto_Y[0], expected_pareto_Y)
+            )
+            self.assertIsNone(acqf.X_pending)
+            new_Y = torch.tensor([[0.5, 3.0, 0.5][:m]], dtype=dtype, device=self.device)
+            mm._posterior._samples = torch.cat(
+                [
+                    baseline_samples,
+                    new_Y,
+                ]
+            ).unsqueeze(0)
+            bd = DominatedPartitioning(
+                ref_point=torch.tensor(ref_point).to(**tkwargs), Y=pareto_Y
+            )
+            initial_hv = bd.compute_hypervolume()
+            # test _initial_hvs
+            if not incremental_nehvi:
+                self.assertTrue(hasattr(acqf, "_initial_hvs"))
+                self.assertTrue(torch.equal(acqf._initial_hvs, initial_hv.view(-1)))
+            # test forward
+            X_test = torch.rand(1, 1, dtype=dtype, device=self.device)
+            with torch.no_grad():
+                val = evaluate(acqf, X_test)
+            bd.update(mm._posterior._samples[0, -1:])
+            expected_val = bd.compute_hypervolume() - initial_hv
+            self.assertAllClose(val, expected_val.view(-1))
+            # test that original base_samples were retained
             self.assertTrue(
                 torch.equal(
                     # sample_shape x batch_shape x n x m
@@ -863,540 +1006,438 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                     original_base_samples[0],
                 )
             )
+            # test X_pending
+            mm._posterior._samples = baseline_samples
+            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+            acqf = acqf_class(
+                model=mm,
+                ref_point=ref_point,
+                X_baseline=X_baseline,
+                sampler=sampler,
+                objective=IdentityMCMultiOutputObjective(),
+                incremental_nehvi=incremental_nehvi,
+                cache_root=False,
+            )
+            # sample_shape x n x m
+            original_base_samples = sampler.base_samples.detach().clone()
+            mm._posterior._samples = torch.cat(
+                [
+                    baseline_samples,
+                    new_Y,
+                ],
+                dim=0,
+            )
+            X_pending = torch.rand(1, 1, dtype=dtype, device=self.device)
+            acqf.set_X_pending(X_pending)
+            if not incremental_nehvi:
+                self.assertAllClose(expected_val, acqf._prev_nehvi)
+            self.assertIsNone(acqf.X_pending)
+            # check that X_baseline has been updated
+            self.assertTrue(torch.equal(acqf.X_baseline[:-1], acqf._X_baseline))
+            self.assertTrue(torch.equal(acqf.X_baseline[-1:], X_pending))
+            # check that partitioning has been updated
+            acqf_pareto_Y = acqf.partitioning.pareto_Y[0]
+            # the box decomposition algorithm is faster on the CPU for m>2,
+            # so NEHVI runs it on the CPU
+            self.assertTrue(torch.equal(acqf_pareto_Y[:-1], expected_pareto_Y))
+            expected_new_Y = new_Y if m == 2 else new_Y.cpu()
+            self.assertTrue(torch.equal(acqf_pareto_Y[-1:], expected_new_Y))
+            # test that base samples were retained
+            self.assertTrue(
+                torch.equal(
+                    # sample_shape x n x m
+                    sampler.base_samples[0, : original_base_samples.shape[1], :],
+                    original_base_samples[0],
+                )
+            )
+            self.assertTrue(
+                torch.equal(
+                    acqf.sampler.base_samples,
+                    acqf.base_sampler.base_samples,
+                )
+            )
 
-            # test that base_samples for X_baseline are fixed
+            # test incremental nehvi in forward
+            new_Y2 = torch.cat(
+                [
+                    new_Y,
+                    torch.tensor(
+                        [[0.25, 9.5, 1.5][:m]], dtype=dtype, device=self.device
+                    ),
+                ],
+                dim=0,
+            )
+            mm._posterior._samples = torch.cat(
+                [
+                    baseline_samples,
+                    new_Y2,
+                ]
+            ).unsqueeze(0)
+            X_test = torch.rand(1, 1, dtype=dtype, device=self.device)
+            with torch.no_grad():
+                val = evaluate(acqf, X_test)
+            if incremental_nehvi:
+                # set initial hv to include X_pending
+                initial_hv = bd.compute_hypervolume()
+            bd.update(mm._posterior._samples[0, -1:])
+            expected_val = bd.compute_hypervolume() - initial_hv
+            self.assertAllClose(val, expected_val.view(-1))
+
+        # add another point
+        X_pending2 = torch.cat(
+            [X_pending, torch.rand(1, 1, dtype=dtype, device=self.device)], dim=0
+        )
+        mm._posterior._samples = mm._posterior._samples.squeeze(0)
+        acqf.set_X_pending(X_pending2)
+        self.assertIsNone(acqf.X_pending)
+        # check that X_baseline has been updated
+        self.assertTrue(torch.equal(acqf.X_baseline[:-2], acqf._X_baseline))
+        self.assertTrue(torch.equal(acqf.X_baseline[-2:], X_pending2))
+        # check that partitioning has been updated
+        acqf_pareto_Y = acqf.partitioning.pareto_Y[0]
+        self.assertTrue(torch.equal(acqf_pareto_Y[:-2], expected_pareto_Y))
+        expected_new_Y2 = new_Y2 if m == 2 else new_Y2.cpu()
+        self.assertTrue(torch.equal(acqf_pareto_Y[-2:], expected_new_Y2))
+
+        # test set X_pending with grad
+        # Get posterior samples to agree with X_pending
+        mm._posterior._samples = torch.zeros(1, 7, m, **tkwargs)
+        with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            acqf.set_X_pending(
+                torch.cat([X_pending2, X_pending2], dim=0).requires_grad_(True)
+            )
+            self.assertIsNone(acqf.X_pending)
+            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
+
+        # test max iep
+        mm._posterior._samples = baseline_samples
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            objective=IdentityMCMultiOutputObjective(),
+            incremental_nehvi=False,
+            max_iep=1,
+            cache_root=False,
+        )
+        mm._posterior._samples = torch.cat(
+            [
+                baseline_samples,
+                new_Y,
+            ]
+        )
+        acqf.set_X_pending(X_pending)
+        self.assertTrue(torch.equal(acqf.X_pending, X_pending))
+        acqf_pareto_Y = acqf.partitioning.pareto_Y[0]
+        self.assertTrue(torch.equal(acqf_pareto_Y, expected_pareto_Y))
+        mm._posterior._samples = torch.cat(
+            [
+                baseline_samples,
+                new_Y2,
+            ]
+        )
+        # check that after second pending point is added, X_pending is set to None
+        # and the pending points are included in the box decompositions
+        acqf.set_X_pending(X_pending2)
+        self.assertIsNone(acqf.X_pending)
+        acqf_pareto_Y = acqf.partitioning.pareto_Y[0]
+        self.assertTrue(torch.equal(acqf_pareto_Y[:-2], expected_pareto_Y))
+        self.assertTrue(torch.equal(acqf_pareto_Y[-2:], expected_new_Y2))
+
+        # test qNEHVI without CBD
+        mm._posterior._samples = baseline_samples
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            objective=IdentityMCMultiOutputObjective(),
+            cache_pending=False,
+            cache_root=False,
+        )
+        mm._posterior._samples = torch.cat(
+            [
+                baseline_samples,
+                new_Y,
+            ]
+        ).unsqueeze(0)
+        X_pending10 = X_pending.expand(10, 1)
+        acqf.set_X_pending(X_pending10)
+        self.assertTrue(torch.equal(acqf.X_pending, X_pending10))
+        acqf_pareto_Y = acqf.partitioning.pareto_Y[0]
+        self.assertTrue(torch.equal(acqf_pareto_Y, expected_pareto_Y))
+        acqf.set_X_pending(X_pending)
+        mm._posterior._samples = torch.cat(
+            [
+                baseline_samples,
+                new_Y2,
+            ]
+        ).unsqueeze(0)
+        with torch.no_grad():
+            val = evaluate(acqf, X_test)
+        bd = DominatedPartitioning(
+            ref_point=torch.tensor(ref_point).to(**tkwargs), Y=pareto_Y
+        )
+        initial_hv = bd.compute_hypervolume()
+        bd.update(mm._posterior._samples.squeeze(0))
+        expected_val = bd.compute_hypervolume() - initial_hv
+        self.assertAllClose(expected_val.view(1), val)
+        # test alpha > 0
+        mm._posterior._samples = baseline_samples
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            objective=IdentityMCMultiOutputObjective(),
+            cache_pending=False,
+            alpha=1e-3,
+            cache_root=False,
+        )
+        if len(ref_point) == 2:
+            partitioning = acqf.partitioning
+        else:
+            partitioning = acqf.partitioning.box_decompositions[0]
+        self.assertIsInstance(partitioning, NondominatedPartitioning)
+        self.assertEqual(partitioning.alpha, 1e-3)
+        # test set_X_pending when X_pending = None
+        acqf.set_X_pending(X_pending10)
+        self.assertTrue(torch.equal(acqf.X_pending, X_pending10))
+        acqf.set_X_pending(None)
+        self.assertIsNone(acqf.X_pending)
+        # test X_pending is not None on __init__
+        mm._posterior._samples = torch.zeros(1, 5, m, **tkwargs)
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            objective=IdentityMCMultiOutputObjective(),
+            alpha=1e-3,
+            X_pending=X_pending2,
+            cache_root=False,
+        )
+        self.assertTrue(torch.equal(X_baseline, acqf._X_baseline))
+        self.assertTrue(torch.equal(acqf.X_baseline[:-2], acqf._X_baseline))
+        self.assertTrue(torch.equal(acqf.X_baseline[-2:], X_pending2))
+
+    def test_constrained_q_noisy_expected_hypervolume_improvement(self) -> None:
+        for dtype, fat in product(
+            (torch.float, torch.double),
+            (True, False),
+        ):
+            with self.subTest(dtype=dtype, fat=fat):
+                self._test_constrained_q_noisy_expected_hypervolume_improvement(
+                    qNoisyExpectedHypervolumeImprovement, dtype, fat
+                )
+
+    def test_constrained_q_log_noisy_expected_hypervolume_improvement(self) -> None:
+        for dtype, fat in product(
+            (torch.float, torch.double),
+            (True, False),
+        ):
+            with self.subTest(dtype=dtype, fat=fat):
+                self._test_constrained_q_noisy_expected_hypervolume_improvement(
+                    qLogNoisyExpectedHypervolumeImprovement, dtype, fat
+                )
+
+    def _test_constrained_q_noisy_expected_hypervolume_improvement(
+        self, acqf_class: Type[AcquisitionFunction], dtype: torch.dtype, fat: bool
+    ):
+        # TODO: improve tests with constraints
+        tkwargs = {"device": self.device, "dtype": dtype}
+        ref_point = [0.0, 0.0]
+        pareto_Y = torch.tensor(
+            [[4.0, 5.0], [5.0, 5.0], [8.5, 3.5], [8.5, 3.0], [9.0, 1.0]], **tkwargs
+        )
+        X_baseline = torch.zeros(pareto_Y.shape[0], 1, **tkwargs)
+        baseline_samples = pareto_Y
+
+        # test q=1
+        # the event shape is `b x q x m` = 1 x 1 x 2
+        samples = torch.cat(
+            [
+                baseline_samples.unsqueeze(0),
+                torch.tensor([[[6.5, 4.5]]], **tkwargs),
+            ],
+            dim=1,
+        )
+        mm = MockModel(MockPosterior(samples=baseline_samples))
+        X = torch.zeros(1, 1, **tkwargs)
+        # test zero slack multiple constraints, multiple etas
+        for eta in [1e-1, 1e-2, torch.tensor([1.0, 10.0])]:
             # set the MockPosterior to use samples over baseline points
             mm._posterior._samples = baseline_samples
             sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
+            acqf = acqf_class(
                 model=mm,
                 ref_point=ref_point,
                 X_baseline=X_baseline,
                 sampler=sampler,
+                constraints=[
+                    lambda Z: torch.zeros_like(Z[..., -1]),
+                    lambda Z: torch.zeros_like(Z[..., -1]),
+                ],
+                eta=eta,
                 cache_root=False,
+                fat=fat,
             )
-            orig_base_sampler = deepcopy(acqf.base_sampler)
             # set the MockPosterior to use samples over baseline points and new
             # candidates
             mm._posterior._samples = samples
-            with torch.no_grad():
-                evaluate(acqf, X)
-            self.assertTrue(
-                torch.equal(
-                    orig_base_sampler.base_samples, acqf.base_sampler.base_samples
-                )
-            )
-            self.assertTrue(
-                torch.allclose(
-                    acqf.base_sampler.base_samples,
-                    acqf.sampler.base_samples[..., : X_baseline.shape[0], :],
-                )
-            )
-            mm._posterior._samples = baseline_samples
-            # test empty pareto set
-            ref_point2 = [15.0, 14.0, 16.0][:m]
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm,
-                ref_point=ref_point2,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                objective=IdentityMCMultiOutputObjective(),
-                cache_root=False,
-            )
-            self.assertTrue((acqf.cell_lower_bounds[..., 0] == 15).all())
-            self.assertTrue((acqf.cell_lower_bounds[..., 1] == 14).all())
-            if m == 3:
-                self.assertTrue((acqf.cell_lower_bounds[..., 2] == 16).all())
-            self.assertTrue(torch.isinf(acqf.cell_upper_bounds).all())
-            for b in (acqf.cell_lower_bounds, acqf.cell_upper_bounds):
-                self.assertEqual(list(b.shape), [1, 1, m])
-                self.assertEqual(list(b.shape), [1, 1, m])
-
-            # test no baseline points
-            ref_point2 = [15.0, 14.0, 16.0][:m]
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm,
-                ref_point=ref_point2,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                objective=IdentityMCMultiOutputObjective(),
-                prune_baseline=True,
-                cache_root=False,
-            )
-            self.assertTrue((acqf.cell_lower_bounds[..., 0] == 15).all())
-            self.assertTrue((acqf.cell_lower_bounds[..., 1] == 14).all())
-            if m == 3:
-                self.assertTrue((acqf.cell_lower_bounds[..., 2] == 16).all())
-            self.assertTrue(torch.isinf(acqf.cell_upper_bounds).all())
-            for b in (acqf.cell_lower_bounds, acqf.cell_upper_bounds):
-                self.assertEqual(list(b.shape), [1, 1, m])
-                self.assertEqual(list(b.shape), [1, 1, m])
-
-            # test X_pending with CBD
-            for incremental_nehvi in (False, True):
-                mm._posterior._samples = baseline_samples
-                sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-                acqf = qNoisyExpectedHypervolumeImprovement(
-                    model=mm,
-                    ref_point=ref_point,
-                    X_baseline=X_baseline,
-                    sampler=sampler,
-                    objective=IdentityMCMultiOutputObjective(),
-                    incremental_nehvi=incremental_nehvi,
-                    cache_root=False,
-                )
-                original_base_samples = sampler.base_samples.detach().clone()
-                # the box decomposition algorithm is faster on the CPU for m>2,
-                # so NEHVI runs it on the CPU
-                expected_pareto_Y = pareto_Y if m == 2 else pareto_Y.cpu()
-                self.assertTrue(
-                    torch.equal(acqf.partitioning.pareto_Y[0], expected_pareto_Y)
-                )
-                self.assertIsNone(acqf.X_pending)
-                new_Y = torch.tensor(
-                    [[0.5, 3.0, 0.5][:m]], dtype=dtype, device=self.device
-                )
-                mm._posterior._samples = torch.cat(
-                    [
-                        baseline_samples,
-                        new_Y,
-                    ]
-                ).unsqueeze(0)
-                bd = DominatedPartitioning(
-                    ref_point=torch.tensor(ref_point).to(**tkwargs), Y=pareto_Y
-                )
-                initial_hv = bd.compute_hypervolume()
-                # test _initial_hvs
-                if not incremental_nehvi:
-                    self.assertTrue(hasattr(acqf, "_initial_hvs"))
-                    self.assertTrue(torch.equal(acqf._initial_hvs, initial_hv.view(-1)))
-                # test forward
-                X_test = torch.rand(1, 1, dtype=dtype, device=self.device)
-                with torch.no_grad():
-                    val = evaluate(acqf, X_test)
-                bd.update(mm._posterior._samples[0, -1:])
-                expected_val = bd.compute_hypervolume() - initial_hv
-                self.assertTrue(torch.equal(val, expected_val.view(-1)))
-                # test that original base_samples were retained
-                self.assertTrue(
-                    torch.equal(
-                        # sample_shape x batch_shape x n x m
-                        sampler.base_samples[0, 0, : original_base_samples.shape[1], :],
-                        original_base_samples[0],
-                    )
-                )
-                # test X_pending
-                mm._posterior._samples = baseline_samples
-                sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-                acqf = qNoisyExpectedHypervolumeImprovement(
-                    model=mm,
-                    ref_point=ref_point,
-                    X_baseline=X_baseline,
-                    sampler=sampler,
-                    objective=IdentityMCMultiOutputObjective(),
-                    incremental_nehvi=incremental_nehvi,
-                    cache_root=False,
-                )
-                # sample_shape x n x m
-                original_base_samples = sampler.base_samples.detach().clone()
-                mm._posterior._samples = torch.cat(
-                    [
-                        baseline_samples,
-                        new_Y,
-                    ],
-                    dim=0,
-                )
-                X_pending = torch.rand(1, 1, dtype=dtype, device=self.device)
-                acqf.set_X_pending(X_pending)
-                if not incremental_nehvi:
-                    self.assertTrue(torch.equal(expected_val, acqf._prev_nehvi))
-                self.assertIsNone(acqf.X_pending)
-                # check that X_baseline has been updated
-                self.assertTrue(torch.equal(acqf.X_baseline[:-1], acqf._X_baseline))
-                self.assertTrue(torch.equal(acqf.X_baseline[-1:], X_pending))
-                # check that partitioning has been updated
-                acqf_pareto_Y = acqf.partitioning.pareto_Y[0]
-                # the box decomposition algorithm is faster on the CPU for m>2,
-                # so NEHVI runs it on the CPU
-                self.assertTrue(torch.equal(acqf_pareto_Y[:-1], expected_pareto_Y))
-                expected_new_Y = new_Y if m == 2 else new_Y.cpu()
-                self.assertTrue(torch.equal(acqf_pareto_Y[-1:], expected_new_Y))
-                # test that base samples were retained
-                self.assertTrue(
-                    torch.equal(
-                        # sample_shape x n x m
-                        sampler.base_samples[0, : original_base_samples.shape[1], :],
-                        original_base_samples[0],
-                    )
-                )
-                self.assertTrue(
-                    torch.equal(
-                        acqf.sampler.base_samples,
-                        acqf.base_sampler.base_samples,
-                    )
-                )
-
-                # test incremental nehvi in forward
-                new_Y2 = torch.cat(
-                    [
-                        new_Y,
-                        torch.tensor(
-                            [[0.25, 9.5, 1.5][:m]], dtype=dtype, device=self.device
-                        ),
-                    ],
-                    dim=0,
-                )
-                mm._posterior._samples = torch.cat(
-                    [
-                        baseline_samples,
-                        new_Y2,
-                    ]
-                ).unsqueeze(0)
-                X_test = torch.rand(1, 1, dtype=dtype, device=self.device)
-                with torch.no_grad():
-                    val = evaluate(acqf, X_test)
-                if incremental_nehvi:
-                    # set initial hv to include X_pending
-                    initial_hv = bd.compute_hypervolume()
-                bd.update(mm._posterior._samples[0, -1:])
-                expected_val = bd.compute_hypervolume() - initial_hv
-                self.assertTrue(torch.equal(val, expected_val.view(-1)))
-
-            # add another point
-            X_pending2 = torch.cat(
-                [X_pending, torch.rand(1, 1, dtype=dtype, device=self.device)], dim=0
-            )
-            mm._posterior._samples = mm._posterior._samples.squeeze(0)
-            acqf.set_X_pending(X_pending2)
-            self.assertIsNone(acqf.X_pending)
-            # check that X_baseline has been updated
-            self.assertTrue(torch.equal(acqf.X_baseline[:-2], acqf._X_baseline))
-            self.assertTrue(torch.equal(acqf.X_baseline[-2:], X_pending2))
-            # check that partitioning has been updated
-            acqf_pareto_Y = acqf.partitioning.pareto_Y[0]
-            self.assertTrue(torch.equal(acqf_pareto_Y[:-2], expected_pareto_Y))
-            expected_new_Y2 = new_Y2 if m == 2 else new_Y2.cpu()
-            self.assertTrue(torch.equal(acqf_pareto_Y[-2:], expected_new_Y2))
-
-            # test set X_pending with grad
-            # Get posterior samples to agree with X_pending
-            mm._posterior._samples = torch.zeros(1, 7, m, **tkwargs)
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
-                acqf.set_X_pending(
-                    torch.cat([X_pending2, X_pending2], dim=0).requires_grad_(True)
-                )
-                self.assertIsNone(acqf.X_pending)
-                self.assertEqual(
-                    sum(issubclass(w.category, BotorchWarning) for w in ws), 1
-                )
-
-            # test max iep
-            mm._posterior._samples = baseline_samples
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm,
-                ref_point=ref_point,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                objective=IdentityMCMultiOutputObjective(),
-                incremental_nehvi=False,
-                max_iep=1,
-                cache_root=False,
-            )
-            mm._posterior._samples = torch.cat(
-                [
-                    baseline_samples,
-                    new_Y,
-                ]
-            )
-            acqf.set_X_pending(X_pending)
-            self.assertTrue(torch.equal(acqf.X_pending, X_pending))
-            acqf_pareto_Y = acqf.partitioning.pareto_Y[0]
-            self.assertTrue(torch.equal(acqf_pareto_Y, expected_pareto_Y))
-            mm._posterior._samples = torch.cat(
-                [
-                    baseline_samples,
-                    new_Y2,
-                ]
-            )
-            # check that after second pending point is added, X_pending is set to None
-            # and the pending points are included in the box decompositions
-            acqf.set_X_pending(X_pending2)
-            self.assertIsNone(acqf.X_pending)
-            acqf_pareto_Y = acqf.partitioning.pareto_Y[0]
-            self.assertTrue(torch.equal(acqf_pareto_Y[:-2], expected_pareto_Y))
-            self.assertTrue(torch.equal(acqf_pareto_Y[-2:], expected_new_Y2))
-
-            # test qNEHVI without CBD
-            mm._posterior._samples = baseline_samples
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm,
-                ref_point=ref_point,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                objective=IdentityMCMultiOutputObjective(),
-                cache_pending=False,
-                cache_root=False,
-            )
-            mm._posterior._samples = torch.cat(
-                [
-                    baseline_samples,
-                    new_Y,
-                ]
-            ).unsqueeze(0)
-            X_pending10 = X_pending.expand(10, 1)
-            acqf.set_X_pending(X_pending10)
-            self.assertTrue(torch.equal(acqf.X_pending, X_pending10))
-            acqf_pareto_Y = acqf.partitioning.pareto_Y[0]
-            self.assertTrue(torch.equal(acqf_pareto_Y, expected_pareto_Y))
-            acqf.set_X_pending(X_pending)
-            mm._posterior._samples = torch.cat(
-                [
-                    baseline_samples,
-                    new_Y2,
-                ]
-            ).unsqueeze(0)
-            with torch.no_grad():
-                val = evaluate(acqf, X_test)
-            bd = DominatedPartitioning(
-                ref_point=torch.tensor(ref_point).to(**tkwargs), Y=pareto_Y
-            )
-            initial_hv = bd.compute_hypervolume()
-            bd.update(mm._posterior._samples.squeeze(0))
-            expected_val = bd.compute_hypervolume() - initial_hv
-            self.assertTrue(torch.equal(expected_val.view(1), val))
-            # test alpha > 0
-            mm._posterior._samples = baseline_samples
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm,
-                ref_point=ref_point,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                objective=IdentityMCMultiOutputObjective(),
-                cache_pending=False,
-                alpha=1e-3,
-                cache_root=False,
-            )
-            if len(ref_point) == 2:
-                partitioning = acqf.partitioning
-            else:
-                partitioning = acqf.partitioning.box_decompositions[0]
-            self.assertIsInstance(partitioning, NondominatedPartitioning)
-            self.assertEqual(partitioning.alpha, 1e-3)
-            # test set_X_pending when X_pending = None
-            acqf.set_X_pending(X_pending10)
-            self.assertTrue(torch.equal(acqf.X_pending, X_pending10))
-            acqf.set_X_pending(None)
-            self.assertIsNone(acqf.X_pending)
-            # test X_pending is not None on __init__
-            mm._posterior._samples = torch.zeros(1, 5, m, **tkwargs)
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm,
-                ref_point=ref_point,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                objective=IdentityMCMultiOutputObjective(),
-                alpha=1e-3,
-                X_pending=X_pending2,
-                cache_root=False,
-            )
-            self.assertTrue(torch.equal(X_baseline, acqf._X_baseline))
-            self.assertTrue(torch.equal(acqf.X_baseline[:-2], acqf._X_baseline))
-            self.assertTrue(torch.equal(acqf.X_baseline[-2:], X_pending2))
-
-    def test_constrained_q_noisy_expected_hypervolume_improvement(self):
-        # TODO: improve tests with constraints
-        for dtype in (torch.float, torch.double):
-            tkwargs = {"device": self.device, "dtype": dtype}
-            ref_point = [0.0, 0.0]
-            pareto_Y = torch.tensor(
-                [[4.0, 5.0], [5.0, 5.0], [8.5, 3.5], [8.5, 3.0], [9.0, 1.0]], **tkwargs
-            )
-            X_baseline = torch.zeros(pareto_Y.shape[0], 1, **tkwargs)
-            baseline_samples = pareto_Y
-
-            # test q=1
-            # the event shape is `b x q x m` = 1 x 1 x 2
-            samples = torch.cat(
-                [
-                    baseline_samples.unsqueeze(0),
-                    torch.tensor([[[6.5, 4.5]]], **tkwargs),
-                ],
-                dim=1,
-            )
-            mm = MockModel(MockPosterior(samples=baseline_samples))
-            X = torch.zeros(1, 1, **tkwargs)
-            # test zero slack multiple constraints, multiple etas
-            for eta in [1e-1, 1e-2, torch.tensor([1.0, 10.0])]:
-                # set the MockPosterior to use samples over baseline points
-                mm._posterior._samples = baseline_samples
-                sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-                acqf = qNoisyExpectedHypervolumeImprovement(
-                    model=mm,
-                    ref_point=ref_point,
-                    X_baseline=X_baseline,
-                    sampler=sampler,
-                    constraints=[
-                        lambda Z: torch.zeros_like(Z[..., -1]),
-                        lambda Z: torch.zeros_like(Z[..., -1]),
-                    ],
-                    eta=eta,
-                    cache_root=False,
-                )
-                # set the MockPosterior to use samples over baseline points and new
-                # candidates
-                mm._posterior._samples = samples
-                res = evaluate(acqf, X)
-                self.assertAlmostEqual(res.item(), 0.5 * 0.5 * 1.5, places=4)
-            # test zero slack single constraint
-            for eta in (1e-1, 1e-2):
-                # set the MockPosterior to use samples over baseline points
-                mm._posterior._samples = baseline_samples
-                sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-                acqf = qNoisyExpectedHypervolumeImprovement(
-                    model=mm,
-                    ref_point=ref_point,
-                    X_baseline=X_baseline,
-                    sampler=sampler,
-                    constraints=[lambda Z: torch.zeros_like(Z[..., -1])],
-                    eta=eta,
-                    cache_root=False,
-                )
-                # set the MockPosterior to use samples over baseline points and new
-                # candidates
-                mm._posterior._samples = samples
-                res = evaluate(acqf, X)
-                self.assertAlmostEqual(res.item(), 0.5 * 1.5, places=4)
-            # set X_pending
-            X_pending = torch.rand(1, 1, **tkwargs)
-            acqf.set_X_pending(X_pending)
-            samples = torch.cat(
-                [
-                    samples,
-                    torch.tensor([[[10.0, 0.5]]], **tkwargs),
-                ],
-                dim=1,
-            )
-            mm._posterior._samples = samples
             res = evaluate(acqf, X)
-            self.assertAlmostEqual(res.item(), 0.5 * 0.5, places=4)
-
-            # test incremental nehvi=False
+            self.assertAlmostEqual(res.item(), 0.5 * 0.5 * 1.5, places=4)
+        # test zero slack single constraint
+        for eta in (1e-1, 1e-2):
+            # set the MockPosterior to use samples over baseline points
             mm._posterior._samples = baseline_samples
-            acqf = qNoisyExpectedHypervolumeImprovement(
+            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+            acqf = acqf_class(
                 model=mm,
                 ref_point=ref_point,
                 X_baseline=X_baseline,
                 sampler=sampler,
                 constraints=[lambda Z: torch.zeros_like(Z[..., -1])],
-                eta=1e-3,
-                incremental_nehvi=False,
+                eta=eta,
                 cache_root=False,
-            )
-            samples = torch.cat(
-                [
-                    baseline_samples.unsqueeze(0),
-                    torch.tensor([[[6.5, 4.5]]], **tkwargs),
-                ],
-                dim=1,
-            )
-            mm._posterior._samples = samples
-            res = evaluate(acqf, X)
-            self.assertAlmostEqual(res.item(), 0.5 * 1.5, places=4)
-            acqf.set_X_pending(X_pending)
-            samples = torch.cat(
-                [
-                    samples,
-                    torch.tensor([[[10.0, 0.5]]], **tkwargs),
-                ],
-                dim=1,
-            )
-            mm._posterior._samples = samples
-            res = evaluate(acqf, X)
-            # test that HVI is not incremental
-            # Note that the cached pending point uses strict constraint evaluation
-            # so the HVI from the cached pending point is 1.5.
-            # The new X contributes an HVI of 0.5, but with a constraint slack of 0,
-            # the sigmoid soft-evaluation yields a constrained HVI of 0.25
-            self.assertAlmostEqual(res.item(), 1.75, places=4)
-
-            # test feasible
-            # set the MockPosterior to use samples over baseline points
-            mm._posterior._samples = baseline_samples
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm,
-                ref_point=ref_point,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                constraints=[lambda Z: -100.0 * torch.ones_like(Z[..., -1])],
-                eta=1e-3,
-                cache_root=False,
-            )
-            samples = torch.cat(
-                [
-                    baseline_samples.unsqueeze(0),
-                    torch.tensor([[[6.5, 4.5]]], **tkwargs),
-                ],
-                dim=1,
-            )
-            mm._posterior._samples = samples
-            res = evaluate(acqf, X)
-            self.assertAlmostEqual(res.item(), 1.5, places=4)
-            # test multiple constraints one eta with
-            # this crashes for large etas, and I do not why
-            # set the MockPosterior to use samples over baseline points
-            etas = [torch.tensor([1.0]), torch.tensor([1.0, 10.0])]
-            constraints = [
-                [lambda Z: torch.ones_like(Z[..., -1])],
-                [
-                    lambda Z: torch.ones_like(Z[..., -1]),
-                    lambda Z: torch.ones_like(Z[..., -1]),
-                ],
-            ]
-            expected_values = [
-                (torch.sigmoid(torch.as_tensor(-1.0 / 1)) * 1.5).item(),
-                (
-                    torch.sigmoid(torch.as_tensor(-1.0 / 1))
-                    * torch.sigmoid(torch.as_tensor(-1.0 / 10))
-                    * 1.5
-                ).item(),
-            ]
-            for eta, constraint, expected_value in zip(
-                etas, constraints, expected_values
-            ):
-                acqf.constraints = constraint
-                acqf.eta = eta
-                res = evaluate(acqf, X)
-
-                self.assertAlmostEqual(
-                    res.item(),
-                    expected_value,
-                    places=4,
-                )
-            # test infeasible
-            # set the MockPosterior to use samples over baseline points
-            mm._posterior._samples = baseline_samples
-            sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-            acqf = qNoisyExpectedHypervolumeImprovement(
-                model=mm,
-                ref_point=ref_point,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                constraints=[lambda Z: 100.0 * torch.ones_like(Z[..., -1])],
-                eta=1e-3,
-                cache_root=False,
+                fat=fat,
             )
             # set the MockPosterior to use samples over baseline points and new
             # candidates
             mm._posterior._samples = samples
             res = evaluate(acqf, X)
-            self.assertAlmostEqual(res.item(), 0.0, places=4)
+            self.assertAlmostEqual(res.item(), 0.5 * 1.5, places=4)
+        # set X_pending
+        X_pending = torch.rand(1, 1, **tkwargs)
+        acqf.set_X_pending(X_pending)
+        samples = torch.cat(
+            [
+                samples,
+                torch.tensor([[[10.0, 0.5]]], **tkwargs),
+            ],
+            dim=1,
+        )
+        mm._posterior._samples = samples
+        res = evaluate(acqf, X)
+        self.assertAlmostEqual(res.item(), 0.5 * 0.5, places=4)
+
+        # test incremental nehvi=False
+        mm._posterior._samples = baseline_samples
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            constraints=[lambda Z: torch.zeros_like(Z[..., -1])],
+            eta=1e-3,
+            incremental_nehvi=False,
+            cache_root=False,
+            fat=fat,
+        )
+        samples = torch.cat(
+            [
+                baseline_samples.unsqueeze(0),
+                torch.tensor([[[6.5, 4.5]]], **tkwargs),
+            ],
+            dim=1,
+        )
+        mm._posterior._samples = samples
+        res = evaluate(acqf, X)
+        self.assertAlmostEqual(res.item(), 0.5 * 1.5, places=4)
+        acqf.set_X_pending(X_pending)
+        samples = torch.cat(
+            [
+                samples,
+                torch.tensor([[[10.0, 0.5]]], **tkwargs),
+            ],
+            dim=1,
+        )
+        mm._posterior._samples = samples
+        res = evaluate(acqf, X)
+        # test that HVI is not incremental
+        # Note that the cached pending point uses strict constraint evaluation
+        # so the HVI from the cached pending point is 1.5.
+        # The new X contributes an HVI of 0.5, but with a constraint slack of 0,
+        # the sigmoid soft-evaluation yields a constrained HVI of 0.25
+        self.assertAlmostEqual(res.item(), 1.75, places=4)
+
+        # test feasible
+        # set the MockPosterior to use samples over baseline points
+        mm._posterior._samples = baseline_samples
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            constraints=[lambda Z: -100.0 * torch.ones_like(Z[..., -1])],
+            eta=1e-3,
+            cache_root=False,
+            fat=fat,
+        )
+        samples = torch.cat(
+            [
+                baseline_samples.unsqueeze(0),
+                torch.tensor([[[6.5, 4.5]]], **tkwargs),
+            ],
+            dim=1,
+        )
+        mm._posterior._samples = samples
+        res = evaluate(acqf, X)
+        self.assertAlmostEqual(res.item(), 1.5, places=4)
+        # test multiple constraints one eta with
+        # this crashes for large etas, and I do not why
+        # set the MockPosterior to use samples over baseline points
+        etas = [torch.tensor([1.0]), torch.tensor([1.0, 10.0])]
+        constraints = [
+            [lambda Z: torch.ones_like(Z[..., -1])],
+            [
+                lambda Z: torch.ones_like(Z[..., -1]),
+                lambda Z: torch.ones_like(Z[..., -1]),
+            ],
+        ]
+        expected_values = [
+            (sigmoid(torch.as_tensor(-1.0 / 1), fat=fat) * 1.5).item(),
+            (
+                sigmoid(torch.as_tensor(-1.0 / 1), fat=fat)
+                * sigmoid(torch.as_tensor(-1.0 / 10), fat=fat)
+                * 1.5
+            ).item(),
+        ]
+        for eta, constraint, expected_value in zip(etas, constraints, expected_values):
+            acqf.constraints = constraint
+            acqf.eta = eta
+            res = evaluate(acqf, X)
+
+            self.assertAlmostEqual(
+                res.item(),
+                expected_value,
+                places=4,
+            )
+        # test infeasible
+        # set the MockPosterior to use samples over baseline points
+        mm._posterior._samples = baseline_samples
+        sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
+        acqf = acqf_class(
+            model=mm,
+            ref_point=ref_point,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            constraints=[lambda Z: 100.0 * torch.ones_like(Z[..., -1])],
+            eta=1e-3,
+            cache_root=False,
+            fat=fat,
+        )
+        # set the MockPosterior to use samples over baseline points and new
+        # candidates
+        mm._posterior._samples = samples
+        res = evaluate(acqf, X)
+        self.assertAlmostEqual(res.item(), 0.0, places=4)
 
         # test >2 objectives
         ref_point = [0.0, 0.0, 0.0]
@@ -1412,7 +1453,13 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
         )
         mm._posterior._samples = baseline_samples
         sampler = IIDNormalSampler(sample_shape=torch.Size([1]))
-        acqf = qNoisyExpectedHypervolumeImprovement(
+        delta = 1e-4
+        special_kwargs = (
+            {}
+            if acqf_class == qNoisyExpectedHypervolumeImprovement
+            else {"tau_max": delta}
+        )
+        acqf = acqf_class(
             model=mm,
             ref_point=ref_point,
             X_baseline=X_baseline,
@@ -1420,6 +1467,8 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             constraints=[lambda Z: -100.0 * torch.ones_like(Z[..., -1])],
             eta=1e-3,
             cache_root=False,
+            fat=fat,
+            **special_kwargs,
         )
         # set the MockPosterior to use samples over baseline points and new
         # candidates
@@ -1432,9 +1481,17 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
         )
         mm._posterior._samples = samples
         res = evaluate(acqf, X)
-        self.assertAlmostEqual(res.item(), 1.5, places=4)
+        self.assertAlmostEqual(res.item(), 1.5, delta=delta)
 
     def test_prune_baseline(self):
+        for acqf_class in (
+            qNoisyExpectedHypervolumeImprovement,
+            qLogNoisyExpectedHypervolumeImprovement,
+        ):
+            with self.subTest(acqf_class.__name__):
+                self._test_prune_baseline(acqf_class)
+
+    def _test_prune_baseline(self, acqf_class: Type[AcquisitionFunction]):
         # test prune_baseline
         no = "botorch.utils.testing.MockModel.num_outputs"
         prune = (
@@ -1456,7 +1513,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                 # Reduce samples to same shape as X_pruned.
                 mm = MockModel(MockPosterior(samples=baseline_samples[:1]))
                 with mock.patch(prune, return_value=X_pruned) as mock_prune:
-                    acqf = qNoisyExpectedHypervolumeImprovement(
+                    acqf = acqf_class(
                         model=mm,
                         ref_point=ref_point,
                         X_baseline=X_baseline,
@@ -1468,6 +1525,14 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                 self.assertTrue(torch.equal(acqf.X_baseline, X_pruned))
 
     def test_cache_root(self):
+        for acqf_class in (
+            qNoisyExpectedHypervolumeImprovement,
+            qLogNoisyExpectedHypervolumeImprovement,
+        ):
+            with self.subTest(acqf_class.__name__):
+                self._test_cache_root(acqf_class)
+
+    def _test_cache_root(self, acqf_class: Type[AcquisitionFunction]):
         sample_cached_path = (
             "botorch.acquisition.cached_cholesky.sample_cached_cholesky"
         )
@@ -1518,7 +1583,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                 model.load_state_dict(state_dict, strict=False)
                 sampler = IIDNormalSampler(sample_shape=torch.Size([5]), seed=0)
                 torch.manual_seed(0)
-                acqf = qNoisyExpectedHypervolumeImprovement(
+                acqf = acqf_class(
                     model=model,
                     ref_point=ref_point,
                     X_baseline=X_baseline,
@@ -1529,7 +1594,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
 
                 sampler2 = IIDNormalSampler(sample_shape=torch.Size([5]), seed=0)
                 torch.manual_seed(0)
-                acqf_no_cache = qNoisyExpectedHypervolumeImprovement(
+                acqf_no_cache = acqf_class(
                     model=model,
                     ref_point=ref_point,
                     X_baseline=X_baseline,
@@ -1563,7 +1628,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                         sample_cached_path, wraps=sample_cached_cholesky
                     ) as mock_sample_cached:
                         torch.manual_seed(0)
-                        val2 = acqf_no_cache(test_X2)
+                        val2 = evaluate(acqf_no_cache, test_X2)
                     mock_sample_cached.assert_not_called()
                     self.assertAllClose(val, val2, **all_close_kwargs)
                     val2.sum().backward()
@@ -1587,21 +1652,38 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
 
     def test_cache_root_w_standardize(self):
         # Test caching with standardize transform.
-        train_x = torch.rand(3, 2, dtype=torch.float64)
-        train_y = torch.randn(3, 2, dtype=torch.float64)
-        model = SingleTaskGP(train_x, train_y, outcome_transform=Standardize(m=2))
-        acqf = qNoisyExpectedHypervolumeImprovement(
-            model=model,
-            X_baseline=train_x,
-            ref_point=torch.ones(2),
-            sampler=IIDNormalSampler(sample_shape=torch.Size([1])),
-            cache_root=True,
-        )
-        self.assertIsNotNone(acqf._baseline_L)
-        self.assertEqual(acqf(train_x[:1]).shape, torch.Size([1]))
-        self.assertEqual(acqf(train_x.unsqueeze(-2)).shape, torch.Size([3]))
+        for acqf_class in (
+            qNoisyExpectedHypervolumeImprovement,
+            qLogNoisyExpectedHypervolumeImprovement,
+        ):
+            with self.subTest(acqf_class.__name__):
+                train_x = torch.rand(3, 2, dtype=torch.float64)
+                train_y = torch.randn(3, 2, dtype=torch.float64)
+                model = SingleTaskGP(
+                    train_x, train_y, outcome_transform=Standardize(m=2)
+                )
+                acqf = acqf_class(
+                    model=model,
+                    X_baseline=train_x,
+                    ref_point=torch.ones(2),
+                    sampler=IIDNormalSampler(sample_shape=torch.Size([1])),
+                    cache_root=True,
+                )
+                self.assertIsNotNone(acqf._baseline_L)
+                self.assertEqual(acqf(train_x[:1]).shape, torch.Size([1]))
+                self.assertEqual(acqf(train_x.unsqueeze(-2)).shape, torch.Size([3]))
 
     def test_with_set_valued_objectives(self):
+        for acqf_class in (
+            qNoisyExpectedHypervolumeImprovement,
+            qLogNoisyExpectedHypervolumeImprovement,
+        ):
+            with self.subTest(acqf_class.__name__):
+                self._test_with_set_valued_objectives(acqf_class)
+
+    def _test_with_set_valued_objectives(
+        self, acqf_class: Type[AcquisitionFunction]
+    ) -> None:
         for dtype in (torch.float, torch.double):
             tkwargs = {"device": self.device, "dtype": dtype}
             tx = torch.rand(5, 2, **tkwargs)
@@ -1622,7 +1704,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                     )
 
             model = MockModel(MockPosterior(samples=baseline_samples))
-            acqf = qNoisyExpectedHypervolumeImprovement(
+            acqf = acqf_class(
                 model=model,
                 ref_point=torch.tensor([0.0, 0.0], **tkwargs),
                 X_baseline=tx,
@@ -1637,13 +1719,28 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                 dim=1,
             )
             acqf.model._posterior._samples = samples
-            res = evaluate(acqf, test_x)
-            self.assertTrue(torch.equal(res, torch.zeros(3, **tkwargs)))
+            res = acqf(test_x)
+            if acqf_class == qNoisyExpectedHypervolumeImprovement:
+                self.assertTrue(torch.equal(res, torch.zeros(3, **tkwargs)))
+            else:
+                self.assertFalse(res.isinf().any())
+                exp_log_res = res.exp()
+                self.assertTrue((0 <= exp_log_res).all())
+                self.assertTrue((exp_log_res < acqf.tau_relu).all())
+
             self.assertEqual(acqf.q_in, 6)
             self.assertEqual(acqf.q_out, 4)
             self.assertEqual(len(acqf.q_subset_indices.keys()), 4)
 
     def test_deterministic(self):
+        for acqf_class in (
+            qNoisyExpectedHypervolumeImprovement,
+            qLogNoisyExpectedHypervolumeImprovement,
+        ):
+            with self.subTest(acqf_class.__name__):
+                self._test_deterministic(acqf_class)
+
+    def _test_deterministic(self, acqf_class: Type[AcquisitionFunction]):
         for dtype, prune in ((torch.float, False), (torch.double, True)):
             tkwargs = {"device": self.device, "dtype": dtype}
             model = GenericDeterministicModel(f=lambda x: x, num_outputs=2)
@@ -1651,7 +1748,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                 RuntimeWarning,
                 _get_cache_root_not_supported_message(GenericDeterministicModel),
             ):
-                acqf = qNoisyExpectedHypervolumeImprovement(
+                acqf = acqf_class(
                     model=model,
                     ref_point=torch.tensor([0.0, 0.0], **tkwargs),
                     X_baseline=torch.rand(5, 2, **tkwargs),
@@ -1664,6 +1761,14 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             )
 
     def test_with_multitask(self):
+        for acqf_class in (
+            qNoisyExpectedHypervolumeImprovement,
+            qLogNoisyExpectedHypervolumeImprovement,
+        ):
+            with self.subTest(acqf_class.__name__):
+                self._test_with_multitask(acqf_class)
+
+    def _test_with_multitask(self, acqf_class: Type[AcquisitionFunction]):
         # Verify that _set_sampler works with MTGP, KroneckerMTGP and HOGP.
         torch.manual_seed(1234)
         tkwargs = {"device": self.device, "dtype": torch.double}
@@ -1680,7 +1785,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
         test_x = torch.rand(2, 3, 2, **tkwargs)
 
         def get_acqf(model):
-            return qNoisyExpectedHypervolumeImprovement(
+            return acqf_class(
                 model=model,
                 ref_point=torch.tensor([0.0, 0.0], **tkwargs),
                 X_baseline=train_x,
@@ -1690,15 +1795,20 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
                 cache_root=False,
             )
 
+        compute_str = (
+            "_compute_qehvi"
+            if acqf_class == qNoisyExpectedHypervolumeImprovement
+            else "_compute_log_qehvi"
+        )
         for model in [mtgp, kmtgp, hogp]:
             acqf = get_acqf(model)
             posterior = model.posterior(acqf.X_baseline)
             base_evals = acqf.base_sampler(posterior)
             base_samples = acqf.base_sampler.base_samples
             with mock.patch.object(
-                qNoisyExpectedHypervolumeImprovement,
-                "_compute_qehvi",
-                wraps=acqf._compute_qehvi,
+                acqf_class,
+                compute_str,
+                wraps=getattr(acqf, compute_str),
             ) as wrapped_compute:
                 acqf(test_x)
             wrapped_compute.assert_called_once()
@@ -1756,13 +1866,18 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             IIDNormalSampler(sample_shape=torch.Size([2])),
             IIDNormalSampler(sample_shape=torch.Size([2])),
         )
-        # This calls _set_sampler which used to error out in
-        # NormalMCSampler._update_base_samples with TransformedPosterior
-        # due to the missing batch_shape (fixed in #1625).
-        qNoisyExpectedHypervolumeImprovement(
-            model=mm,
-            ref_point=torch.tensor([0.0, 0.0]),
-            X_baseline=torch.rand(3, 2),
-            sampler=sampler,
-            cache_root=False,
-        )
+        for acqf_class in (
+            qNoisyExpectedHypervolumeImprovement,
+            qLogNoisyExpectedHypervolumeImprovement,
+        ):
+            with self.subTest(acqf_class.__name__):
+                # This calls _set_sampler which used to error out in
+                # NormalMCSampler._update_base_samples with TransformedPosterior
+                # due to the missing batch_shape (fixed in #1625).
+                acqf_class(
+                    model=mm,
+                    ref_point=torch.tensor([0.0, 0.0]),
+                    X_baseline=torch.rand(3, 2),
+                    sampler=sampler,
+                    cache_root=False,
+                )


### PR DESCRIPTION
Summary: This commit introduces `qLogNEHVI` to the `get_acquisition_function` factory and reduces code duplication.

Differential Revision: D50386440

