### PR TITLE
Clean up unused Dict[hashable, SupervisedDataset] training data

### DIFF
--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -8,7 +8,7 @@ r"""Multi-task Gaussian Process Regression models with fully Bayesian inference.
 """
 
 
-from typing import Any, Dict, List, Mapping, NoReturn, Optional, Tuple
+from typing import Any, Dict, List, Mapping, NoReturn, Optional, Tuple, Union
 
 import pyro
 import torch
@@ -24,7 +24,7 @@ from botorch.models.multitask import MultiTaskGP
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
 from botorch.posteriors.fully_bayesian import FullyBayesianPosterior, MCMC_DIM
-from botorch.utils.datasets import SupervisedDataset
+from botorch.utils.datasets import MultiTaskDataset, SupervisedDataset
 from gpytorch.distributions.multivariate_normal import MultivariateNormal
 from gpytorch.kernels import MaternKernel
 from gpytorch.kernels.kernel import Kernel
@@ -381,15 +381,15 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
     @classmethod
     def construct_inputs(
         cls,
-        training_data: Dict[str, SupervisedDataset],
+        training_data: Union[SupervisedDataset, MultiTaskDataset],
         task_feature: int,
         rank: Optional[int] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        r"""Construct `Model` keyword arguments from dictionary of `SupervisedDataset`.
+        r"""Construct `Model` keyword arguments from a dataset and other args.
 
         Args:
-            training_data: Dictionary of `SupervisedDataset`.
+            training_data: A `SupervisedDataset` or a `MultiTaskDataset`.
             task_feature: Column index of embedded task indicator features. For details,
                 see `parse_training_data`.
             rank: The rank of the cross-task covariance matrix.

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -20,7 +20,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Hashable,
     List,
     Mapping,
     Optional,
@@ -180,7 +179,7 @@ class Model(Module, ABC):
     @classmethod
     def construct_inputs(
         cls,
-        training_data: Union[SupervisedDataset, Dict[Hashable, SupervisedDataset]],
+        training_data: SupervisedDataset,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         r"""Construct `Model` keyword arguments from a dict of `SupervisedDataset`."""

--- a/botorch/models/utils/parse_training_data.py
+++ b/botorch/models/utils/parse_training_data.py
@@ -9,17 +9,14 @@ r"""Parsing rules for BoTorch datasets."""
 
 from __future__ import annotations
 
-from typing import Any, Dict, Hashable, Type, Union
+from typing import Any, Dict, Type
 
 import torch
-from botorch.exceptions import UnsupportedError
 from botorch.models.model import Model
-from botorch.models.multitask import MultiTaskGP
 from botorch.models.pairwise_gp import PairwiseGP
 from botorch.utils.datasets import RankingDataset, SupervisedDataset
 from botorch.utils.dispatcher import Dispatcher
-from torch import cat, Tensor
-from torch.nn.functional import pad
+from torch import Tensor
 
 
 def _encoder(arg: Any) -> Type:
@@ -32,13 +29,13 @@ dispatcher = Dispatcher("parse_training_data", encoder=_encoder)
 
 def parse_training_data(
     consumer: Any,
-    training_data: Union[SupervisedDataset, Dict[Hashable, SupervisedDataset]],
+    training_data: SupervisedDataset,
     **kwargs: Any,
 ) -> Dict[str, Tensor]:
-    r"""Prepares a (collection of) datasets for consumption by a given object.
+    r"""Prepares a dataset for consumption by a given object.
 
     Args:
-        training_datas: A SupervisedDataset or dictionary thereof.
+        training_datas: A SupervisedDataset.
         consumer: The object that will consume the parsed data, or type thereof.
 
     Returns:
@@ -72,62 +69,3 @@ def _parse_pairwiseGP_ranking(
         "datapoints": datapoints,
         "comparisons": comparisons,
     }
-
-
-@dispatcher.register(Model, dict)
-def _parse_model_dict(
-    consumer: Model,
-    training_data: Dict[Hashable, SupervisedDataset],
-    **kwargs: Any,
-) -> Dict[str, Tensor]:
-    if len(training_data) != 1:
-        raise UnsupportedError(
-            "Default training data parsing logic does not support "
-            "passing multiple datasets to single task models."
-        )
-    return dispatcher(consumer, next(iter(training_data.values())))
-
-
-@dispatcher.register(MultiTaskGP, dict)
-def _parse_multitask_dict(
-    consumer: Model,
-    training_data: Dict[Hashable, SupervisedDataset],
-    *,
-    task_feature: int = 0,
-    task_feature_container: Hashable = "train_X",
-    **kwargs: Any,
-) -> Dict[str, Tensor]:
-    cache = {}
-    for task_id, dataset in enumerate(training_data.values()):
-        parse = parse_training_data(consumer, dataset, **kwargs)
-        if task_feature_container not in parse:
-            raise ValueError(f"Missing required term `{task_feature_container}`.")
-
-        if cache and cache.keys() != parse.keys():
-            raise UnsupportedError(
-                "Cannot combine datasets with heterogeneous parsed formats."
-            )
-
-        # Add task indicator features to specified container
-        X = parse[task_feature_container]
-        d = X.shape[-1]
-        i = d + task_feature + 1 if task_feature < 0 else task_feature
-        if i < 0 or d < i:
-            raise ValueError("Invalid `task_feature`: out-of-bounds.")
-
-        if i == 0:
-            X = pad(X, (1, 0), value=task_id)
-        elif i == d:
-            X = pad(X, (0, 1), value=task_id)
-        else:
-            A, B = X.split([i, d - i], dim=-1)
-            X = cat([pad(A, (0, 1), value=task_id), B], dim=-1)
-        parse[task_feature_container] = X
-
-        if cache:
-            for key, val in parse.items():
-                cache[key].append(val)
-        else:
-            cache = {key: [val] for key, val in parse.items()}
-
-    return {key: cat(tensors, dim=0) for key, tensors in cache.items()}

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -48,7 +48,7 @@ from gpytorch.likelihoods import FixedNoiseGaussianLikelihood
 from gpytorch.likelihoods.gaussian_likelihood import GaussianLikelihood
 from gpytorch.means import ConstantMean
 
-from .test_multitask import _gen_datasets
+from .test_multitask import _gen_multi_task_dataset
 
 EXPECTED_KEYS = [
     "latent_features",
@@ -566,7 +566,7 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
         for dtype, infer_noise in [(torch.float, False), (torch.double, True)]:
             tkwargs = {"device": self.device, "dtype": dtype}
             task_feature = 0
-            datasets, (train_X, train_Y, train_Yvar) = _gen_datasets(
+            datasets, (train_X, train_Y, train_Yvar) = _gen_multi_task_dataset(
                 yvar=None if infer_noise else 0.05, **tkwargs
             )
 

--- a/test/models/utils/test_parse_training_data.py
+++ b/test/models/utils/test_parse_training_data.py
@@ -5,15 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from botorch.exceptions import UnsupportedError
 from botorch.models.model import Model
-from botorch.models.multitask import MultiTaskGP
 from botorch.models.pairwise_gp import PairwiseGP
 from botorch.models.utils.parse_training_data import parse_training_data
 from botorch.utils.containers import SliceContainer
 from botorch.utils.datasets import RankingDataset, SupervisedDataset
 from botorch.utils.testing import BotorchTestCase
-from torch import cat, long, rand, Size, tensor
+from torch import long, rand, Size, tensor
 
 
 class TestParseTrainingData(BotorchTestCase):
@@ -61,50 +59,3 @@ class TestParseTrainingData(BotorchTestCase):
 
         comparisons = tensor([[0, 1], [2, 1]], dtype=long)
         self.assertTrue(comparisons.equal(parse["comparisons"]))
-
-    def test_dict(self):
-        n = 3
-        m = 2
-        datasets = {
-            i: SupervisedDataset(
-                X=rand(n, 2),
-                Y=rand(n, 1),
-                feature_names=["a", "b"],
-                outcome_names=["y"],
-            )
-            for i in range(m)
-        }
-        parse_training_data(Model, {0: datasets[0]})
-        with self.assertRaisesRegex(UnsupportedError, "multiple datasets to single"):
-            parse_training_data(Model, datasets)
-
-        _datasets = datasets.copy()
-        _datasets[m] = SupervisedDataset(
-            rand(n, 2),
-            rand(n, 1),
-            Yvar=rand(n, 1),
-            feature_names=["a", "b"],
-            outcome_names=["y"],
-        )
-        with self.assertRaisesRegex(UnsupportedError, "Cannot combine .* hetero"):
-            parse_training_data(MultiTaskGP, _datasets)
-
-        with self.assertRaisesRegex(ValueError, "Missing required term"):
-            parse_training_data(MultiTaskGP, datasets, task_feature_container="foo")
-
-        with self.assertRaisesRegex(ValueError, "out-of-bounds"):
-            parse_training_data(MultiTaskGP, datasets, task_feature=-m - 2)
-
-        with self.assertRaisesRegex(ValueError, "out-of-bounds"):
-            parse_training_data(MultiTaskGP, datasets, task_feature=m + 1)
-
-        X = cat([dataset.X for dataset in datasets.values()])
-        Y = cat([dataset.Y for dataset in datasets.values()])
-        for i in (0, 1, 2):
-            parse = parse_training_data(MultiTaskGP, datasets, task_feature=i)
-            self.assertTrue(torch.equal(Y, parse["train_Y"]))
-
-            X2 = cat([parse["train_X"][..., :i], parse["train_X"][..., i + 1 :]], -1)
-            self.assertTrue(X.equal(X2))
-            for j, task_features in enumerate(parse["train_X"][..., i].split(n)):
-                self.assertTrue(task_features.eq(j).all())


### PR DESCRIPTION
Summary: This was implemented in BoTorch side but never had any usage. We later implemented special subclasses like `MultiTaskDataset` and `ContextualDataset` that made this design fully obsolete. Cleaning up the code to avoid future confusion.

Differential Revision: D51130752


