### PR TITLE
Update use cases of deprecated fixed-noise models

### DIFF
--- a/botorch/models/contextual.py
+++ b/botorch/models/contextual.py
@@ -6,28 +6,29 @@
 
 from typing import Any, Dict, List, Optional
 
-from botorch.models.gp_regression import FixedNoiseGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.kernels.contextual_lcea import LCEAKernel
 from botorch.models.kernels.contextual_sac import SACKernel
 from botorch.utils.datasets import SupervisedDataset
 from torch import Tensor
 
 
-class SACGP(FixedNoiseGP):
+class SACGP(SingleTaskGP):
     r"""A GP using a Structural Additive Contextual(SAC) kernel."""
 
     def __init__(
         self,
         train_X: Tensor,
         train_Y: Tensor,
-        train_Yvar: Tensor,
+        train_Yvar: Optional[Tensor],
         decomposition: Dict[str, List[int]],
     ) -> None:
         r"""
         Args:
             train_X: (n x d) X training data.
             train_Y: (n x 1) Y training data.
-            train_Yvar: (n x 1) Noise variances of each training Y.
+            train_Yvar: (n x 1) Noise variances of each training Y. If None,
+                we use an inferred noise likelihood.
             decomposition: Keys are context names. Values are the indexes of
                 parameters belong to the context. The parameter indexes are in
                 the same order across contexts.
@@ -62,7 +63,7 @@ class SACGP(FixedNoiseGP):
         }
 
 
-class LCEAGP(FixedNoiseGP):
+class LCEAGP(SingleTaskGP):
     r"""A GP using a Latent Context Embedding Additive (LCE-A) Kernel.
 
     Note that the model does not support batch training. Input training
@@ -73,7 +74,7 @@ class LCEAGP(FixedNoiseGP):
         self,
         train_X: Tensor,
         train_Y: Tensor,
-        train_Yvar: Tensor,
+        train_Yvar: Optional[Tensor],
         decomposition: Dict[str, List[int]],
         train_embedding: bool = True,
         cat_feature_dict: Optional[Dict] = None,
@@ -85,7 +86,8 @@ class LCEAGP(FixedNoiseGP):
         Args:
             train_X: (n x d) X training data.
             train_Y: (n x 1) Y training data.
-            train_Yvar: (n x 1) Noise variance of Y.
+            train_Yvar: (n x 1) Noise variance of Y. If None,
+                we use an inferred noise likelihood.
             decomposition: Keys are context names. Values are the indexes of
                 parameters belong to the context.
             train_embedding: Whether to train the embedding layer or not. If False,

--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -170,6 +170,7 @@ class FixedNoiseLCEMGP(LCEMGP):
     (LCE-M) kernel, with known observation noise.
 
     DEPRECATED: Please use `LCEMGP` with `train_Yvar` instead.
+    Will be removed in a future release (~v0.11).
     """
 
     def __init__(

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -182,7 +182,7 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
         >>> ])
         >>> train_Y = torch.cat(f1(X1), f2(X2)).unsqueeze(-1)
         >>> train_Yvar = 0.01 * torch.ones_like(train_Y)
-        >>> mtsaas_gp = SaasFullyBayesianFixedNoiseMultiTaskGP(
+        >>> mtsaas_gp = SaasFullyBayesianMultiTaskGP(
         >>>     train_X, train_Y, train_Yvar, task_feature=-1,
         >>> )
         >>> fit_fully_bayesian_model_nuts(mtsaas_gp)

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -30,7 +30,8 @@ model like `MultiTaskGP`.
 
 from __future__ import annotations
 
-from typing import Any, List, NoReturn, Optional
+import warnings
+from typing import NoReturn, Optional
 
 import torch
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
@@ -43,7 +44,6 @@ from botorch.models.utils.gpytorch_modules import (
     get_matern_kernel_with_gamma_prior,
     MIN_INFERRED_NOISE_LEVEL,
 )
-from botorch.sampling.base import MCSampler
 from gpytorch.constraints.constraints import GreaterThan
 from gpytorch.distributions.multivariate_normal import MultivariateNormal
 from gpytorch.likelihoods.gaussian_likelihood import (
@@ -63,7 +63,7 @@ from torch import Tensor
 
 
 class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
-    r"""A single-task exact GP model.
+    r"""A single-task exact GP model, supporting both known and inferred noise levels.
 
     A single-task exact GP using relatively strong priors on the Kernel
     hyperparameters, which work best when covariates are normalized to the unit
@@ -78,16 +78,35 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
     training data, use the ModelListGP. When modeling correlations between
     outputs, use the MultiTaskGP.
 
+    An example of a case in which noise levels are known is online
+    experimentation, where noise can be measured using the variability of
+    different observations from the same arm, or provided by outside software.
+    Another use case is simulation optimization, where the evaluation can
+    provide variance estimates, perhaps from bootstrapping. In any case, these
+    noise levels can be provided to `SingleTaskGP` as `train_Yvar`.
+
+    `SingleTaskGP` can also be used when the observations are known to be
+    noise-free. Noise-free observations can be modeled using arbitrarily small
+    noise values, such as `train_Yvar=torch.full_like(train_Y, 1e-6)`.
+
     Example:
+        >>> # Model with inferred noise levels.
         >>> train_X = torch.rand(20, 2)
         >>> train_Y = torch.sin(train_X).sum(dim=1, keepdim=True)
-        >>> model = SingleTaskGP(train_X, train_Y)
+        >>> inferred_noise_model = SingleTaskGP(train_X, train_Y)
+        >>> # With known observation variance of 0.2.
+        >>> train_Yvar = torch.full_like(train_Y, 0.2)
+        >>> observed_noise_model = SingleTaskGP(train_X, train_Y, train_Yvar)
+        >>> # To model noise-free observations.
+        >>> train_Yvar = torch.full_like(train_Y, 1e-6)
+        >>> noise_free_model = SingleTaskGP(train_X, train_Y, train_Yvar)
     """
 
     def __init__(
         self,
         train_X: Tensor,
         train_Y: Tensor,
+        train_Yvar: Optional[Tensor] = None,
         likelihood: Optional[Likelihood] = None,
         covar_module: Optional[Module] = None,
         mean_module: Optional[Mean] = None,
@@ -98,8 +117,12 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
         Args:
             train_X: A `batch_shape x n x d` tensor of training features.
             train_Y: A `batch_shape x n x m` tensor of training observations.
+            train_Yvar: An optional `batch_shape x n x m` tensor of observed
+                measurement noise.
             likelihood: A likelihood. If omitted, use a standard
-                GaussianLikelihood with inferred noise level.
+                `GaussianLikelihood` with inferred noise level if `train_Yvar`
+                is None, and a `FixedNoiseGaussianLikelihood` with the given
+                noise observations if `train_Yvar` is not None.
             covar_module: The module computing the covariance (Kernel) matrix.
                 If omitted, use a `MaternKernel`.
             mean_module: The mean function to be used. If omitted, use a
@@ -116,18 +139,28 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                 X=train_X, input_transform=input_transform
             )
         if outcome_transform is not None:
-            train_Y, _ = outcome_transform(train_Y)
-        self._validate_tensor_args(X=transformed_X, Y=train_Y)
+            train_Y, train_Yvar = outcome_transform(train_Y, train_Yvar)
+        self._validate_tensor_args(X=transformed_X, Y=train_Y, Yvar=train_Yvar)
         ignore_X_dims = getattr(self, "_ignore_X_dims_scaling_check", None)
         validate_input_scaling(
-            train_X=transformed_X, train_Y=train_Y, ignore_X_dims=ignore_X_dims
+            train_X=transformed_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            ignore_X_dims=ignore_X_dims,
         )
         self._set_dimensions(train_X=train_X, train_Y=train_Y)
