### PR TITLE
Fix PyTorch version in test-against-stable workflow

### DIFF
--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -78,7 +78,7 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version=$(if [[ "${min_torch_version}"=="1.13.1" && "${PYTHON_VERSION}"=="3.11" && "${OS}"=="macos-latest" ]]; then echo "2.0.1"; else echo "${min_torch_version}"; fi)
+        min_torch_version=$(if $min_torch_version == "1.13.1" && $PYTHON_VERSION == "3.11" && $OS == "macos-latest"; then echo "2.0.1"; else echo $min_torch_version; fi)
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -75,8 +75,8 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        # min_torch_version="$(if "${min_torch_version}" == "1.13.1" && ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
-        min_torch_version="$(if ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
+        min_torch_version="$(if ${{ min_torch_version == '1.13.1' }} && ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
+        # min_torch_version="$(if ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -75,7 +75,7 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version=${{if ( $min_torch_version == "1.13.1" && ${{ matrix.python-version }} == "3.11" && ${{ matrix.os }} == "macos-latest" ); then echo "2.0.1"; else echo $min_torch_version; fi}}
+        min_torch_version=$(if ( $min_torch_version == "1.13.1" && ${{ matrix.python-version }} == "3.11" && ${{ matrix.os }} == "macos-latest" ); then echo "2.0.1"; else echo $min_torch_version; fi)
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -75,8 +75,7 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version="$(if $min_torch_version == '1.13.1' && ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
-        # min_torch_version="$(if ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
+        min_torch_version="$(if ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -70,15 +70,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      env:
-        PYTHON_VERSION: ${{ matrix.python-version }}
-        OS: ${{ matrix.os }}
       run: |
         python setup.py egg_info
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version=$(if $min_torch_version == "1.13.1" && $PYTHON_VERSION == "3.11" && $OS == "macos-latest"; then echo "2.0.1"; else echo $min_torch_version; fi)
+        min_torch_version=${{if ( $min_torch_version == "1.13.1" && ${{ matrix.python-version }} == "3.11" && ${{ matrix.os }} == "macos-latest" ); then echo "2.0.1"; else echo $min_torch_version; fi}}
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -75,7 +75,8 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version=$(if "${min_torch_version}" == "1.13.1" && ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)
+        # min_torch_version="$(if "${min_torch_version}" == "1.13.1" && ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
+        min_torch_version="$(if ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -75,7 +75,7 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version=$(if ( $min_torch_version == "1.13.1" && ${{ matrix.python-version }} == "3.11" && ${{ matrix.os }} == "macos-latest" ); then echo "2.0.1"; else echo $min_torch_version; fi)
+        min_torch_version=$(if ${min_torch_version} == "1.13.1" && ${{ matrix.python-version }} == "3.11" && ${{ matrix.os }} == "macos-latest"; then echo "2.0.1"; else echo ${min_torch_version}; fi)
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -75,7 +75,7 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version=$(if ${min_torch_version} == "1.13.1" && ${{ matrix.python-version }} == "3.11" && ${{ matrix.os }} == "macos-latest"; then echo "2.0.1"; else echo ${min_torch_version}; fi)
+        min_torch_version=$(if "${min_torch_version}" == "1.13.1" && ${{ matrix.python-version == "3.11" }} && ${{ matrix.os == "macos-latest" }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -75,7 +75,7 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version=$(if "${min_torch_version}" == "1.13.1" && ${{ matrix.python-version == "3.11" }} && ${{ matrix.os == "macos-latest" }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)
+        min_torch_version=$(if "${min_torch_version}" == "1.13.1" && ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -75,7 +75,7 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version="$(if ${{ min_torch_version == '1.13.1' }} && ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
+        min_torch_version="$(if ${{ $min_torch_version == '1.13.1' }} && ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
         # min_torch_version="$(if ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -75,7 +75,7 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version="$(if ${{ $min_torch_version == '1.13.1' }} && ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
+        min_torch_version="$(if $min_torch_version == '1.13.1' && ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
         # min_torch_version="$(if ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -78,7 +78,7 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version=$(if [[ "${min_torch_version}"=="1.13.1" ]] && [[ "${PYTHON_VERSION}"=="3.11" ]] && [[ "${OS}"=="macos-latest" ]]; then echo "2.0.1"; else echo "${min_torch_version}"; fi)
+        min_torch_version=$(if [[ "${min_torch_version}"=="1.13.1" && "${PYTHON_VERSION}"=="3.11" && "${OS}"=="macos-latest" ]]; then echo "2.0.1"; else echo "${min_torch_version}"; fi)
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"


### PR DESCRIPTION
It seems that the conditional block was always evaluating to true, leading to PyTorch 2.0.1 being used across the board as the minimum version. With this change, all jobs except for Python 3.11 on macOS use PyTorch 1.31.1.

Note: I could not get the expression to work while keeping the `min_torch_version == '1.13.1'` check in place, so I removed it. It doesn't have any functional effect as long as we address the TODO when we bump the min version.

Old run that used PyTorch 2.0.1 for all jobs: https://github.com/pytorch/botorch/actions/runs/6739329549/job/18320600699
New run that uses correct versions: https://github.com/pytorch/botorch/actions/runs/6774951160/job/18413146849

1.13.1 with ubuntu jobs:
<img width="917" alt="Screenshot 2023-11-06 at 10 25 48 AM" src="https://github.com/pytorch/botorch/assets/9263852/83b4e15e-8e74-48ae-898b-b6b9817a7d19">
1.13.1 with Py 3.9 on MacOs:
<img width="981" alt="Screenshot 2023-11-06 at 10 26 21 AM" src="https://github.com/pytorch/botorch/assets/9263852/634a593d-09a6-4e13-8211-930ee749330d">
2.0.1 with Py 3.11 on MacOS:
<img width="985" alt="Screenshot 2023-11-06 at 10 31 10 AM" src="https://github.com/pytorch/botorch/assets/9263852/1ac147ee-78d5-42fb-8678-07d3153497e0">
