### PR TITLE
Fix dataset equality checks

### DIFF
--- a/botorch/utils/datasets.py
+++ b/botorch/utils/datasets.py
@@ -144,7 +144,7 @@ class SupervisedDataset:
             and (
                 other.Yvar is None
                 if self.Yvar is None
-                else torch.equal(self.Yvar, other.Yvar)
+                else other.Yvar is not None and torch.equal(self.Yvar, other.Yvar)
             )
             and self.feature_names == other.feature_names
             and self.outcome_names == other.outcome_names

--- a/test/utils/test_datasets.py
+++ b/test/utils/test_datasets.py
@@ -118,6 +118,11 @@ class TestDatasets(BotorchTestCase):
         self.assertIsInstance(dataset.Yvar, Tensor)
         self.assertIsInstance(dataset._Yvar, DenseContainer)
 
+        # More equality checks with & without Yvar.
+        self.assertEqual(dataset, dataset)
+        self.assertNotEqual(dataset, dataset2)
+        self.assertNotEqual(dataset2, dataset)
+
     def test_fixedNoise(self):
         # Generate some data
         X = rand(3, 2)


### PR DESCRIPTION
Summary: This was erroring out when self.Yvar was a tensor but other.Yvar was None. Updated to equality checks to handle this case.

Differential Revision: D50818635