-        train_X, train_Y, _ = self._transform_tensor_args(X=train_X, Y=train_Y)
+        train_X, train_Y, train_Yvar = self._transform_tensor_args(
+            X=train_X, Y=train_Y, Yvar=train_Yvar
+        )
         if likelihood is None:
-            likelihood = get_gaussian_likelihood_with_gamma_prior(
-                batch_shape=self._aug_batch_shape
-            )
+            if train_Yvar is None:
+                likelihood = get_gaussian_likelihood_with_gamma_prior(
+                    batch_shape=self._aug_batch_shape
+                )
+            else:
+                likelihood = FixedNoiseGaussianLikelihood(
+                    noise=train_Yvar, batch_shape=self._aug_batch_shape
+                )
         else:
             self._is_custom_likelihood = True
         ExactGP.__init__(
@@ -142,11 +175,12 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                 batch_shape=self._aug_batch_shape,
             )
             self._subset_batch_dict = {
-                "likelihood.noise_covar.raw_noise": -2,
                 "mean_module.raw_constant": -1,
                 "covar_module.raw_outputscale": -1,
                 "covar_module.base_kernel.raw_lengthscale": -3,
             }
+            if train_Yvar is None:
+                self._subset_batch_dict["likelihood.noise_covar.raw_noise"] = -2
         self.covar_module = covar_module
         # TODO: Allow subsetting of other covar modules
         if outcome_transform is not None:
@@ -163,37 +197,11 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
         return MultivariateNormal(mean_x, covar_x)
 
 
-class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
+class FixedNoiseGP(SingleTaskGP):
     r"""A single-task exact GP model using fixed noise levels.
 
-    A single-task exact GP that uses fixed observation noise levels, differing from
-    `SingleTaskGP` only in that noise levels are provided rather than inferred.
-    This model also uses relatively strong priors on the Kernel hyperparameters,
-    which work best when covariates are normalized to the unit cube and outcomes
-    are standardized (zero mean, unit variance).
-
-    This model works in batch mode (each batch having its own hyperparameters).
-
-    An example of a case in which noise levels are known is online
-    experimentation, where noise can be measured using the variability of
-    different observations from the same arm, or provided by outside software.
-    Another use case is simulation optimization, where the evaluation can
-    provide variance estimates, perhaps from bootstrapping. In any case, these
-    noise levels must be provided to `FixedNoiseGP` as `train_Yvar`.
-
-    `FixedNoiseGP` is also commonly used when the observations are known to be
-    noise-free.  Noise-free observations can be modeled using arbitrarily small
-    noise values, such as `train_Yvar=torch.full_like(train_Y, 1e-6)`.
-
-    `FixedNoiseGP` cannot predict noise levels out of sample. If this is needed,
-    use `HeteroskedasticSingleTaskGP`, which will create another model for the
-    observation noise.
-
-    Example:
-        >>> train_X = torch.rand(20, 2)
-        >>> train_Y = torch.sin(train_X).sum(dim=1, keepdim=True)
-        >>> train_Yvar = torch.full_like(train_Y, 0.2)
-        >>> model = FixedNoiseGP(train_X, train_Y, train_Yvar)
+    DEPRECATED: `FixedNoiseGP` has been merged into `SingleTaskGP`. Please use
+    `SingleTaskGP` with `train_Yvar` instead.
     """
 
     def __init__(
@@ -206,139 +214,21 @@ class FixedNoiseGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
         outcome_transform: Optional[OutcomeTransform] = None,
         input_transform: Optional[InputTransform] = None,
     ) -> None:
-        r"""
-        Args:
-            train_X: A `batch_shape x n x d` tensor of training features.
-            train_Y: A `batch_shape x n x m` tensor of training observations.
-            train_Yvar: A `batch_shape x n x m` tensor of observed measurement
-                noise.
-            covar_module: The module computing the covariance (Kernel) matrix.
-                If omitted, use a `MaternKernel`.
-            mean_module: The mean function to be used. If omitted, use a
-                `ConstantMean`.
-            outcome_transform: An outcome transform that is applied to the
-                training data during instantiation and to the posterior during
-                inference (that is, the `Posterior` obtained by calling
-                `.posterior` on the model will be on the original scale).
-            input_transform: An input transfrom that is applied in the model's
-                forward pass.
-        """
-        with torch.no_grad():
-            transformed_X = self.transform_inputs(
-                X=train_X, input_transform=input_transform
-            )
-        if outcome_transform is not None:
-            train_Y, train_Yvar = outcome_transform(train_Y, train_Yvar)
-        self._validate_tensor_args(X=transformed_X, Y=train_Y, Yvar=train_Yvar)
-        validate_input_scaling(
-            train_X=transformed_X, train_Y=train_Y, train_Yvar=train_Yvar
+        r"""DEPRECATED. See SingleTaskGP."""
+        warnings.warn(
+            "`FixedNoiseGP` has been merged into `SingleTaskGP`. "
+            "Please use `SingleTaskGP` with `train_Yvar` instead.",
+            DeprecationWarning,
         )
-        self._set_dimensions(train_X=train_X, train_Y=train_Y)
-        train_X, train_Y, train_Yvar = self._transform_tensor_args(
-            X=train_X, Y=train_Y, Yvar=train_Yvar
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            covar_module=covar_module,
+            mean_module=mean_module,
+            outcome_transform=outcome_transform,
+            input_transform=input_transform,
         )
-        likelihood = FixedNoiseGaussianLikelihood(
-            noise=train_Yvar, batch_shape=self._aug_batch_shape
-        )
-        ExactGP.__init__(
-            self, train_inputs=train_X, train_targets=train_Y, likelihood=likelihood
-        )
-        if mean_module is None:
-            mean_module = ConstantMean(batch_shape=self._aug_batch_shape)
-        self.mean_module = mean_module
-        if covar_module is None:
-            covar_module = get_matern_kernel_with_gamma_prior(
-                ard_num_dims=transformed_X.shape[-1],
-                batch_shape=self._aug_batch_shape,
-            )
-            self._subset_batch_dict = {
-                "mean_module.raw_constant": -1,
-                "covar_module.raw_outputscale": -1,
-                "covar_module.base_kernel.raw_lengthscale": -3,
-            }
-        self.covar_module = covar_module
-        # TODO: Allow subsetting of other covar modules
-        if input_transform is not None:
-            self.input_transform = input_transform
-        if outcome_transform is not None:
-            self.outcome_transform = outcome_transform
-
-        self.to(train_X)
-
-    def fantasize(
-        self,
-        X: Tensor,
-        sampler: MCSampler,
-        observation_noise: Optional[Tensor] = None,
-        **kwargs: Any,
-    ) -> FixedNoiseGP:
-        r"""Construct a fantasy model.
-
-        Constructs a fantasy model in the following fashion:
-        (1) compute the model posterior at `X` (if `observation_noise=True`,
-        this includes observation noise taken as the mean across the observation
-        noise in the training data. If `observation_noise` is a Tensor, use
-        it directly as the observation noise to add).
-        (2) sample from this posterior (using `sampler`) to generate "fake"
-        observations.
-        (3) condition the model on the new fake observations.
-
-        Args:
-            X: A `batch_shape x n' x d`-dim Tensor, where `d` is the dimension of
-                the feature space, `n'` is the number of points per batch, and
-                `batch_shape` is the batch shape (must be compatible with the
-                batch shape of the model).
-            sampler: The sampler used for sampling from the posterior at `X`.
-            observation_noise: The noise level for fantasization if
-                provided. If `None`, the mean across the observation
-                noise in the training data is used as observation noise in
-                the posterior from which the samples are drawn and
-                the fantasized noise level. If observation noise is
-                provided, it is assumed to be in the outcome-transformed
-                space, if an outcome transform is used.
-
-        Returns:
-            The constructed fantasy model.
-        """
-        # self.likelihood.noise is an `batch_shape x n x s(m)`-dimensional tensor
-        if observation_noise is None:
-            if self.num_outputs > 1:
-                # make noise ... x n x m
-                observation_noise = self.likelihood.noise.transpose(-1, -2)
-            else:
-                observation_noise = self.likelihood.noise.unsqueeze(-1)
-            observation_noise = observation_noise.mean(dim=-2, keepdim=True)
-
-        return super().fantasize(
-            X=X,
-            sampler=sampler,
-            observation_noise=observation_noise,
-            **kwargs,
-        )
-
-    def forward(self, x: Tensor) -> MultivariateNormal:
-        # TODO: reduce redundancy with the 'forward' method of
-        # SingleTaskGP, which is identical
-        if self.training:
-            x = self.transform_inputs(x)
-        mean_x = self.mean_module(x)
-        covar_x = self.covar_module(x)
-        return MultivariateNormal(mean_x, covar_x)
-
-    def subset_output(self, idcs: List[int]) -> BatchedMultiOutputGPyTorchModel:
-        r"""Subset the model along the output dimension.
-
-        Args:
-            idcs: The output indices to subset the model to.
-
-        Returns:
-            The current model, subset to the specified output indices.
-        """
-        new_model = super().subset_output(idcs=idcs)
-        full_noise = new_model.likelihood.noise_covar.noise
-        new_noise = full_noise[..., idcs if len(idcs) > 1 else idcs[0], :]
-        new_model.likelihood.noise_covar.noise = new_noise
-        return new_model
 
 
 class HeteroskedasticSingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP):

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -202,6 +202,7 @@ class FixedNoiseGP(SingleTaskGP):
 
     DEPRECATED: `FixedNoiseGP` has been merged into `SingleTaskGP`. Please use
     `SingleTaskGP` with `train_Yvar` instead.
