### PR TITLE
Remove stable Ax from BoTorch CI, add smoke test tutorials to test-against-stable workflow

### DIFF
--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -91,3 +91,11 @@ jobs:
       smoke_test: false
       use_stable_pytorch_gpytorch: true
       use_stable_ax: false
+
+  run_tutorials_stable_smoke_test:
+    name: Run tutorials with smoke test on min req. versions of PyTorch & GPyTorch and latest Ax
+    uses: ./.github/workflows/reusable_tutorials.yml
+    with:
+      smoke_test: true
+      use_stable_pytorch_gpytorch: true
+      use_stable_ax: false

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -91,11 +91,3 @@ jobs:
       smoke_test: false
       use_stable_pytorch_gpytorch: true
       use_stable_ax: false
-
-  run_tutorials_stable_w_stable_ax:
-    name: Run tutorials without smoke test on min req. versions of PyTorch & GPyTorch and stable Ax
-    uses: ./.github/workflows/reusable_tutorials.yml
-    with:
-      smoke_test: false
-      use_stable_pytorch_gpytorch: true
-      use_stable_ax: true


### PR DESCRIPTION
Stable Ax often lacks changes that would make it compatible with latest BoTorch. As a result, this was creating more noise than the signal it provided. Removing it to clean up signals.

Also adds a smoke-test tutorial run to the workflow, which should help provide faster signals when something fails.

Running in https://github.com/pytorch/botorch/actions/runs/6776353879
(there are a couple pre-existing failures, fixed in https://github.com/pytorch/botorch/pull/2083)