### PR TITLE
Raise FullyBayesianPosterior deprecation warning only when used

### DIFF
--- a/botorch/posteriors/fully_bayesian.py
+++ b/botorch/posteriors/fully_bayesian.py
@@ -144,8 +144,11 @@ class GaussianMixturePosterior(GPyTorchPosterior):
 class FullyBayesianPosterior(GaussianMixturePosterior):
     """For backwards compatibility."""
 
-    warn(
-        "`FullyBayesianPosterior` is marked for deprecation, consider using "
-        "`GaussianMixturePosterior` instead.",
-        DeprecationWarning,
-    )
+    def __init__(self, distribution: MultivariateNormal) -> None:
+        """DEPRECATED."""
+        warn(
+            "`FullyBayesianPosterior` is marked for deprecation, consider using "
+            "`GaussianMixturePosterior` instead.",
+            DeprecationWarning,
+        )
+        super().__init__(distribution=distribution)

--- a/botorch/posteriors/posterior_list.py
+++ b/botorch/posteriors/posterior_list.py
@@ -11,11 +11,9 @@ Abstract base module for all botorch posteriors.
 from __future__ import annotations
 
 from functools import cached_property
-
 from typing import Any, List, Optional
 
 import torch
-from botorch.posteriors import FullyBayesianPosterior
 from botorch.posteriors.fully_bayesian import GaussianMixturePosterior, MCMC_DIM
 from botorch.posteriors.posterior import Posterior
 from torch import Tensor
@@ -54,7 +52,7 @@ class PosteriorList(Posterior):
         mcmc_samples = [
             p.mean.shape[MCMC_DIM]
             for p in self.posteriors
-            if isinstance(p, (GaussianMixturePosterior, FullyBayesianPosterior))
+            if isinstance(p, GaussianMixturePosterior)
         ]
         if len(set(mcmc_samples)) > 1:
             raise NotImplementedError(


### PR DESCRIPTION
Summary: Currently, this warns on import, which leads to excessive warnings since it is imported in the `__init__` file. Moving to `FullyBayesianPosterior.__init__` resolves the issue.

Differential Revision: D51445186


