### PR TITLE
fix fantasization with known noise and empty X

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -374,6 +374,8 @@ class FantasizeMixin(ABC):
                 + torch.Size([0, self.num_outputs])
             )
             Y = torch.empty(output_shape, dtype=X.dtype, device=X.device)
+            if observation_noise is not None:
+                kwargs["noise"] = observation_noise.expand(Y.shape[1:])
             return self.condition_on_observations(
                 X=self.transform_inputs(X),
                 Y=Y,


### PR DESCRIPTION
Summary: Previously with a FixedNoiseGaussianLikelihood `noise` was not passed as an argument when X is empty (as with decoupled AFs).

Differential Revision: D51115939


