### PR TITLE
Speed up decoupled_mobo tutorial by reducing NUM_FANTASIES and NUM_PARETO in SMOKE_TEST mode

### DIFF
--- a/tutorials/decoupled_mobo.ipynb
+++ b/tutorials/decoupled_mobo.ipynb
@@ -333,7 +333,7 @@
         "from botorch.sampling.list_sampler import ListSampler\n",
         "from botorch.sampling.normal import IIDNormalSampler\n",
         "\n",
-        "NUM_PARETO = 10\n",
+        "NUM_PARETO = 2 if SMOKE_TEST else 10\n",
         "NUM_FANTASIES = 2 if SMOKE_TEST else 8\n",
         "NUM_HVKG_RESTARTS = 1\n",
         "\n",

--- a/tutorials/decoupled_mobo.ipynb
+++ b/tutorials/decoupled_mobo.ipynb
@@ -334,7 +334,7 @@
         "from botorch.sampling.normal import IIDNormalSampler\n",
         "\n",
         "NUM_PARETO = 10\n",
-        "NUM_FANTASIES = 8\n",
+        "NUM_FANTASIES = 2 if SMOKE_TEST else 8\n",
         "NUM_HVKG_RESTARTS = 1\n",
         "\n",
         "\n",


### PR DESCRIPTION
## Motivation

This tutorial is running too slowly. This change reduces the runtime from 94s to 58s in SMOKE_TEST mode on a Macbook.

## Test Plan

Timed tutorial with `python scripts/run_tutorials.py -p ~/repos/botorch -s -n decoupled_mobo.ipynb`