+    Will be removed in a future release (~v0.12).
     """
 
     def __init__(

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -192,7 +192,9 @@ class FixedNoiseMultiFidelityGP(SingleTaskMultiFidelityGP):
         outcome_transform: Optional[OutcomeTransform] = None,
         input_transform: Optional[InputTransform] = None,
     ) -> None:
-        r"""DEPRECATED: Use `SingleTaskMultiFidelityGP` instead."""
+        r"""DEPRECATED: Use `SingleTaskMultiFidelityGP` instead.
+        Will be removed in a future release (~v0.11).
+        """
         warnings.warn(
             "`FixedNoiseMultiFidelityGP` has been deprecated. "
             "Use `SingleTaskMultiFidelityGP` with `train_Yvar` instead.",

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -31,7 +31,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 from botorch.exceptions.errors import UnsupportedError
-from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.kernels.downsampling import DownsamplingKernel
 from botorch.models.kernels.exponential_decay import ExponentialDecayKernel
 from botorch.models.kernels.linear_truncated_fidelity import (
@@ -67,6 +67,7 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         self,
         train_X: Tensor,
         train_Y: Tensor,
+        train_Yvar: Optional[Tensor] = None,
         iteration_fidelity: Optional[int] = None,
         data_fidelities: Optional[Union[List[int], Tuple[int]]] = None,
         data_fidelity: Optional[int] = None,
@@ -82,6 +83,8 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
                 where `s` is the dimension of the fidelity parameters (either one
                 or two).
             train_Y: A `batch_shape x n x m` tensor of training observations.
+            train_Yvar: An optional `batch_shape x n x m` tensor of observed
+                measurement noise.
             iteration_fidelity: The column index for the training iteration fidelity
                 parameter (optional).
             data_fidelities: The column indices for the downsampling fidelity parameter.
@@ -142,17 +145,19 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         super().__init__(
             train_X=train_X,
             train_Y=train_Y,
+            train_Yvar=train_Yvar,
             likelihood=likelihood,
             covar_module=covar_module,
             outcome_transform=outcome_transform,
             input_transform=input_transform,
         )
         self._subset_batch_dict = {
-            "likelihood.noise_covar.raw_noise": -2,
             "mean_module.raw_constant": -1,
             "covar_module.raw_outputscale": -1,
             **subset_batch_dict,
         }
+        if train_Yvar is None:
+            self._subset_batch_dict["likelihood.noise_covar.raw_noise"] = -2
         self.to(train_X)
 
     @classmethod
@@ -173,27 +178,7 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         return inputs
 
 
-class FixedNoiseMultiFidelityGP(FixedNoiseGP):
-    r"""A single task multi-fidelity GP model using fixed noise levels.
-
-    A FixedNoiseGP model analogue to SingleTaskMultiFidelityGP, using a
-    DownsamplingKernel for the data fidelity parameter (if present) and
-    an ExponentialDecayKernel for the iteration fidelity parameter (if present).
-
-    This kernel is described in [Wu2019mf]_.
-
-    Example:
-        >>> train_X = torch.rand(20, 4)
-        >>> train_Y = train_X.pow(2).sum(dim=-1, keepdim=True)
-        >>> train_Yvar = torch.full_like(train_Y) * 0.01
-        >>> model = FixedNoiseMultiFidelityGP(
-        >>>     train_X,
-        >>>     train_Y,
-        >>>     train_Yvar,
-        >>>     data_fidelities=[3],
-        >>> )
-    """
-
+class FixedNoiseMultiFidelityGP(SingleTaskMultiFidelityGP):
     def __init__(
         self,
         train_X: Tensor,
@@ -207,99 +192,24 @@ class FixedNoiseMultiFidelityGP(FixedNoiseGP):
         outcome_transform: Optional[OutcomeTransform] = None,
         input_transform: Optional[InputTransform] = None,
     ) -> None:
-        r"""
-        Args:
-            train_X: A `batch_shape x n x (d + s)` tensor of training features,
-                where `s` is the dimension of the fidelity parameters (either one
-                or two).
-            train_Y: A `batch_shape x n x m` tensor of training observations.
-            train_Yvar: A `batch_shape x n x m` tensor of observed measurement noise.
-            iteration_fidelity: The column index for the training iteration fidelity
-                parameter (optional).
-            data_fidelities: The column indices for the downsampling fidelity parameter.
-                If a list of indices is provided, a kernel will be constructed for
-                each index (optional).
-            data_fidelity: The column index for the downsampling fidelity parameter
-                (optional). Deprecated in favor of `data_fidelities`.
-            linear_truncated: If True, use a `LinearTruncatedFidelityKernel` instead
-                of the default kernel.
-            nu: The smoothness parameter for the Matern kernel: either 1/2, 3/2, or
-                5/2. Only used when `linear_truncated=True`.
-            outcome_transform: An outcome transform that is applied to the
-                training data during instantiation and to the posterior during
-                inference (that is, the `Posterior` obtained by calling
-                `.posterior` on the model will be on the original scale).
-            input_transform: An input transform that is applied in the model's
-                forward pass.
-        """
-        if data_fidelity is not None:
-            warnings.warn(
-                "The `data_fidelity` argument is deprecated and will be removed in "
-                "a future release. Please use `data_fidelities` instead.",
-                DeprecationWarning,
-            )
-            if data_fidelities is not None:
-                raise ValueError(
-                    "Cannot specify both `data_fidelity` and `data_fidelities`."
-                )
-            data_fidelities = [data_fidelity]
-
-        self._init_args = {
-            "iteration_fidelity": iteration_fidelity,
-            "data_fidelities": data_fidelities,
-            "linear_truncated": linear_truncated,
-            "nu": nu,
-            "outcome_transform": outcome_transform,
-        }
-        if iteration_fidelity is None and data_fidelities is None:
-            raise UnsupportedError(
-                "FixedNoiseMultiFidelityGP requires at least one fidelity parameter."
-            )
-        with torch.no_grad():
-            transformed_X = self.transform_inputs(
-                X=train_X, input_transform=input_transform
-            )
-        self._set_dimensions(train_X=transformed_X, train_Y=train_Y)
-        covar_module, subset_batch_dict = _setup_multifidelity_covar_module(
-            dim=transformed_X.size(-1),
-            aug_batch_shape=self._aug_batch_shape,
-            iteration_fidelity=iteration_fidelity,
-            data_fidelities=data_fidelities,
-            linear_truncated=linear_truncated,
-            nu=nu,
+        r"""DEPRECATED: Use `SingleTaskMultiFidelityGP` instead."""
+        warnings.warn(
+            "`FixedNoiseMultiFidelityGP` has been deprecated. "
+            "Use `SingleTaskMultiFidelityGP` with `train_Yvar` instead.",
+            DeprecationWarning,
         )
         super().__init__(
             train_X=train_X,
             train_Y=train_Y,
             train_Yvar=train_Yvar,
-            covar_module=covar_module,
+            iteration_fidelity=iteration_fidelity,
+            data_fidelities=data_fidelities,
+            data_fidelity=data_fidelity,
+            linear_truncated=linear_truncated,
+            nu=nu,
             outcome_transform=outcome_transform,
             input_transform=input_transform,
         )
-        self._subset_batch_dict = {
-            "likelihood.noise_covar.raw_noise": -2,
-            "mean_module.raw_constant": -1,
-            "covar_module.raw_outputscale": -1,
-            **subset_batch_dict,
-        }
-        self.to(train_X)
-
-    @classmethod
-    def construct_inputs(
-        cls,
-        training_data: SupervisedDataset,
-        fidelity_features: List[int],
-        **kwargs,
-    ) -> Dict[str, Any]:
-        r"""Construct `Model` keyword arguments from a dict of `SupervisedDataset`.
-
-        Args:
-            training_data: Dictionary of `SupervisedDataset`.
-            fidelity_features: Column indices of fidelity features.
-        """
-        inputs = super().construct_inputs(training_data=training_data, **kwargs)
-        inputs["data_fidelities"] = fidelity_features
-        return inputs
 
 
 def _setup_multifidelity_covar_module(

--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -6,11 +6,9 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import Any, Callable, Dict, List, Optional
 
 import torch
-from botorch.exceptions.warnings import InputDataWarning
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.kernels.categorical import CategoricalKernel
 from botorch.models.transforms.input import InputTransform
@@ -64,6 +62,7 @@ class MixedSingleTaskGP(SingleTaskGP):
         train_X: Tensor,
         train_Y: Tensor,
         cat_dims: List[int],
+        train_Yvar: Optional[Tensor] = None,
         cont_kernel_factory: Optional[
             Callable[[torch.Size, int, List[int]], Kernel]
         ] = None,
@@ -78,6 +77,8 @@ class MixedSingleTaskGP(SingleTaskGP):
             train_Y: A `batch_shape x n x m` tensor of training observations.
             cat_dims: A list of indices corresponding to the columns of
                 the input `X` that should be considered categorical features.
+            train_Yvar: An optional `batch_shape x n x m` tensor of observed
+                measurement noise.
             cont_kernel_factory: A method that accepts  `batch_shape`, `ard_num_dims`,
                 and `active_dims` arguments and returns an instantiated GPyTorch
                 `Kernel` object to be used as the base kernel for the continuous
@@ -118,7 +119,7 @@ class MixedSingleTaskGP(SingleTaskGP):
                     lengthscale_constraint=GreaterThan(1e-04),
                 )
 
-        if likelihood is None:
+        if likelihood is None and train_Yvar is None:
             # This Gamma prior is quite close to the Horseshoe prior
             min_noise = 1e-5 if train_X.dtype == torch.float else 1e-6
             likelihood = GaussianLikelihood(
@@ -173,6 +174,7 @@ class MixedSingleTaskGP(SingleTaskGP):
         super().__init__(
             train_X=train_X,
             train_Y=train_Y,
+            train_Yvar=train_Yvar,
             likelihood=likelihood,
             covar_module=covar_module,
             outcome_transform=outcome_transform,
@@ -195,13 +197,6 @@ class MixedSingleTaskGP(SingleTaskGP):
             likelihood: Optional likelihood used to constuct the model.
         """
         base_inputs = super().construct_inputs(training_data=training_data, **kwargs)
