### PR TITLE
Input constructors for qEI, qLogEI, qPI with LearnedObjective

### DIFF
--- a/botorch/models/utils/assorted.py
+++ b/botorch/models/utils/assorted.py
@@ -111,7 +111,8 @@ def add_output_dim(X: Tensor, original_batch_shape: torch.Size) -> Tuple[Tensor,
         except RuntimeError:
             raise RuntimeError(
                 "The trailing batch dimensions of X must match the trailing "
-                "batch dimensions of the training inputs."
+                f"batch dimensions of the training inputs. Got {X.shape=} "
+                f"and {original_batch_shape=}."
             )
     # insert `m` dimension
     X = X.unsqueeze(-3)

--- a/test/acquisition/test_integration.py
+++ b/test/acquisition/test_integration.py
@@ -76,10 +76,9 @@ class TestObjectiveAndConstraintIntegration(BotorchTestCase):
 
         pref_sample_shapes = [1, 8]
         test_acqf_classes_and_kws = [
-            # Not yet working
-            # (qExpectedImprovement, {}),
-            # (qProbabilityOfImprovement, {}),
-            # (qLogExpectedImprovement, {}),
+            (qExpectedImprovement, {}),
+            (qProbabilityOfImprovement, {}),
+            (qLogExpectedImprovement, {}),
             (qNoisyExpectedImprovement, {"prune_baseline": prune_baseline}),
             (qLogNoisyExpectedImprovement, {"prune_baseline": prune_baseline}),
         ]


### PR DESCRIPTION
Summary: updating `get_best_f_mc`, which is used by input constructors of qEI/qLogEI/qP,I to be compatible with LearnedObjective and other `MCAcquisitionObjectives` that generate a greater number of samples than 1. This is an alternative to D51358951

Differential Revision: D51379290

