### PR TITLE
apply constraints in prune_inferior_points

### DIFF
--- a/botorch/acquisition/logei.py
+++ b/botorch/acquisition/logei.py
@@ -384,6 +384,7 @@ class qLogNoisyExpectedImprovement(
                 objective=objective,
                 posterior_transform=posterior_transform,
                 marginalize_dim=kwargs.get("marginalize_dim"),
+                constraints=self._constraints,
             )
         self.register_buffer("X_baseline", X_baseline)
         # registering buffers for _get_samples_and_objectives in the next `if` block

--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -499,6 +499,7 @@ class qNoisyExpectedImprovement(
                 X=X_baseline,
                 objective=objective,
                 posterior_transform=posterior_transform,
+                constraints=self._constraints,
                 marginalize_dim=marginalize_dim,
             )
         self.register_buffer("X_baseline", X_baseline)

--- a/test/acquisition/test_logei.py
+++ b/test/acquisition/test_logei.py
@@ -30,6 +30,7 @@ from botorch.acquisition.objective import (
     PosteriorTransform,
     ScalarizedPosteriorTransform,
 )
+from botorch.acquisition.utils import prune_inferior_points
 from botorch.exceptions import BotorchWarning, UnsupportedError
 from botorch.exceptions.errors import BotorchError
 from botorch.models import SingleTaskGP
@@ -492,30 +493,56 @@ class TestQLogNoisyExpectedImprovement(BotorchTestCase):
     def test_prune_baseline(self):
         no = "botorch.utils.testing.MockModel.num_outputs"
         prune = "botorch.acquisition.logei.prune_inferior_points"
+        constraints = [lambda Y: Y[..., 1] + 0.1]
+        # only the last sample if feasible and it has the worst objective value
+
         for dtype in (torch.float, torch.double):
-            X_baseline = torch.zeros(1, 1, device=self.device, dtype=dtype)
-            X_pruned = torch.rand(1, 1, device=self.device, dtype=dtype)
+            samples = torch.tensor(
+                [[1.0, 1.0], [0.0, 0.0], [-1.0, -1.0]],
+                device=self.device,
+                dtype=dtype,
+            )
+            mm = MockModel(
+                MockPosterior(
+                    samples=samples,
+                )
+            )
+            X_baseline = torch.zeros(3, 1, device=self.device, dtype=dtype)
             with mock.patch(no, new_callable=mock.PropertyMock) as mock_num_outputs:
-                mock_num_outputs.return_value = 1
-                mm = MockModel(MockPosterior(samples=X_baseline))
-                with mock.patch(prune, return_value=X_pruned) as mock_prune:
+                mock_num_outputs.return_value = 2
+                with mock.patch(prune, wraps=prune_inferior_points) as mock_prune:
                     acqf = qLogNoisyExpectedImprovement(
                         model=mm,
                         X_baseline=X_baseline,
                         prune_baseline=True,
                         cache_root=False,
+                        objective=GenericMCObjective(objective=lambda Y: Y[..., 0]),
+                        constraints=constraints,
                     )
                 mock_prune.assert_called_once()
-                self.assertTrue(torch.equal(acqf.X_baseline, X_pruned))
-                with mock.patch(prune, return_value=X_pruned) as mock_prune:
+                self.assertIs(mock_prune.call_args[1]["constraints"], constraints)
+                self.assertTrue(torch.equal(acqf.X_baseline, X_baseline[[-1]]))
+                # test marginalize_dim
+                samples2 = torch.stack([samples, samples * 2], dim=0)
+                mm = MockModel(
+                    MockPosterior(
+                        samples=samples2,
+                    )
+                )
+                with mock.patch(prune, wraps=prune_inferior_points) as mock_prune:
                     acqf = qLogNoisyExpectedImprovement(
                         model=mm,
                         X_baseline=X_baseline,
                         prune_baseline=True,
-                        marginalize_dim=-3,
                         cache_root=False,
+                        marginalize_dim=-3,
+                        objective=GenericMCObjective(objective=lambda Y: Y[..., 0]),
+                        constraints=constraints,
                     )
+                    mock_prune.assert_called_once()
                     _, kwargs = mock_prune.call_args
+                    self.assertIs(kwargs["constraints"], constraints)
+                    self.assertTrue(torch.equal(acqf.X_baseline, X_baseline[[-1]]))
                     self.assertEqual(kwargs["marginalize_dim"], -3)
 
     def test_cache_root(self):

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -270,6 +270,26 @@ class TestPruneInferiorPoints(BotorchTestCase):
                 mm = MockModel(MockPosterior(samples=samples))
                 X_pruned = prune_inferior_points(model=mm, X=X)
             self.assertTrue(torch.equal(X_pruned, X[:2]))
+            # test constraints
+            constraints = [lambda Y: Y[..., 1] + 0.1]
+            # only the last sample if feasible and it has the worst objective value
+            samples = torch.tensor(
+                [[1.0, 1.0], [0.0, 0.0], [-1.0, -1.0]],
+                device=self.device,
+                dtype=dtype,
+            )
+            mm = MockModel(
+                MockPosterior(
+                    samples=samples,
+                )
+            )
+            X_pruned = prune_inferior_points(
+                model=mm,
+                X=X,
+                objective=GenericMCObjective(objective=lambda Y: Y[..., 0]),
+                constraints=constraints,
+            )
+            self.assertTrue(torch.equal(X_pruned, X[[-1]]))
 
 
 class TestFidelityUtils(BotorchTestCase):

--- a/test/utils/test_objective.py
+++ b/test/utils/test_objective.py
@@ -240,6 +240,15 @@ class TestApplyConstraints(BotorchTestCase):
                 eta=torch.tensor([0.1], device=self.device),
             )
 
+        # test marginalize_dim
+        samples = torch.randn(1, 2, 1, 1)
+        ind = compute_feasibility_indicator(
+            constraints=[zeros_f], samples=samples, marginalize_dim=-3
+        )
+        self.assertAllClose(ind, torch.ones_like(ind))
+        self.assertTrue(ind.shape == torch.Size([1, 1]))
+        self.assertEqual(ind.dtype, torch.bool)
+
 
 class TestGetObjectiveWeightsTransform(BotorchTestCase):
     def test_NoWeights(self):


### PR DESCRIPTION
Summary: See title. Constraints used to be applied in prune_inferior points through `ConstrainedMCObjective`, but now `SampleReducingMCAcquisitionFunction` handles constraints separately. This takes the constraint-handling logic used in `prune_inferior_points_multi_objective` and shares it with the single objective version

Differential Revision: D50599985


