### PR TITLE
`PosteriorStandardDeviation` docstring correction and upgrades to other documentation

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -878,9 +878,24 @@ class PosteriorStandardDeviation(AnalyticAcquisitionFunction):
     or combined with a `posterior_transform` to produce a single-output posterior.
 
     Example:
-        >>> model = SingleTaskGP(train_X, train_Y)
-        >>> PSTD = PosteriorMean(model)
+        >>> import torch
+        >>> from botorch.models.gp_regression import SingleTaskGP
+        >>> from botorch.models.transforms.input import Normalize
+        >>> from botorch.models.transforms.outcome import Standardize
+        >>>
+        >>> # Set up a model
+        >>> train_X = torch.rand(20, 2, dtype=torch.float64)
+        >>> train_Y = torch.sin(train_X).sum(dim=1, keepdim=True)
+        >>> model = SingleTaskGP(
+        ...     train_X, train_Y, outcome_transform=Standardize(m=1),
+        ...     input_transform=Normalize(d=2),
+        ... )
+        >>> # Now set up the acquisition function
+        >>> PSTD = PosteriorStandardDeviation(model)
+        >>> test_X = torch.zeros((1, 2), dtype=torch.float64)
         >>> std = PSTD(test_X)
+        >>> std.item()
+        0.16341639895667773
     """
 
     def __init__(

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -90,16 +90,34 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
     noise values, such as `train_Yvar=torch.full_like(train_Y, 1e-6)`.
 
     Example:
-        >>> # Model with inferred noise levels.
-        >>> train_X = torch.rand(20, 2)
+        Model with inferred noise levels:
+
+        >>> import torch
+        >>> from botorch.models.gp_regression import SingleTaskGP
+        >>> from botorch.models.transforms.outcome import Standardize
+        >>>
+        >>> train_X = torch.rand(20, 2, dtype=torch.float64)
         >>> train_Y = torch.sin(train_X).sum(dim=1, keepdim=True)
-        >>> inferred_noise_model = SingleTaskGP(train_X, train_Y)
-        >>> # With known observation variance of 0.2.
+        >>> outcome_transform = Standardize(m=1)
+        >>> inferred_noise_model = SingleTaskGP(
+        ...     train_X, train_Y, outcome_transform=outcome_transform,
+        ... )
+
+        Model with a known observation variance of 0.2:
+
         >>> train_Yvar = torch.full_like(train_Y, 0.2)
-        >>> observed_noise_model = SingleTaskGP(train_X, train_Y, train_Yvar)
-        >>> # To model noise-free observations.
+        >>> observed_noise_model = SingleTaskGP(
+        ...     train_X, train_Y, train_Yvar,
+        ...     outcome_transform=outcome_transform,
+        ... )
+
+        With noise-free observations:
+
         >>> train_Yvar = torch.full_like(train_Y, 1e-6)
-        >>> noise_free_model = SingleTaskGP(train_X, train_Y, train_Yvar)
+        >>> noise_free_model = SingleTaskGP(
+        ...     train_X, train_Y, train_Yvar,
+        ...     outcome_transform=outcome_transform,
+        ... )
     """
 
     def __init__(

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -42,15 +42,16 @@ Here's a quick run down of the main components of a Bayesian Optimization loop.
     from botorch.models import SingleTaskGP
     from botorch.fit import fit_gpytorch_mll
     from gpytorch.mlls import ExactMarginalLogLikelihood
+    from botorch.models.transforms.outcome import Standardize
 
-    train_X = torch.rand(10, 2)
-    Y = 1 - (train_X - 0.5).norm(dim=-1, keepdim=True)  # explicit output dimension
-    Y += 0.1 * torch.rand_like(Y)
-    train_Y = (Y - Y.mean()) / Y.std()
+    train_X = torch.rand(10, 2, dtype=torch.float64)
+    # explicit output dimension -- Y is 10 x 1
+    train_Y = 1 - (train_X - 0.5).norm(dim=-1, keepdim=True)
+    train_Y += 0.1 * torch.rand_like(train_Y)
 
-    gp = SingleTaskGP(train_X, train_Y)
+    gp = SingleTaskGP(train_X, trainb_Y, outcome_transform=Standardize(m=1))
     mll = ExactMarginalLogLikelihood(gp.likelihood, gp)
-    fit_gpytorch_mll(mll);
+    fit_gpytorch_mll(mll)
     ```
 
 2. Construct an acquisition function


### PR DESCRIPTION
## Motivation

* #2060 introduced a typo in a docstring where `PosteriorMean` was used instead of `PosteriorStandardDeviation`
* The `SingleTaskGP` and "Getting Started" documentation use single-precision data and non-standardized outcome data, which is not recommended usage and raises warnings. I changed the documentation to use an outcome transform and double-precision data.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A

## Related PRs

#2060 