-        if base_inputs.pop("train_Yvar", None) is not None:
-            # TODO: Remove when SingleTaskGP supports optional Yvar [T162925473].
-            warnings.warn(
-                "`MixedSingleTaskGP` only supports inferred noise at the moment. "
-                "Ignoring the provided `train_Yvar` observations.",
-                InputDataWarning,
-            )
         return {
             **base_inputs,
             "cat_dims": categorical_features,

--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -540,6 +540,12 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
         except AttributeError:
             pass
 
+        # Subset fixed noise likelihood if present.
+        if isinstance(self.likelihood, FixedNoiseGaussianLikelihood):
+            full_noise = new_model.likelihood.noise_covar.noise
+            new_noise = full_noise[..., idcs if len(idcs) > 1 else idcs[0], :]
+            new_model.likelihood.noise_covar.noise = new_noise
+
         return new_model
 
 

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -373,9 +373,10 @@ class FantasizeMixin(ABC):
                 + self.batch_shape
                 + torch.Size([0, self.num_outputs])
             )
+            Y = torch.empty(output_shape, dtype=X.dtype, device=X.device)
             return self.condition_on_observations(
                 X=self.transform_inputs(X),
-                Y=torch.empty(output_shape, dtype=X.dtype, device=X.device),
+                Y=Y,
                 **kwargs,
             )
         propagate_grads = kwargs.pop("propagate_grads", False)

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -327,6 +327,7 @@ class FixedNoiseMultiTaskGP(MultiTaskGP):
     r"""Multi-Task GP model using an ICM kernel, with known observation noise.
 
     DEPRECATED: Please use `MultiTaskGP` with `train_Yvar` instead.
+    Will be removed in a future release (~v0.10).
     """
 
     def __init__(

--- a/botorch/models/utils/parse_training_data.py
+++ b/botorch/models/utils/parse_training_data.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Hashable, Type, Union
 import torch
 from botorch.exceptions import UnsupportedError
 from botorch.models.model import Model
-from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
+from botorch.models.multitask import MultiTaskGP
 from botorch.models.pairwise_gp import PairwiseGP
 from botorch.utils.datasets import RankingDataset, SupervisedDataset
 from botorch.utils.dispatcher import Dispatcher
@@ -88,7 +88,7 @@ def _parse_model_dict(
     return dispatcher(consumer, next(iter(training_data.values())))
 
 
-@dispatcher.register((MultiTaskGP, FixedNoiseMultiTaskGP), dict)
+@dispatcher.register(MultiTaskGP, dict)
 def _parse_multitask_dict(
     consumer: Model,
     training_data: Dict[Hashable, SupervisedDataset],

--- a/botorch/utils/datasets.py
+++ b/botorch/utils/datasets.py
@@ -154,6 +154,7 @@ class FixedNoiseDataset(SupervisedDataset):
     observations variances so that `Y[i] ~ N(f(X[i]), Yvar[i])`.
 
     NOTE: This is deprecated. Use `SupervisedDataset` instead.
+    Will be removed in a future release (~v0.11).
     """
 
     def __init__(

--- a/docs/models.md
+++ b/docs/models.md
@@ -3,119 +3,123 @@ id: models
 title: Models
 ---
 
-Models play an essential role in Bayesian Optimization (BO). A model is used as a
-surrogate function for the actual underlying black box function to be optimized.
-In BoTorch, a `Model` maps a set of design points to a posterior probability
-distribution of its output(s) over the design points.
+Models play an essential role in Bayesian Optimization (BO). A model is used as
+a surrogate function for the actual underlying black box function to be
+optimized. In BoTorch, a `Model` maps a set of design points to a posterior
+probability distribution of its output(s) over the design points.
 
-In BO, the model used is traditionally a Gaussian Process (GP),
-in which case the posterior distribution is a multivariate
-normal. While BoTorch supports many GP models, **BoTorch makes no
-assumption on the model being a GP** or the posterior being multivariate normal.
-With the exception of some of the analytic acquisition functions in the
+In BO, the model used is traditionally a Gaussian Process (GP), in which case
+the posterior distribution is a multivariate normal. While BoTorch supports many
+GP models, **BoTorch makes no assumption on the model being a GP** or the
+posterior being multivariate normal. With the exception of some of the analytic
+acquisition functions in the
 [`botorch.acquisition.analytic`](../api/acquisition.html#analytic-acquisition-function-api)
 module, BoTorch’s Monte Carlo-based acquisition functions are compatible with
-any model that conforms to the `Model` interface, whether user-implemented or provided.
+any model that conforms to the `Model` interface, whether user-implemented or
+provided.
 
-Under the hood, BoTorch models are PyTorch `Modules` that implement
-the light-weight [`Model`](../api/models.html#model-apis) interface.
-When working with GPs, [`GPyTorchModel`](../api/models.html#module-botorch.models.gp_regression)
+Under the hood, BoTorch models are PyTorch `Modules` that implement the
+light-weight [`Model`](../api/models.html#model-apis) interface. When working
+with GPs,
+[`GPyTorchModel`](../api/models.html#module-botorch.models.gp_regression)
 provides a base class for conveniently wrapping GPyTorch models.
 
-Users can extend `Model` and `GPyTorchModel` to generate their own models.
-For more on implementing your own models, see
+Users can extend `Model` and `GPyTorchModel` to generate their own models. For
+more on implementing your own models, see
 [Implementing Custom Models](#implementing-custom-models) below.
-
 
 ## Terminology
 
 ### Multi-Output and Multi-Task
-A `Model` (as in the BoTorch object) may have
-multiple outputs, multiple inputs, and may exploit correlation
-between different inputs. BoTorch uses the following terminology to
-distinguish these model types:
 
-* *Multi-Output Model*: a `Model` with multiple
-  outputs. Most BoTorch `Model`s are multi-output.
-* *Multi-Task Model*: a `Model` making use of a logical grouping of
+A `Model` (as in the BoTorch object) may have multiple outputs, multiple inputs,
+and may exploit correlation between different inputs. BoTorch uses the following
+terminology to distinguish these model types:
+
+- _Multi-Output Model_: a `Model` with multiple outputs. Most BoTorch `Model`s
+  are multi-output.
+- _Multi-Task Model_: a `Model` making use of a logical grouping of
   inputs/observations (as in the underlying process). For example, there could
-  be multiple tasks where each task has a different fidelity.
-  In a multi-task model, the relationship between different
-  outputs is modeled, with a joint model across tasks.
+  be multiple tasks where each task has a different fidelity. In a multi-task
+  model, the relationship between different outputs is modeled, with a joint
+  model across tasks.
 
 Note the following:
-* A multi-task (MT) model may or may not be a multi-output model.
-For example, if a multi-task model uses different tasks for modeling
-but only outputs predictions for one of those tasks, it is single-output.
-* Conversely, a multi-output (MO) model may or may not be a multi-task model.
-For example, multi-output `Model`s that model
-different outputs independently rather than
-building a joint model are not multi-task.
-* If a model is both, we refer to it as a multi-task-multi-output (MTMO) model.
+
+- A multi-task (MT) model may or may not be a multi-output model. For example,
+  if a multi-task model uses different tasks for modeling but only outputs
+  predictions for one of those tasks, it is single-output.
+- Conversely, a multi-output (MO) model may or may not be a multi-task model.
+  For example, multi-output `Model`s that model different outputs independently
+  rather than building a joint model are not multi-task.
+- If a model is both, we refer to it as a multi-task-multi-output (MTMO) model.
 
 ### Noise: Homoskedastic, fixed, and heteroskedastic
+
 Noise can be treated in several different ways:
 
-* *Homoskedastic*: Noise is not provided as an input and is inferred, with a
-constant variance that does not depend on `X`. Many models, such as
-`SingleTaskGP`, take this approach. Use these models if you know that
-your observations are noisy, but not how noisy.
+- _Homoskedastic_: Noise is not provided as an input and is inferred, with a
+  constant variance that does not depend on `X`. Many models, such as
+  `SingleTaskGP`, take this approach. Use these models if you know that your
+  observations are noisy, but not how noisy.
 
-* *Fixed*: Noise is provided as an input and is not fit. In “fixed noise” models
-like `FixedNoiseGP`, noise cannot be predicted out-of-sample because it has
-not been modeled. Use these models if you have estimates of the noise in
-your observations (e.g. observations may be averages over individual samples
-in which case you would provide the mean as observation and the standard
-error of the mean as the noise estimate), or if you know your observations are
-noiseless (by passing a zero noise level).
+- _Fixed_: Noise is provided as an input, `train_Yvar`, and is not fit. In
+  “fixed noise” models like `SingleTaskGP` with noise observations, noise cannot
+  be predicted out-of-sample because it has not been modeled. Use these models
+  if you have estimates of the noise in your observations (e.g. observations may
+  be averages over individual samples in which case you would provide the mean
+  as observation and the standard error of the mean as the noise estimate), or
+  if you know your observations are noiseless (by passing a zero noise level).
 
-* *Heteroskedastic*: Noise is provided as an input and is modeled to allow for
-predicting noise out-of-sample. Models like `HeteroskedasticSingleTaskGP`
-take this approach.
+- _Heteroskedastic_: Noise is provided as an input and is modeled to allow for
+  predicting noise out-of-sample. Models like `HeteroskedasticSingleTaskGP` take
+  this approach.
 
 ## Standard BoTorch Models
 
 BoTorch provides several GPyTorch models to cover most standard BO use cases:
 
 ### Single-Task GPs
+
 These models use the same training data for all outputs and assume conditional
 independence of the outputs given the input. If different training data is
-required for each output, use a [`ModelListGP`](../api/models.html#module-botorch.models.model_list_gp_regression)
+required for each output, use a
+[`ModelListGP`](../api/models.html#module-botorch.models.model_list_gp_regression)
 instead.
-* [`SingleTaskGP`](../api/models.html#botorch.models.gp_regression.SingleTaskGP): a single-task
-  exact GP that infers a homoskedastic noise level (no noise observations).
-* [`FixedNoiseGP`](../api/models.html#botorch.models.gp_regression.FixedNoiseGP): a single-task exact GP that
-  differs from `SingleTaskGP` in using
-  fixed observation noise levels. It requires noise observations.
-* [`HeteroskedasticSingleTaskGP`](../api/models.html#botorch.models.gp_regression.HeteroskedasticSingleTaskGP):
-  a single-task exact GP that differs from `SingleTaskGP` and `FixedNoiseGP`
-  in that it models heteroskedastic noise using an additional
-  internal GP model. It requires noise observations.
-* [`MixedSingleTaskGP`](../api/models.html#botorch.models.gp_regression_mixed.MixedSingleTaskGP): a single-task exact
-  GP that supports mixed search spaces, which combine discrete and continuous features.
-* [`SaasFullyBayesianSingleTaskGP`](../api/models.html#botorch.models.fully_bayesian.SaasFullyBayesianSingleTaskGP):
-  a fully Bayesian single-task GP with the SAAS prior. This model is suitable for
-  sample-efficient high-dimensional Bayesian optimization.
+
+- [`SingleTaskGP`](../api/models.html#botorch.models.gp_regression.SingleTaskGP):
+  a single-task exact GP that supports both inferred and observed noise. When
+  noise observations are not provided, it infers a homoskedastic noise level.
+- [`HeteroskedasticSingleTaskGP`](../api/models.html#botorch.models.gp_regression.HeteroskedasticSingleTaskGP):
+  a single-task exact GP that differs from `SingleTaskGP` with observed noise in
+  that it models heteroskedastic noise using an additional internal GP model. It
+  requires noise observations.
+- [`MixedSingleTaskGP`](../api/models.html#botorch.models.gp_regression_mixed.MixedSingleTaskGP):
+  a single-task exact GP that supports mixed search spaces, which combine
+  discrete and continuous features.
+- [`SaasFullyBayesianSingleTaskGP`](../api/models.html#botorch.models.fully_bayesian.SaasFullyBayesianSingleTaskGP):
+  a fully Bayesian single-task GP with the SAAS prior. This model is suitable
+  for sample-efficient high-dimensional Bayesian optimization.
 
 ### Model List of Single-Task GPs
-* [`ModelListGP`](../api/models.html#module-botorch.models.model_list_gp_regression): A multi-output model in
-  which outcomes are modeled independently, given a list of any type of
-  single-task GP. This model should be used when the same training data is not
-  used for all outputs.
+
+- [`ModelListGP`](../api/models.html#module-botorch.models.model_list_gp_regression):
+  A multi-output model in which outcomes are modeled independently, given a list
+  of any type of single-task GP. This model should be used when the same
+  training data is not used for all outputs.
 
 ### Multi-Task GPs
-* [`MultiTaskGP`](../api/models.html#module-botorch.models.multitask): a Hadamard multi-task,
-  multi-output GP using an ICM kernel, inferring a homoskedastic noise level (does not
-  require noise observations).
-* [`FixedNoiseMultiTaskGP`](../api/models.html#botorch.models.multitask.FixedNoiseMultiTaskGP):
-  a Hadamard multi-task, multi-output GP using an ICM kernel, with fixed
-  observation noise levels (requires noise observations).
-* [`KroneckerMultiTaskGP`](../api/models.html#botorch.models.multitask.KroneckerMultiTaskGP): A multi-task,
-  multi-output GP using an ICM kernel, with Kronecker structure. Useful for
-  multi-fidelity optimization.
-* [`SaasFullyBayesianMultiTaskGP`](../api/models.html#saasfullybayesianmultitaskgp):
-  a fully Bayesian multi-task GP using an ICM kernel. The data kernel uses the SAAS
-  prior to model high-dimensional parameter spaces.
+
+- [`MultiTaskGP`](../api/models.html#module-botorch.models.multitask): a
+  Hadamard multi-task, multi-output GP using an ICM kernel. Supports both known
+  observation noise levels and inferring a homoskedastic noise level (when noise
+  observations are not provided).
+- [`KroneckerMultiTaskGP`](../api/models.html#botorch.models.multitask.KroneckerMultiTaskGP):
+  A multi-task, multi-output GP using an ICM kernel, with Kronecker structure.
+  Useful for multi-fidelity optimization.
+- [`SaasFullyBayesianMultiTaskGP`](../api/models.html#saasfullybayesianmultitaskgp):
+  a fully Bayesian multi-task GP using an ICM kernel. The data kernel uses the
+  SAAS prior to model high-dimensional parameter spaces.
 
 All of the above models use Matérn 5/2 kernels with Automatic Relevance
 Discovery (ARD), and have reasonable priors on hyperparameters that make them
@@ -124,59 +128,60 @@ cube** and the **observations are standardized** (zero mean, unit variance).
 
 ## Other useful models
 
-* [`ModelList`](../api/models.html#botorch.models.model.ModelList): a multi-output model container
-  in which outcomes are modeled independently by individual `Model`s (as in `ModelListGP`, but the
-  component models do not all need to be GPyTorch models).
-* [`SingleTaskMultiFidelityGP`](../api/models.html#botorch.models.gp_regression_fidelity.SingleTaskMultiFidelityGP) and
-  [`FixedNoiseMultiFidelityGP`](../api/models.html#botorch.models.gp_regression_fidelity.FixedNoiseMultiFidelityGP):
-  Models for multi-fidelity optimization.  For more on Multi-Fidelity BO, see the
-  [tutorial](../tutorials/discrete_multi_fidelity_bo).
-* [`HigherOrderGP`](../api/models.html#botorch.models.higher_order_gp.HigherOrderGP): A GP model with
-  matrix-valued predictions, such as images or grids of images.
-* [`PairwiseGP`](../api/models.html#module-botorch.models.pairwise_gp): A probit-likelihood GP that
-  learns via pairwise comparison data, useful for preference learning.
-* [`ApproximateGPyTorchModel`](../api/models.html#botorch.models.approximate_gp.ApproximateGPyTorchModel): for
-  efficient computation when data is large or responses are non-Gaussian.
-* [Deterministic models](../api/models.html#module-botorch.models.deterministic), such as
+- [`ModelList`](../api/models.html#botorch.models.model.ModelList): a
+  multi-output model container in which outcomes are modeled independently by
+  individual `Model`s (as in `ModelListGP`, but the component models do not all
+  need to be GPyTorch models).
+- [`SingleTaskMultiFidelityGP`](../api/models.html#botorch.models.gp_regression_fidelity.SingleTaskMultiFidelityGP):
+  A GP model for multi-fidelity optimization. For more on Multi-Fidelity BO, see
+  the [tutorial](../tutorials/discrete_multi_fidelity_bo).
+- [`HigherOrderGP`](../api/models.html#botorch.models.higher_order_gp.HigherOrderGP):
+  A GP model with matrix-valued predictions, such as images or grids of images.
+- [`PairwiseGP`](../api/models.html#module-botorch.models.pairwise_gp): A
+  probit-likelihood GP that learns via pairwise comparison data, useful for
+  preference learning.
+- [`ApproximateGPyTorchModel`](../api/models.html#botorch.models.approximate_gp.ApproximateGPyTorchModel):
+  for efficient computation when data is large or responses are non-Gaussian.
+- [Deterministic models](../api/models.html#module-botorch.models.deterministic),
+  such as
   [`AffineDeterministicModel`](../api/models.html#botorch.models.deterministic.AffineDeterministicModel),
   [`AffineFidelityCostModel`](../api/models.html#botorch.models.cost.AffineFidelityCostModel),
   [`GenericDeterministicModel`](../api/models.html#botorch.models.deterministic.GenericDeterministicModel),
   and
   [`PosteriorMeanModel`](../api/models.html#botorch.models.deterministic.PosteriorMeanModel)
-  express known input-output relationships; they conform
-  to the BoTorch `Model` API, so they can easily be used in conjunction with other
-  BoTorch models. Deterministic models are
-  useful for multi-objective optimization with known objective
-  functions and for encoding cost functions for cost-aware acquisition.
-* [`SingleTaskVariationalGP`](../api/models.html#botorch.models.approximate_gp.SingleTaskVariationalGP): an
-  approximate model for faster computation when you have a lot of data or your responses
-  are non-Gaussian.
-
+  express known input-output relationships; they conform to the BoTorch `Model`
+  API, so they can easily be used in conjunction with other BoTorch models.
+  Deterministic models are useful for multi-objective optimization with known
+  objective functions and for encoding cost functions for cost-aware
+  acquisition.
+- [`SingleTaskVariationalGP`](../api/models.html#botorch.models.approximate_gp.SingleTaskVariationalGP):
+  an approximate model for faster computation when you have a lot of data or
+  your responses are non-Gaussian.
 
 ## Implementing Custom Models
 
 The configurability of the above models is limited (for instance, it is not
 straightforward to use a different kernel). Doing so is an intentional design
-decision -- we believe that having a few simple and easy-to-understand models for
-basic use cases is more valuable than having a highly complex and configurable
-model class whose implementation is difficult to understand.
+decision -- we believe that having a few simple and easy-to-understand models
+for basic use cases is more valuable than having a highly complex and
+configurable model class whose implementation is difficult to understand.
 
-Instead, we advocate that users implement their own models to cover
-more specialized use cases. The light-weight nature of BoTorch's Model API makes
-this easy to do. See the
+Instead, we advocate that users implement their own models to cover more
+specialized use cases. The light-weight nature of BoTorch's Model API makes this
+easy to do. See the
 [Using a custom BoTorch model in Ax](../tutorials/custom_botorch_model_in_ax)
 tutorial for an example.
 
 The BoTorch `Model` interface is light-weight and easy to extend. The only
 requirement for using BoTorch's Monte-Carlo based acquisition functions is that
-the model has a `posterior` method. It takes in a Tensor `X` of design points, and
-returns a Posterior object describing the (joint) probability distribution of
-the model output(s) over the design points in `X`.  The `Posterior` object must
-implement an `rsample()` method for sampling from the posterior of the model.
-If you wish to use gradient-based optimization algorithms, the model should
-allow back-propagating gradients through the samples to the model input.
+the model has a `posterior` method. It takes in a Tensor `X` of design points,
+and returns a Posterior object describing the (joint) probability distribution
+of the model output(s) over the design points in `X`. The `Posterior` object
+must implement an `rsample()` method for sampling from the posterior of the
+model. If you wish to use gradient-based optimization algorithms, the model
+should allow back-propagating gradients through the samples to the model input.
 
-If you happen to implement a model that would be useful for other
-researchers as well (and involves more than just swapping out the Matérn kernel
-for an RBF kernel), please consider [contributing](getting_started#contributing)
-this model to BoTorch.
+If you happen to implement a model that would be useful for other researchers as
+well (and involves more than just swapping out the Matérn kernel for an RBF
+kernel), please consider [contributing](getting_started#contributing) this model
+to BoTorch.

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -80,7 +80,7 @@ from botorch.acquisition.utils import (
     project_to_target_fidelity,
 )
 from botorch.exceptions.errors import UnsupportedError
-from botorch.models import FixedNoiseGP, MultiTaskGP, SingleTaskGP
+from botorch.models import MultiTaskGP, SingleTaskGP
 from botorch.models.deterministic import FixedSingleSampleModel
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
@@ -357,7 +357,7 @@ class TestAnalyticAcquisitionFunctionInputConstructors(InputConstructorBaseTestC
         for acqf_cls in [NoisyExpectedImprovement, LogNoisyExpectedImprovement]:
             with self.subTest(acqf_cls=acqf_cls):
                 c = get_acqf_input_constructor(acqf_cls)
-                mock_model = FixedNoiseGP(
+                mock_model = SingleTaskGP(
                     train_X=torch.rand((2, 2)),
                     train_Y=torch.rand((2, 1)),
                     train_Yvar=torch.rand((2, 1)),
@@ -1269,7 +1269,7 @@ class TestInstantiationFromInputConstructor(InputConstructorBaseTestCase):
             qLogNoisyExpectedImprovement,
             qProbabilityOfImprovement,
         ]
-        model = FixedNoiseGP(
+        model = SingleTaskGP(
             train_X=torch.rand((4, 2)),
             train_Y=torch.rand((4, 1)),
             train_Yvar=torch.ones((4, 1)),

--- a/test/models/test_contextual.py
+++ b/test/models/test_contextual.py
@@ -10,48 +10,59 @@ from typing import Dict, Tuple
 import torch
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.contextual import LCEAGP, SACGP
-from botorch.models.gp_regression import FixedNoiseGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.kernels.contextual_lcea import LCEAKernel
 from botorch.models.kernels.contextual_sac import SACKernel
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.distributions.multivariate_normal import MultivariateNormal
+from gpytorch.likelihoods.gaussian_likelihood import (
+    FixedNoiseGaussianLikelihood,
+    GaussianLikelihood,
+)
 from gpytorch.means import ConstantMean
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from torch import Tensor
 
 
 def _gen_datasets(
+    infer_noise: bool = False,
     **tkwargs,
 ) -> Tuple[Dict[int, SupervisedDataset], Tuple[Tensor, Tensor, Tensor]]:
     train_X = torch.tensor(
         [[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]], **tkwargs
     )
     train_Y = torch.tensor([[1.0], [2.0], [3.0]], **tkwargs)
-    train_Yvar = 0.01 * torch.ones(3, 1, **tkwargs)
+    train_Yvar = None if infer_noise else torch.full_like(train_Y, 0.01)
 
     datasets = SupervisedDataset(
         X=train_X,
         Y=train_Y,
+        Yvar=train_Yvar,
         feature_names=[f"x{i}" for i in range(train_X.shape[-1])],
         outcome_names=["y"],
-        Yvar=train_Yvar,
     )
     return datasets, (train_X, train_Y, train_Yvar)
 
 
 class TestContextualGP(BotorchTestCase):
     def test_SACGP(self):
-        for dtype in (torch.float, torch.double):
+        for dtype, infer_noise in ((torch.float, False), (torch.double, True)):
             tkwargs = {"device": self.device, "dtype": dtype}
-            datasets, (train_X, train_Y, train_Yvar) = _gen_datasets(**tkwargs)
+            datasets, (train_X, train_Y, train_Yvar) = _gen_datasets(
+                infer_noise, **tkwargs
+            )
             self.decomposition = {"1": [0, 3], "2": [1, 2]}
 
             model = SACGP(train_X, train_Y, train_Yvar, self.decomposition)
             mll = ExactMarginalLogLikelihood(model.likelihood, model)
             fit_gpytorch_mll(mll, optimizer_kwargs={"options": {"maxiter": 1}})
 
-            self.assertIsInstance(model, FixedNoiseGP)
+            self.assertIsInstance(model, SingleTaskGP)
+            self.assertIsInstance(
+                model.likelihood,
+                GaussianLikelihood if infer_noise else FixedNoiseGaussianLikelihood,
+            )
             self.assertDictEqual(model.decomposition, self.decomposition)
             self.assertIsInstance(model.mean_module, ConstantMean)
             self.assertIsInstance(model.covar_module, SACKernel)
@@ -90,13 +101,14 @@ class TestContextualGP(BotorchTestCase):
             self.assertTrue(train_Yvar.equal(data_dict["train_Yvar"]))
             self.assertDictEqual(data_dict["decomposition"], self.decomposition)
 
-    def testLCEAGP(self):
-        for dtype in (torch.float, torch.double):
+    def test_LCEAGP(self):
+        for dtype, infer_noise in ((torch.float, False), (torch.double, True)):
             tkwargs = {"device": self.device, "dtype": dtype}
-            datasets, (train_X, train_Y, train_Yvar) = _gen_datasets(**tkwargs)
+            datasets, (train_X, train_Y, train_Yvar) = _gen_datasets(
+                infer_noise, **tkwargs
+            )
             # Test setting attributes
             decomposition = {"1": [0, 1], "2": [2, 3]}
-
             # test instantiate model
             model = LCEAGP(
                 train_X=train_X,
@@ -110,6 +122,10 @@ class TestContextualGP(BotorchTestCase):
             self.assertIsInstance(model, LCEAGP)
             self.assertIsInstance(model.covar_module, LCEAKernel)
             self.assertDictEqual(model.decomposition, decomposition)
+            self.assertIsInstance(
+                model.likelihood,
+                GaussianLikelihood if infer_noise else FixedNoiseGaussianLikelihood,
+            )
 
             test_x = torch.rand(5, 4, device=self.device, dtype=dtype)
             posterior = model(test_x)

--- a/test/models/utils/test_parse_training_data.py
+++ b/test/models/utils/test_parse_training_data.py
@@ -6,13 +6,12 @@
 
 import torch
 from botorch.exceptions import UnsupportedError
-from botorch.models.gp_regression import FixedNoiseGP
 from botorch.models.model import Model
 from botorch.models.multitask import MultiTaskGP
 from botorch.models.pairwise_gp import PairwiseGP
 from botorch.models.utils.parse_training_data import parse_training_data
 from botorch.utils.containers import SliceContainer
-from botorch.utils.datasets import FixedNoiseDataset, RankingDataset, SupervisedDataset
+from botorch.utils.datasets import RankingDataset, SupervisedDataset
 from botorch.utils.testing import BotorchTestCase
 from torch import cat, long, rand, Size, tensor
 
@@ -32,26 +31,17 @@ class TestParseTrainingData(BotorchTestCase):
         self.assertIsInstance(parse, dict)
         self.assertTrue(torch.equal(dataset.X, parse["train_X"]))
         self.assertTrue(torch.equal(dataset.Y, parse["train_Y"]))
-
-    def test_fixedNoise(self):
-        # Test passing a `SupervisedDataset`
-        dataset = SupervisedDataset(
-            X=rand(3, 2), Y=rand(3, 1), feature_names=["a", "b"], outcome_names=["y"]
-        )
-        parse = parse_training_data(FixedNoiseGP, dataset)
         self.assertTrue("train_Yvar" not in parse)
-        self.assertTrue(torch.equal(dataset.X, parse["train_X"]))
-        self.assertTrue(torch.equal(dataset.Y, parse["train_Y"]))
 
-        # Test passing a `FixedNoiseDataset`
-        dataset = FixedNoiseDataset(
+        # Test with noise
+        dataset = SupervisedDataset(
             X=rand(3, 2),
             Y=rand(3, 1),
             Yvar=rand(3, 1),
             feature_names=["a", "b"],
             outcome_names=["y"],
         )
-        parse = parse_training_data(FixedNoiseGP, dataset)
+        parse = parse_training_data(Model, dataset)
         self.assertTrue(torch.equal(dataset.X, parse["train_X"]))
         self.assertTrue(torch.equal(dataset.Y, parse["train_Y"]))
         self.assertTrue(torch.equal(dataset.Yvar, parse["train_Yvar"]))

--- a/test/sampling/pathwise/test_update_strategies.py
+++ b/test/sampling/pathwise/test_update_strategies.py
@@ -12,7 +12,7 @@ from itertools import chain
 from unittest.mock import patch
 
 import torch
-from botorch.models import FixedNoiseGP, SingleTaskGP, SingleTaskVariationalGP
+from botorch.models import SingleTaskGP, SingleTaskVariationalGP
 from botorch.models.transforms.input import Normalize
 from botorch.models.transforms.outcome import Standardize
 from botorch.sampling.pathwise import (
@@ -61,8 +61,8 @@ class TestPathwiseUpdates(BotorchTestCase):
                 input_transform = Normalize(d=X.shape[-1], bounds=bounds)
                 outcome_transform = Standardize(m=Y.shape[-1])
 
-                # SingleTaskGP in eval mode
-                self.models[SingleTaskGP].append(
+                # SingleTaskGP w/ inferred noise in eval mode
+                self.models["inferred"].append(
                     SingleTaskGP(
                         train_X=X,
                         train_Y=Y,
@@ -74,9 +74,9 @@ class TestPathwiseUpdates(BotorchTestCase):
                     .eval()
                 )
 
-                # FixedNoiseGP in train mode
-                self.models[FixedNoiseGP].append(
-                    FixedNoiseGP(
+                # SingleTaskGP w/ observed noise in train mode
+                self.models["observed"].append(
+                    SingleTaskGP(
                         train_X=X,
                         train_Y=Y,
                         train_Yvar=0.01 * torch.rand_like(Y),
@@ -89,7 +89,7 @@ class TestPathwiseUpdates(BotorchTestCase):
                 # SingleTaskVariationalGP in train mode
                 # When batched, uses a multitask format which break the tests below
                 if not kernel.batch_shape:
-                    self.models[SingleTaskVariationalGP].append(
+                    self.models["variational"].append(
                         SingleTaskVariationalGP(
                             train_X=X,
                             train_Y=Y,

--- a/test/test_cross_validation.py
+++ b/test/test_cross_validation.py
@@ -10,7 +10,7 @@ import warnings
 import torch
 from botorch.cross_validation import batch_cross_validation, gen_loo_cv_folds
 from botorch.exceptions.warnings import OptimizationWarning
-from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.utils.testing import _get_random_data, BotorchTestCase
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 
@@ -57,7 +57,7 @@ class TestFitBatchCrossValidation(BotorchTestCase):
             self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
             self.assertEqual(cv_results.observed_Y.shape, expected_shape)
 
-            # Test FixedNoiseGP
+            # Test with noise observations
             noisy_cv_folds = gen_loo_cv_folds(
                 train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar
             )
@@ -71,7 +71,7 @@ class TestFitBatchCrossValidation(BotorchTestCase):
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=OptimizationWarning)
                 cv_results = batch_cross_validation(
-                    model_cls=FixedNoiseGP,
+                    model_cls=SingleTaskGP,
                     mll_cls=ExactMarginalLogLikelihood,
                     cv_folds=noisy_cv_folds,
                     fit_args={"optimizer_kwargs": {"options": {"maxiter": 1}}},

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -11,7 +11,7 @@ import torch
 from botorch.acquisition import ExpectedImprovement, qExpectedImprovement
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.fit import fit_gpytorch_mll
-from botorch.models import FixedNoiseGP, SingleTaskGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.optim import optimize_acqf
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
@@ -56,7 +56,7 @@ class TestEndToEnd(BotorchTestCase):
                 optimizer_kwargs={"options": {"maxiter": 5}},
                 max_attempts=1,
             )
-        model_fn = FixedNoiseGP(
+        model_fn = SingleTaskGP(
             self.train_x, self.train_y, self.train_yvar.expand_as(self.train_y)
         )
         self.model_fn = model_fn.to(device=self.device, dtype=dtype)

--- a/test/utils/test_gp_sampling.py
+++ b/test/utils/test_gp_sampling.py
@@ -12,7 +12,7 @@ import torch
 from botorch.models.converter import batched_to_model_list
 from botorch.models.deterministic import DeterministicModel
 from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
-from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.model import ModelList
 from botorch.models.multitask import MultiTaskGP
 from botorch.models.transforms.input import Normalize
@@ -652,7 +652,7 @@ class TestRandomFourierFeatures(BotorchTestCase):
     def test_with_fixed_noise(self):
         for n_samples in (1, 20):
             gp_samples = get_gp_samples(
-                model=FixedNoiseGP(
+                model=SingleTaskGP(
                     torch.rand(5, 3, dtype=torch.double),
                     torch.randn(5, 1, dtype=torch.double),
                     torch.rand(5, 1, dtype=torch.double) * 0.1,

--- a/test/utils/test_sampling.py
+++ b/test/utils/test_sampling.py
@@ -14,7 +14,7 @@ from unittest import mock
 import numpy as np
 import torch
 from botorch.exceptions.errors import BotorchError
-from botorch.models import FixedNoiseGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.sampling.pathwise import draw_matheron_paths
 from botorch.utils.sampling import (
     _convert_bounds_to_inequality_constraints,
@@ -514,7 +514,7 @@ class TestOptimizePosteriorSamples(BotorchTestCase):
 
             # having a noiseless model all but guarantees that the found optima
             # will be better than the observations
-            model = FixedNoiseGP(X, Y, torch.full_like(Y, eps))
+            model = SingleTaskGP(X, Y, torch.full_like(Y, eps))
             paths = draw_matheron_paths(
                 model=model, sample_shape=torch.Size([num_optima])
             )


### PR DESCRIPTION
Summary:
Updates use cases of fixed noise models that were deprecated in  https://github.com/pytorch/botorch/pull/2052 & elsewhere.

I'll update Ax usage in a separate diff.

Differential Revision: D50429032

