### PR TITLE
Speed up Multi-objective multi-fidelity tutorial in smoke test mode

### DIFF
--- a/tutorials/Multi_objective_multi_fidelity_BO.ipynb
+++ b/tutorials/Multi_objective_multi_fidelity_BO.ipynb
@@ -1,1616 +1,1870 @@
 {
-  "metadata": {
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "python3",
-      "language": "python",
-      "isCinder": true
-    },
-    "toc": {
-      "base_numbering": 1,
-      "nav_menu": [],
-      "number_sections": true,
-      "sideBar": true,
-      "skip_h1_title": false,
-      "title_cell": "Table of Contents",
-      "title_sidebar": "Contents",
-      "toc_cell": false,
-      "toc_position": [],
-      "toc_section_display": true,
-      "toc_window_display": false
-    },
-    "varInspector": {
-      "cols": {
-        "lenName": 16,
-        "lenType": 16,
-        "lenVar": 40
-      },
-      "kernels_config": {
-        "python": {
-          "delete_cmd_postfix": "",
-          "delete_cmd_prefix": "del ",
-          "library": "var_list.py",
-          "varRefreshCmd": "print(var_dic_list())"
-        },
-        "r": {
-          "delete_cmd_postfix": ") ",
-          "delete_cmd_prefix": "rm(",
-          "library": "var_list.r",
-          "varRefreshCmd": "cat(var_dic_list()) "
-        }
-      },
-      "position": {
-        "height": "423.4px",
-        "left": "858.8px",
-        "right": "20px",
-        "top": "120px",
-        "width": "350px"
-      },
-      "types_to_exclude": [
-        "module",
-        "function",
-        "builtin_function_or_method",
-        "instance",
-        "_Feature"
-      ],
-      "window_display": false
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "originalKey": "4be3ab76-0dde-4daa-81b7-68df50547590",
+    "outputsInitialized": false,
+    "showInput": false
+   },
+   "source": [
+    "# Multi-fidelity Multi-Objective optimization  "
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2,
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "4be3ab76-0dde-4daa-81b7-68df50547590",
-        "showInput": false,
-        "outputsInitialized": false
-      },
-      "source": [
-        "# Multi-fidelity Multi-Objective optimization  "
-      ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "originalKey": "8fb7e5e3-8176-4b7f-b9b6-9a20bfb7ad37",
+    "outputsInitialized": false,
+    "showInput": false
+   },
+   "source": [
+    "In this tutorial notebook we demonstrate how to perform multi-objective multi-fidelity optimization in BoTorch using the multi-fidelity Hypervolume Knowledge Gradient (MF-HVKG) [3] and a method called Multi-Objective Multi-Fidelity (MOMF) [1]. \n",
+    "\n",
+    "MF-HVKG performs one-step lookahead: it operates under the assumption that we can make one additional observation, and after receiving that additional observation, we will select the Pareto set of optimal designs. HVKG seeks to select the design `x` to evaluate that maximizes the value of information about the Pareto set by maximizing the hypervolume under the posterior mean (conditional on receiving on new observation for the design `x`).\n",
+    "\n",
+    "MOMF is an alternative approach that introduces an additional \"fidelity objective\" that is optimized along with the problem objectives. This fidelity objective can be thought of as a trust objective that rewards the optimization when going to higher fidelity. Thus, the MOMF explicitly optimizes for getting more high-fidelity (trustworthy) data while taking into account the higher computational costs associated with it.\n",
+    "\n",
+    "HVKG is generally more cost efficient [3], since it explicitly targets the goal of MF optimization: select design points and fidelities that enable identifying about the Pareto Frontier at the target fidelity in a cost-aware fashion. MOMF will typically result in faster candidate generation. If the application is high-throughput and requires fast candidate generation, MOMF will be preferable. Otherwise, MF-HVKG will likely give better sample efficiency and performance [3].\n",
+    "\n",
+    "In this tutorial, we will optimize a synthetic function that is a modified multi-fidelity Branin-Currin [1]. This is a 3-dimesional, bi-objective problem with one of the input dimensions being the fidelity. For the MOMF, this results in a 3-objective problem since it also takes the fidelity objective into account. In this case the fidelity objective is a linear function of fidelity, $ f(s)=s$, where $s$ is the fidelity. The MOMF algorithm can accept any discrete or continuous cost functions as an input. In this example, we choose an exponential dependency of the form $C(s)=\\exp(4.8s)$. The goal of the optimization is to find the Pareto front, which is a trade-off solution set for Multi-objective problems, at the highest fidelity. \n",
+    "\n",
+    "Note: pymoo is an optional dependency that is used for determining the Pareto set of optimal designs under the model posterior mean using NSGA-II (which is not a sample efficient method, but sample efficiency is not critical for this step). If pymoo is not available, the Pareto set of optimal designs is selected from a discrete set. This will work okay for low-dim (e.g. \n",
+    " dimensions) problems, but in general NSGA-II will yield far better results.\n",
+    "\n",
+    "[1] [Irshad, Faran, Stefan Karsch, and Andreas Döpp. \"Expected hypervolume improvement for simultaneous multi-objective and multi-fidelity optimization.\" arXiv preprint arXiv:2112.13901 (2021).](https://arxiv.org/abs/2112.13901)\n",
+    "\n",
+    "[2] [S. Daulton, M. Balandat, and E. Bakshy. Parallel Bayesian Optimization of Multiple Noisy Objectives. NeurIPS, 2021.](https://proceedings.neurips.cc/paper/2021/hash/11704817e347269b7254e744b5e22dac-Abstract.html)\n",
+    "\n",
+    "[3] [S. Daulton, M. Balandat, and E. Bakshy. Hypervolume Knowledge Gradient for Multi-Objective Bayesian Optimization with Partial Information. ICML, 2023.](https://proceedings.mlr.press/v202/daulton23a.html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "code_folding": [],
+    "collapsed": false,
+    "customOutput": null,
+    "executionStartTime": 1700239921224,
+    "executionStopTime": 1700239921225,
+    "hidden_ranges": [],
+    "originalKey": "f53fac8a-e151-4f47-ac57-e3c49bc10fb8",
+    "outputsInitialized": true,
+    "requestMsgId": "8ae17837-397d-4cff-a52a-82c4a268d159"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from typing import Callable, Dict\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "originalKey": "313624cb-6e9b-4419-aa46-53bc5dfdbae6",
+    "outputsInitialized": false,
+    "showInput": false
+   },
+   "source": [
+    "### Set dtype and device \n",
+    "Setting up the global variable that determine the device to run the optimization. The optimization is much faster when it runs on GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "code_folding": [],
+    "collapsed": false,
+    "customOutput": null,
+    "executionStartTime": 1700239921898,
+    "executionStopTime": 1700239921904,
+    "hidden_ranges": [],
+    "originalKey": "e7934480-1e9d-484c-8d49-d15d4cfcccc4",
+    "outputsInitialized": false,
+    "requestMsgId": "a2204a02-e2a6-4a9a-92db-effb9607bb05"
+   },
+   "outputs": [],
+   "source": [
+    "tkwargs = {  # Tkwargs is a dictionary contaning data about data type and data device\n",
+    "    \"dtype\": torch.double,\n",
+    "    \"device\": torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\"),\n",
+    "}\n",
+    "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "originalKey": "6ab54ce1-7768-4460-b965-369fa1c4f664",
+    "outputsInitialized": false,
+    "showInput": false
+   },
+   "source": [
+    "### Define the problem and optimization settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "code_folding": [],
+    "collapsed": false,
+    "customOutput": null,
+    "executionStartTime": 1700239922349,
+    "executionStopTime": 1700239922400,
+    "hidden_ranges": [],
+    "originalKey": "1bffa4ee-f329-4e1a-be27-554eb1b7419b",
+    "outputsInitialized": false,
+    "requestMsgId": "76495050-3917-414e-94f4-d3bcacd0cfb5"
+   },
+   "outputs": [],
+   "source": [
+    "from botorch.test_functions.multi_objective_multi_fidelity import MOMFBraninCurrin\n",
+    "\n",
+    "BC = MOMFBraninCurrin(negate=True).to(**tkwargs)\n",
+    "dim_x = BC.dim\n",
+    "dim_y = BC.num_objectives\n",
+    "\n",
+    "ref_point = torch.zeros(dim_y, **tkwargs)\n",
+    "\n",
+    "\n",
+    "BATCH_SIZE = 1  # For batch optimization, BATCH_SIZE should be greater than 1\n",
+    "# This evaluation budget is set to be very low to make the notebook run fast. This should be much higher.\n",
+    "EVAL_BUDGET = 2.05  # in terms of the number of full-fidelity evaluations\n",
+    "n_INIT = 2  # Initialization budget in terms of the number of full-fidelity evaluations\n",
+    "# Number of Monte Carlo samples, used to approximate MOMF\n",
+    "MC_SAMPLES = 8 if SMOKE_TEST else 128\n",
+    "# Number of restart points for multi-start optimization\n",
+    "NUM_RESTARTS = 2 if SMOKE_TEST else 10\n",
+    "# Number of raw samples for initial point selection heuristic\n",
+    "RAW_SAMPLES = 2 if SMOKE_TEST else 512\n",
+    "\n",
+    "standard_bounds = torch.zeros(2, dim_x, **tkwargs)\n",
+    "standard_bounds[1] = 1\n",
+    "# mapping from index to target fidelity (highest fidelity)\n",
+    "target_fidelities = {2: 1.0}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "originalKey": "6a44ae07-fe2e-49e1-9825-e4cc13bff750",
+    "outputsInitialized": false,
+    "showInput": false
+   },
+   "source": [
+    "### Helper functions to define Cost \n",
+    "\n",
+    "The cost_func function returns an exponential cost from the fidelity. The cost_callable is a wrapper around it that takes care of the input output shapes. This is provided to the MF algorithms which inversely weight the expected utility by the cost."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false,
+    "customOutput": null,
+    "executionStartTime": 1700239923177,
+    "executionStopTime": 1700239923187,
+    "originalKey": "248720f2-59b3-4e39-848a-ada6084f8b89",
+    "output": {
+     "id": "839707961268436"
     },
+    "outputsInitialized": true,
+    "requestMsgId": "a77f8c50-0b31-42a4-a036-2223c7da5474"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "8fb7e5e3-8176-4b7f-b9b6-9a20bfb7ad37",
-        "showInput": false,
-        "outputsInitialized": false
-      },
-      "source": [
-        "In this tutorial notebook we demonstrate how to perform multi-objective multi-fidelity optimization in BoTorch using the multi-fidelity Hypervolume Knowledge Gradient (MF-HVKG) [3] and a method called Multi-Objective Multi-Fidelity (MOMF) [1]. \n",
-        "\n",
-        "MF-HVKG performs one-step lookahead: it operates under the assumption that we can make one additional observation, and after receiving that additional observation, we will select the Pareto set of optimal designs. HVKG seeks to select the design `x` to evaluate that maximizes the value of information about the Pareto set by maximizing the hypervolume under the posterior mean (conditional on receiving on new observation for the design `x`).\n",
-        "\n",
-        "MOMF is an alternative approach that introduces an additional \"fidelity objective\" that is optimized along with the problem objectives. This fidelity objective can be thought of as a trust objective that rewards the optimization when going to higher fidelity. Thus, the MOMF explicitly optimizes for getting more high-fidelity (trustworthy) data while taking into account the higher computational costs associated with it.\n",
-        "\n",
-        "HVKG is generally more cost efficient [3], since it explicitly targets the goal of MF optimization: select design points and fidelities that enable identifying about the Pareto Frontier at the target fidelity in a cost-aware fashion. MOMF will typically result in faster candidate generation. If the application is high-throughput and requires fast candidate generation, MOMF will be preferable. Otherwise, MF-HVKG will likely give better sample efficiency and performance [3].\n",
-        "\n",
-        "In this tutorial, we will optimize a synthetic function that is a modified multi-fidelity Branin-Currin [1]. This is a 3-dimesional, bi-objective problem with one of the input dimensions being the fidelity. For the MOMF, this results in a 3-objective problem since it also takes the fidelity objective into account. In this case the fidelity objective is a linear function of fidelity, $ f(s)=s$, where $s$ is the fidelity. The MOMF algorithm can accept any discrete or continuous cost functions as an input. In this example, we choose an exponential dependency of the form $C(s)=\\exp(4.8s)$. The goal of the optimization is to find the Pareto front, which is a trade-off solution set for Multi-objective problems, at the highest fidelity. \n",
-        "\n",
-        "Note: pymoo is an optional dependency that is used for determining the Pareto set of optimal designs under the model posterior mean using NSGA-II (which is not a sample efficient method, but sample efficiency is not critical for this step). If pymoo is not available, the Pareto set of optimal designs is selected from a discrete set. This will work okay for low-dim (e.g. \n",
-        " dimensions) problems, but in general NSGA-II will yield far better results.\n",
-        "\n",
-        "[1] [Irshad, Faran, Stefan Karsch, and Andreas Döpp. \"Expected hypervolume improvement for simultaneous multi-objective and multi-fidelity optimization.\" arXiv preprint arXiv:2112.13901 (2021).](https://arxiv.org/abs/2112.13901)\n",
-        "\n",
-        "[2] [S. Daulton, M. Balandat, and E. Bakshy. Parallel Bayesian Optimization of Multiple Noisy Objectives. NeurIPS, 2021.](https://proceedings.neurips.cc/paper/2021/hash/11704817e347269b7254e744b5e22dac-Abstract.html)\n",
-        "\n",
-        "[3] [S. Daulton, M. Balandat, and E. Bakshy. Hypervolume Knowledge Gradient for Multi-Objective Bayesian Optimization with Partial Information. ICML, 2023.](https://proceedings.mlr.press/v202/daulton23a.html)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "f53fac8a-e151-4f47-ac57-e3c49bc10fb8",
-        "code_folding": [],
-        "hidden_ranges": [],
-        "collapsed": false,
-        "requestMsgId": "8ae17837-397d-4cff-a52a-82c4a268d159",
-        "customOutput": null,
-        "executionStartTime": 1700239921224,
-        "executionStopTime": 1700239921225,
-        "outputsInitialized": true
-      },
-      "source": [
-        "import os\n",
-        "from typing import Callable, Dict, Tuple\n",
-        "\n",
-        "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
-        "import torch"
-      ],
-      "execution_count": 9,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "313624cb-6e9b-4419-aa46-53bc5dfdbae6",
-        "showInput": false,
-        "outputsInitialized": false
-      },
-      "source": [
-        "### Set dtype and device \n",
-        "Setting up the global variable that determine the device to run the optimization. The optimization is much faster when it runs on GPU."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "e7934480-1e9d-484c-8d49-d15d4cfcccc4",
-        "code_folding": [],
-        "hidden_ranges": [],
-        "collapsed": false,
-        "requestMsgId": "a2204a02-e2a6-4a9a-92db-effb9607bb05",
-        "customOutput": null,
-        "executionStartTime": 1700239921898,
-        "executionStopTime": 1700239921904,
-        "outputsInitialized": false
-      },
-      "source": [
-        "tkwargs = {  # Tkwargs is a dictionary contaning data about data type and data device\n",
-        "    \"dtype\": torch.double,\n",
-        "    \"device\": torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\"),\n",
-        "}\n",
-        "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")"
-      ],
-      "execution_count": 10,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "6ab54ce1-7768-4460-b965-369fa1c4f664",
-        "showInput": false,
-        "outputsInitialized": false
-      },
-      "source": [
-        "### Define the problem and optimization settings"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "1bffa4ee-f329-4e1a-be27-554eb1b7419b",
-        "collapsed": false,
-        "requestMsgId": "76495050-3917-414e-94f4-d3bcacd0cfb5",
-        "customOutput": null,
-        "executionStartTime": 1700239922349,
-        "executionStopTime": 1700239922400,
-        "code_folding": [],
-        "hidden_ranges": [],
-        "outputsInitialized": false
-      },
-      "source": [
-        "from botorch.test_functions.multi_objective_multi_fidelity import MOMFBraninCurrin\n",
-        "\n",
-        "BC = MOMFBraninCurrin(negate=True).to(**tkwargs)\n",
-        "dim_x = BC.dim\n",
-        "dim_y = BC.num_objectives\n",
-        "\n",
-        "ref_point = torch.zeros(dim_y, **tkwargs)\n",
-        "\n",
-        "\n",
-        "BATCH_SIZE = 1  # For batch optimization, BATCH_SIZE should be greater than 1\n",
-        "# This evaluation budget is set to be very low to make the notebook run fast. This should be much higher.\n",
-        "EVAL_BUDGET = 2.05  # in terms of the number of full-fidelity evaluations\n",
-        "n_INIT = 2  # Initialization budget in terms of the number of full-fidelity evaluations\n",
-        "# Number of Monte Carlo samples, used to approximate MOMF\n",
-        "MC_SAMPLES = 8 if SMOKE_TEST else 128\n",
-        "# Number of restart points for multi-start optimization\n",
-        "NUM_RESTARTS = 2 if SMOKE_TEST else 10\n",
-        "# Number of raw samples for initial point selection heuristic\n",
-        "RAW_SAMPLES = 4 if SMOKE_TEST else 512\n",
-        "\n",
-        "standard_bounds = torch.zeros(2, dim_x, **tkwargs)\n",
-        "standard_bounds[1] = 1\n",
-        "# mapping from index to target fidelity (highest fidelity)\n",
-        "target_fidelities = {2: 1.0}"
-      ],
-      "execution_count": 11,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "6a44ae07-fe2e-49e1-9825-e4cc13bff750",
-        "showInput": false,
-        "outputsInitialized": false
-      },
-      "source": [
-        "### Helper functions to define Cost \n",
-        "\n",
-        "The cost_func function returns an exponential cost from the fidelity. The cost_callable is a wrapper around it that takes care of the input output shapes. This is provided to the MF algorithms which inversely weight the expected utility by the cost."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "248720f2-59b3-4e39-848a-ada6084f8b89",
-        "collapsed": false,
-        "requestMsgId": "a77f8c50-0b31-42a4-a036-2223c7da5474",
-        "customOutput": null,
-        "executionStartTime": 1700239923177,
-        "executionStopTime": 1700239923187,
-        "outputsInitialized": true,
-        "output": {
-          "id": "839707961268436"
-        }
-      },
-      "source": [
-        "from math import exp\n",
-        "def cost_func(x):\n",
-        "    \"\"\"A simple exponential cost function.\"\"\"\n",
-        "    exp_arg = torch.tensor(4.8, **tkwargs)\n",
-        "    val = torch.exp(exp_arg * x)\n",
-        "    return val\n",
-        "\n",
-        "\n",
-        "# Displaying the min and max costs for this optimization\n",
-        "print(f\"Min Cost: {cost_func(0)}\")\n",
-        "print(f\"Max Cost: {cost_func(1)}\")\n",
-        "\n",
-        "def cost_callable(X: torch.Tensor) -> torch.Tensor:\n",
-        "    r\"\"\"Wrapper for the cost function that takes care of shaping\n",
-        "    input and output arrays for interfacing with cost_func.\n",
-        "    This is passed as a callable function to MOMF.\n",
-        "\n",
-        "    Args:\n",
-        "        X: A `batch_shape x q x d`-dim Tensor\n",
-        "    Returns:\n",
-        "        Cost `batch_shape x q x m`-dim Tensor of cost generated\n",
-        "        from fidelity dimension using cost_func.\n",
-        "    \"\"\"\n",
-        "\n",
-        "    return cost_func(X[..., -1:])"
-      ],
-      "execution_count": 12,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Min Cost: 1.0\nMax Cost: 121.51041751873485\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "2f3f70a4-3654-4e65-ab6c-69b1e16ab3d6",
-        "showInput": false,
-        "outputsInitialized": false
-      },
-      "source": [
-        "### Model Initialization \n",
-        "We use a multi-output SingleTaskGP to model the problem with a homoskedastic Gaussian likelihood with an inferred noise level. \n",
-        "The model is initialized with random points, where the fidelity is sampled from a probability distribution with a PDF that is inversely proportional to the cost: $p(s)=C(s)^{-1}$. The initialization is given a budget equivalent to 2 full-fidelity evaluations."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "b35c722b-c75a-4e13-ab18-ff9fd01fad95",
-        "collapsed": false,
-        "requestMsgId": "dcdc2b90-8d52-479b-9aea-e7a69bf194a3",
-        "customOutput": null,
-        "executionStartTime": 1700239924281,
-        "executionStopTime": 1700239924318,
-        "outputsInitialized": false
-      },
-      "source": [
-        "from botorch.models.gp_regression import SingleTaskGP\n",
-        "from botorch.models.model_list_gp_regression import ModelListGP\n",
-        "from botorch.models.transforms.outcome import Standardize\n",
-        "from gpytorch.kernels import MaternKernel, ScaleKernel\n",
-        "from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood\n",
-        "from gpytorch.priors import GammaPrior\n",
-        "from botorch.utils.transforms import normalize\n",
-        "\n",
-        "\n",
-        "def inv_transform(u):\n",
-        "    # define inverse transform to sample from the probability distribution with\n",
-        "    # PDF proportional to 1/(c(x))\n",
-        "    # u is a uniform(0,1) rv\n",
-        "    return (\n",
-        "        5 / 24 * torch.log(-exp(24 / 5) / (exp(24 / 5) * u - u - exp(24 / 5)))\n",
-        "    )\n",
-        "\n",
-        "\n",
-        "def gen_init_data(n: int):\n",
-        "    r\"\"\"\n",
-        "    Generates the initial data. Sample fidelities inversely proportional to cost.\n",
-        "    \"\"\"\n",
-        "    # total cost budget is n\n",
-        "    train_x = torch.empty(\n",
-        "        0, BC.bounds.shape[1], dtype=BC.bounds.dtype, device=BC.bounds.device\n",
-        "    )\n",
-        "    total_cost = 0\n",
-        "    # assume target fidelity is 1\n",
-        "    total_cost_limit = (\n",
-        "        n\n",
-        "        * cost_callable(\n",
-        "            torch.ones(\n",
-        "                1, BC.bounds.shape[1], dtype=BC.bounds.dtype, device=BC.bounds.device\n",
-        "            )\n",
-        "        ).item()\n",
-        "    )\n",
-        "    while total_cost < total_cost_limit:\n",
-        "        new_x = torch.rand(\n",
-        "            1, BC.bounds.shape[1], dtype=BC.bounds.dtype, device=BC.bounds.device\n",
-        "        )\n",
-        "        new_x[:, -1] = inv_transform(new_x[:, -1])\n",
-        "        total_cost += cost_callable(new_x)\n",
-        "        train_x = torch.cat([train_x, new_x], dim=0)\n",
-        "    train_x = train_x[:-1]\n",
-        "    train_obj = BC(train_x)\n",
-        "    return train_x, train_obj\n",
-        "\n",
-        "\n",
-        "def initialize_model(train_x, train_obj, state_dict=None):\n",
-        "    \"\"\"Initializes a ModelList with Matern 5/2 Kernel and returns the model and its MLL.\n",
-        "    \n",
-        "    Note: a batched model could also be used here.\n",
-        "    \"\"\"\n",
-        "    models = []\n",
-        "    for i in range(train_obj.shape[-1]):\n",
-        "        m = SingleTaskGP(\n",
-        "            train_x,\n",
-        "            train_obj[:, i : i + 1],\n",
-        "            train_Yvar=torch.full_like(train_obj[:, i : i + 1], 1e-6),\n",
-        "            outcome_transform=Standardize(m=1),\n",
-        "            covar_module=ScaleKernel(\n",
-        "                MaternKernel(\n",
-        "                    nu=2.5,\n",
-        "                    ard_num_dims=train_x.shape[-1],\n",
-        "                    lengthscale_prior=GammaPrior(2.0, 2.0),\n",
-        "                ),\n",
-        "                outputscale_prior=GammaPrior(2.0, 0.15),\n",
-        "            ),\n",
-        "        )\n",
-        "        models.append(m)\n",
-        "    model = ModelListGP(*models)\n",
-        "    mll = SumMarginalLogLikelihood(model.likelihood, model)\n",
-        "    if state_dict is not None:\n",
-        "        model.load_state_dict(state_dict=state_dict)\n",
-        "    return mll, model"
-      ],
-      "execution_count": 13,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "dcc1666f-f387-40b0-8137-25b133d22dd2",
-        "showInput": false,
-        "outputsInitialized": false
-      },
-      "source": [
-        "### Helper function to optimize acquisition function \n",
-        "This is a helper function that initializes, optimizes the acquisition function MOMF and returns the new_x and new_obj. The problem is called from within this helper function.\n",
-        "\n",
-        "A simple initialization heuristic is used to select the 20 restart initial locations from a set of 1024 random points. Multi-start optimization of the acquisition function is performed using LBFGS-B with exact gradients computed via auto-differentiation."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "9095cc6a-0e14-4be1-ae9b-e56535e2dcba",
-        "collapsed": false,
-        "requestMsgId": "fe16757e-7f35-462b-a5ca-cd0ddf689f79",
-        "customOutput": null,
-        "executionStartTime": 1700239926777,
-        "executionStopTime": 1700239926816,
-        "code_folding": [],
-        "hidden_ranges": [],
-        "outputsInitialized": false
-      },
-      "source": [
-        "from botorch.acquisition.multi_objective.multi_fidelity import MOMF\n",
-        "from botorch.optim.optimize import optimize_acqf\n",
-        "from botorch.sampling.normal import SobolQMCNormalSampler\n",
-        "from botorch.utils.multi_objective.box_decompositions.non_dominated import (\n",
-        "    FastNondominatedPartitioning,\n",
-        ")\n",
-        "from botorch.utils.transforms import unnormalize\n",
-        "\n",
-        "\n",
-        "dim_y_momf = dim_y + 1  # Output Dimesnion for MOMF optimization\n",
-        "ref_point_momf = torch.zeros(dim_y_momf, **tkwargs)\n",
-        "\n",
-        "def fid_obj(X: torch.Tensor) -> torch.Tensor:\n",
-        "    \"\"\"\n",
-        "    A Fidelity Objective that can be thought of as a trust objective.\n",
-        "    Higher Fidelity simulations are rewarded as being more\n",
-        "    trustworthy. Here we consider just a linear fidelity objective.\n",
-        "    \"\"\"\n",
-        "    fid_obj = 1 * X[..., -1]\n",
-        "    return fid_obj\n",
-        "\n",
-        "\n",
-        "def get_objective_momf(x: torch.Tensor) -> torch.Tensor:\n",
-        "    \"\"\"Wrapper around the Objective function to take care of fid_obj stacking\"\"\"\n",
-        "    y = BC(x)  # The Branin-Currin is called\n",
-        "    fid = fid_obj(x)  # Getting the fidelity objective values\n",
-        "    fid_out = fid.unsqueeze(-1)\n",
-        "    # Concatenating objective values with fid_objective\n",
-        "    y_out = torch.cat([y, fid_out], -1)\n",
-        "    return y_out\n",
-        "\n",
-        "\n",
-        "def optimize_MOMF_and_get_obs(\n",
-        "    model: SingleTaskGP,\n",
-        "    train_obj: torch.Tensor,\n",
-        "    sampler: SobolQMCNormalSampler,\n",
-        "    ref_point: torch.Tensor,\n",
-        "    standard_bounds: torch.Tensor,\n",
-        "    BATCH_SIZE: int,\n",
-        "    cost_call: Callable[[torch.Tensor], torch.Tensor],\n",
-        "):\n",
-        "    \"\"\"\n",
-        "    Wrapper to call MOMF and optimizes it in a sequential greedy\n",
-        "    fashion returning a new candidate and evaluation\n",
-        "    \"\"\"\n",
-        "    partitioning = FastNondominatedPartitioning(\n",
-        "        ref_point=torch.tensor(ref_point, **tkwargs), Y=train_obj\n",
-        "    )\n",
-        "    acq_func = MOMF(\n",
-        "        model=model,\n",
-        "        ref_point=ref_point,  # use known reference point\n",
-        "        partitioning=partitioning,\n",
-        "        sampler=sampler,\n",
-        "        cost_call=cost_call,\n",
-        "    )\n",
-        "    # Optimization\n",
-        "    candidates, vals = optimize_acqf(\n",
-        "        acq_function=acq_func,\n",
-        "        bounds=standard_bounds,\n",
-        "        q=BATCH_SIZE,\n",
-        "        num_restarts=NUM_RESTARTS,\n",
-        "        raw_samples=RAW_SAMPLES,  # used for intialization heuristic\n",
-        "        options={\"batch_limit\": 5, \"maxiter\": 200, \"nonnegative\": True},\n",
-        "        sequential=True,\n",
-        "    )\n",
-        "    # if the AF val is 0, set the fidelity parameter to zero\n",
-        "    if vals.item() == 0.0:\n",
-        "        candidates[:, -1] = 0.0\n",
-        "    # observe new values\n",
-        "    new_x = unnormalize(candidates.detach(), bounds=standard_bounds)\n",
-        "    new_obj = get_objective_momf(new_x)\n",
-        "    return new_x, new_obj"
-      ],
-      "execution_count": 14,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "f580b5fe-d172-4d7f-a40a-98bc8acdd0f8",
-        "showInput": false,
-        "customInput": null,
-        "outputsInitialized": false
-      },
-      "source": [
-        "### Define helper functions for MF-HVKG\n",
-        "\n",
-        "`get_current_value` optimizes the current posterior mean at the full fidelity to determine the hypervolume under the current model.\n",
-        "\n",
-        "`optimize_HVKG_and_get_obs` creates the MF-HVKG acquisition function, optimizes it, and returns the new design and corresponding observation.\n",
-        ""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "1d61db27-bd71-4e4c-bffc-b8279771e682",
-        "showInput": true,
-        "customInput": null,
-        "collapsed": false,
-        "requestMsgId": "e3e094aa-d96f-42f2-b499-0bdce21228d6",
-        "executionStartTime": 1700239931973,
-        "executionStopTime": 1700239932009,
-        "outputsInitialized": false
-      },
-      "source": [
-        "from botorch.acquisition.cost_aware import InverseCostWeightedUtility\n",
-        "from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction\n",
-        "from botorch.acquisition.multi_objective.hypervolume_knowledge_gradient import (\n",
-        "    _get_hv_value_function,\n",
-        "    qMultiFidelityHypervolumeKnowledgeGradient,\n",
-        ")\n",
-        "from botorch.acquisition.utils import project_to_target_fidelity\n",
-        "from botorch.models.deterministic import GenericDeterministicModel\n",
-        "from torch import Tensor\n",
-        "\n",
-        "NUM_INNER_MC_SAMPLES = 32\n",
-        "NUM_PARETO = 10\n",
-        "NUM_FANTASIES = 8\n",
-        "\n",
-        "\n",
-        "def get_current_value(\n",
-        "    model: SingleTaskGP,\n",
-        "    ref_point: torch.Tensor,\n",
-        "    bounds: torch.Tensor,\n",
-        "    normalized_target_fidelities: Dict[int, float],\n",
-        "):\n",
-        "    \"\"\"Helper to get the hypervolume of the current hypervolume\n",
-        "    maximizing set.\n",
-        "    \"\"\"\n",
-        "    fidelity_dims, fidelity_targets = zip(*normalized_target_fidelities.items())\n",
-        "    # optimize\n",
-        "    non_fidelity_dims = list(set(range(dim_x)) - set(fidelity_dims))\n",
-        "    curr_val_acqf = FixedFeatureAcquisitionFunction(\n",
-        "        acq_function=_get_hv_value_function(\n",
-        "            model=model,\n",
-        "            ref_point=ref_point,\n",
-        "            sampler=SobolQMCNormalSampler(\n",
-        "                sample_shape=torch.Size([NUM_INNER_MC_SAMPLES]),\n",
-        "                resample=False,\n",
-        "                collapse_batch_dims=True,\n",
-        "            ),\n",
-        "            use_posterior_mean=True,\n",
-        "        ),\n",
-        "        d=dim_x,\n",
-        "        columns=fidelity_dims,\n",
-        "        values=fidelity_targets,\n",
-        "    )\n",
-        "    # optimize\n",
-        "    _, current_value = optimize_acqf(\n",
-        "        acq_function=curr_val_acqf,\n",
-        "        bounds=bounds[:, non_fidelity_dims],\n",
-        "        q=NUM_PARETO,\n",
-        "        num_restarts=1,\n",
-        "        raw_samples=1024,\n",
-        "        return_best_only=True,\n",
-        "        options={\"nonnegative\": True},\n",
-        "    )\n",
-        "    return current_value\n",
-        "\n",
-        "\n",
-        "normalized_target_fidelities = {}\n",
-        "for idx, fidelity in target_fidelities.items():\n",
-        "    lb = standard_bounds[0, idx].item()\n",
-        "    ub = standard_bounds[1, idx].item()\n",
-        "    normalized_target_fidelities[idx] = (fidelity - lb) / (ub - lb)\n",
-        "project_d = dim_x\n",
-        "\n",
-        "\n",
-        "def project(X: Tensor) -> Tensor:\n",
-        "\n",
-        "    return project_to_target_fidelity(\n",
-        "        X=X,\n",
-        "        d=project_d,\n",
-        "        target_fidelities=normalized_target_fidelities,\n",
-        "    )\n",
-        "\n",
-        "\n",
-        "def optimize_HVKG_and_get_obs(\n",
-        "    model: SingleTaskGP,\n",
-        "    ref_point: torch.Tensor,\n",
-        "    standard_bounds: torch.Tensor,\n",
-        "    BATCH_SIZE: int,\n",
-        "    cost_call: Callable[[torch.Tensor], torch.Tensor],\n",
-        "):\n",
-        "    \"\"\"Utility to initialize and optimize HVKG.\"\"\"\n",
-        "    cost_model = GenericDeterministicModel(cost_call)\n",
-        "    cost_aware_utility = InverseCostWeightedUtility(cost_model=cost_model)\n",
-        "    current_value = get_current_value(\n",
-        "        model=model,\n",
-        "        ref_point=ref_point,\n",
-        "        bounds=standard_bounds,\n",
-        "        normalized_target_fidelities=normalized_target_fidelities,\n",
-        "    )\n",
-        "\n",
-        "    acq_func = qMultiFidelityHypervolumeKnowledgeGradient(\n",
-        "        model=model,\n",
-        "        ref_point=ref_point,  # use known reference point\n",
-        "        num_fantasies=NUM_FANTASIES,\n",
-        "        num_pareto=NUM_PARETO,\n",
-        "        current_value=current_value,\n",
-        "        cost_aware_utility=cost_aware_utility,\n",
-        "        target_fidelities=normalized_target_fidelities,\n",
-        "        project=project,\n",
-        "    )\n",
-        "    # Optimization\n",
-        "    candidates, vals = optimize_acqf(\n",
-        "        acq_function=acq_func,\n",
-        "        bounds=standard_bounds,\n",
-        "        q=BATCH_SIZE,\n",
-        "        num_restarts=1,\n",
-        "        raw_samples=RAW_SAMPLES,  # used for intialization heuristic\n",
-        "        options={\"batch_limit\": 5},\n",
-        "    )\n",
-        "    # if the AF val is 0, set the fidelity parameter to zero\n",
-        "    if vals.item() == 0.0:\n",
-        "        candidates[:, -1] = 0.0\n",
-        "    # observe new values\n",
-        "    new_x = unnormalize(candidates.detach(), bounds=BC.bounds)\n",
-        "    new_obj = BC(new_x)\n",
-        "    return new_x, new_obj"
-      ],
-      "execution_count": 15,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "bdb86f2e-6774-4b00-af78-d081948812a5",
-        "showInput": false,
-        "outputsInitialized": false
-      },
-      "source": [
-        "### Define helper functions for MF-HVKG\n",
-        "\n",
-        "We run MOMF to optimize the multi-fidelity versions of the Branin-Currin functions. The optimization loop works in the following sequence. \n",
-        "\n",
-        "1. At the start with an initialization equivalent to 2 full fidelity evaluations.\n",
-        "2. The models are used to generate an acquisition function that is optimized to select new input parameters\n",
-        "3. The objective function is evaluated at the suggested new_x and returns a new_obj.\n",
-        "4. The models are updated with the new points and then are used again to make the next prediction.\n",
-        "\n",
-        "The evaluation budget for the optimization is set to 4 full fidelity evaluations.\n",
-        "\n",
-        "Note: running this takes some time.\n",
-        ""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "ec218c40-b012-40cc-bc28-ff0b2bedc941",
-        "showInput": true,
-        "customInput": null,
-        "collapsed": false,
-        "requestMsgId": "e5e1ca9f-350b-4d84-85cc-b5765bd5479e",
-        "executionStartTime": 1700239933421,
-        "executionStopTime": 1700239933474,
-        "customOutput": null,
-        "outputsInitialized": false
-      },
-      "source": [
-        "from botorch import fit_gpytorch_mll"
-      ],
-      "execution_count": 16,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "d250edba-f44e-4630-a1d1-90d050115f80",
-        "collapsed": false,
-        "requestMsgId": "a740fdb3-387b-46f7-9715-1247be0f0c7b",
-        "customOutput": null,
-        "executionStartTime": 1700239934173,
-        "executionStopTime": 1700239960450,
-        "code_folding": [],
-        "hidden_ranges": [],
-        "outputsInitialized": false,
-        "output": {
-          "id": "339093968712897"
-        }
-      },
-      "source": [
-        "# Intializing train_x to zero\n",
-        "verbose = False\n",
-        "torch.manual_seed(0)\n",
-        "train_x_momf, _ = gen_init_data(n_INIT)\n",
-        "train_obj_momf = get_objective_momf(train_x_momf)\n",
-        "# Generate Sampler\n",
-        "momf_sampler = SobolQMCNormalSampler(sample_shape=torch.Size([MC_SAMPLES]))\n",
-        "\n",
-        "# run N_BATCH rounds of BayesOpt after the initial random batch\n",
-        "iteration = 0\n",
-        "total_cost = cost_callable(train_x_momf).sum().item()\n",
-        "while total_cost < EVAL_BUDGET * cost_func(1):\n",
-        "    if verbose:\n",
-        "        print(f\"cost: {total_cost}\")\n",
-        "\n",
-        "    # reinitialize the models so they are ready for fitting on next iteration\n",
-        "    mll, model = initialize_model(normalize(train_x_momf, BC.bounds), train_obj_momf)\n",
-        "\n",
-        "    fit_gpytorch_mll(mll=mll)  # Fit the model\n",
-        "\n",
-        "    # optimize acquisition functions and get new observations\n",
-        "    new_x, new_obj = optimize_MOMF_and_get_obs(\n",
-        "        model=model,\n",
-        "        train_obj=train_obj_momf,\n",
-        "        sampler=momf_sampler,\n",
-        "        ref_point=ref_point_momf,\n",
-        "        standard_bounds=standard_bounds,\n",
-        "        BATCH_SIZE=BATCH_SIZE,\n",
-        "        cost_call=cost_callable,\n",
-        "    )\n",
-        "    # Updating train_x and train_obj\n",
-        "    train_x_momf = torch.cat([train_x_momf, new_x], dim=0)\n",
-        "    train_obj_momf = torch.cat([train_obj_momf, new_obj], dim=0)\n",
-        "    iteration += 1\n",
-        "    total_cost += cost_callable(new_x).sum().item()"
-      ],
-      "execution_count": 17,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "2e193c2e-f4c4-4d2c-b592-f51a6cc3d5a9",
-        "showInput": false,
-        "customInput": null,
-        "collapsed": false,
-        "requestMsgId": "2e193c2e-f4c4-4d2c-b592-f51a6cc3d5a9",
-        "executionStartTime": 1699738891403,
-        "executionStopTime": 1699738891407,
-        "outputsInitialized": false
-      },
-      "source": [
-        "### Run MF-HVKG"
-      ],
-      "attachments": {}
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "4a9f3f42-dd1f-45f2-9125-511f72ad337a",
-        "showInput": true,
-        "customInput": null,
-        "collapsed": false,
-        "requestMsgId": "de9c995c-66dd-49de-b8cf-dc834e52fc38",
-        "executionStartTime": 1700239960506,
-        "executionStopTime": 1700240950614,
-        "outputsInitialized": false,
-        "customOutput": null,
-        "output": {
-          "id": "379210377773864"
-        }
-      },
-      "source": [
-        "torch.manual_seed(0)\n",
-        "train_x_kg, train_obj_kg = gen_init_data(n_INIT)\n",
-        "MF_n_INIT = train_x_kg.shape[0]\n",
-        "iteration = 0\n",
-        "total_cost = cost_callable(train_x_kg).sum().item()\n",
-        "while total_cost < EVAL_BUDGET * cost_func(1):\n",
-        "    if verbose:\n",
-        "        print(f\"cost: {total_cost}\")\n",
-        "\n",
-        "    # reinitialize the models so they are ready for fitting on next iteration\n",
-        "    mll, model = initialize_model(normalize(train_x_kg, BC.bounds), train_obj_kg)\n",
-        "\n",
-        "    fit_gpytorch_mll(mll=mll)  # Fit the model\n",
-        "    # optimize acquisition functions and get new observations\n",
-        "    new_x, new_obj = optimize_HVKG_and_get_obs(\n",
-        "        model=model,\n",
-        "        ref_point=ref_point,\n",
-        "        standard_bounds=standard_bounds,\n",
-        "        BATCH_SIZE=BATCH_SIZE,\n",
-        "        cost_call=cost_callable,\n",
-        "    )\n",
-        "    # Updating train_x and train_obj\n",
-        "    train_x_kg = torch.cat([train_x_kg, new_x], dim=0)\n",
-        "    train_obj_kg = torch.cat([train_obj_kg, new_obj], dim=0)\n",
-        "    iteration += 1\n",
-        "    total_cost += cost_callable(new_x).sum().item()"
-      ],
-      "execution_count": 18,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/botorch/optim/initializers.py:432: BadInitialCandidatesWarning:\n\nUnable to find non-zero acquisition function values - initial conditions are being selected randomly.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/botorch/optim/initializers.py:432: BadInitialCandidatesWarning:\n\nUnable to find non-zero acquisition function values - initial conditions are being selected randomly.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "bc189d13-6ad9-4687-8e67-c506dcc1dad1",
-        "showInput": false,
-        "outputsInitialized": true,
-        "output": {
-          "id": "1977100562657087"
-        }
-      },
-      "source": [
-        "### Result:  Evaluating the Pareto front at the highest fidelity using NSGA-II on the posterior mean\n",
-        ""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "275b1f0b-4d84-4318-99b1-c1a7505bf1a4",
-        "collapsed": false,
-        "requestMsgId": "19199126-7e1c-4adb-88bb-35d42d1f26af",
-        "customOutput": null,
-        "executionStartTime": 1700240950637,
-        "executionStopTime": 1700240950639,
-        "outputsInitialized": false
-      },
-      "source": [
-        "from botorch.utils.multi_objective.pareto import (\n",
-        "    _is_non_dominated_loop,\n",
-        "    is_non_dominated,\n",
-        ")\n",
-        "from gpytorch import settings\n",
-        "\n",
-        "try:\n",
-        "    from pymoo.algorithms.nsga2 import NSGA2\n",
-        "    from pymoo.model.problem import Problem\n",
-        "    from pymoo.optimize import minimize\n",
-        "    from pymoo.util.termination.max_gen import MaximumGenerationTermination\n",
-        "\n",
-        "    def get_pareto(\n",
-        "        model,\n",
-        "        non_fidelity_indices,\n",
-        "        project,\n",
-        "        population_size=250,\n",
-        "        max_gen=100,\n",
-        "        is_mf_model=True,\n",
-        "    ):\n",
-        "        \"\"\"Optimize the posterior mean using NSGA-II.\"\"\"\n",
-        "        tkwargs = {\n",
-        "            \"dtype\": BC.ref_point.dtype,\n",
-        "            \"device\": BC.ref_point.device,\n",
-        "        }\n",
-        "        dim = len(non_fidelity_indices)\n",
-        "\n",
-        "        class PosteriorMeanPymooProblem(Problem):\n",
-        "            def __init__(self):\n",
-        "                super().__init__(\n",
-        "                    n_var=dim,\n",
-        "                    n_obj=BC.num_objectives,\n",
-        "                    type_var=np.double,\n",
-        "                )\n",
-        "                self.xl = np.zeros(dim)\n",
-        "                self.xu = np.ones(dim)\n",
-        "\n",
-        "            def _evaluate(self, x, out, *args, **kwargs):\n",
-        "                X = torch.from_numpy(x).to(**tkwargs)\n",
-        "                if is_mf_model:\n",
-        "                    X = project(X)\n",
-        "                with torch.no_grad():\n",
-        "                    with settings.cholesky_max_tries(9):\n",
-        "                        # eval in batch mode\n",
-        "                        y = model.posterior(X.unsqueeze(-2)).mean.squeeze(-2)\n",
-        "                out[\"F\"] = -y.cpu().numpy()\n",
-        "\n",
-        "        pymoo_problem = PosteriorMeanPymooProblem()\n",
-        "        algorithm = NSGA2(\n",
-        "            pop_size=population_size,\n",
-        "            eliminate_duplicates=True,\n",
-        "        )\n",
-        "        res = minimize(\n",
-        "            pymoo_problem,\n",
-        "            algorithm,\n",
-        "            termination=MaximumGenerationTermination(max_gen),\n",
-        "            seed=0,  # fix seed\n",
-        "            verbose=False,\n",
-        "        )\n",
-        "        X = torch.tensor(\n",
-        "            res.X,\n",
-        "            **tkwargs,\n",
-        "        )\n",
-        "        # project to full fidelity\n",
-        "        if is_mf_model:\n",
-        "            if project is not None:\n",
-        "                X = project(X)\n",
-        "        # determine Pareto set of designs under model\n",
-        "        with torch.no_grad():\n",
-        "            preds = model.posterior(X.unsqueeze(-2)).mean.squeeze(-2)\n",
-        "        pareto_mask = is_non_dominated(preds)\n",
-        "        X = X[pareto_mask]\n",
-        "        # evaluate Pareto set of designs on true function and compute hypervolume\n",
-        "        if not is_mf_model:\n",
-        "            X = project(X)\n",
-        "        X = unnormalize(X, BC.bounds)\n",
-        "        Y = BC(X)\n",
-        "        # compute HV\n",
-        "        partitioning = FastNondominatedPartitioning(ref_point=BC.ref_point, Y=Y)\n",
-        "        return partitioning.compute_hypervolume().item()\n",
-        "\n",
-        "except ImportError:\n",
-        "    NUM_DISCRETE_POINTS = 100 if SMOKE_TEST else 100000\n",
-        "    CHUNK_SIZE = 512\n",
-        "\n",
-        "    def get_pareto(\n",
-        "        model,\n",
-        "        non_fidelity_indices,\n",
-        "        project,\n",
-        "        population_size=250,\n",
-        "        max_gen=100,\n",
-        "        is_mf_model=True,\n",
-        "    ):\n",
-        "        \"\"\"Optimize the posterior mean over a discrete set.\"\"\"\n",
-        "        tkwargs = {\n",
-        "            \"dtype\": BC.ref_point.dtype,\n",
-        "            \"device\": BC.ref_point.device,\n",
-        "        }\n",
-        "        dim_x = BC.dim\n",
-        "\n",
-        "        discrete_set = torch.rand(NUM_DISCRETE_POINTS, dim_x - 1, **tkwargs)\n",
-        "        if is_mf_model:\n",
-        "            discrete_set = project(discrete_set)\n",
-        "        discrete_set[:, -1] = 1.0  # set to target fidelity\n",
-        "        with torch.no_grad():\n",
-        "            preds_list = []\n",
-        "            for start in range(0, NUM_DISCRETE_POINTS, CHUNK_SIZE):\n",
-        "                preds = model.posterior(\n",
-        "                    discrete_set[start : start + CHUNK_SIZE].unsqueeze(-2)\n",
-        "                ).mean.squeeze(-2)\n",
-        "                preds_list.append(preds)\n",
-        "            preds = torch.cat(preds_list, dim=0)\n",
-        "            pareto_mask = _is_non_dominated_loop(preds)\n",
-        "            pareto_X = discrete_set[pareto_mask]\n",
-        "        if not is_mf_model:\n",
-        "            pareto_X = project(pareto_X)\n",
-        "        pareto_X = unnormalize(pareto_X, BC.bounds)\n",
-        "        Y = BC(pareto_X)\n",
-        "        # compute HV\n",
-        "        partitioning = FastNondominatedPartitioning(ref_point=BC.ref_point, Y=Y)\n",
-        "        return partitioning.compute_hypervolume().item()"
-      ],
-      "execution_count": 19,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "ad70a987-1877-4bc1-a4cd-49fca37dff2b",
-        "showInput": false,
-        "customInput": null,
-        "outputsInitialized": false
-      },
-      "source": [
-        "## Evaluate MF-HVKG\n",
-        "\n",
-        "We evaluate performance after every 5 evaluations (this is to speed things up, since there are many observations)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "41ef8566-7400-441c-8087-d5842df6117d",
-        "showInput": true,
-        "customInput": null,
-        "collapsed": false,
-        "requestMsgId": "7ff2bd5b-cf9b-4843-9b7b-9fc463b52385",
-        "executionStartTime": 1700240950661,
-        "executionStopTime": 1700241053956,
-        "customOutput": null,
-        "outputsInitialized": false,
-        "output": {
-          "id": "1259701838157405"
-        }
-      },
-      "source": [
-        "hvs_kg = []\n",
-        "costs = []\n",
-        "for i in range(MF_n_INIT, train_x_kg.shape[0] + 1, 5):\n",
-        "\n",
-        "    mll, model = initialize_model(\n",
-        "        normalize(train_x_kg[:i], BC.bounds), train_obj_kg[:i]\n",
-        "    )\n",
-        "    fit_gpytorch_mll(mll)\n",
-        "    hypervolume = get_pareto(\n",
-        "        model, project=project, non_fidelity_indices=[0, 1]\n",
-        "    )\n",
-        "    hvs_kg.append(hypervolume)\n",
-        "    costs.append(cost_callable(train_x_kg[:i]).sum().item())"
-      ],
-      "execution_count": 20,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "11350000-d066-49a3-b950-f7633e1c507a",
-        "showInput": false,
-        "customInput": null,
-        "collapsed": false,
-        "requestMsgId": "11350000-d066-49a3-b950-f7633e1c507a",
-        "executionStartTime": 1699739200762,
-        "executionStopTime": 1699739200768,
-        "outputsInitialized": false
-      },
-      "source": [
-        "## Evaluate MOMF\n",
-        "\n",
-        "We evaluate performance after every evaluation (there are not as many evaluations since MOMF queries higher fidelities more frequently)."
-      ],
-      "attachments": {}
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "7770db5f-be4d-40eb-b525-c6d18932c198",
-        "showInput": true,
-        "customInput": null,
-        "collapsed": false,
-        "requestMsgId": "89819efc-dd7a-42cf-8144-d9b6480bb5ae",
-        "executionStartTime": 1700241054021,
-        "executionStopTime": 1700241163531,
-        "outputsInitialized": false,
-        "customOutput": null,
-        "output": {
-          "id": "3721915894755385"
-        }
-      },
-      "source": [
-        "hvs_momf = []\n",
-        "costs_momf = []\n",
-        "for i in range(MF_n_INIT, train_x_momf.shape[0] + 1):\n",
-        "\n",
-        "    mll, model = initialize_model(\n",
-        "        normalize(train_x_momf[:i], BC.bounds), train_obj_momf[:i, :2]\n",
-        "    )\n",
-        "    fit_gpytorch_mll(mll)\n",
-        "    hypervolume = get_pareto(model, project=project, non_fidelity_indices=[0, 1])\n",
-        "    hvs_momf.append(hypervolume)\n",
-        "    costs_momf.append(cost_callable(train_x_momf[:i]).sum().item())"
-      ],
-      "execution_count": 21,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n\nVery small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "f9e4b24a-6f83-4dd3-b1a4-9a3ebc231813",
-        "showInput": false,
-        "customInput": null,
-        "outputsInitialized": false
-      },
-      "source": [
-        "### Plot log inference hypervolume regret (under the model) vs cost\n",
-        "\n",
-        "Log inference hypervolume regret, defined as the logarithm of the difference between the maximum hypervolume dominated by the Pareto frontier and the hypervolume corresponding to the Pareto set identified by each algorithm, is a performance evaluation criterion for multi-information source multi-objective optimization [3]."
-      ],
-      "attachments": {}
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "0f68e995-1461-40bc-b71b-40d66dabefca",
-        "showInput": true,
-        "customInput": null,
-        "collapsed": false,
-        "requestMsgId": "0f0468b8-cbaf-47a1-b66a-200ebc3f5d89",
-        "executionStartTime": 1700241163589,
-        "executionStopTime": 1700241164394,
-        "outputsInitialized": true,
-        "output": {
-          "id": "1783893625394451"
-        }
-      },
-      "source": [
-        "plt.plot(\n",
-        "    costs_momf,\n",
-        "    np.log10(BC.max_hv - np.array(hvs_momf)),\n",
-        "    \"--\",\n",
-        "    marker=\"s\",\n",
-        "    ms=10,\n",
-        "    label=\"MOMF\",\n",
-        ")\n",
-        "plt.plot(\n",
-        "    costs, np.log10(BC.max_hv - np.array(hvs_kg)), \"--\", marker=\"d\", ms=10, label=\"HVKG\"\n",
-        ")\n",
-        "plt.ylabel(\"Log Inference Hypervolume Regret\")\n",
-        "plt.xlabel(\"Cost\")\n",
-        "plt.legend()"
-      ],
-      "execution_count": 22,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "<matplotlib.legend.Legend at 0x7f333f203cd0>"
-          },
-          "metadata": {},
-          "execution_count": 22
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": "<Figure size 1500x1000 with 1 Axes>",
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAABPUAAANJCAYAAABkiAl0AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAADz1klEQVR4nOzdeXiU1d3/8c89SzLZQ/Y9hM0NBEVWBUFxt2q11lZbq221tlUfuzxq+7T9tbWt2lZbq9ZqW5da676vdUGQTVQQWUR2skFC9n32+/cHEAkzgWQyk5kk79d1eUnOfWbmOzA3kA/nnK+xadMmUwAAAAAAAACGDEu0CwAAAAAAAADQP4R6AAAAAAAAwBBDqAcAAAAAAAAMMYR6AAAAAAAAwBBDqAcAAAAAAAAMMYR6AAAAAAAAwBBDqAcAAAAAAAAMMYR6AAAAAAAAwBBji3YBkCZMmBDtEhCE3+9XbXWFcgtLZLGQfwPRxj0JxBbuSSB2cD8CsYV7EgO1efPmPs3j0wUAAAAAAAAMMYR6AAAAAAAAwBBDqAcAAAAAAAAMMYR6AAAAAAAAwBBDqAcAAAAAAAAMMYR6AAAAAAAAwBBDqAcAAAAAAAAMMbZoFwAAAAAAAID+8/l8am5uVmdnZ7RLQR9YLBZlZGQoISEhLM9HqAcAAAAAADDE+Hw+VVdXa9SoUcrIyJBhGNEuCYfh8Xi0e/duFRYWymq1Dvj52H4LAAAAAAAwxDQ3N2vUqFFKSUkh0Bsi7Ha7srKy1NDQEJbnI9QDAAAAAAAYYjo7O5WcnBztMtBPCQkJcrlcYXkuQj0AAAAAAIAhiBV6Q084f804Uw8AAAAAAGAEqmr2q7HD7PfjMpIMFaWzTizaCPUAAAAAAABGmKpmv076Y4dc3v4/Nt4mLf1xEsFelPGzDwAAAAAAMMI0dpghBXqS5PIqpBV+CC9W6gEAAAAAACBm/P7Ov+itt9/VGaedoh//4Lqgc375m9u0bPlKff3SS3T5174iSfL7/Xrz7Xf11jvvaseOcjldLmVmZmjKsZN04fnnqqystMdzfO2Kq1W7p043/uh6nXbq/IDX8Pl8+srXv6Xm5hb98bZbNPnYiZKk087+4iHrf/Sh+5WXmzOAn4G+IdQDAAAAAABATHE4HFqydIWu+97Vio+P73Gtvb1DH3y4Wo4Dxr1er355y21at2GjvnLxhfr+Nd9WclKSdu2u0UuvvK7v3/C/+vEN1+qU+XMDXuftdxYHDfVWrV4jpzN4p9rzv3C2Lr3kS0GvpaWlhviu+4dQDwAAAAAAYBg5968dh53T6Q7v9tm/L3XrxbWe7q9f+V7SgJ5v3NgylVdUavn7H2j+yXN6XHtv6XIVFuSpq8vZPfboY09q9cef6E9/vFVHTBjXPZ6Tk60pkyfp7r8+oDv/cq/Gjx+r4qLC7uvHTzlW73/wkerrG5SVldnjdRYuek+TJx2jlR+uCqjP4YhXRsaoAb3HgeJMPQAAAAAAgGFkVYX/sP9trAlvqFfV3PP5B8pisWjmjGl6e+HigGvvvLtYs2ZO7/7a7XbrhZde1Rmnn9oj0DvQt795uWw2m1565fUe42PHlCk7K1MLF73XY7zL6dSyFR9o9qzpilWEegAAAAAAAIg58+acqFWr16ipubl7rK6+XuvWf6r5cz9fvbd5y1Z1dnVpxrSpvT5XgsOhKZMnadXqNQHXTp57UkB4uHzFSjkc8ZoyeVLY3k+4EeoBAAAAAAAg5kw9fopSU1P07qIl3WML312i0aUlPZpe1Nc3Svu22h5Kbk6O6hsaAsYXnHKyduws19ZtO7rH3nn3Pc2be5IsFmuY3k34caYeAAAAAAAAYo7VatW8uSfp7YWLdOEFX5D2nXN3cLMLq21v8Ob3H3pLsd/vl2EErm8rG12qMWNG6+2FizRubJmaW1q0+uNP9PVLL+n1uZ59/mW9+PLrAePJSUl6/NF/9Pk9DgShHgAAAAAAwDAyteTwGzM73WZYz9UrSrf06XX769T5J+v5F19ReUWl/H6/duws1y0n/7THnOx9DS5219Ro3NiyXp+rds8e5WRnBr22YP7Jeua5l3TVNy/XosVLlZuTraOOnKCa2j1B559x2im6+KILAsYtlsHbFEuoBwAAAAAAMIz0pfPs2mqfzri7M2yvedVJcbrqpLiwPd9+R0wYp+LiQr27aIl8Pp8mHnNUwDbb8ePGKj0tVctXfKA5J84K+jxdTqc+WbtB5559RtDr8+fN1T8eelSfrNsQdDXgwZKTk1RYkD+AdzZwnKkHAAAAAACAmHXq/JP1wUer9P4HH+rU+ScHXLdarbrwgvO0cNF7WrtuQ9DnePDhf0umqfPOOTPo9azMDE05dpLefGuhPtu0RafMO3SoFwtYqQcAAAAAAICYder8k/Wvfz8hq8WiOScFX4n35S9doC3btun/fnGLLrn4Qs2eNV3JycnavbtGL7/6hlZ+8JF+cuMPlJub0/vrnDJXd/z5Xo0fN1bFRYURfEfhQaiHkFU1+9XY0f/99xlJhorSWSQKAAAAAAAOLy83R8ccdaSSU5KUmpISdI7VatUvfnqj3nl3sd548x29+PKr6ujsUlZmho4/brL+evcdhw3q5pw4S3ff+4BOmTcnQu8kvIxNmzaF71REhGTChAnRLqHfqpr9OumPHXJ5+//YeJu09MdJMR/s+f1+1VZXKLewZFAPugQQHPckEFu4J4HYwf0IxJbBuicrKytVXFwc8uNHwvf1sepwv3abN2/u0/OwUg8haewwQ7rxJcnl3fv4ovRwVwUAAAAAAPqiKN2ipT9OYgfeEEaoBwAAAAAAMAIVpVtYcDOEEasCAAAAAAAAQwyhHgAAAAAAADDEEOoBAAAAAAAAQwyhHgAAAAAAADDEEOoBAAAAAACg23vNzTp3/Xq919wc7VJwCIR6AAAAAAAAkCR1+f26tbJSu91u3VpZqS6/P9oloReEegAAAAAAAJAkPVRTozqPR5JU5/Ho4ZqaaJeEXhDqAQAAAAAAQJVOpx6uqZG572tT0sO1tap0OqNcGYKxRbsAAAAAAAAARJdpmrq9sjL4eFWV7h47VoZhDEotv7/zL/po1cd66rGHgl7/2hVX66gjj1Bra5uqqnfp0Yf+Josl+Lq1635wkzo6OvTgA/foX/9+Qo/+50m9+sKTiouL657T1tauH974U/n8fv3p979TWlpq97Wqqmo99ewL+viTdWpoaFRcnF052dmaNWOaLr7oAiUnJ0XgZ6BvWKkHAAAAAAAwwi1uadGKtjb5Dhr3SVrR2qr3WlqiVFnvzjpjgfbU1WnNJ+uCXq+orNJnmzbrzNNP7fU5nE6XfvbL36iry6nbf/vLHoHeyg8+0jXX/VB19Q26/vvf0UMP3KO77rhNXzjnTL3+5tv63vU/UlNT9JqJEOoBAAAAAACMYF1+v26vrOw1JLJIui0Gm2acOHuGUlNT9N+3Fga9/tbb78pms+m0BfODXvd6vfr1b2/X7ppa3fbbXyo7K6v7WmNjk373+z9p1ozp+t2vf65pU49Tbm6OSkuK9YVzztRf7rxdHZ2dWrjovYi9v8Nh+y1CkpFkKN4mubz9f2y8be/jAQAAAABA+F2xaVO/5te43d3NMYLxH9A047sFBUHn/GfPHr3Z1NT99cNHHNGvGkJht9t16vyT9dobb6qjo0NJSZ9vhfX7/Xrn3cWaOf0EjUpPD3isaZr6/R1/0cZNm/XH225RUWHP9/XqG2/K5XLpmquvDLrtOC83R0899pCsVmuE3t3hEeohJEXpFi39cZIaO8zuseZOvy75Z+DhmZdOs+kbMz/fq56RZKgonUWiAAAAAABEwrqOjrA/5/6mGedmZKjY4Qi4XuN2R+R1D+esMxbo+Rdf0aL3lumcs07vHl+9Zq3q6ht0w3XfDfq4v97/T614/wPd9ttfauyYsoDra9dt0Jiy0crMyOj1taMZ6IlQDwNRlG5R0QFht2lagq7e8/qkYwuj+0EHAAAAAAADs7+Zxt3jxkW8aUZzc4u+cOFXg15zuVw66si9KwHLRpfqyCMm6M23F/YI9d58a6Gys7N0wtTjAh7/6GNP6oWXXtXRRx2pI48YH/Q1GhobVVJcFLb3EwmEeggbwzBUmG5oe73ZY7y62ez1MQAAAAAAYGjwSVrR1qadTqfKEhIi+lqpKSm6687bgl778U0/7/H1WWecqj/95T5VVlWruKhQHZ2dWv7+Sl180QVBu+K+8ebbuvpb39A/H/63HvjnI/ru1d8MmGOz2uQPcobg967/kSqrdvUYe/m5x0N4hwNHqIewKky3aHt9z1451S2xdZAmAAAAAADoP6uk6ampGh1k+224WawWFRbkB6/D2jOom3/yHP3t7w/pzbcW6ltXfl2L31sqj8erM08L3vX2L3fervz8PBmGofv/8bDGlI3WGaed0mNOVlamdu+uDXjsL392szzevVsUly57X/946F8DeJcDQ6iHsCpMC1x+u6vZlN9vymKhOQYAAAAAAJE26YCGEYfj8vu1uaurT3MNw9BNxcXBG0fExfXrdcMpISFBJ885UW8vXKxvXvE1vf3OYh035Vjl5uYEnZ+ZufecvC9deL42bdmqu+75m4qLC3X0kZ8395h+wvH66/3/VFVVtYqKCrvHc3Kyu3+cnp4W0fd1OIR6CKuCIA0w3D6pvsNUTgqhHgAAAAAAkdbfzrN/3bVLD9bU6FCHZxmSrsjNVXF8fNDrl+bk6NKc4CHaYDjz9AV64813tHT5+9qw8TP99KYf9ulxP/yf76u8vFK/+s3tuveuPyprX+B36vyT9cTTz+kvf31Av/3Vz2S32wMeW1FRGfb30R+0IEVYFaYHD+44Vw8AAAAAgNh0ZV6esu32XkMii6Rsu11X5OUNcmV9d8zRR6q0pFj33Pd3pSQna/bM6X16XILDof/3s5vkdrv1y1tuldvtliSlpCTrZzf/SFu3bdcP//f/tHT5+9pdU6vqXbu1ZNkK/fQXt+jp517UJRd/McLvrHeEegirwiAr9SSpuplz9QAAAAAAiEUJFotuKi5Wb9+5+yXdXFyshCBNJ2LJmaefqsbGJi04dV7QlXW9KSzI180/vkGbt2zTn/5yX/f4xGOO1t/u+ZMmTjxaDz7yb1393f/RNdf+UA//6z/Kz8vVA3/9s7595eURejeHZ2zatIklVFE2YcKEaJcQNlvr/Frwn1qlHV+nltXZcu1OliT9v3Pidc2cuGiX1y9+v1+11RXKLSwJ2i0HwODingRiC/ckEDu4H4HYMlj3ZGVlpYqLi8P2fKZp6rqtW/VBW5sObH+5vznG3WPHBj1LD/13uF+7zZs39+l5ht2ZeitWfqRnnn9JTqdLv/75Td2HH/ZFZ2eXFi5aok/WbVB9Q6MMQ8rPy9XsmdM1e+a0Hh/elR+u1r8ee7LX58rPy9XPbu7b/u3hJCPFVPrUPbIk+JQ+dY/2vJ4o02dhpR4AAAAAADFsfxOMiz79NOg4gV7sGTahXlt7ux5/8jmtXf9pv5ZY7tfc0qo//vletbS0asa043XKvDnq6urS0uUr9Z8nn1Xtnj268Pxzu+d37esMc+r8uRpdGpiuJiREvr1zLHqisVaWBJ8MQ7Ik+JR8ZJPaNmRqF2fqAQAAAAAQ04odDl2Rl9fdNONwzTEQXcMm1Lv9jrvl8/n0vauv1JtvL9KWbdv79fiXXnlDTU3NuvjC8zRv7ond4zOnn6Bf3/pHLVy0VAtOOVmpKSnSvlV9knT0kRN05BHjw/xuhqZKp1MP19Rof3hvGFLyUY3qLE9RdQvbAAAAAAAAiHVX5uXp5YYG7fF4Yr45xkg3bJKWMaNL9NMbb9DRR/WvbfN+o0alacrkiZo9c1qP8cTEBI0tGy3TNLVrd233eOe+lXoJCQkDrHx4ME1Tt1cGtnK2GNLMsxr063NJ9QEAAAAAiHUJFot+Ulys/Lg4/WQINMcYyYbNSr1vfuOyAT3+C2ef0eu1/QFe4gEB3v6VeomJe8f8fr/8fr9stv7/lPr9Q/+8ucUtLVrR1hYwbhrSDrWrI61Nfn9aVGoL1f5fl+Hw6wMMB9yTQGzhngRiB/cjEFsG6540TVOmGZmjruakpWlOWlr36yC8TNMMy+dj2IR6kVK9a7e2btuhnOwsFRcVdI/vD/pWrPxQH69Zp/qGRvn9fmVmZmj2zGk67ZSTZbVa+/QatdUVEat/MDhNU7c2NsuQFOxWNyTdWr5TozPS5RiCB2vW7a6KdgkADsA9CcQW7kkgdnA/ArEl0vek2+WWx+OO6GsgMtwuZ1iyoJgM9V5/850+zZs3Z3ZEt782NTXrgX/+S4Zh6NJLLurR6WX/Sr2PVq3RSbNnKD8/T62tbVq8ZLlefvW/2rmzQt/59jf61B0mt7AkYu9hMNy3e7ca/WbQQE/7gr5Gv6nXrXG6Jj9/kKsLnd/vV93uKmXnF0W0DTmAvuGeBGIL9yQQO7gfgdgyWPfkrl27JBkhNQtF9Ph8PsXFO5RbWNTrnLatW/v0XDEZ6r3y2pt9mjd96nERC/XKK6p0/z8eVkdHp674+lc0ftyYHtfPO+cMOZ1OjR1bpgTH551uZ06fqtvvuFvrNmzU2vWfavKkYw77WkP5D95Kp1OP1Nb2GujtZ0p6ZM8efSEzU8WOodUZ2GKxDOlfI2C44Z4EYgv3JBA7uB+B2BLpezIzM1M1NTXKyspSQkJCnxYVIbp8Pp927dqlnJycsHw2YjLUu/fPt0f19T9atUb/fuIZxcXZ9f1rvqUJ48cGzBk3tizoY61Wq+bNna3HnnhWGz/b3KdQb6jqrTnG4ebfPW4cv9kAAAAAADAACQkJKiwsVENDgxoaGqJdDvooJydHjjAtdorJUC+a3l64WM+/9JoK8vP0nW9/Q1mZGf1+jtSUFElSl9MZgQpjx06nM2hzjN74JK1oa9NOp1NldA0GAAAAAGBArFarcnJyol0GooRQ7wDvLV2h5196TUcdMV7fvvLrcjjig85zudzasPEzWSwWTTl2YsD1mj11kqSMUaMiXnM0jXY4NCslRR+0tcnXh/lWSdNTUzV6iG2/BQAAAAAAiDUj7sAFn8+nmto9amhs6jG+fcdOPf3cSxo7ZrS+c9UVvQZ6kmSzWfXUsy/q4Uef0J66+h7XOju7tGjxUhmGoeOnTIrY+4gFhmHopuLifs9n6y0AAAAAAMDADIuVeg2NTSqv+Pxst7aOdknSho2blJycJEnKzMhQaUmRmptbdMutd6ikuFA3/ej67sc8/dzL8vv9mnTMUVq3/tOgr5Ofl6v8vFxZrVZdfOF5evjRJ3THXX/VnNkzlZ2dpaamZi1d/r6amlt09pkLVFxUGPH3Hm3FDoeuyMvTgzU1h26WYUrebaNUNCVu8IoDAAAAAAAYpoZFqLd5yzb9+/GnA8affOaF7h/PmDZVl1/25V6fo6KySpL0wsuv9zrn7DMW6JyzTpMkTT1uskalp+mdRUv0/oer1Nbaprj4OJUWF+krF39RE485aoDvaui4Mi9PLzc0qM7jCRrsmabk77Jpz5pRajzbVGYSK/UAAAAAAAAGYliEerNmnKBZM07o09zMzIyg3XVD6bg7pmy0xpSN7vfjhpsEi0U3FRfrR9u3B71uGFLz6myZPouqm01lJg16iQAAAAAAAMPKiDtTD5FxclqapiUnB73m7bDJtWtvklfd7B/kygAAAAAAAIYfQj2EhWEY+r+SkqDXfB02SXu33FY3H/LkPQAAAAAAAPQBoR7CptjhUK7dHjBuTfB1/5iVegAAAAAAAANHqIewOiElJWDMmuSRLHtX6LFSDwAAAAAAYOAI9RBWYxyOgDHDsi/YY6UeAAAAAABAWBDqIaxKgoR6kmRLdkus1AMAAAAAAAgLQj2EVUl8fNBxW8relXq1baZcXoI9AAAAAACAgSDUQ1gVxcfv63Pbky3F3f3jmhZCPQAAAAAAgIEg1ENYOSwW5cXFBYzbkj3dP+ZcPQAAAAAAgIEh1EPYBduCu3/7rSRVca4eAAAAAADAgBDqIeyChXrWRK8M694VeqzUAwAAAAAAGBhCPYRdbx1wrfu24O7iTD0AAAAAAIABIdRD2JX22gF3b7MMVuoBAAAAAAAMjC3aBWD4OXD7rcVjlbPFLm+bXf6uvR+3as7UAwAAAAAAGBBCPYRdfny8Hj7iCJXEx+snz3j0/Bpvj+vVzX6ZpinDMKJWIwAAAAAAwFDG9luEnc0wNCkpSWk2mwrTAz9iHW6ppSsqpQEAAAAAAAwLhHqIqKL04KvxOFcPAAAAAAAgdGy/RUQVpltkGFJeiqHCdEOF6RYVphtKcbD1FgAAAAAAIFSEeoiok8dbVf6bZNmthHgAAAAAAADhQqiHiCLMAwAAAAAACD/O1AMAAAAAAACGGEI9AAAAAAAAYIhh+y0ixjRN1Xu9qnA6VeFyqcLplE/SD4uKol0aAAAAAADAkEaoh4j52c6deqOpqcdYosWiHxQWyjA4aw8AAAAAACBUbL9FxBTExQWMdfr9avB6o1IPAAAAAADAcEGoh4gpdjiCjlc4nYNeCwAAAAAAwHDC9ltETGl8fNDx+1d3yFFr05eOt2vOOD6CAAAAAAAA/cVKPURMSS8r9d6t7tJTq71aU+Ub9JoAAAAAAACGA0I9REy61aoUqzVg3JbsliRVN5tRqAoAAAAAAGDoI9RDxBiGoZIgW3BtKR5JUnWzPwpVAQAAAAAADH2Eeoio0iBbcG3JHskwWakHAAAAAAAQIroUIKKKg6zUM6ymrAleVTcbUakJAAAAAABgqGOlHiKqtw64thS3Wp1Sq5PVegAAAAAAAP1FqIeI6q0DrnXfuXq7OFcPAAAAAACg3wj1EFHBGmVo/7l6dMAFAAAAAAAICaEeIirJalWmLfDoRluKW5JU3cJKPQAAAAAAgP4i1EPE9doBl5V6AAAAAAAAISHUQ8QF64BrTfJIFlPVnKkHAAAAAADQb4R6iLhgHXANi2RL8rBSDwAAAAAAIASEeoi4XjvgJrtZqQcAAAAAABACQj1EXK8dcFM82t1iyudntR4AAAAAAEB/EOoh4ori42UEGbeluOX1S3vaCPUAAAAAAAD6g1APERdvsSg/Lq77a7/HIndjvHyddokOuAAAAAAAAP1mi3YBGBluLi7WthrpJ4/75XdapQPW7lU3+3VCqTWq9QEAAAAAAAwlhHoYFCempanA45ff2RFwjZV6AAAAAAAA/cP2Wwya/LRgJ+uJDrgAAAAAAAD9RKiHQeOwG8pO/jzYS4yTxudYNCoxeNgHAAAAAACA4Nh+i0F1/6UOpTgMFaZblJ4gGQaBHgAAAAAAQH8R6mFQzRrDRw4AAAAAAGCg2H4LAAAAAAAADDGEegAAAAAAAMAQw15IDLoWr1cVLpfKnU5VuFz6ek6OUmx8FAEAAAAAAPqKJAWD5t3mZt1SXq4Wn6/H+Jy0NE0i1AMAAAAAAOgztt9i0KRYrQGBniSVO51RqQcAAAAAAGCoItTDoCmJjw86XuFyDXotAAAAAAAAQxmhHgZNtt0uhyXwI/d+bZde/MQTlZoAAAAAAACGIkI9DBrDMFQaZLXemkanbnuT1XoAAAAAAAB9RaiHQVUcJNSzJru1q9kvv9+MSk0AAAAAAABDDaEeBlWpwxEwZrGb8tp9qu8g1AMAAAAAAOgLQj0Mqt6aZdhS3KpuJtQDAAAAAADoC0I9DKreQz2Pqpv9g14PAAAAAADAUESoh0FVEmT7rSTZklmpBwAAAAAA0FeEehhU6TabUq3WgHErK/UAAAAAAAD6jFAPgy7YFlxbsoeVegAAAAAAAH1EqIdBF6wDri3Zo6oWX1TqAQAAAAAAGGoI9TDogq3UM6ymdrk8UakHAAAAAABgqCHUw6DrrQNum8WlLg9bcAEAAAAAAA6HUA+DrtcOuCke7W4h1AMAAAAAADgcQj0Mut5W6llT3HTABQAAAAAA6ANCPQy6RKtVaRZbwDgdcAEAAAAAAPqGUA9RURIXuFrPxko9AAAAAACAPiHUQ1SMTep5rp7pM2R6LKoi1AMAAAAAADiswD2QwCA4IyNDLy2zak+NXb52u3ydNkmGdo1j+y0AAAAAAMDhEOohKqanpKi4zaqqPb4e49V0vwUAAAAAADgstt8iagrTjYCx6ma/TJNgDwAAAAAA4FAI9RA1hemBHz+XV2rqjEo5AAAAAAAAQwbbbxE18yZY5bDHqTDdosJ0Q0XpFuWlGoqzBa7gAwAAAAAAwOcI9RA1M8tsmlnGRxAAAAAAAKC/2H4LAAAAAAAADDGEegAAAAAAAMAQw95HxIROn08VLpcqnE6NTUjQ2ISEaJcEAAAAAAAQswj1EDXNXq9u3L5d5S6X6j2e7vHv5ucT6gEAAAAAABwCoR6iJsVq1ScdHfKaZo/xCpcrajUBAAAAAAAMBZyph6ixGoaK4+MDxgn1AAAAAAAADo1QD1FVEiTU29HlVKfbDDofAAAAAAAAw3D77YqVH+mZ51+S0+nSr39+kzIzM/r82MamJr298D19tmmLGpualZDgUHZWpk6aPUMnHD9FFkvPDNTn8+nd95bpgw9Xa09dvaxWi4oKC3Tq/Lk6duLREXh3w0+CJy5grN3v07IKl04b54hKTQAAAAAAALFu2IR6be3tevzJ57R2/aey2+39fnxFZbXuuvd+yZROnD1DhQX56ujo0LL3P9Aj/35Sn23aossvu6THY/75yGP6ZO0GTTzmKM0/+SR5vV4tW7FS9//jEX3l4i9qzokzw/gOh6dMBYZ6krSh1aXTRKgHAAAAAAAQzLAJ9W6/4275fD597+or9ebbi7Rl2/Z+Pf65F16R0+nSD667RuPGlnWPz5o5TbfceodWfrhaZ55+qnKysyRJa9au1ydrN+iE46foysu/2j1/xrTj9bvf/1nPvfiqphw7USkpyWF8l8PP0WkOqTNwfFuHU1JaNEoCAAAAAACIecPmTL0xo0v00xtv0NFHHRHS46dMmaQLzju7R6AnSQkOh8pKSyRJTU3N3eMrP1glSTp1/twe8+Pi4nTS7Blyu91atWZtSLWMJJNHJQQdr/bQLAMAAAAAAKA3w2al3je/cdmAHj9vzuyg4z6fT7t218hqtSovL7d7fPvOctntdhUV5gc8ZkxZ6d4523f2+rzYKy/eLnkNydazMUajSagHAAAAAADQm2ET6oWT0+mSy+XSnrp6vfnOItU3NOriC89TWmpK9/X29g5lZ2UGNM+QpFGj0iVJdfUNfXo9v98f5ncwtNhdcfLYeoZ4HTZ31H9e9r9+tOsAsBf3JBBbuCeB2MH9CMQW7kkMlpgM9V5/850+zZs3Z7YSEoJv3xyIO/9yn6p37ZYkFRbk6/rvXaXx48Z0X3e69gZQ8fHxQR8fH7d33Ol09un1aqsrwlD10JXotqolqeeYL8Gt3ZXlsliMaJXVrW53VbRLAHAA7kkgtnBPArGD+xGILdyTiLSYDPVeee3NPs2bPvW4iIR6l33lS2rv6FBjY5NWfrBKf/nr33Xm6afonDNP6+Mz7N1Kahh9C6RyC0sGUO3Ql7ejSi0HdcswbKY60vI1LjV4d9zB4Pf7Vbe7Stn5RUFXZAIYXNyTQGzhngRiB/cjEFu4JzFQbVu39mleTIZ69/759qi+fmlJUfePT5o9Q3/7xyN67Y23VVxUqGMnHq0Eh0M6YMXewfaPO/bNO5yRfpOXxMdrU5DxtU0uTUjv289hJFkslhH/awTEEu5JILZwTwKxg/sRiC3ck4g0Pl2HYRiGZk6fKklav2GjJCk+Pk5pqSlqbm4Juke+oaFJkpSTkzXI1Q5N45ODB3eftfVt+zIAAAAAAMBIQ6gnqb6+QT/71a368933B73u8Xikgw65HDe2TF6vV+UVlQHzt2zdLkmacMA5fOjdpF5W4+3o45mEAAAAAAAAI82IC/V8Pp9qaveoobGpeywjY5QsFou2bt+hrdt29Jhvmqbe/2CVJGnc2M9DutmzZkiS3l74Xo/5nZ1dWrpipZKSEnXc5EkRfjfDwxEZcfK5Aj+KNT53VOoBAAAAAACIdTF5pl5/NTQ29Vgx19bRLknasHGTkpP3tlXNzMhQaUmRmptbdMutd6ikuFA3/eh6ad8+90svuUj3PfCQ7r3/QZ00a7oKCwvU1eXUqtVrtKO8QmPHlGna1Cndr3HkhHGaNeMErVj5ke574CEdN+VYuVwuLV6yXK2tbfrWFZdFpInHcJTqkMyOOCm+58q8ZgU/sxAAAAAAAGCkGxah3uYt2/Tvx58OGH/ymRe6fzxj2lRdftmXe32OIyeM0//d9AO9vXCxNmzcpCXLV8owDOXmZOn8c8/S/HknyWq19njMpZdcpKKiQi1f8YGeePo5Wa1WjS4t0VcvuVDjx7L1tq8Mw5DDHSeveoZ6TrtbXtOUrY9dhAEAAAAAAEaKYRHqzZpxgmbNOKFPczMzM3rtrpuTnaVLL7moz69rsVg0b85szZszu8+PQXDpZpzqDx60SLvdbhXHx0enKAAAAAAAgBg14s7UQ2zKswU2yzD90i4nW3ABAAAAAAAONixW6mHoG+dwaOXWNHnb7PK2x8nbZpevw67Cm5KjXRoAAAAAAEDMIdRDTDgqNUEtr+cEjFc3+1WUzoJSAAAAAACAA5GWICYUpgVvhlHdbA56LQAAAAAAALGOUA8xobfVeNXN/kGvBQAAAAAAINax/RYxIS/N0AklFhWkW1SYbqgwbe//jymwRrs0AAAAAACAmEOoh5hgtxp6+XtJ0S4DAAAAAABgSGD7LQAAAAAAADDEEOoBAAAAAAAAQwzbbxGzXH6/qlwueUxTRyYmRrscAAAAAACAmEGoh5jy99279XF7uypcLtW43TIlHZ+crL9PmBDt0gAAAAAAAGIGoR5iytqODq1sa+sxVu50Rq0eAAAAAACAWMSZeogpJfHxAWMNXq86fL6o1AMAAAAAABCLCPUQU4KFepJU4XINei0AAAAAAACxilAPMWVnZfAd4RVswQUAAAAAAOhGqIeY8tL7wT+SrNQDAAAAAAD4HKEeYkqRwy7TZwSME+oBAAAAAAB8jlAPMaUozSpvuz1gnA64AAAAAAAAnyPUQ0wpTDeChno7nS6ZphmVmgAAAAAAAGINoR5iSmG6Rb62uIDxDr9PzT5fVGoCAAAAAACINYR6iCmF6Ya8bYEr9UQHXAAAAAAAgG6EeogphemWoNtvRbMMAAAAAACAboR6iCn5aYa8QbbfipV6AAAAAAAA3Qj1EFMcdkOZNpv8HiPgWjkr9QAAAAAAACRCPcSivVtwA1frVRLqAQAAAAAASIR6iEV7O+AGnqtX4XLJb5pRqQkAAAAAACCWEOoh5uztgBu4Us/p96vO44lKTQAAAAAAALGEUA8xhw64AAAAAAAAh0aoh5jT20o90QEXAAAAAABAItRDLDrUSj064AIAAAAAAEi2aBcAHKwwzZDptsq5K1E+p02+dru8bXG69OhEfX9KSrTLAwAAAAAAiDpCPcSczCRD8TapcWlhj/H2XJviLSwuBQAAAAAAICFBzLFYDBWkGQHj1c1mVOoBAAAAAACINYR6iEmF6YEfzeoWf1RqAQAAAAAAiDVsv0VMKkw3lGCXikZZVJhuqDDdotEZgav3AAAAAAAARiJCPcSk27/o0J++JBkGQR4AAAAAAMDBCPUQk+JthHkAAAAAAAC94Uw9AAAAAAAAYIgh1MOQ4jVNVbtc0S4DAAAAAAAgqth+i5i2uq1Ni1paVOF0qsLlUpXLJb+kpVOmyGEhkwYAAAAAACMToR5i2qednXpsz56A8SqXS+MSEqJSEwAAAAAAQLSx1AkxrcThCDpewRZcAAAAAAAwghHqIaaVxMcHHa9wOge9FgAAAAAAgFjB9lvErOZOU3vqrDIkmQddY6UeAAAAAAAYyViph5j1+EcenX+fU542e8A1Qj0AAAAAADCSEeohZhWmG5Ikb3uQUI/ttwAAAAAAYAQj1EPMKkzf+/H0tsUFXGvwetXu80WhKgAAAAAAgOgj1EPM6l6pF2T7rSRVsgUXAAAAAACMUIR6iFk5yYbsVskXZPutJJWzBRcAAAAAAIxQhHqIWRaLofw0I+j2W9EsAwAAAAAAjGCEeohphWkW+TptMn1GwDWaZQAAAAAAgJGKUA8xbe+5ekbwDris1AMAAAAAACMUoR5i2ucdcANDvXKXS6ZpRqEqAAAAAACA6CLUQ0z7vANu4Ll67T6fmr3eKFQFAAAAAAAQXYR6iGkF+1bq9doBly24AAAAAABgBCLUQ0wrOsRKPXGuHgAAAAAAGKEI9RDTCtJ6P1NPdMAFAAAAAAAjFKEeYlqKw1CaQ/K7rPJ7Aj+urNQDAAAAAAAjUUih3soPVqmpqfmQczZs3KSFi5aEWhfQbW8HXCN4B1xW6gEAAAAAgBEopFDv0cefVnlF1SHn1NTU6u133wu1LqDb/g64nqZ4uRvi1bkzRf4tmfrd6NH69ejR0S4PAAAAAABg0Nn6OrF6125VVe3q/nrz1m1y9bL10e3xaPnKD+VysjUSA7d3pZ5PLatyu8cMQ5p/UbLibEZUawMAAAAAAIiGPod6n27cpBdfeaP76/eWrjjsY46bPCn0yoB99q/UO5BpSrWtpoozCPUAAAAAAMDI0+dQ77RT52nG9KnasaNCf3/oUR03eZLy8nKCzrVarMrKzNBxUwj1MHB7V+oFqmr2qziDXi8AAAAAAGDk6XOoJ0mpKSmafOwxGje2TCfPma1xY8siVxmwz8Er9XJTjKCr9wAAAAAAAEaKfoV6+91w7XfCXwnQi6PzrXr2qgQVpluUl2YonnP0AAAAAADACBdSqCdJnZ2devPtRVr36UY1NTXre1d/s3vl3ruLl+mEqZOVkpwczloxQiXHG5o9NuSPKgAAAAAAwLATUlLS3t6hP/zpHjU0Nslqtcrn88mU2X3t2Rde1qIly/TjG75HsAcAAAAAAACEWUhdBt54a6GaW1p12Ve+pFv+3809riUnJ+mqb35dLS0tevPtReGqE+iV3zTlNc1olwEAAAAAADBoQlqpt37DRs2eOU2zZpygrq6ugOuTJx2j2TOna/2GjbrognPDUScgSWryerWkpUXlTqcqXC5VOJ2qdLn0+zFjdFJaWrTLAwAAAAAAGBQhhXrNLS0qLSk+5JzRpcVasfLDUOsCgqp3u/Wr8vKA8QqXKyr1AAAAAAAARENI22+tVqvcbvch53R0dMlqsYZaFxBUkcMRdLzc6Rz0WgAAAAAAAKIlpFCvsKBAa9au7/V6Z2en3lu6XEWFBQOpDQiQYLEo124PGK9kpR4AAAAAABhBQtp+e/JJs/TQo4/rwUce0+RjJ0qS9uypk8vp0vad5Vq+4kO1d3ToC+ecEe56McJ1uk1lW+JVK0+P8XJCPQAAAAAAMIKEFOpNPX6ydtXU6L9vvavVa9ZJkh5/6vkec8487RQdP+XY8FSJEa/DZWra7R1q6jSVdrxVSeN6Xq9xu+X0++WwhLT4FAAAAAAAYEgJKdSTpC+cfYamHjdZq1Z/ot01tXK5XHI4HCrIz9Pxxx2r/Lzc8FaKES0xTvL4TEmStz1w+60kVblcGpeQMMiVAQAAAAAADL6QQr0up1NxdrsK8vNUcE5e+KsCDmIYhgrTLdpU65e3LXioV+F0EuoBAAAAAIARod97FT1er2786a/00ao1kakI6EVhuiFJ8rbFBb3OuXoAAAAAAGCk6HeoZ7fZlDEqXU3NLZGpCOhFYfrej6uvwy7TH3i9glAPAAAAAACMECF1Fbj4wvO0ZPn7+mj1Gvl8vvBXBQSxf6WeTEO+jsAtuBVO5+AXBQAAAAAAEAUhnan3/oerlJebo0f+/aQee+JZpaelKiHBEWSmoRt/eO3AqwQkFaR9nkF72+yypXh6XGelHgAAAAAAGClCCvXWfLK++8cej0d19Q3hrAkIqnulniRve5ykzh7XG71etfl8SrFao1AdAAAAAADA4Akp1PvVz28KfyXAYRSl91ypF0yl06mjk5IGsSoAAAAAAIDBF1Kol5kxKvyVAIeRl2rIMCTTPHQHXEI9AAAAAAAw3IUU6u2pq5fVapVhHHqexbAoKSlRdnvwVVVAf8TZDOWmGKppNeVrD/6ZolkGAAAAAAAYCUIK9X79uz/2ea5hGBpdWqzzzj1T48eOCeXlgG6F6ftCvU6bTK8hw2b2uF5OswwAAAAAADACWPowJ8DEY47SmLJSaV9ol5uTrbLRpcrLzZGxb/le2egSjR0zWhkZo7RjZ4Xu+es/VF5RGd7qMeIUdp+rZ8gbZLVeJaEeAAAAAAAYAUJaqffli87THXfdpzknztTZZy5QSnJy97WOjk699t+3tX3HTl3//auV4HBox85y3Xv/Q/rvW+/q6m9dHs76A6xY+ZGeef4lOZ0u/frnNykzM6PPj21satLbC9/TZ5u2qLGpWQkJDmVnZeqk2TN0wvFTZLF8noGu/HC1/vXYk70+V35ern528w8H/H7QU88OuHbZ0909rpc7nTJNsztcBgAAAAAAGI5CCvWef/E1jS0r1SVfuiDgWlJSoi6+8Dw99K/H9dIrb+iSL12gstGlmjd3tpYuWxmOmoNqa2/X408+p7XrPw3pDL+Kymrdde/9kimdOHuGCgvy1dHRoWXvf6BH/v2kPtu0RZdfdkn3/K6uLknSqfPnanRpccDzJSQ4BviOEExh2oEdcOMkdfS43uH3q9HrVSbnOAIAAAAAgGEspFBv0+atuuiCcw855+gjJ+jFV9/oDv5yc7K7g7BIuP2Ou+Xz+fS9q6/Um28v0pZt2/v1+OdeeEVOp0s/uO4ajRtb1j0+a+Y03XLrHVr54WqdefqpysnOkiR1du59L0cfOUFHHjE+zO8GvemxUq/NLr/XkK8tTidkOXRCdoJK4uMVbwlpVzkAAAAAAMCQEVKo5/F6VN/YeMg5Tc0t6uzs7P66oaFJSclJobxcn4wZXaKLLzpfKcnJevPtRf1+/JQpk3TMMUf2CPQkKcHhUFlpidasXa+mpubPQ719AWVCQkKY3gH64vMz9aSu8lR17UyVZGj+F+P19YK4qNYGAAAAAAAwWEIK9Qry87Rw0RJNGDdW48cFdrStrNqldxcvVVZmpiRpx85yLVqyTGNGlw684l588xuXDejx8+bMDjru8/m0a3eNrFar8vJyu8f3r9RLTNwb6vn9fvn9ftls/f8p9fv9Idc90uSnHfCF+fmqvaomf9h/Hvc/H78+QGzgngRiC/ckEDu4H4HYwj2JwRJSqHfW6afq/n/+S3fd+4AyMkYpNztLcfFx8nq8qm9oVO2eOknSeeeeKUl65fW31NXZpQWnzA1v9RHidLrkcrm0p65eb76zSPUNjbr4wvOUlprSPWf/Sr0VKz/Ux2vWqb6hUX6/X5mZGZo9c5pOO+VkWa3WPr1ebXVFxN7LcGOaksOWIae3ZyOMbbvbVVvdHpHXrNtdFZHnBRAa7kkgtnBPArGD+xGILdyTiLSQQr2Jxxyla779Db3y+luqrKpWY2NTj+vZWZk6fcE8zZoxTZI05diJOvO0UzSmbHSfnv/1N9/p07x5c2ZHZPvrnX+5T9W7dkuSCgvydf33rgpYkbh/pd5Hq9bopNkzlJ+fp9bWNi1eslwvv/pf7dxZoe98+xt96sKaW1gS9vcwnBWN6tTWOrPHWJsvQbmFfe903Bd+v191u6uUnV/Uo/MxgOjgngRiC/ckEDu4H4HYwj2JgWrburVP80IK9STpmKOP1DFHH6muri7VNzTK5XbLbrMrY1S6UlKSe8ydc+LMfj33K6+92ad506ceF5FQ77KvfEntHR1qbGzSyg9W6S9//bvOPP0UnXPmad1zzjvnDDmdTo0dW6YEx+edbmdOn6rb77hb6zZs1Nr1n2rypGMO+3rc5P3znTlxcnv3nq9XmG6oMN2i9AT1KUANhcVi4dcIiCHck0Bs4Z4EYgf3IxBbuCcRaSGHevslJCSouKgwPNXsc++fbw/r8/VXaUlR949Pmj1Df/vHI3rtjbdVXFSoYyceLUkBDTX2s1qtmjd3th574llt/Gxzn0I99M/XptMQAwAAAAAAjGwhR8adnZ164aXXdMttd+iHN/1cW7ft6L727uJlamuPzPlmg80wDM2cPlWStH7Dxj49JjVl79l7XU5nRGsDAAAAAADAyBTSSr329g794U/3qKGxSVarVT6fT6bM7mvPvvCyFi1Zph/f8D2lJCcf9vmirb6+QX++9wFlZWTohuu+E3Dd4/FIB3Sucbnc2rDxM1ksFk05dmLA/Jp9jUIyRo2KeO0AAAAAAAAYeUJaqffGWwvV3NKqy77yJd3y/27ucS05OUlXffPramlp0ZtvLwpXnWHj8/lUU7tHDQc098jIGCWLxaKt23f0WHEoSaZp6v0PVkmSxo3d2yzDZrPqqWdf1MOPPqE9dfU95nd2dmnR4qUyDEPHT5k0KO9ppPu0o0OvNzbq/l279H87dujrn32mv+7aFe2yAAAAAAAAIiaklXrrN2zU7JnTNGvGCerq6gq4PnnSMZo9c7rWb9ioiy44Nxx1HlJDY5PKKyq7v27r2Lv1d8PGTUpOTpIkZWZkqLSkSM3NLbrl1jtUUlyom350vbTv8MpLL7lI9z3wkO69/0GdNGu6CgsL1NXl1KrVa7SjvEJjx5Rp2tQp0r5z8y6+8Dw9/OgTuuOuv2rO7JnKzs5SU1Ozli5/X03NLTr7zAVhP2sQwf3Ptm1q9Hp7jI2yDfi4SAAAAAAAgJgVUvLR3NKi0pLiQ84ZXVqsFSs/DLWuftm8ZZv+/fjTAeNPPvNC949nTJuqyy/7cq/PceSEcfq/m36gtxcu1oaNm7Rk+UoZhqHcnCydf+5Zmj/vJFmt1u75U4+brFHpaXpn0RK9/+EqtbW2KS4+TqXFRfrKxV/UxGOOisA7RTAl8fEBoV6lyxW1egAAAAAAACItpFDParXK7XYfck5HR5esFush54TLrBknaNaME/o0NzMzo9fuujnZWbr0kov6/LpjykZrTNnoPs9HZJQ4HFrT0dFjrNrlksc0ZTeMqNUFAAAAAAAQKSGdqVdYUKA1a9f3er2zs1PvLV2uosKCgdQG9ElxXFzAmE/SLlbrAQAAAACAYSqklXonnzRLDz36uB585DFN3tf9dc+eOrmcLm3fWa7lKz5Ue0eHvnDOGeGuF5AkPbjcrdfWe1Xd4ld9opQ6K3BOhculUocjGuUBAAAAAABEVEih3tTjJ2tXTY3++9a7Wr1mnSTp8aee7zHnzNNO0fFTjg1PlcBBdjb4tWy7T5Jk89qVGmROhdMppaUNem0AAAAAAACRFnKL0C+cfYamHjdZq1Z/ot01tXK5XHI4HCrIz9Pxxx2r/Lzc8FYKHKAw/fOd4952e9A55Wy/BQAAAAAAw1TIoZ4kFeTnqeCcvPBVA/RRYfoBDTB8Fnk7bLIl0QEXAAAAAACMDCE1yuirlta2SD49RrCi9J4fXV+Q1XrlTucgVgQAAAAAADB4+rVSz+Vy693FS7Vl6zZZLBaNLi3RKfNOUkJCQsDcVas/0VPPvqjbf/uLcNYLSAev1JPkbYtTfG5Xj7Faj0ddfr8SLBHNrgEAAAAAAAZdn0M9j8ejP939N1VV7+oe27hpi1Z88JFu/OG1Sk1JkSR1dnbqiadf0Oo1a2UlTEGEZCYZirdJrn07br1twc/Vq3K5ND5I6AwAAAAAADCU9TnUW7hoqaqqd2n6CcfrpNkzZLNZ9cm6DXrrncV69vlXdOXlX9WGTz/TY08+q9bWNhUXFeiyr3wpstVjxLJYDBWkGdrRYEqSvO1xQedVOJ2EegAAAAAAYNjpc6j38SfrNKZstC6/7MvdYyXFRZIpvfveUj32xDNasfIj2Ww2nXfOmVpwylxZWKmHCCpMt2hHg086xEo9OuACAAAAAIDhqM+pW11dvY6bPDFgfOrxk+V2e7Ri5UcaO2a0fnrjDTp9wTwCPUTcgefq+TrsMv2Bc+iACwAAAAAAhqM+r9Rzud1KS0sNGE/fN3b2GQt09pkLwlsdcAiFB3bANQ35OuyypXh6zKEDLgAAAAAAGI76tZzOYgRON4y9q6XGjx8TvqqAPgjsgBu4BbeClXoAAAAAAGAYYo8shqweK/UkedsCm2U0eb1q83oHsSoAAAAAAIDII9TDkBUQ6rUHb5bBaj0AAAAAADDc9C/UMw516RAXgQgoSDt4+23gSj3RARcAAAAAAAxDfW6UIUn//s/Tevyp53oOmnv/97d/PCKrtWdGaMjQbb/5+cCrBIJIjDM0KtFQU+feD+H+M/UMUxqd4FBJfLxK4uM1Oj4+ypUCAAAAAACEV79CPafLJfWy6MlJl1FEQWH656Gev8um2ldHa+KoOD1zbXK0SwMAAAAAAIiYPod69/zptshWAoSgMN2i9bv8+74y5Ouwaxc7wQEAAAAAwDBHowwMaUXpgQleXbspp8eMSj0AAAAAAACDgVAPQ9rBHXD3291CqAcAAAAAAIavfp2pB8SaI/MsmjfBqsJ0iwrTDBWmW1SUbig3lT24AAAAAABg+CLUw5A2f4JN8yfwMQYAAAAAACML228BAAAAAACAIYZQDwAAAAAAABhi2LeIYafL71eV06lyl0sVLpcqnE55TVO/KSuLdmkAAAAAAABhMaBQb3dNrdZ/+pkaG5s0/+STlJOdJUlqbm5RenpauGoE+uW35eV6vampx1icYehXpimrQQMNAAAAAAAw9IUc6j393EtavGR599fHH3escrKz5PP59Nvf/0nTph6nL190frjqBPqsxOEIGHObpmrdbhXEx0elJgAAAAAAgHAK6Uy9FSs/1OIlyzVubFlAcOfxeDVh3Fi9t3SFVqz8MFx1An1W2ktwV+FyDXotAAAAAAAAkRBSqLf8/Q81pmy0brj2O5o2dUqPaw5HvK765tc1bmyZlq34IFx1An0WbKWeCPUAAAAAAMAwEtL22127a3TeOWcecs7U4ybr5Vf/G2pdQJ/tafPruY+9qmr2q7rZVGW7V5oZOK/c6YxGeQAAAAAAAGEXUqjn8/nk6GU11H5xcXFyezyh1gX0WVOnqV+9duAqPEO5k62yJvh6zKtkpR4AAAAAABgmQtp+Oyo9XZVV1Yecs3b9BmWMSg+1LqDPCtICP8bednvAWDmhHgAAAAAAGCZCCvUmTzpGS5ev1IaNm7rHDBmSpD119XrsiWf0ydoNmnzsxPBVCvQixWEo7aCFo962uIB5u1wuefz+wSsMAAAAAAAgQkLafnvGafO17tONuu+Bh5SYmCBJ+td/npLL6VJHZ6ckKS83R6cvmBfeaoFeFKZb1FLzeWDnawtcqeeXVO12a/Rhto4DAAAAAADEupBW6iUkJOh/b7hWp86fK7t9b3jS2Nikjs5OjUpP14JTTtaPb/i+EghPMEgK040eX3vbA1fqSVIFzTIAAAAAAMAwENJKPUlyOOL1xfPO1hfPO1tdXV1yudxyOBxyOOLDWyHQB4XpFkmfN8bwBlmpJ87VAwAAAAAAw0TIod6BEhISlJCQEI6nAkISuFLPLtOUjJ7DdMAFAAAAAADDQsihXmVVtdau+1Qtra3y+YI3HzAM6WtfvXgg9QF9snel3gH8Fvk6bbIleXsMl7P9FgAAAAAADAMhhXqr16zVQ/96XKZpHnYuoR4Gw8Er9bSvA+7BoV4FK/UAAAAAAMAwEFKo98abCxUfF6fTTp2ngoI8OeI5Rw/RFbBSb38H3LyeY3s8HnX5fEqwWgevOAAAAAAAgDALKdSrq6/XWaefqtMXzA9/RUAIclMMWQzJf8DiUW978GYZlS6XJiQmDl5xAAAAAAAAYRa4vKkPEhMTlZKSEv5qgBDZrIbyUg9qltEWF3QuHXABAAAAAMBQF1KoN/W4Y7X+043hrwYYgIO34Hrbel+pBwAAAAAAMJSFFOp94ZwzZZqm/vnwY/ps0xbtqatXY1NT0P+AwVJ0ULMMX6ddZpDGzHTABQAAAAAAQ11IZ+p1dnTK7XLrs81b9fEn63qdZxiG7r7z1oHUB/RZQLMM05C33S57qkcWSQXx8SqJj9cRnKcHAAAAAACGuJBCvf88+aw+27xVOdlZys/PpfstYkLhQSv1JKn5gzw99NVEzS1MkN0S0sJUAAAAAACAmBNSqLdt+07NmHa8vn7pl8NfERCigJV6kjyNDpkd8QR6AAAAAABgWAkp6TBlasL4ceGvBhiAYCv1JKm6OcjBegAAAAAAAENYSKHeuDFlqt61K/zVAAMQbKWeJFU1m4NeCwAAAAAAQCSFtP32kosv0F/vf0hZmSs0a+Y02W0hPQ0QVqmOvf8lxhkqTDdUmG5RQZqh2WOs0S4NAAAAAAAgrEJK4x5+9EnFxdn11LMv6unnXlJqSrKsQYI9Q9Kvfn5TOOoEDsswDG34ebJs1uDbcAEAAAAAAIaLkEK97Tt2dv/YNE21tLaFsyYgZAR6AAAAAABgJAgp1PvzH34jG1tuAQAAAAAAgKgIKZkj0MNQ4/H7VeV2q9LpVLnLpQqXS9/Lz9couz3apQEAAAAAAPRbRNM5n88nq5UmBYiut5qa9NMdO+Q/aPysUaMI9QAAAAAAwJAUUqh37Q9u7tM8wzB09523hvISQNjk2O0BgZ4klbtcOj4lJQoVAQAAAAAADExIod6o9HQZQfoReH0+te5rmlFYkK+EBMeACwQGqsQR/HNY4XQOei0AAAAAAADhEFKod8v/632lnsfr1fIVH+i9ZSt0xde/OpDagLBIt1qVYrWqzefrMV7hckWtJgAAAAAAgIEI+5l6dptNJ8+Zra4up55/8VVdeTnBHiKvqtmvxg5TkrSr2a/dLab2tPm1p91UXZspTbBLjp6h3uZ2p6qa/SpKt0SpagAAAAAAgNBErFHGhPFj9O57SyP19EC3qma/Tvpjh1ze3uekp9qVOLrndttqt1sn/bFdS3+cTLAHAAAAAACGlIglGR2dXXK7PZF6eqBbY4d5yEBPkrztgV1uDaspb5y3e4UfAAAAAADAUBHSSr3GpqZer3m9PtXuqdMLL7+m7KzMgdQGhI23LS7ouC3FPei1AAAAAAAADFRIod4vfn17n+Z97asXh/L0QNj52gJX6kmSNYXVpAAAAAAAYOgJKdQbN6ZMMoJfs1qtSk9L1ZTJkzTpmKMGWB4QHt52VuoBAAAAAIDhI6RQ74brvhP+SoAIMr0W+bqssib07IBrS2alHgAAAAAAGHpo+YkRI9i5eja23wIAAAAAgCGoTyv1Xnvj7ZCe3DCks85YENJjgXDzttsVn9PVY8ya6JHX9EuyRq0uAAAAAACA/upbqPff0EI9iVAPsSPYSj3DItX53JKCN9IAAAAAAACIRX0K9ehii+Ggtw64NV6XpKRBrwcAAAAAACBUfQr1Zk6fGvlKgAjztvcS6vlcg14LAAAAAADAQITU/fZAtbV1qq2rk9vlVrwjXvm5OcrKygxPdUAYedvtMs29Zz0eqJZQDwAAAAAADDEhh3qfbdqip559UXvq6gOuFRcV6qtf/qJKiosGWh8QPn6LfB022ZK9PYZrvYR6AAAAAABgaAkp1CuvqNR9Dzwkv2lqTNlo5eflKM5ul8vt1q5dNdpZUam77n1AN/7gOuXmZoe/aiBE3va4gFCP7bcAAAAAAGCoCSnUe/PtRbLHxekH131HhQX5Add3llfqr/c/qDfeWqhvfO2ScNQJ9CojyVC8TXJ5Dz/X22aX8j7/2tdlU/Eoh7ymKdvB+3IBAAAAAABiVEih3rYdOzVvzuyggZ4kjS4t1tw5s7Ti/Q8HWh9wWEXpFi39cZIaO8zusd0tfl3xL2fA3DPSMjQ5LV251njl2uKUn2xTUbplkCsGAAAAAAAYmJBCva7OrsNuq83LzVF7e0eodQH9UpRuUVH651+Pzwke1KV7EvStsY7BKwwAAAAAACACQlqi5EhwqLml9ZBzmlta5XAQniA6EuyGRiUGjte2mcGmAwAAAAAADCkhhXqjS0u06L1lampuDnq9salJixYvVVlZ6UDrA0KWmxL48d7dQqgHAAAAAACGvpC23552ysm6694H9Jtb79SkiUerID9XdnucOjo6tLumVus//UwyTZ2xYF74Kwb6KC/N0Ge1e3/ssEv5qYYK02mGAQAAAAAAhr6QQr1xY8t05eVf1ZPPvKCPVq8JuJ6amqKvfvlClY1mpR6i55fnxEvnSHmpFqU6JIPutgAAAAAAYJgIKdSTpOOnHKtjJx6tLdu2q6Zmj1wut+Lj41WQn6txY8tktVrDWynQT0fk8hkEAAAAAADDU0ih3rIVK3X8cZOV4HDoqCMm6KgjJoS/MgAAAAAAAABBhRTqPf7U83rm+Zd17KRjNHPaVB15xHi2NmLI8ZmmatxulbtcqnQ6dUxSkiYmJUW7LAAAAAAAgMMKKdQ7fcE8rfp4rVat/kSrVn+itNQUTZ82VTOmHa+83JzwVwmEUavXq29u3qwql0se8/NuuN/KyyPUAwAAAAAAQ0JIod5555yp8845UzvLK/XRqo+1+pN1euudRXrrnUUaXVKsGdOnaupxk5WYmBD+ig9jxcqP9MzzL8npdOnXP79JmZkZIT/Xxk2bdc99/5Qk3fvn2wOu+3w+vfveMn3w4WrtqauX1WpRUWGBTp0/V8dOPHpA7wORk2K1arfb3SPQk6QKpzNqNQEAAAAAAPRHyI0yJGl0abFGlxbroi9+QZu2bNOq1Wv0ydoNevKZF/TsC6/o2IlH6ZvfuCx81R5CW3u7Hn/yOa1d/6nsdvuAn8/pdOmxJ5495Jx/PvKYPlm7QROPOUrzTz5JXq9Xy1as1P3/eERfufiLmnPizAHXgfAzDEOl8fHa1NXVY7zC5YpaTQAAAAAAAP1hCceTGIahIyeM02Vf+ZJuveVnuuwrX1JCgkOr16wLx9P3ye133K0d5RX63tVXqrS4aMDP9/xLr6q9vUO5OdlBr69Zu16frN2gE46fou9edYVmzThBc06cqR9e/11lZ2XquRdfVVtb+4DrQGQUx8cHjFW4XDIPWr0HAAAAAAAQiwa0Uu9AdfUNWv3xWq1Zu05V1btlmuaAtr7215jRJbr4ovOVkpysN99eNKDn2rR5q5at+EDnnXOmPt24SbV76gLmrPxglSTp1Plze4zHxcXppNkz9PxLr2nVmrWaN2f2gGrBwHl9puraTdW2mqpp9cvjk0qzHAHzuvx+1Xs8yo6Li0qdAAAAAAAAfTWgUK+hsUmr16zV6o8/UWXVLklSYkKCZs+crhnTjtOYstHhqvOwwrXN1+ly6bEnnlFxUaEWnDJXn27cFHTe9p3lstvtKirMD7g2pqx075ztOwn1ouyGp7v09Gqv/AcswMtNMfSbawJX6mnfaj1CPQAAAAAAEOtCCvUWLlqi1R+v1c6KSkmS1WrV5EnHaPoJx2viMUfKarWGu85B8+LLr6ulpVXXXHWFLJbgu5OdTpfa2zuUnZUZdM6oUenSvtWLfeH3+wdYNXrjsKlHoCdJde2m8q3Bz13c6XTquH0dcPf/uvDrA8QG7kkgtnBPArGD+xGILdyTGCwhhXrPvfiqtG9F2rSpx4W90+3rb77Tp3nz5sxWQkL4Xnfzlm1asux9nXPmAhXk5/U6z7mvoUJ8kHPZJCk+bu+4s4/dVGurK0KqF4eXpARJiT3G/Kbk2h08cP2svk61zo4eY3W7qyJaI4D+4Z4EYgv3JBA7uB+B2MI9iUgLKdQ758wFmnbC8cqK0Jl5r7z2Zp/mTZ96XNhCPbfbrceeeEYF+Xk6fcH8AT7b3qVhhmH0aXZuYckAXw+9GVfjkVa6A8YdSUVKc7eqxefrMd5gj+v+9fD7/arbXaXs/KJeV20CGDzck0Bs4Z4EYgf3IxBbuCcxUG1bt/ZpXr9DPbfbo3cXL1NWVmbEQr17/3x7RJ73UF54+XU1NjXrxh9ee9jtwwmOvU0W9q/YO9j+cYcjsBlDMNzkkZOfFvzXck/b3g64LZ2dPcYr3O6AXw+LxcKvERBDuCeB2MI9CcQO7kcgtnBPItL6HerFxdllt9vU1tYemYqiYOv2HXpv6QrNPWmWkpOT1NTc3H3N6/VKUvfYqPR0xcfHKS01Rc3NLfL7/QE3aUNDkyQpJydrUN8HAuWlBl8tWdNqqjTfofUHhXpVLpd8pilrH1dZAgAAAAAARENo22/POl2vvvGWykaXqGx0afirGmSbNm2VaZpavGS5Fi9ZHnTOz355q3TAKsJxY8u06uO1Kq+oDPg52LJ1uyRpwrgxEa8dh5aXGvxfRWpaTZWMDjwT0WOaqnG7VdjLeYkAAAAAAACxIKRQr3ZPnUpLinTnX/6mzIxRysrMkCMhcKupIUPfuuKycNQZNj6fT3X1DbLb7crMGCVJOmHqFJWUFAWd/9Irb2jX7hpdc9UVPcZnz5qhVR+v1dsL39NV3/x693hnZ5eWrlippKREHTd5UoTfDQ4nLWFvB1ynt+d4batfx/cS3JW7XIR6AAAAAAAgpoUU6r3z7nvdP65vaFR9Q2M4a+q3hsYmlVdUdn/d1rF3a/CGjZuUnJwkScrMyFBpSZGam1t0y613qKS4UDf96HpJUm5OtnJzsoM+9zsL977XSccc1WP8yAnjNGvGCVqx8iPd98BDOm7KsXK5XFq8ZLlaW9v0rSsuC2tnXoTGMAzlphoqbzR7jO9uNVXSy5mHFU6nZqemDlKFAAAAAAAA/RdSqPc/3786/JUMwOYt2/Tvx58OGH/ymRe6fzxj2lRdftmXw/q6l15ykYqKCrV8xQd64unnZLVaNbq0RF+95EKNH8vW21iRl2pReWPPLre1raZK4nsJ9XppgAIAAAAAABArQgr1xsfYWXGzZpygWTNO6NPczMyMfnXXveG67/R6zWKxaN6c2Zo3Z3afnw+DL1izjJpWvxKtVmXZ7ar3eHpcI9QDAAAAAACxbkC9lTs6OrV6zVq9vXCxmpo+7xjrdnsO+ThgMAUL9Zq7pC6PqdIgZ+dVOJ2DVBkAAAAAAEBoQlqpJ0kLFy3Ry6/9Vx7P3g4EpaXFGjUqXX6/X7fceodOnjtbC+bPDWetQEh664C7dwtuvFa1t/cY3+12y+33h35zAAAAAAAARFhIK/U+WbdBz734qkalp2vBKSf3uOZ0OpWamqwXXnpNn6zbEK46gZDlBlmpp31bcIM1y/BLqmYLLgAAAAAAiGEhhXqL3lumgvw8/eTGG3T6qfN6XEtMTNQPrrtGRYUFWrxkebjqBEIWbPutDlipd7BRNpuavN5BqAwAAAAAACA0Ie0wrKrepbNOP1V2m01eT+D5eTabTTOnT9Ubby4MR43AgPS2/XZ3q6kZiYm6Oi9PxQ6HSuPjVRIfrxTb3tvC7/cPcqUAAAAAAAB9E1Ko53a5lZycfMg5SUmJcrpoOIDo6237bW2rX3lxDn2noGDQawIAAAAAABiIkLbfpqWlqrZ2zyHnbN6yTampqaHWBYRNYpyhtMCj81TTakajHAAAAAAAgAELKdQ7+qgjtHjpClXv2t09Zmjvaqgup1Ovv/mO3v9glSYefWT4KgUGIC8t8KNOqAcAAAAAAIaqkLbfnnX6qVq7boN+f+c9ys/LkSS98PJr8vn8qqndI4/Ho9TUFJ1x2inhrhcISW6qoU21PcdqWzkzDwAAAAAADE0hhXppaan63x9eq2dfeEXr1n0qSdpZXilJslqtOn7KJH3x/HOUlpoS3mqBEF0y1a6Tx9mUm2ooP9VQbqql1664AAAAAAAAsS6kUE+SRqWn69tXfE0ej0e1e+rkcrnlcMQrJydbdlvITwtExIVT7NEuAQAAAAAAIGwGnL7Z7XYVFRbI6/XKRpgHAAAAAAAARFzIKdyeunq99c4ibd6yTY1NzTJNUxaLRVmZGTr6yAk6df5cjRqVHt5qgQgzTVN1Ho8qXC75/X4VR7sgAAAAAACAIEIK9Soqq3TXPQ/I5XZLkpKSEmW32+V2u7Wnrl576ur1wUcf63+uvVqFBfnhrhkIuz9VVenDtjZVuFzq8u9toDExMVG3JTmiXRoAAAAAAECAkEK9F195Q26PR1++6HxNmzpFCQkJ3dc6Ozv1/ger9PxLr+nFV97Q966+Mpz1AhFR6XJpU1dXj7Fyl0tmYnzUagIAAAAAAOhNSKHezp0VmjdntuaeNCvgWmJiok6ZN0f1DY1a+eGqcNQIRFxpfGB41+bzqdU0lReVigAAAAAAAHpnCeVBpkwVFxceck5JcZFkhloWMLiKHcG32e7y+Qa9FgAAAAAAgMMJKdQryM9TY1PzIefUNzSooIA1Tohdbq+pPW17z88LtlJPknb5/INcFQAAAAAAwOGFtP32nDNP078ff1rHTjxaBfmBwV1N7R4tWfq+Lv/aJeGoEQiLB5e7tXCTVzWtpmpaTTV0mMpPNbT6p8kq6WWlXjUr9QAAAAAAQAwKKdSr3VOnoqJC3fqHuzRubJkKC/LlcMTL4/GqpqZWm7ZsVdnoUpWXV6q8vLL7cYYhnXXGgnDWD/TZZ7V+vbOpZ0i3p92Uz28qy2ZTosWiTn/PlXms1AMAAAAAALEopFDvmedf7v7xlq3btWXr9oA5vY0T6iFa8lKMgDGfX6pvN5WbalFxfHxAB9xqLyv1AAAAAABA7Akp1Pve1VfKZrPJMAJDEiBW5aUF/7zWtJrKTZVKHY6AUG+XzyfTpOMLAAAAAACILSGFerk52crMzAh/NUAE5aYG7wtT02pqsqTiIM0yXJLqPB7lWa2DUCEAAAAAAEDfhBTq/fK3f9AR48dq9qzpmjzpGFkJPDAE5Kf2tlLv0B1wK1wu5fXSSAMAAAAAACAaQgr1iosK9dnmrfps81YlJSVqxrSpmj1zmvJyc8JfIRAmub2EerWte7fX9tYBt8Ll0vSIVgYAAAAAANA/IYV6N/7wWtXXN+jD1Wu0avUnWrhoiRYuWqIxZaN14qzpOn7KJNnt9vBXCwxARqKhOKvkPqj3Rc3+UO8QK/UAAAAAAABiSUihniRlZWXqrNNP1Vmnn6qq6l36aNUarfp4rR79z1N6+rmXNG3qFM2eOV3FRQXhrRgIkWEYyk01VNnUs/HF/u23aTab0qxWtfh6pn6EegAAAAAAINaEHOodqKiwQEWFBbrgvLO1Zdt2vfraW1qy7H0tWfa+xpSN1hmnzdcxRx0RjpcCBiQvaKj3+delDofWdnT0uE6oBwAAAAAAYk3wdqAhaG1r09vvvqfnXnhFW7fvkCSVjS5R7Z49uu+Bh/TgI/+R1+sN18sBIckL0gH3wFAvWAfcardbXtMMGAcAAAAAAIiWAa3U8/v92rBxk1a8/6E2fPqZfH6/EhMSNG/uiTpp9gzl5ebI7Xbrldff1MJFS5WenqYLzz8nfNUD/RSsWUZTpymX11S8zQjaAddrmtrtdgcN/AAAAAAAAKIhpFBvT129Vqz8SCs/XKXW1jZJ0ujSYs2ZPVPHH3dsjyYZcXFxuvD8c9XW1qEPPlxNqIeoyjtEB9ySDKP3DrhOJ6EeAAAAAACIGSGFer/+3R8lSY74eM05caZOmj1DhQX5h3zMUUdO0MefrAutSiBMgm2/1b5mGSUZlkN2wD0xwrUBAAAAAAD0VUihXnFRgU6aPVPTpk5RXFxcnx5TNrpEX7/04lBeDgib3lbq7T9Xr7fVeLvc7ojWBQAAAAAA0B8hhXo3/ej6fj8mOytT2VmZobwcEDa9r9TbG+olWq06PzNTo2w2FcfFKaWtWZMLS5TZx/AaAAAAAABgMPQ51NuybXtILzB+7JiQHgdEQrBGGdq3/Xa/X5SWSvsawdQ6O5Rht8swgj8OAAAAAAAgGvoc6t11zwMhvcA9f7otpMcBkZAcbyg5Xmp39Rzfv1IPAAAAAABgKOhzqDf52GNkqOdqJZ/Pp3UbNmrcmDIlJydFoj4g7PJSLdpa5+8xVkuoBwAAAAAAhpA+h3pXXfn1gLHOzi7d+H+/0jlnn8Y2WwwZeamGttb1HDtw+y0AAAAAAECsC6lRxn4cM4ahaHKRVT6/lJdmKC/VUG6KRcWj+DADAAAAAIChY0ChHjAU/eys+GiXAAAAAAAAMCCWaBcAAAAAAAAAoH8I9YDDME1TTV6v1nd0RLsUAAAAAAAAie23QHDLW1v1WkODtre1andji1p9PknSe5MnK8lqjXZ5AAAAAABghCPUA4KodDr1elNTwHiFy6WjEhOjUhMAAAAAAMB+fQ71nn/ptYAxr9crSVqy9H2t3/BZwHVD0gXnnT3QGoFBV+JwBB2vcDoJ9QAAAAAAQNT1OdR75933er22es3aXq8R6mEoKo0P3iG3wuUa9FoAAAAAAAAO1udQ72tfvTiylQAxJDcuTnbDkMc0e4wT6gEAAAAAgFjQ51Bv5vSpka0EGEQflfu0bpdPNa2malr8qmkzJVN68tt7t9ZaDUNF8fHa4XT2eFz5QV8DAAAAAABEA40yMCI9scqjxz7w9BizWSS/35TFYkj7tuAeHOpVuFwyTVOGYQxqvQAAAAAAAAeyRLsAIBryUwNDOa9fauz8fLttcZBz9dp8PjX7fBGvDwAAAAAA4FAI9TAi5QYJ9SRpd8vnoV5Jb80y2IILAAAAAACijFAPI1JeavCPfm3b4UO9cpplAAAAAACAKCPUw4iU18tKvZpWf/ePewv1KlmpBwAAAAAAooxQDyNSr6HeAdtvM202JQSZxko9AAAAAAAQbQMO9dra21VeUSWnk6ADQ0dGoiG7NXC85oDtt4ZhqMAaOKmCUA8AAAAAAESZLdQHbt9Rrmeef1kVlVWSpP+59mqNHztGkvT3hx7V/LknadzYsvBVCoSRxWIoJ8VQdbPZY7ymxd/j60KrVdu8PbvdVjid8pumLEbw1X4AAAAAAACRFtJKvepdu/WXv/5d1bt2q2x0aY9r7e0d2rRpq+69/0FVVe8KV51A2OUH2YJb29oz5Cu0Bt4iLtNUnccT0doAAAAAAAAOJaRQ779vLZQjPl4//d8b9N2rruhxLTk5ST+96QYlOOL11juLw1UnEHa5QTrgHrj9VlLQ7bfiXD0AAAAAABBlIYV6W7fv1JwTZyo3N1vBdiBmjBqlOSfO1NbtO8JQIhAZwZpl1Lebcns/D/Z6C/Uq6IALAAAAAACiKKRQr6O9Q9nZWYeck5WVqfb2jlDrAiKutw64e9o/D/WCbb8VzTIAAAAAAECUhRTqJSQkqLW19ZBz9uypV0KCI9S6gIgLtv1WkmpaPg/1ki0WpQfrgMtKPQAAAAAAEEUhhXpjxpRq2YoP5Ha7g17fum2H3l28VGPHjB5ofUDEBGuUIUk1rT074JY4AsNpVuoBAAAAAIBosoXyoDMWnKI77/qrfvf7P+voo46QJK1a/YnWrd+oHTvLtWNnhaxWq85YcEq46wXCJreXUO/gDrhTk5OVarWq1OFQSXz83v+CBH0AAAAAAACDJaRQr7SkSFd/63I99uSzem/pCknS0uUru6+npaXq0ksuUklxYfgqBcIsr7fttweFet/Lz5fFEtKiVgAAAAAAgIgIKdSTpGOOPlK3/OJmbdm2Q7t318jlcsvhiFdBfp7GjS0jBEHMS3EYSoqTOg7aRX7w9lsAAAAAAIBYE3KoJ0lWq1VHThinIyeM6x7z+XwEehgy8lINbavvuTLv4JV6AAAAAAAAsSbk9O2zTVt02x/v0q7dNT3GV364Sr+57U5t3rItHPUBERVsCy6hHgAAAAAAiHUhhXo7dlbovgce0q7dtfJ6vT2uJScnq76hQff+7Z8qr6gMV51AROxvlpHqkMbnWDR3nFUnjrVGuywAAAAAAIBDCmn77RtvvqP0Uem6/rvfVmZmRo9rx048Wr/62U368z3367X/vqPvXnVFuGoFwu6WLzj0hwulxLjgnXABAAAAAABiUUgr9corqzRvzokBgd5+aWmpmnvSLFVUVg20PiCiMpIMAj0AAAAAADDkhBTqOZ0uxcfHHXJOUlKiurqcodYFxLx2n09OP51yAQAAAADA4Atp+212VqY+27RZs2dO63XOmrXrlZ2VOZDagJhR7/HolYYGVbhce/9zOtXg9eoPY8bolPT0aJcHAAAAAABGmJBCveknHKcXX3lDCQnPaca0qcrOzpTdbpfL6dKumhotXbZSa9d9qvO/cFb4KwaioN3n0927dgWMVzhZjQoAAAAAAAZfSKHeKfPmaEd5hZat+EDLVnwQdM6xk47WqfPmDLQ+ICYUxsXJKsl30HiFyxWligAAAAAAwEgWUqhntVp19Tcv1yfrNmj1mrWqqdkjl8ul+Ph45efl6vjjjtWxE48Of7VAlNgtFhXEx6vyoBCPUA8AAAAAAERDSKHefpMnHaPJk44JXzVADCsJFuqx/RYAAAAAAETBgEI9YDhweU3taTW1u9Wv2lZTu1tNdbpNXT/P3mNeSXy8lh302AavV+0+n5Kt1kGtGQAAAAAAjGwhh3pLlr2v1WvWqrm5RT6/P+gcQ9Kvfn7TQOoDIu6nL7j0n488PcbsVum6k3veHiUOR9DHV7pcOioxMaI1AgAAAAAAHCikUO/dxUv17AuvhL8aIApyU42AMY9PaursOVYSHx/08W80NhLqAQAAAACAQRVSqLd0+UrlZGfpa1/9koqLCmW32/vwKCA2BQv1JGl3q19ZB3xd2kuo93x9va4pKFCCxRKhCgEAAAAAAHoKKYVoaGzS/JNP0piy0QR6GPLyU4PfBrWtZo+vc+PiFGcEBoAdfr8erqmJWH0AAAAAAAAHCynUS0pMkM1GYwAMD72t1Ks5KNSzGIaKe1mt93BtrSrphAsAAAAAAAZJSNtvJx87Ues//UyzZkwLf0XAIMtPCx7q1baaUkHPseK4OG0LEt6Zpqnbq6p099ixMoKs5gNGuveam/X7qirdWFSkuenp0S4HQD9VNfvV2NHzH7tMv18NdVbtkU+GxQz6uIwkQ0XpHE8BAAAQCSGFehd84Szd/89/6fGnntP8uScqOztLVisr9zA0ZSYZslok30FNnHe3Bn6D0ltg55O0orVV77W06GQCC6CHLr9ft1ZWao/Ho1srKzUtNZUzKIEhpKrZr5P+2CGXN9jVdEm9r1SPt0lLf5xEsAcAABABIYV6v7n9TzL9pjZt3qplKz7odZ5hGLr7zlsHUh8QcVaLoZxkIyDEq23r+XWX36+P2tt7fR6LpNsqKzWdwALo4aGaGtV5PJKkOo9HD9fU6LsFBYd9HIDY0Nhh9hLoHZ7Lu/fxRfx7FwAAQNiFFOp5PB7ZrDZljOJvaBge8tKChHoHff1QTY3afb5en8NPYAEEqHQ69XBNjfbfTea+MyjPzchQscMR5eoAAAAAYOgKKdS79dc/C38lYbJi5Ud65vmX5HS69Ouf36TMzIyQn2vjps26575/SpLu/fPtPa6t/HC1/vXYk70+Nj8vVz+7+YchvzYGV26KZV8s97kDG2UcHEz0hsAC+Jxpmrq9sjL4OGdQAgAAAMCAhBTqxaK29nY9/uRzWrv+U9nt9gE/n9Pp0mNPPNvr9a6uLknSqfPnanRpccD1hAQCnaEkWLOM+g5THl/vwURv9s+/e9w4AguMaItbWrSirS1gnDMoAQAAAGDgBhTqbfj0M63/9DM1NjbpvHPPVGFBviSpvKJSpSWBQVck3X7H3fL5fPre1VfqzbcXacu27QN6vudfelXt7R3KzclW7Z66gOudnXtDvaOPnKAjjxg/oNdC9OWmBoZvpik1dFrkcbmCBhO98Ula0damnU6nyhISwlwpMDR0+f26vbJSgWtg9+IMSgAAAAAYmJC+k/L7/br/H4/ovr8/rCXL3teGjZvUuW/lmtvt1p/vuV9/+/vD8vuDfSsXGWNGl+inN96go486YsDPtb8ByNlnLFBqSkrQOfvfbwKhzbCQnxr8VqjrsGh0fLxmpaSor/2drZJmpaZqNNtvMYLtb47R258CB55BCQAAAADov5BW6i1cvFTrNmzU9BOO03GTJ+n+f/7rgKuGTpw1Q4veW6ZF7y3TKfPmhK/aQ/jmNy4Ly/M4XS499sQzKi4q1IJT5urTjZuCztu/Ui8xcW+o5/f75ff7ZbP1/6d0MMNPBJeTHHy8rtMi0zT1v0VFunjjxj49l2EYurGwUKZpyjQPdwofMPxUulz9OoPy7FGjVBwff9jn3f97Jb9nAoPLHOA9Z/r98vs5jgKIJP6MBGIL9yQGS0ih3ker1mjiMUfp8ssu6T5bbr+4OLu+9MUvqLGpSR98tHrQQr1wefHl19XS0qprrrpClkNsCdu/Um/Fyg/18Zp1qm9olN/vV2ZmhmbPnKbTTjlZVmvf1nbVVleErX6ExtZllRR4tteedovqdlcpTtKXEh16qtN5yKDCkPSlhHjZ62tVG9GKgdhkmqZ+09J22EBvP79p6jdbt+hXaSl9PoOybnfVgGoE0D8NdcH/jOz742tUq967xwMIH/6MBGIL9yQiLaRQb09dnU6cNf2QcyYefaSee+HVkIp6/c13+jRv3pzZYd3+unnLNi1Z9r7OOXOBCvLzDjl3/0q9j1at0UmzZyg/P0+trW1avGS5Xn71v9q5s0Lf+fY3+vRNam5hSdjeA0LjyDAldQaM13UYys4vksVi0bV+vxZu3KiGXrYUWiRl2e36/rgJcnBGGEaoHU6nVtc39Xm+X9Jqj1ddWbkqO8yWdb/fr7rdVd33JIDBsUc+Sc6QH5+Znafcwr4eYgEgFPwZCcQW7kkMVNvWrX2aF1Ko5/ebh91mahiGfP7Q/lX2ldfe7NO86VOPC1uo53a79dgTz6ggP0+nL5h/2PnnnXOGnE6nxo4tU8IB34jOnD5Vt99xt9Zt2Ki16z/V5EnHHPa5uMmjLz3RlMMuOT09x+s6LLJY9v6XaLHo5uJi/Wh78CYsfkk3FxcrMYQt2MBw8Vlnp4x9W2v7wippemqqxiQk9Hml3v57EsDgKG8a2Co7g3sWGDT8GQnEFu5JRFpI6UN2Vqa2bd+hWTNO6HXOBx99rOysrJCKuvfPt4f0uIF44eXX1djUrBt/eG2fts2OG1sWdNxqtWre3Nl67IlntfGzzX0K9RB9hmEoP9XQjoaeUURdR8/fgE9OS9OslBR90NbWYyPR/mBiblpa0Off4XSqxu3WrNTUiNQPRJvb79edVVV6ur6+X48zDEM3FRf3OdADMLi21/t18wuhr9IDAABA5IQUGU89frJWfrhaS5a9L5fLLUkyZMjlcmvjps26+69/15at23XC8VPCXW9EbN2+Q+8tXaE5J85UcnKSmpqbu//zer2S1P11X+zvmNvl5C/BQ0lukA64B4d6+wOIgx0qmNjjduvarVv1P1u36rXGxjBXDUTfbrdb3968uf+BnqQrcnP71CQDwOCravbry//oVFPg6RQAAACIASGt1Fswf64+27RFTz7zgp585gVJ0j1/+2d3ACZJ48eN0anzh0aTjE2btso0TS1eslyLlywPOudnv7xV2reK0OVya8PGz2SxWDTl2IkBc2v21EmSMkaNinDlCKe81MBAzu0LHCt2OHRFXp4e3Nfd81DBRKvXq2u3blWNe2/4/fOdO9Xk8eiy3NwIvQtgcL3f2qqf7tihFl//tuftP4PyirxDn18KIDr2tPn15b93qrqZLu4AAACxKqRQz2az6frvXaWly1fqw1VrtLumVi6XS4kJCSrIz9PU4yfrxFnTY3LvuM/nU119g+x2uzIz9oZuJ0ydopKSoqDzX3rlDe3aXaNrrrqie8xms+qpZ1+U0+nST2+8QTnZn28z7uzs0qLFS2UYho6fMmkQ3hHC5Rsz7Tr7GJtyUw3lp1qUlWyqubZSUuCW2Svz8vRyQ4P2eDzK7iWYcPr9+sG2bdp20IrNO6ur1eD16rqCArYcYsjym6YerKnR33bv7vP5eT0ev+8MyoQY/HMCGOkaO0xd8o+ugCMpQhFvkzKS+LMOAAAgEkI+0d9isWjuSbM096RZ4a0oBA2NTSqvqOz+uq2jXZK0YeMmJScnSZIyMzJUWlKk5uYW3XLrHSopLtRNP7pekpSbk63cnOygz/3OwvckSZOOOap7zGq16uILz9PDjz6hO+76q+bMnqns7Cw1NTVr6fL31dTcorPPXKDiosKIvm+E18yynreD3x+sx+1eCRaLflJcrN9XVenGoqKgwcRLDQ1a09ER9PGP1NaqwePRz0pLZSfYwxDT6vXq5zt3amlra69zHBaL/q+4WK81Nvb7DEoA0dPmNHXpQ536rDb4n4FH5Rm69XyHEuIMmX6/GupqlJmdJ6OXgD4jyVBROuE9AABAJPQ71HO7PbrzL/fprDNOjZkmEJu3bNO/H386YHz/1mBJmjFtqi6/7Mthe82px03WqPQ0vbNoid7/cJXaWtsUFx+n0uIifeXiL2riASEghqe56emam57e6/WLs7JU63br4draoNdfaWxUs9er28aMYbUShoyNnZ26cft27dq3pTyY0vh4/WHMGI1NSNCkpCRd9OmnPa7THAOITW6vqa8/3KVPqoIHehPzLXr6qkSlJ+69d/1+Q7XyKbfQetjdGbta/MpPNbjvAQAAwqjfoV5cnF1NTc1qael9hcZgmzXjhEN24j1QZmZGv7rr3nDdd3q9NqZstMaUje7zc2FkMQxD1xUWKtNu1x1VVUHnLG1t1Xe3bNGfx45Vui3khbPAoHihvl63V1bKbfa+Je/U9HT9orRUyfu6iPflDEqP3y+XaXY/BkB02K3SyeOtWrkz8IzMcdkWPf6thO5Ar6/8flMPv+/RLa+7dNv5Dl1ygj2MFQMAAIxsIS0PmnfyiVr03jI1NfWtGywwkl2ak6PfjB4tWy+rE9Z1dOjbmzd3N9MAYpHPNPVqY2OvgZ5V0g8KC3V7WVlAOHdlXp6y7Xu/kT/wDMomr1f/3L1b527YoH/u3j0I7wLAoRiGoR+cGq9fnduz8VNJhqGnvp2grOT+/bVxV4tfX32wS//3kktOj/Szl52qbOr9aAsAAAD0T0hLg5ISE1WQn6df/vYPGjdmtDIzM5SQkBAwz5B0wXlnh6NOYEg7KyND6Tab/nf7dnUFOatvh9Opb27apLvHjdPYIPcSEG1Ww9Dvysp02caNajig07kkZdpsun3MGB2XnBz0sQefQVnjcuk/dXV6taFBrn0h4XMNDboqP1+JrNYDou7qk+KUFCf97/Mu5aYYevrbicpP61+g98o6j370rFOtB/SKandJNzzt1NPfTpDFwjZcAACAgQop1Hvq2Re7f7xpyzZpy7Ze5xLqAXvNSk3V/ePH6/pt29R8UCgiSbUej769ebP+PHasJvcSjgDRlG2367ayMl2zZUt344vjk5N1a1mZsuyH3lJ34BmUP9mxQ282NfW43u7z6eWGBl2SkxOx+gH03WXT45TiMHRknkUlGf3f2GGzqEegt9/y7T79fZlH35kTF55CAQAARrCQQr2vffXi8FcCjADHJCXpwQkTdO3WrUEbDbT6fPruli26razskE04gGg5PiVF1xUW6s/V1fp6To6uLSzsdWt5by7NyQkI9STp8bo6fSk7W1YO0gdiwnnHhn7+3ZnH2PWVqV49sSrwH7Fu/a9L8yZYdUQuK3MBAAAGIqRQb+b0qeGvBIgxnW5TFc0WVfl8mjY6fN1pSx0OPXjEEbpu61Zt6eoKuO4yTf14+3b9rLRU52Vmhu11gXD5Wk6Ojk1KCnlF6aSkJE1OStInHR09xitdLi1padE8Am1gWPj1Fxxauq1DVc09z+J0eaVrn3Tq1e8lKs5GiA8AABCqASUVfr9f5RWVWr1mrdra28NXFRAl973n1tw7O3TEL9s0/peduuCxUbr4H06Zh+j2GYpsu11/nzBBU3sJRXySflVerodqasL+2kBvPu3oUJcvsOvlwQzDGPAW8Ut72Wb7nz17BvS8AA7vyY88qm2NfMOKFIehu77sULDFt+t3+fWnhTSIAgAAGIiQQ73Va9bq57+6VX/407168JH/qKb282/Efn/n3Vr18SfhqhEYNC1dprbs8fc4B8jllZo6w/9aKVar7h43TqccYlXSPbt26Y6qKvkJ9hBBpmnqqbo6Xbl5s35XWTkoQfK89HTlxwWeqbWqvV2fdUbghgMgSfrXSrdueMapC+7vHJROtLPH2HT1icG38f7lXbdWVRz+HxIAAAAQXEih3tZtO/TQvx6X1+fT1OMm97jW3tGh9o5OPfzoE9qybXu46gQGRX5a8G1AtW2R+cYn3mLRbWVluigrq9c577a0qCVIYw0gHLp8Pv1s507dXlkpr2nqtcZGPVNfH/HXtRmGvpKdHfQaq/WAyHjmY49ufsElSdrZYOqCv3VqW13kg72bz4jXhJzAv3L6Ten6p7rU6eYfrgAAAEIRUqj31sLFyhiVrp/f/CNd8qULelxLTkrSzT+6XpkZo/TOu0vCVScwKHJTgod6u1si9w2H1TD0k+JiXZ2XF3AtzWrVPePGadRhOosCodjpdOobmzbpjYOaVvyxqkrrDzrvLhLOz8pSoiXwj6H/NjWpzuOJ+OsDI8lr6z264WmnDlyIu6vF1Bfv79TGmsiulnPYDd1ziUO2IH/r3F5v6jevuyL6+gAAAMNVSKHezvIKnThrhpKTk4Kek5KYmKATZ89QRUVlGEoEBk9eWvBborY1sqsIDMPQdwoK9JPiYu2/pRwWi+4aN05lDkdEXxsj09tNTfr6Z59pm9MZcM1rmrpx+/aIrxBNsVp1fpBmMF7T1NN1dRF9bWAkeXezV9c87pQvyKK8unZTH5ZHfgvspEKrfrQgcMu9JD20wqNFm1mRDgAA0F8hhXrOLqdGjUo75JxRaWnq6Azs7AnEsrzUXlbqDcKB4pL0pexs3V5WpgSLRX8oK9OkpKRBeV2MHB7T1J+qqnTTjh3q9Pf+uf5CZqaSrdaI1/OVnBwFu+ueqauT8xD1AeibFdu9+uajXfL0ktv99Mw4XT4jeNgWbteeHKepJcH/6vmDZ5xq7mQbLgAAQH+EFOolJSepvqHxkHPKK6uUnEwggaElK8mQJUjCEOmVegc6ddQovTxxomanHTo4B/qrzuPRd7ds0b8PcWZditWqP48dq+8WFMgabCl2mBXFx2t+kGYxLT6fXms89J8zAA5tTaVPlz/SJWcvu9mvnx+n6+bFD1o9Nquhv3w5QQlBTpSoaTX10xcDVw4DAACgdyGFehPGj9WSpSvU0tIacM00TX3w0WotWbZCR4wfF44agUFjsxrKCXKu3mCGepI0ymYb1NfD8Le6rU2Xbdyoj9vbe51zREKCHjvySM0Z5ED50pycoOOP1dbS+RkI0cYan776YKfaezmu7luz7br59MFZoXegMVkW/eLs4EHi85949eInnKcJAADQVyElB2efsUDr12/Ub2//k8aOGS1JenfxUi1+b7l2VlSqublFDodDZ55+SrjrBSIuN9VQzUEh3mBtv+2vf9fWKi8uTgtGjYp2KYhRpmnq0T17dE91tQ51atYFmZm6sbhY8UEaV0TalKQkHZ2YqE87O3uM73S5tKK1VSeyahXol211fl3yjy4193IKyldPsOvX58bLGITVuMF8Y6Zd/93o1aLNgb8r3fyCUzPKrMpLHfzfiwAAAIaakP7GlJOdpeu/f7WysjK0bsNGSdLadZ9qzdr1am5uUWlJkf7n+1cpJzsr3PUCERfsG4nBXqnXFy83NOhP1dW6eccOmgogqDafTzfu2KG7DhHoxRmGflFSop+XlkYl0NO+RjG9rtY7xFZhAIEqm/z68j86Vdce/M+t84+16Q8XxssS7KyJQWIYhu68yKH0hMBrzV3SD59xymSVLgAAwGGFvMevpLhQN/7wOtXVN2jX7hq5XG4lOOJVkJ+nzMyM8FYJDKJgzTLq2k15faZs1uh9E3SgJS0tuqW8XJJkSrqtslINHo++k58ftZUXiC1bu7r0v9u3q8LVy947SYVxcfr9mDE6MjFxUGsLZsGoUfpLdbX2eHpuvVvZ1qatXV0alxDku38APdS27g30drUED8ROP8qquy9xyBrFQG+//DSLbr3Aoe8+HniO3rubfVq506eZZRxFAQAAcCh9WpbxwD//pY2bNnd/fde9D2jrth2SpOysTE2edIymn3CcJk08mkAPQ15ukDP1/KZ6XfUw2NZ1dOim7dsDVl79vaZGv6uslI/VDSPea42N+samTYcM9E5KTdW/jzwyJgI9SbIbhr6cnR302n9YrQccVkOHX5f8s0s7G4L/GTBnnFX3X5oge4z845QkXTDZrvOP7Rnc5aUa+s83Ewj0AAAA+qBPod6GjZtUV9fQ/fWWrdvV3t4RybqAqMlPC35bxMoW3KUtLXL1Etw9V1+vm7Zvl8sfm2cAIrLcfr9uq6jQz3fulLOXz4BF0vcLCvSnsWOVGmMNWS7MypIjyBbg1xsb1ejh8HygN61OU5c+2KVNtcHv+2mlFj309QQ57LET6O136wWO7n9Mu2CyTQtvSNL8CbH1exMAAECs6tPfmjJGpevFl1/X5i3bFB+/t2PZ4qXLu8/T641hSF/76sXhqRQYJLlBtt9qX7OMKbIOej0HuyY/XwkWi+7etSvo9XdbWnTt1q26c8wYpcRYaIPIqvd49HpTU6/X0202/W70aM1ITR3UuvoqzWbTuRkZeqa+vse4xTC0sbNTs1JSolYbEKs63aa+9lCX1lYHD/QmFlj06BWJSoqPvUBPkkYlGrrryw41dZq6YLI92uUAAAAMKX36jv/cs07Xv594WmvWru8e27J1e59egFAPQ01+L6FerKzUMwxDV+TlKcNu12/Ky4M2QFjd3q5vb96se8aNU3ZcXBSqRDQUxMfr16Wl+uH2wN+fJyYm6vYxY5QX45+HS3NyukO9XLtdl2Rn64tZWUq12eRnBSrQg9Nj6spHu/RhefBWOONzLHr8mwlKS4jNQG+/k8fzD1AAAACh6NPfoqYeP1lHHzVBe+rq5XK59Ze//l3nnLlA48aOiXyFwCDLDdL9VpJ2x0iot995mZlKt9l08/btQbfjbnU6deXmzbp33DiVOhxRqRGD7+T0dF2Zm6uHamu7xy7JztYPCgtlj1J32/4odTj0jdxcHZGQoFNGjZKdxi9Aryqa/FpXHTzQK80w9NS3E5SVHPv3PQAAAELT538aTUhIUGlJsSRp3NgyjR83VuPGlkWyNiAq0hMkh01yenuO17bG3iqhuWlp+tv48fqfbdvU6gv8xm63261vbt6su8aO1cSkpKjUiMF3TUGB1nd2al1Hh/6vpERnZwytBkbXFxZGuwRgSJiQY9WzVyfqkn909WjmlJ9q6OlvJyqvl3+kAgAAwPAQ0t/2brj2OwR6GLYMwwh6rl5NjK3U2+/Y5GT9c8IE5dqDn0XU7PXqmi1btLy1ddBrQ3TYDEO/Gz1ajxxxxJAL9AD0z1F5Vj3/nUQVpO39cysr2dBTVyWqOGP4BXp+f2z+OQwAABAtIR9ismt3jT5Zu15NzS3y+YKvYKJRBoaq3FSLyht7rnyL1VBPksYkJOjBI47QdVu3arvTGXC9y+/XDVu36pejRxPyDHHrOjo0qQ+rLjPsdmX0EvQCGF7GZlv0wjWJuvqxLv3xQofGZQ+vQM80TT25yqu/L3XrhWsSleJgWz4AAIBCDfU2frZZ9/394T4dWk6oh6EoWLOMWNx+e6C8uDj9Y8IE/WDbNn3S0RFw3Sfp5zt3qsnj0WW5uVGpEaFz+v36fWWlXmxo0K1lZTp91KholwQghhSPsui17yfKGGbnUNa3+/Xj51z676d7z8T4f6+4dOeXOCcWAABAoYZ6r7z+puw2m05bME/FRYWKYzUIhpnZY62Ks0kpRqvGFqQrP90yJM4mSrPZdO/48frJ9u1a0st22zurq9Xg9eq6goJh983fcFXlcunG7du1qatLknRLebnGOxwqS0iIdmkAYshw+z39jQ0e/fg5lxo6Pl8p//hHHp1+lFVnHsPfPQEAAEIK9Wpq9+iM0+br9AXzw18REAMunxGnr03zq7a6S7mF2bIMga6h+yVYLPrj2LH6bUWFXmpoCDrnkdpa1Xs8+kVpqWzD7JvA4ea9lhb9YudOtR3QCKXT79f/7tihfx1xhBKt1qjWFw3NXq/irFYlj8D3jpGpqtmvovSh8+dQOJimqQeWenoEevv9+DmXTii10tkXAACMeCH9bchqsSo9PT381eD/t3ff4W1Wd//HP7eGNby3HdvZe5EQQkIgYe9VoBA2AQK0rLbQQsfT59f1lEJLS0uhLQQII0DYm0KBQiCEMEIIWc4iiTO846lhjfv3RwZxLNmW4ym/X9fVq+S+j6QjS0fjo3POF+gUNsPQ/w4cqCtbWWbrtFhEJNJ7hUxT9+/YoR9t3Ngs0NvrG59Pv926tUf61lM2+3y6r75RZ6xapWcqKnq6O0C3eOaLgGb8sVEvLg/0dFe6lWEY+uv5TiUmtDxX1WjqJy/4ZZq9d69bAACA7tChUG/48CEqKdnW+b0B0GkMw9CNBQW6tbCwxbnj0tJ0e1FR3C3Vihe7AgHduGGDHiotjdom0WLRCf3kx5VP6+p084YNOn/tWr3p88tvmnqmokKBduzrCvRlr30d0I+e8ykQkm5Y6NOCT5t6ukvdqijDot+eGXn/vH+vDurZZcFu7xMAAEBv0qFQ79yzTteXK1bq82XLO79HADrVxTk5+r/Bg/cts52SlKTfDR4sK4Fer/R1Y6MuWbtWn9bXR20zzOnU46NH6/h+Uizj0bIyLT5gj8iKQED/qanpsT4BXe3d4qCuf9qn8J7JaKa5e9npAx/1r2DvwsNsOnlM5N1ifvGKTyW7CPcBAED/1aE99d58+z0NyM/T/Mef1vMvvaaszAzZbJGv6gc3XHuwfQRwkE7JyFCazaYHdu7U3cOGydGH9gjsL0zT1LOVlbp72zYFW1lSdkp6uv5n4EC5+tF+cpfk5OiTCCHnk+XlOjU9nRmniDsfbwpq7uNeBVquvNf/e82vQ4usOmxQ/3gNMAxDfzzXoc/vCbXYX6/BL/3wWZ+eneuSxcLrAAAA6H86FOot/eyLff9dX9+g+vqGzuwTgC4wPSVF05KTCUB6IW8opN9t3ap/79oVtY3NMHRrYaHOz8rqd4/hESkpGuJ06hufr9nxNR6Pljc2anJSUo/1DehsX5aEdPl8r3xRVpb+8LiEfhPo7ZWdbNEfz3Xoqsd9Lc59vCmkBxcHdN3MCJvvAQAAxLkOhXq//NmtslmtUj/7Ygn0de0Ng0KmyfLcbrLZ59NtmzZpo6/ll9W9cu123Tl0qCYkJnZr33oLwzB2LyOPUBhkQVkZoR7ixuqdIV38sEeNUVbYXnOkXbed2D/Dq1PH2TV7SlALv2iZdt7xll/HjLRqVG7/CjsBAAA6tAYvNydbmZkZysxIb/N/APqWhlBIVxYX6+XKyp7uStx7d9cuXb52bauB3rTkZC0YPbrfBnp7nZaRodQIS47fr63VNr+/R/oEdKYNFWHNfsirGm/k8xdPtevXZzj63Uzd/f3mTKcK0lref39QuukZn5qCVMMFAAD9CxtrAVG8vy6ovyx264anfTr3Xx4d+acGjf9tg8xW9jvr65rCYf1k0yat8nj0m61b9XBpaVzf354SME39Zds23fbNN2pspYLr1Xl5unf4cKXb7d3av97IabHovKysFsdNSU+Xl/dIn4DOUlId1ux5HlU2RH69PecQm+46p38HepKU4jT0t/MjV8P9entY97zXv4qIAAAAtHv57aKPlnToBmYddUSHLgf0tCXfhPX4cpek5juV1/mkVFePdavLhE1T/7t5c7Oqq/ft2KGqQEC3FhbK0s+/THaWikBAP/vmG33ZEH0v0mSrVb8dPFgzU1O7tW+93flZWXqsrEwHLr57uapK1w0YoOR+VDwE8aO0Lqzz53m0ozZyoHfyGJv+eoFTVgpBSJJmDLPp2qPseuCjQItzf3u/SSeMtunQgbwWAACA/qHdod4zz7/coRsg1ENflZcS+QtUaV1Yqa74+sJgmqb+tG2b/lNT0+Lc0xUVqg4G9etBg5RA1dyD9lldXauB3iiXS38cOlQFDke39qsvyLLbNcuRoPf8zWfjeMJhvVRZqctyc3usb0BHVDWGNXueV1uqIwd6s4Zb9c+LnbJbCfT297OTHXp/XUjrypvPdA6FpZue8eo/NyfKncDfDAAAxL92h3qnnnS8xOcj9CPRQz1To+IwO0izRX85eHvXLtUGg/rj0KFKZDbUQTktM1PLGhr0YlVVi3NnZ2bq9qIiOQhPo/qO29ki1NOe8PminBzZmFGKPqLWa+rCh7wtgqm9pg6y6pHLXXLaeU4fyGk3dO9sp06/z6PgAX++TZWmfvemX78/O/IyXQAAgHjS7lDv9FNP7NqeAL1MbpRQr6wu/vaYMwxD1+bnK9Nm0x9KShTpK+bS+npdu26d7h0+XBns8XZQflJUpLVer9Z4PJKkBMPQ7UVF+k6EPePQ3FCbTVOSkvTFAbMdS5ua9N+aGp2YToEm9H6eJlOXzfdo5Y7Igd6EAoueuNLFbLNWTCyw6pbjE3TXf1qG/I8sCeikMTYdM7LdH3MBAAD6JKaDAFHkJkf+MrWzLnphg77uvOxs3TlkiBKizHZa6/XqqnXrqDZ6kBwWi+4aMkQpVqsKEhL0yKhRBHoxuCg7O+LxJymYgT7AFzA15zGvPtsS+b1kZI5FT13lUoqTQK8tNx2ToEOLIn+UveU5nzxN8fcjHAAAwP4I9YAocpINGWr5hSAeZ+rt77j0dP19+HAlRlkCWuL366riYhXvmWWGjhngcOhvw4fridGjNdrt7unu9CkzU1JUFGHPwRWNjfq6sbFH+gS0RyBk6ronvfpwQyji+cGZhp6Z61JmIh/P2sNmNfS3C1xyHjB5PCPR0O/OcjDTEQAAxD0+NQJR2K2GMlwtA7ydUSoUxpMpycmaN3KkMqPss1cVDOqadev02X6VcrFbUzisDV5vu9pOSExUSit7GSIyi2EwWw990j8/bNLbayIHegNSDT0z163cFD6axWJYtkX/e9q3If9JY6x6/4dunTaebSIAAED845Mj0IrspJbLo8rq43f57f5Gut16ZNQoDYxShbUxHNZNGzbonV27ur1vvVVpU5OuWbdO165bp51NLfd5Quc5MzNTyRGKtry7axd/e/Ra1xyZoJPGtHzeZiftDvSK0vlY1hFzptt1+nib7j7PofmXu5SdzN8RAAD0D3zqAVqRndgywCvtBzP19ipwOPTwyJEaG2V5aMA09dNvvtEzFRXd3rfeZmldnS5Zu1YrPR7VhkK6fdMmNYX7RwDcE9xWq86NsA9hSNJCZuuhl3LaDc271KWzJ347QzfNJS2c69KwbD6SdZRh7P67Xjw1QQYVsAEAQD/CJ0igFdnulqFMeYOpULj/BHvpdrv+NWKEpicnRzxvSrqzpET/2LFDptl//i57hU1TD+3cqRs2bFBNMLjv+CqPR3/etq1H+xbvLsjOVss5T9KLVVXyhCIvcQR6mt1q6L4LnbroMLsSE6Qnr3JrTF6kZzIAAADQOkI9oBU5EZbfhsJSVWP/Cq/cVqvuGTZMp6SnR20zr7RUvy8pUbAfBXt1waB+tHGj7t+5M0JJFenZykq9UVXVAz3rH/ISEnRChOek22LRFio0oxezWgz96VyH3ropUZOLCPQAAADQMR3aof2V1/8tq9UqQ60vcbBYLEpKStSIYUOVmxt5U3OgN4u0/FZ7imXkRJ64FrfsFot+O3iwMuz2qMUIXqisVFM4rF8PHtzt/etuazwe3b5pk7a3sn/bIIdDI6ls26UuzsnRW3v2dRzrduvinBydkJ4uO0vw0MtZLIaGZfM87SrbasKq7sAPcBmJhgrT+M0bAAD0DR0K9d5+5/2YLzNj+lRdPPu8jtwc0GNyooR6ZXX9Zzba/iyGoVsKCpRls+lvO3a0OJ9gGDo7M7NH+tadXqqs1J0lJWpqZVbi8Wlp+t9Bg5QUoZgDOs/4xERdlZurGampmpSYyH5aALStJqyj/tQof7AdjQ/gsEkf/TiRYA8AAPQJHQr1rrnyMn3x5XJ9+dVKjR0zSsOHDpbb7ZbX69XGTZu1ak2xjph2mAYPKlJNbZ2+WPaVPv7kMxUMyNfRM2d0/r0AukjUmXp1/bcAgmEYuiIvT+l2u363ZYv27lxmkfT7IUN0aJS99+KBLxzWXSUlermVJbVWSTcVFOjSnBwCpm5yQ0FBT3cB2Oe1rwN6fWVQfz3fqQQbrwE9obrR7FCgJ0n+4O7LF6Z1dq8AAAA6X4dCPdM0taZ4vW79wfUaPKio2bkTjjtaW7Zu0z8efETTph6qI6ZN1cknHKs/3XO/Pvn0C0I99CnRQr3+OlNvf2dlZirdZtPtmzbJb5r62cCBOjYtfr8FbfP7ddumTSr2eqO2ybTZ9Ic4DzYBRPfu2qCuf9qnQEiq93n14KUuuewEewAAAOgaHVpb8NY7/9Wxs45qEejtNWhgoWYeOV2vvfmf3TdisejwqYeqLMo+XEBvleY0ZY+wepJQb7eZqan654gR+mFBgc7Nyurp7nSZRbW1unTt2lYDvclJSVowZgyBHtBPfbwxqLlPeBXYM3353eKQLnvEqwY/7xcAAADoGh0K9XaWlik9PbXVNhnp6dqytWTfv11Op/pRUUzECcOQcpNbzrLoz8tvDzQxKUmX5eb2dDe6RMg0df+OHfrRxo2qD4WitrssJ0f/GDFC2XZ7t/YPQO+wbGtIlz/qle+AJZ+LN4V04UMeeQN8AAIAAEDn61Co53AkaPWada222bBxU7N/F6/boLTUlI7cHNCj8lJahnrM1OuY0lYqxfY2uwIB3bRhgx4qLY3aJtFi0V1DhuiHhYVUWwX6qVU7Qrr4YY8ao7y8TR1klbNDm50AAAAAretQqDdm1Eh9+dXXevzJZ7Rh4zeqq6+Xz+9XQ0OjNm8p0XMvvqqlny3T0CGDJUmvvvGWPv18mSaMH9vZ/Qe6XG6EUG8noV7MltbV6ZxVq/REWVlPd6VNXzc26pK1a7W0vj5qm2FOpx4bPVrHp6d3a98Qu80+n7xhZtei860vD2n2Q17V+iKfv2yaXf97moOiOQAAAOgSHfrt+DtnnaZvtmzV0s+WaelnyyK2SXS7de7Zp0uSSkvLlZ+Xq1NOPPbgegv0gPxUQ5mJhvJSdv8vN8Wi/BRDpmnyRa2d1ng8+vGmTWoyTf1l+3ZVBQK6uaCg1/79niovV1kgEPX8Kenp+p+BA+WyRthwEb2CaZr6rL5eC8rL9VFdnX5eVKTzsrN7uluII1urw5o9z6uqxsg/8pw7yaY/nE2gBwAAgK7ToVAvLTVFv7jtR1qy9DMVr9ugyqpq+ZuaZLfZlJ6epuFDh+jIIw5XUlKiJOnM005SdnaWrHwBRh/0q9MS9Nszee52VInPp5s3bJBnv5lSj5WXqyoY1C8HDeqVy1Z/PnCg1no82uL3NztuMwzdWlio87Oy+KLeS4VNU69VV+vJ8nKt36+wyYLycp2TlSULjxs6wc7asC6Y54k6a/uUsTb99XynLBaebwAAAOg6Hd7lJSHBrqNnztDRM2e02TYvLz430Uf/QHjTcZ5QSDds2KDqYLDFuderq1UTDOrOIUN63Yy3JKtVdw0dqiuKi+XbE0bm2u26c+hQTUhM7OnuoRWGpOcqKpoFepK0xe/Xx3V1Oiq19SJPQFsqG8K6YJ5XW6ojB3pHj7Dqnxc7ZbPy3gEAAICu1aE99fZXVlahFStX6/MvluvrVWtUWVnVOT0D0Oe5rVZdmJMT9fziujp9b/161UQI/XracJdLvxg4UJI0LTlZC0aPJtDrAwzD0MVRnnNPlpd3e38QX2q9pi56yKsNFZH3aJw22KqHL3PJYSPQAwAAQNfr8Ey9tcXr9czzL6u8orLFuaLCAl10wTkaWFR4sP0D0MddnJOjTJtN/7tli4Jmy5ktKz0eXV1crL+PGKH8hIQe6WM0p2VkKMli0ZGpqbIyY7PPOD49XX/bvr3FvohL6+u13uvVCJerx/qGvqvRb+rSRzxauTNyoHdIoUWPz3HJncBrRV8XCFEMCwAA9A0dmqm3ZWuJ/vHAI6qorNLQIYN15BGH69hZR2rG9KkaPLBIJdu266/3PaCysorO7zGAPufkjAz9ddgwuS2RX3I2+/26qrhYGw5YMtlVKgIB7Wrn7MBZaWkEen2M3TB0QZSiGE8xWw8d4AuYmvOYV59vjRzojc616Mkr3Up28loRD+77IHqhJAAAgN6kQzP13n7nfdkTEvSjm65TwYD8Fuc3bynR/f96WP/+z3u64tLZndFPAH3c9JQU/WvECN28cWPEQK08ENDcdev0l2HDNDkpqcv6say+Xj/95huNcLn0t+HDCezi1LlZWXqwtHTfnoh7vVldrRsHDFCG3d5jfUPf0hQ0dc0Crz7aGIp4fkimoYVzXcpI5LUkXry5KqjHljbp8mm9a/Y4AADAgTo0U2/jN5t1zMwZEQM9SRo8qEizZh6hdes3HGz/AMSRsYmJenjkSBVEWWZbHwrphvXr9UFNTafftmmaerysTN9bv15VwaA+qa/Xgzt3dvrtoHdIsdl0ZkZGi+NNpqnnKltuGwFEEgqbuukZn95ZGznQK0gz9Mw1buUkH/QWxehEGYmGHB3eYGa3X7zs19LNvW+/VwAAgP116COP1+NVbm7kpU175eXmqKGhsaP9AhCnBjqdemjUKN28YYPWRVhu6zdN/XjTJv1i4EB9JyurU26zIRTSr7ds0XsHhIUPlpZqfGIiFVHj1EU5OXquslIH7o71TEWFrsjNlSPKcnBgr9te8OuVFZGDnewkQ8/MdaswjedRb1OYZtFHP05UdWPbe+NtrgrrB8/45DvgYQ6GpblP+PTWTW4NSOUxBgAAvVOHQj2ny6ma2rpW29TU1snpdHa0X0CvUloX1saKsErrTJXVmdpZF1ZVo6n7ZjtlsHwzZtl2ux4YOVK3btyoLxoaWpwPS/rt1q2qDgZ1ZW7uQf2NN3i9+smmTdrq90c8/8vNm7Vg9GgNcDg6fBvonQY5nZqZmqpFtbXNju8KBvXv6mqd3UmhMeLXYYOseuqLgA6s8ZPulp6Z69LQLMKe3qowzaLCtLbbTSywymrZHeAdqM5r6qttIUI9AADQa3XoU8rgQQP1/qLF2hVliVz1rl16/4OPNGTIoIPtH9ArPLQ4oO8+6NWNC3367Zt+zVsc0IvLg6qPnBOhHZKtVt07fLiOT4v+reu+HTv0x23bFI5QNXdRTY3OWLlSi1pZqvtGdbWuKC6OGuhJ0sTERCVZrR24B+gLLs7JiXj8yfJymRGeV8D+Lppq1/0XOmXb79NSkkN68iq3RufxuhEvTh9v14+Oa74tRG6yoeevdevUcey/CQAAeq8OzdQ78bij9df7HtDv7vizJowfqwH5ubLbE9TY2KidpWVauXqtZJo6+YRjOr/HQA/IS4k8U6y0LqwUJ1/sOsphseiOIUN0V0lJ1H3OFlZUqDoQ0G8GD1bCnuWS3nBYd5SUqDwQ0B0lJZqakiLXfkspA+Gw/rx9u56piF6B2yLp+wMGaE5urizMtoxbhyUlaaTL1WKp9wafT5/W12taSkqP9Q19w3cOscttN3Ttk14ZhvT4HJcmFfK6H29+fEKCVu0M6e01IU0ZaNG8S13KS2GGHgAA6N06FOoNHzZEV15+kRY+95I+X7a8xfmUlGRddMG5GjKYmXqID7lRQr2yOlMjI08EQjtZDUM/LSpSpt2uf0UpXPGfmhoNKS3VdQMGSJIeKS1VRSAgSaoIBDS/tFTf33OutKlJt2/apJUeT9TbTLPZ9PvBgwl0+gHDMHRxTo5+tWVLi3MLyst5DqBdThpr0+NzXAqFpelDDrICA3oli8XQ32e79I9FTfrBcQly2PixBwAA9H4d/mR66KSJmjh+rNZv3KTS0nL5/U1yOBwakJ+r4cOGyMpyNsSRaL/W76xl+V5nMAxD1+bnK9Nm0x9KShQ+4PyExERdnpcnSSrx+TS/tHRf8QNT0vyyMp2RkaEdTU36+ebNqglGr1g43u3WnUOHKi9KBV7En5PT03Xv9u2qOuB5sbiuTt/4fBrC/q9oh5nDCfPiXbLT0G0nsb8qAADoOw7qE6rNZtOYUSM1ZtTIzusR0AvlpUaZqVd/YPyEg3FedrbSbTb9YvNmNe3Z72yI06l7hg2Ty2KRaZq6s6SkxeVM09RNGzeqpJW98yRpdna2flRQIDtVT/uVBItF52dn658RZoI+VV6unw8c2CP9AgAAAICD0WXfbL9euVo/+fmvuurqgW6VkxRlTz1m6nW649LT9ffhw5VosSjXbtffhw9Xmm337w8f1NZqSX29QgdcJiS1Gug5LRb9dvBg3VZURKDXT303K0uOCHsnvlZV1erMTsS/94qDWl9+4KsKAAAA0Pt12bfbYCgkr9fXVVcPdKsEm6GsCMFeaR2hXleYkpysh0aO1L3Dh+9bJusNh3VnSUnML1qDHA49OmqUTsvI6JK+om9It9sjPgf8pqkXohRpQfz7aENQVz3u1Tn/8mrVDoI9tM/HG4N6aHFTT3cDAACg60I9IN7kJbcM9Vh+23VGuN0a5nLt+/fe4hix/MWPS0vTY6NHa/h+14P+6+KcyFVtFlZUKBBmLPc3n28J6YrHvPIHpapGU+c94NEXWwn2EJ1pmnr44yZd8JBXv3zNr3fXMssXAAD0LEI9oJ0iVcClUEb3OLA4Rlsskn5YUKC7hgxREkV7sMdQl0tHRKh2m22376umjP7h6+0hXfKIR579JlvV+qQL5nn08UaCGrTkC5i69Xm/fvGKX6GwZJrS9U97tbGCHwQAAEDPIdQD2ikvteVwKa83FQ4T7HWlaMUxWjPG7dalOTkyIuyhhv5t72w9Q9KxqamaN3KkHh81SgMcVLzsL9aVh3Thw17VRdghxNMkvbGKUA/NhcKmLpjn1VOfNw//63zSnMe8qvfxOQAAAPSMg6p+C/QnkZbfBsO7l21lRziHzrHZ59OS+vqYLrPK49Fmn09DWHaLAxyRnKzv5+frlIwMFRLk9TtbqsKaPc+r6sbIIcx5k236zRk8L9Cc1WLo9PE2fbal5fLsDRVhXT7fo1+d7pBhaf2zQEaiocI0fk8HAKCjttWEo36Oa008vwcT6gHtlJcapQJunans5G7vTr8x2OnUEcnJ+jRC1dtIrJIOT0nRYKezG3qHvsYwDM3Nz+/pbqAH7KgN64KHPFELHJ06zqZ7vuuUpY1gBv3TtUfZ9fWOkJ7/suVMzk82h3XKfd42r8Nhkz76cWLcfqkAAKArbasJ66g/NcrfgUUV8fwe3O5Qb978J2K64trauo70B+i18lIivwCU1pmaUNDt3ek3DMPQ7UVFOm/16pjas/QWwF6VDWFdMM+rrdWRA71jRlr1j4ucsll53UBkhmHoj+c69dW2Rm2o6NhyW39Qqm40VZjW6d0DACDuVTeaHQr0FOfvwe0O9ZZ/tbJrewL0crlRltiW1rFJdlcrcjo1Jy9PD7dRLMOQNCc3V0UsqwSwR43H1IUPRS9oMH2IVQ9d6pLDRqCH1rnshn51ukOXzo+wISMAAEAPaHeo94Mbru3angC9XH6U5bdlUZZyoXNdmZenV6uqVBkIKNJXc4ukLLtdc/LyeqB3AHqjBr+pS+d7tGpn5EBvUqFFj13hkjuBQA/tk53ctct2QmFT3v3qcez/zIw2AX3/45Ha2yy79wVs63abXWdrt8FMeAAAeo12h3ojhg/t2p4AvVyG25DdKgUO2NhtJ6Fet3BZLLq9qEi3btoU8XxY0k+LiuSyxN8+CQBi5w2YmvOoV19sjRzojc61aMGVbiU7CSjQe2yoCOuYv3g69TrvPs+hi6cmtNrmkke8+mB9e3aubd3evG9kjkXv/yix1bYfrA/qsvnf7kUYLcBsNkLbCDAfvsylo0e0/vXmtPsam83cjXQ9RpQbjdSvGUOteuCS1gtzvbA8oF+/7m/1Nls7rgjHF17t1rDs1j/zHH9PoxqbzHbfTvO7bbQ4fvp4m356cuurIeYvadL8T75NpmO9r5H+9C9d51aiI/prdaPf1Hcf/HbcxHo7kR7vCw+ztTlu7vvAr3fXfjtuDnzMWns8I/XFlWBo/uWtP5dKdoV1+4vfzhY+mPtq7Dlz5Qx7m+Pmz+/6tWrHfuOmHfcnYrs9/5+fauj/nd76/terd4Z03wdNMd1GW8evm5mg0XnWVm/3j//xq6z+2+93rf7IEeW4JMk05WlM1CFDArr6yNbHzedbQnrpq/3GzcHc1z3//f2ZCW3+EPWn//jl3++lvz2PXWvnJhRYdOo4e6u3+fGmoD7ZFPlG27pPrJCLjEIZQDtZLIZykg1tr2ke4pXx4tJtjk5NjVg0Y29xjFmpqT3YO8QD0zS1rKFBhyQlycZslD6rKWjqmie8WrwpckgxNMvQwrkuZSTyGAOdyTSb/39rwmbLH0oPVrgdt9vgl+piWkHd+pXW+dq+UW+TqfL6zv0RONiOO7t1V1gN/jabRdHy+ivacR8qG0wVl3XuZ+O27mrIlJZv69zbnDW89eBHkjZWmFryTec9iZPbsXuMp8nUf9d17sA5aWzb9/XTzaFOCf73Gplj0f87vfU2ZfWmXljewQ3UojjrELtGt7Go59Wvg1pf3lnPJ6fK/SFdfWTrrYrLQnro40DrjWI0e4q9zWKO//qo6SBeI1q6+DB726HexpDufrep1TaIDVNagBjkpbT8AhitkiI6394iGNGOsyQIHdUUDuvVqipdvHatrl2/Xu/V1PR0l9BBwZCpGxf69G5x5C8fBWmGFs51K6eLl1ECHdGeMKxLbrcnbrMffXzqqbvaE3/jfvSwAkCvwEw9IAa7K+A2/+WGUK97HVg0g+IYOBj+cFiPlZXp2YoKVQW//TX4yfJynZSe3qN9Q+zCYVM/fsGnV7+O/Mt+TrKhZ+e6VZhGoIf+w2ixeKwbbrOHfmPriZvtV78n9tTj2kv/xmYPpKYE//GJ4B8Hg0+1QAz2n6lnMXb/uyjdaLHBNLrWlXl5yrbvntqdTXEMHAS7YeiN6upmgZ4kfd3YqK8bG3usX4idaZr65at+LfwicqCX7pYWXu3SkCw++gAAWtdbg8SuQPAff7fZY/rVne09mKkHxOCqGQn67mS78lINZSUasll55eoJLotFPysq0l3btum2wkKKY6DDLIahi3JydGdJSYtzC8rK9IehFInqK6oaTb21JnKgl+yQnrrK3ebm2EBPy0w0dMvxuzfn338Gxf4/HcZ6fEx+2++RZ06wadyeds2up43binb7Ocltfz4qSDM0Z/q3ey+15760dS4/te3bPXWcTVOKwlFvM9a/9Zi8tv++gzIsOnvit1+7OnRfDziZ1ErhiL2OH22TPyCZ+13zwTyvRuW2777u3Y8ulvsT7Ta154f01lgNaeqgva/vnXNfcyNsuXOggjSLxg+wtLyiNu5PtHPu1utySJISbIaG7ymQ0uxq97uiWO9rUjsWu2QlGipIM1pc9kDtfT5ntmNP2wTrt+2i/z2jPN5R+mFrx1cGl/3bxyLi9cTwvDJNU+35mmLs9zxv7bkDRGIUFxfH1VNlydLP9dyLr8jn8+s3v7xdmZkZ7brc0s+W6bEFC6Oez8/L1f/89JZmx0KhkP67aLE+/WyZyisqZbVaVFgwQMcfO0sTx49td59HjhzZ7rboPuFwWGXbtyq3YKAshEZAj+uqMekNhXTaypWqCzXfg80i6ZVx45TP0u4+Y3tNWBfM82hT5bcfbZx26emrXZo2mN8xO1t/fJ9csT2kk+/teHXat25ya2IB4TI6X38cj0Bv1pVjcv+l39ECTIuhNvcb9wfNVq8jWqgYrb3VIrnsrd+mN2CqKdj69TQ//u0/Vu0IafZDMVU6aqavvQevW7euXe3i5hNufUODnlr4glasXC27vfWKK5F4vV5J0vHHztLgQS034ne5WpbcfujRBfpqxSqNHzdGxx59lILBoBYvWap/zXtUF55/jmYeOb2D9wYA0F1cVqvOycrSo2VlzY6HJT1dUaEfFRb2WN8Qm4I0i168zq3Z87xaWxZWglWafzmBHgAAiB/7h3UHs5TZYev+VWcuuyFXTHHNt31Mc8fVfLROEzefcu+8+16FQiFdf+2Vevud97V+46aYLu/x7A71xo4eqdGjRrTZfvmKlfpqxSoddugkXXn5RfuOT5t6qH5/1z164eXXNWnieCUnJ3Xg3gAAutPs7Gw9UVamA+ulvlhZqWvz85Vo7Tu/6vV3OckWvXCdW1c86tH1sxJ09Ii4+agDAAAANBM3c7OHDh6on9/2Q40dM6pDl/fsmanncrna1X7pp19Ie2b27S8hIUFHzZimpqYmfbF8RYf6AgDoXrkJCTohQrXbxnBYr1RV9Uif0HHpbkMvXefWKeNin7kPAAAA9BVxE+pddcUlSk7q+Ky4vTP13O7doV44HFYwGHnDbUnatHmL7Ha7CgvyW5wbOmTQ7jabNne4PwCA7nVJTk7E40+VlyvETsV9jqWtndWBDshINOTo4ORPh2335QEAQOx4D46MNSl77J2pt2TpZ/py+deqrKpWOBxWZmaGZkyfqhOPO1rWPcuvfD6/GhoalZ2VGXHTy/T0NElSRWX7ZneEw+FOvS/oHHsfFx4foHfo6jE5xuXSIYmJ+qqxsdnx7U1N+mDXLh2TltYlt4vYlNaFlZcSN79J9mn98X1yQIr04S0uVTfGHvRnJBoakNK//l7oPv1xPAK9GWOy8/EeHFmvDPXefPvddrU7ZuaMdi+XbcvemXqff7FcR82Ypvz8PNXV1euDDz/Wq6+/pc2bt+q6uVfIMAz5/H5JkiNKRURHwu7jPl/7KrOUbd/aKfcBXaNi57ae7gKA/XTlmDzNauirCMcf3b5NYxrruux20T7Ld9p0wyspuu5wjy6f3PHqZ+hc/e190iYp8rzeNjRKZY3taAcchP42HoHejjHZuXgPbqlXhnqvvfF2u9odPmVyp4V6Z51+snw+n4YNGyKX89tKt9MPn6I7775XX69aoxUrV+uQCePacW27k+O2SkjvlVswsMP9RtcJh8Oq2LlN2fmFLWZkmqapWp9UVmeqrM5UeUNY353M3k1AV2ptTHaWs01Tj65Zox1NTc2OrwwEVZ2epTFud5fcLtr29faQfvC6T96gdM/HibI403TL8fZ2v9ei83XHmATQPoxHoHdhTOJg1W/Y0K52vTLUu++eO7v9NocPGxLxuNVq1TGzZmjB089rzdp1OmTCuH2h394Zewfae9y5XzjYGgZ572axWJo9Rve+79ef322SL9C83WnjE5Tk4Msl0NUOHJOdet2SLsrJ0d3bWv6q+lRFhX43JPJ7BbpWcVlIFz3iV/1+b7t/fi+gxibp/53uINjrYV05JgHEhvEI9C6MSXQ1nl3tkJKcLEny7llO63AkKDUlWTU1tRHXZFdV7ZIk5eRkdXNP0R0cNqNFoCftnrUHoO87KzNTiRE+fL29a5fKD5jBh663uSqs2fO82uVp+Rr7r48CenZZ9KJWAAAAQDwj1JPk9zdp2fIVWr5iZcTzpeUVkqSM9PR9x4YPG6JgMKgtW0tatF+/YZMkaeTwoV3WZ/ScvJTIM0JK6+Jv002gP0qyWvWdrJY/yoQkPVNR0SN96q+214R1/oMeldVH/tHk9PE2nTupVy46AAAAALpcvwv1QqGQSsvKVVW9a98xm82qZ55/WfMff1rlFZXN2ns8Xr3/wUcyDEOHTpqw7/iMI6ZJkt55b1GL9h8tWarERLcmHzJBiD/RQz1m6gHx4sLs7IhvkC9UVsobh1WzeqOK+rBmz/NoW03k19bjRll1/4VO2awsvQUAAED/FBc/b1dV72o2Y66+sUGStGpNsZKSEiVJmRkZGjSwUDU1tfrtHXdrYFGBbr/1ZmnPvnnnn3uW5j/+tO7+6/2aOWO6srOztGtXjT76+BPtqqnVaaecoKLCgn23MXrkcB0x7TAtWfq5/vHAI5o8aaL8fr8++PBj1dXV6+o5l3RaEQ/0LnkpkbNwZuoB8WOAw6Fj09L0bk1Ns+O1oZBer6rSd7Oze6xv/cEuj6kLH/JqY2XkQO+IIVbNu9SlBBuBHgAAAPqvuAj11q3fqCeeerbF8YXPvbTvv6dNnaLLL7kg6nVMmXyI0tNS9e77H+qTz75QfV29EhwJGlRUqAvPP0fjx41pcZmLZ5+nwsICfbzkUz397AuyWq0aPGigLpp9rkYMY+ltvMplph7QL1yck9Mi1JOkJ8vLdW5WliwUZ+gSDX5Tlzzi0erSyD+UHFpk0WNzXHLZ+fsDAACgf4uLUO+IaYfpiGmHtattZmZG1Oq6Q4cM1tAhg9t9uxaLRcfMnKFjZs5o92XQ9zlshtLdRotN2ymUAcSXQxITNc7t1iqPZ98xQ9Jgp1MNoZBSbHHxFtqreJpMXT7fqy9LIgd6Y/MsWnClm0rjAAAAQH/cUw/oDPkRZuux/BaIL4Zh6JKcHEmSy2LR7OxsvTh2rP48bBiBXhdoCpq6ZoFXS74JRTw/LMvQ01e7lOYm0AMAAAAULzP1gO6Wm2JodWnzYyy/BeLPcenp+kkwqNMzMpRMkNdlgiFT1z/t03vFkQO9onRDz1zjVnYyv0UCAAAAe/ENBeiA/BSLpOZfPsvqTJmmKYN9toC4YTcMXbhnth66Rjhs6pbnfXp9ZTDi+dxkQ8/MdWtAKoEeAAAAsD8+IQMdEKlYRlNIqvYwWw8A2ss0Tf38Fb+eXRY50MtINLRwrkuDM/m4AgAAAByIT8lAB+SlRp6NR7EMAGgf0zT1f/9u0qOfBCKeT3ZIT13l0qhca7f3DQAAAOgLCPWADsiLsq/TTkI9AGiXN1cFdd8HTRHPuezSgqvcmlhAoAcAAABEQ6gHdECk5beSVEYFXABol5PH2nTJ4fYWxx026dErXJo6iEAPAAAAaA2hHtAB+VGW35bWMlMP6E+awmG9s2uXTJOxHyurxdAfz3Ho2qO+DfZsFumBi12aOZw6XgAAAEBb+NQMdEBmoiGrRQodMDGvtJ4v9kB/sCsY1PMVFXqmokJVwaDuGz5c01NSerpbfY5hGPrV6Q4lOQzd816T/j7bqZPG8tEEAAAAaA8+OQMdYLUYyk02tOOAmXmltSy/BeJZbTCoe7dv1xvV1fLvNzvvyfJyQr0OMgxDPznRoTMn2DQ6jyW3AAAAQHux/BbooEj76jFTD4hvbotFi2prmwV6krS4rk7feL091q94QKAHAAAAxIZQD+igvJSWw6eM6rdAXLNbLLogOzviuacqKrq9PwAAAAD6L0I9oIPyIszUq2gwFQgR7AHx7LzsbDmMluP/taoq7QoGe6RPvdVX20K64lGPGvy8LgIAAACdjT31gA46frRNmYmGclMM5adYlJtiKC/FkI2oHIhr6TabTs/M1AuVlc2O+01TL1RU6Or8/B7rW2+ytjSkix72aJdHumCeRwuudCvdHblyOAAAAIDYET8AHXT8KJtuPcGhSw9P0PGjbRo/wKqsJIuMCDN4AMSXi6MswX2mslKBMAVzNlWGNfshr3Z5dv/7y5KwznvAo4p6/jYAAABAZyHUAwAgRkNcLs2IUO22MhDQ27t29UifeottNWFdMM+j8gMKB60pDeucf3lUTrAHAAAAdApCPQAAOuDinJyIxxeUl8s0++cecuX1Yc2e59H2msj3f0iWRWkuZjMDAAAAnYFQDwCADpienKxhTmeL48Ver5Y1NPRIn3pSdaOp2fO82lQZOdA7cqhVD1ziUoKNUA8AAADoDIR6AAB0gGEYuqiV2Xr9Sb3P1MWPeLS2LPLS2ikDLZp/hUsuO4EeAAAA0FkI9QAA6KBTMzKUZmtZSH5Rba1KfL4e6VN38zSZumy+V19tixzojc+36Ik5biU5CPQAAACAzkSoBwBABzktFp2fldXiuCnpqYqKHulTd/IHTV39hFdLN4cinh+ebdFTV7uU5ibQAwAAADoboR7QicJhU5UNVHYE+pPzs7NlN1qGVq9UVak+GOyRPnWHYMjU95/y6f11kQO9gRmGnpnrUlYSHzUAAACArtByzRCAdvv3qoCeXx5UaW1YpXWmyupNBULSxt8kyZ3AzBSgP8i023VKerpera5udtwbDuvFqipdnpvbY33rKuGwqR8+59ObqyKHlnkphp6d61Z+KoEeAAAA0FX4tA0chM3Vpl77OqjPt4a1rWZ3oCdJpXWRqz8CiE8XRymY8XR5uYJmfL0emKapn77s1/NfRg70MhINLZzr0sAMPmIAAAAAXYlP3MBByE+JPBuvtI4luEB/MtLt1tTk5BbHywIBvbdrV4/0qSuYpqnfvOHX40sDEc+nOqWFV7s0Msfa7X0DAAAA+htCPeAg5EYN9eJrZg6AtkWbrbegvLzb+9JV/vxuk/75YeRAz50gLbjKrfEDCPQAAACA7kCoBxyEvJTIQ6iMUA/od45KSdEgh6PZMZfFonGJiQqE+/7s3X992KQ/vdMU8ZzDJj16uUtTBhLoAQAAAN2FQhnAQYg+U6/vf4EHEBuLYeiinBz9oaREuXa7LszJ0TmZmUq2xcdb7fBsi5w2yXfAVno2izTvUpeOGh4f9xMAAADoK/gEDhwEl91Qmkuq8TY/zvJboH86IyNDqTabjk1Lk92IrwrYx4+26YkrXbr8Ua88eybsWQzpvgudOmE0HycAAACA7sbyW+AgRVqCS6gH9E8uq1UnpafHXaC315HDbHpmrlupzt3//vN5Tp010d7T3QIAAAD6JX5aBw5SboqhtWXNj7H8FkC8mjLQqueudWv5tpBmH0agBwAAAPQUQj3gIOVH2FevrM6UaZoy4nS2DoD+bfwAK1VuAQAAgB5GqAccpNwIy2/9wd377KW7e6RLPW5bTVjVjbEvQc5INFSYxq4AAAAAAAC0hVAPOEh5rVTATXf3v5ks22rCOupPjfIH29H4AA6b9NGPEwn2gB6ytjSkBr902KD+99oFAAAA9DV8cwYOUvRQr38Wy6huNDsU6GnPDMeOzPAD+oqaYFCvVFX1dDci2lQZ1gXzvJr9kEcfbejgIAYAAADQbZipBxykSNVvJam0lnAKwG7f+Hx6qrxcr1VVyW+aGu50amxiYk93a59tNWGd/6BHFQ27X7cune/Vg5e4dOIYPiYAAAAAvRUz9YCDlJcaffktgP5th9+vmzds0HdXr9bzlZXym7tDswXl5T3dtX3K6sK64EGPduz3Q4Q/KF31uFevrAj0aN8AAAAAREeoBxykrERDlgi5Xlk9M/WA/i7VZtPyhoYWx/+za5fKm5p6pE/7q240Nfshr76pavl6FQxLCz4LyDR5LQMAAAB6I0I94CDZrIayk1qmeiy/BZBoteo7WVktjockLayo6JE+7VXnM3XRwx4Vl0WeVXzYQIsevtQlw4g8GxkAAABAzyLUAzpBpCW4pfX9b/ltg9/Uf4vZYB/Y34XZ2RHfbF+orJQ3FOqBHkmeJlOXzfdqxfbIr1PjB1j0xJVuJToI9AAAAIDeih2wgU6Ql2zRV2r+5bi/zNRr9Jv6z9qgXlkR1H+Lg/KR6QHNDHA4dGxamt6tqWl2vC4U0mvV1To/O7tb++MPmrryca8+3Rw5UByRY9FTV7mU6iLQAwAAAHozQj2gE0SaqVfRYCoYMmWzxt8X40a/qXf2BHnvEeQBbbokJ6dFqCdJT5WX67ysLFm6aYlrIGTquid9WrQ+cqA3KMPQwqtdykpiIj8AAADQ2xHqAZ1gRLZFkwotykuxKC/FUG6KofwUi8JxNFnP0/RtkPducVC+LiqK+dnmkCYWWLvmyoEeMjExUePcbq3yeJod3+L3a3FdnWampnZ5H0JhUz941qe3VkdO4fNTDD071638VAI9AAAAoC8g1AM6wdVHJujqIxN6uhudztNk6t21Qb3ydVDvrO26IG9///OqXw1Npm4+JoEN+hE3DMPQpTk5+tnmzS3OLSgv7/JQzzRN3f6SXy8ujxzoZSYaWjjXpaIMAj0AAACgryDUA9DM3iDv1T1BnrcbgrwD/eGtJn21Lay/nu9UspNgD/HhuPR05W7frrJA80H1WX291nk8Gul2d8ntmqapX73u14JPIw/mVKe08GqXRuQwQxYAAADoS/hJHoAk6a3VQV33pFfjf9uga5/06dWvYw/0hmUZunhq5/xW8OaqoE67z6MNFf2vijDik80wdGFOTsRzT5aXd9nt/umdJj3wUeTBnJggPXmVW+MGEOgBAAAAfQ2hHgBJ0sIvAnplRexB3tAsQz84NkHv/sCtD29N1BXTO28Z8oaKsE79e6P+vaoHpgsCXeCczEy5LC3fev+9a5cqA53/PL//gyb9+d2miOecNumxK1w6dCCBHgAAANAXEeoBkCSdNbH9M+yGZBq6+dgEvXOzWx/dmqifnuzQ2HyrDMNQRqIhRycu7G/wS1c+7tOdb/sViqfKI+iXkm02nZWZ2eJ4wDT1XEVFp97Wo5806bdv+iOes1uleZe6NGMYu3AAAAAAfRWf5oE45w2YWlcW1iGFrc/GOXG0TU6b5Iu8j76GZBo6Y4JdZ020aVy+JWoRi8I0iz76caKqG2ML4FZsC+n//u1XjTfy+Xvea9KK7SHdN9ulNDf77KHvuig7W89UVOjAEfJcZaWuzMuTI8JMvlgFQqaeWBp55p/FkO6/0KnjR/MRAAAAAOjL+EQPxCFvwNR/i4N67eug3l4TlM0irfifJCXYoodhiQ5Dx42y6Y1V36Z6g/cGeRNsGj8gepB3oMI0iwrTYuvzxAKrjh1l09VPePXVtsj76L1XHNKp9zXq4ctcGpPHkkH0TUVOp2alpuqD2tpmx3cFg3qzulrfyco66NuwWw09c41blz7i0bKS5uPpL9916owJ9oO+DQAAAAA9i1APiBO+gKn/rgvq1RW7g7zGA7bR+nBDqM2ZOWdOtGnVzpDOnGDXmRNtmhBDkNcZCtIseuk6t372kk9PfxF5yuDmKlOn3+fRPec7ddZEggn0TRfn5LQI9bSnYMbZmZmdMu7S3YYWznXrike9+nhTSJJ0x9kOXTCFcQMAAADEA0I9oJOsLw/p8y1hldaFVVZvqrTOVGldWC9e55bL3jXBmC9g6v11Qb3ydVD/WRNUQ+TtsyRJr34daDvUm2DT2RNt3RrkHchpN/Tn7zo1qSigX77qVyDUso03IF33pE/Lt4X085MdsllZjou+ZUpSkka5XCr2Nl9vvtHn0yf19ToiJaVTbifJYeiJK12a+4RXM4ZaNeeIzitkAwAAAKBnEeoBneTdtSH9+o2WqVp5nalBmZ0XOvkCpj5YH9IrKwJ6u40gb39vrgrqrnPMVpfgWi29IxwzDENXTE/Q2Hyr5j7hVXl95P35Xlwe1PWzEpSV1Dv6DbSXYRi6JCdH/7tlS4tzT5aXd1qoJ0kuu6HHrnD1mvENAAAAoHNQ/RboJLkpkb8w76yLvD9cLPxBU2+vDurGhV5N/F2D5jzm1QvL2x/oSVKdT1q8KcK0t15s6iCr3r7JramDWr5U7a3emZXEyxj6ppPS05Vlb74UNsdu19TkZJlm51Z6JtADAAAA4g8z9YBOkhcl1Cur69iXc3/Q1KI9M/LeWh1UfQwB3v4K0wydNdGmMyfYdUhh3wvAclMseu4at/7fa37N/+Tbap7/d5ZDUwZSLAN9l91i0QVZWbp/506Nc7t1cU6Ojk9Plz2G5e+VDWFlJho9umQeAAAAQM8g1AMOwraasKobd4d2td7I4d2ykpCGZDUP0zISDRWmtR6wff8pn95cFblYRFsK9gvyJhV2b7GLrpBgM3THd5w6pNCqn77k03mT7bpsGnuDoe87LztbU5KTdUhiYszjtGRXWN/5p0enjbfpN2c4+vw4BwAAABAbQj2gg7bVhHXUnxrlbyN3e+CjgB74KNDsmMMmffTjxFaDvRNH22IK9QrSDJ05YXeQN7mo7wd5kVx4mF0TBlg0PKfvzTgEIkmz2TQpKSnmy5XVhXXBPI921Jqatzggj1+661wHy2wBAACAfoRQD+ig6kazzUAvGn9w9+UL06K3OWWcTbe9KAVb2ZJvQOruIO+sifEb5B1o3ID2Lbk1TVPfVJkamkUAiPhS1RjWBfO82lz17ezgJz8PqLHJ1L2znbJTDRoAAADoFwj1gB4SDre+116629DM4Vb9d13z4hYDUg2dsTfIK7TIwsyciOYtDuh3b/r1u7McLNVF3KjzmbroYa/WlbdM+19eEdTgzCb99GRHj/QNAAAAQPci1AN6yModYU0qar3NWRPt+u+60L4g78wJdh1aRJDXlo83BfXrN/wKhaXbXvTrq+1h/d9ZDjls/N3Qd3maTF36iFdfb488fXdCgUXXH02ADQAAAPQXhHpAD1m0IaRLp7Xe5rTxNg3LdmsKQV677agN67onfQrtl3ss+DSgNTtDevBSlwakshwXfY8vYOrKx7z6bEso4vmRORY9dZVLKU5eJwAAAID+gm+3QA/5cENQoTaW4KY4DU0dZCXQayd/0NTcJ7yqbGj5d11WEtbJ93q0ZFMHN0IEesA3Pp+eLivX9570adGGyIHe4ExDC+e6lJnIWzoAAADQn/ANAOghNV7pk28if0lHx9gs0lHDok9ArmwwdcE8r+YtbpJpth6oAj3FNE0travTzRs26LurV+uP27bpnRJPxLYDUg09c7VbeSm8nQMAAAD9Dd8CgB5y9kSbcvki3qmsFkM/P8WhBy9xKjHK1mLBsPTLV/26+RmfvAGCPfQuazweXbhmja7fsEGL6+p2HzSkpBE1LdpmJRl6Zq5bRRm8jgAAAAD9Ed8EgB5y/dEJGp7NEOwKZ0yw6/Ub3BqaFX3Z8nNfBnXWPzwqqY5cdADoCTl2u7b4/S2Ou4bUybB/O7M3zSUtvNqlYbyGAAAAAP0W3wYAxKVRuVa9eWOiThpjjdpm5Y6wTv67R4vWs88eeodMu12nZmS0OG6xmUocWitJSkyQnrzKrbH50Z/bAAAAAOIfoR6AuJXiNPTIZS795IQoa3El7fKYuuhhr+7/gH320DtYtqZFPJ44olZOu6nH5rg0uYhADwAAAOjvCPUAxDWLxdAtJzj02BUupTgjtwmb0m/f9Ot7T/nU6CfYQ8+Zv6RJ979ukb/M1eKc1R3UTRc2acbQ6MVgAAAAAPQfhHoA+oUTx9j05o2JGpkT/WXvlRVBnXG/R99Uss8eut8zXwT0s5d376fXsC49Ypvl1kpmlAIAAACQCPUA9CdDsyx64wa3zpgQfabT2rKwTvl7o95Zyz576D5rSkP60XO+ff/273QrUGdv0W6Vx6MVjY3d3DsAAAAAvRGhHtBBGYmGHB1cBeew7b48ul+iw9ADFzv1i1MSZInyENT5pCse9TJjD91mdK5Ftzbb+9FQ4/rIe+stKC/vtn4BAAAA6L3YmAfooMI0iz76caKqG2NfCpeRaKgwjUy9pxiGoRuPcWhCgVXff8qrXZ6WbW45PkFDsniM0D0Mw9AtxzvkTjD069d3L8H1bk5R7qHV8huhZm3/W1Oj7X6/ChyOHuotAAAAgN6AUA84CIVpFhVGnkyDPuDoETb9+8ZEXf24Vyt3fjsr76QxVv3ouOgVc4Gu8r2ZCUpMkG5/ya8fHu2UOy9Lj5SVNWsTlrSwokK3FBb2WD8BAAAA9DymoQDo1wZmWPTy9906d9Lu3ziGZhm6d7ZLlmhrc4Eudtm0BL15g1s/OTFBF2RnyxqhzUuVlWoIhSKcAQAAANBfEOoB6PfcCYb+Ptup353p0MOXuZTiJNBDzzqk0CrDMJSTkKCT0ltWwm0Mh/VKVVWP9A0AAABA70CoBwB79jS7+sgEjcqNNC+qpXA49r0UgY64JDc34vGny8sVMnkeAgAAAP0VoR4AxGhtaUgn/s2j1TtZ/oj2K60La86jXpXXx1ZVeYzbrclJSS2Ob29q0gc1NZ3YQwAAAAB9CaEeAMSg1mvqqse9Wl0a1hn3e/TSV4Ge7hL6gMqGsC6Y59Vba4L6zj89KtkVW7B3cU5OxOMLyss7qYcAAAAA+hpCPQBop3DY1A1Pe/VN1e4lj96A9P2nfPrVaz4FQyyDRGS1XlMXPezV+vLdQd43Vaa+80+PNlW2P9g7OjVVBQktKzIvb2zUqsbGTu0vAAAAgL6BUA8A2unud5v0bnHLJbf/+iigCx/yqrIhttlXiH+NflOXzfdo5Y7mz40dtbuDveKy9i3hthqGLmK2HgAAAID9EOoBQDsEQqYWb4wewCzeFNLJ93q0fBv77GE3X8DUnMe8+mxL5LA3I9FQdlL734bPysxUoqV5+7Fut45JSzvovgIAAADoewj1AKAd7FZDz8x16aoj7FHb7J19tfBz9tnr7wIhU9c96dVHUYLgIZmGFl7tUkai0e7rTLRadU5WliySjktL07yRI/XYqFE6KT29E3sOAAAAoK8g1AOAdkqwGfq/s5366/lOOWyR2/iD0g+f8+lnL/nUFGSfvf4oFDZ100Kf3l4TOdAbkGpo4Vy3clNifwu+PDdXL40bpz8OHarJSUkyjG9DwUU1NTpj5UotoiIuAAAA0C8Q6gFAjC6YYtfL33OrIC36LKv5nwT03Qe9Kqtjn73+JBw29ZMX/Hp5RTDi+ewkQ89e41ZResfefjPtdhU4HC2Oe8Nh3VFSop1NTbqjpETeMM87AAAAIN4R6gFABxxSaNW/b3TrqGHWqG0+27J7n73PtrDPXn9gmqb+9zW/noqy/DrdLS2c69LQrM5/632ktFQVgd23WxEIaH5paaffBgAAAIDeJcoCsr5rydLP9dyLr8jn8+s3v7xdmZkZ7brc0s+W6bEFC6Oez8/L1f/89JYOtwcQf7KSLHrqKpd+/5Zf/1gUOcgpqzd13gMe/fZMhy6fZm+2XBLx5c63m/TQx5GfB0kO6ckr3RqTFz0E7qgSn0/zS0u1d7G3KWl+WZnOyMhQkdPZ6bcHAAAAoHeIm1CvvqFBTy18QStWrpbdHn0j+2i8Xq8k6fhjZ2nwoKIW510u50G1BxCfbFZD/3uaUxMLrLrlOZ+8ETKdQEj66Ut+fbUtrN+f7ZDTTrAXb+5936+//rcp4jmnXXp8jkuTijo/0DNNU3eWlEQ+vm2b7h02jCAZAAAAiFNxE+rdefe9CoVCuv7aK/X2O+9r/cZNMV3e49kd0o0dPVKjR43o9PYA4tt3DrFrZI5FVz3u1ZbqyAUynvo8oDWlIc271KWCNHY/iBcPf9yk3/87cqCXYJUevsyl6UO65u32g9paLamvb3E8JGlJXZ0W1dbq6LS0LrltAAAAAD0rbr5VDh08UD+/7YcaO2ZUhy7v2TPzzuVydUl7APFvbL5V/74xUceNij4ja/m2sE6+16PiMvbZiwcLPw/oF6/4I56zWqR/XOTUsSO7JtDzhsO6s6Qk6hu5RdIfKJoBAAAAxK24CfWuuuISJScldfjye2feud27Q7pwOKxgMHL1wo60B9A/pLkNPXaFSz84NiFqm8GZhgZnxs3Lb7/16oqAbnneF/GcYUj3nO/UaeNj3w6ivfYWx4gW2YUpmgEAAADEtbhZfnuw9s68W7L0M325/GtVVlUrHA4rMzNDM6ZP1YnHHS2r1drh9q0JM4uiV9r7uPD4IFaGpNtOtGtigaEfPOtXw34TuXKSDT1wsUN2i6lwOPIyXUTWm8bku8VBXf+0X9Eewj+cnaBzD7F2WV9L/P5mxTGi2Vs047T0dBU5HF3SF/RfvWlMAv0d4xHoXRiT6C69MtR78+1329XumJkzOm35696Zd59/sVxHzZim/Pw81dXV64MPP9arr7+lzZu36rq5V+zbcDzW9q0p2761U+4DukbFzm093QX0UZNTpUfPs+jWN1K0ucYqm8XUHSfUyqgPqqzlNmhop14xJhttctuTVedvOePyRzMadWJBlcq2d81Nm6ap39XWtxno7RU2Tf1uw3r9OjWZohnoEr1iTAKQGI9Ar8OYRFfrlaHea2+83a52h0+Z3Gmh3lmnnyyfz6dhw4bI5fy2cu30w6fozrvv1der1mjFytU6ZMK4DrVvTW7BwE65D+hc4XBYFTu3KTu/UBYLSyXRMbkF0r+Hm/rhc37NHGbVKVMH9HSX+qzeNCZzC6Tn88O66GGvKhu/PX7LcXbdekJOl972Nz6fllXuanf7sKRlgaCWJ6bolPT0Lu0b+pfeNCaB/o7xCPQujEkcrPoNG9rVrleGevfdc2e33+bwYUMiHrdarTpm1gwtePp5rVm7bl9IF2v71jDIezeLxcJjhIOS6t5dAVUSM6U6QW8Zk+MLLHrpe4m6YJ5HO2pNfW+mXT8+0dHlj/FQl0tHJCfr0/p6xVJu5ZdbtuiNXbt0XX6+JiQmdmEP0d/0ljEJgPEI9DaMSXQ1nl3tkJKcLEny+iJviH6w7QHEP8Mw2hX2+AKm7njLrwY/++31BcOyLXrpOrduPT5B/3ta1wd62vNcur2oqEOXXVJXpznFxbppwwZ93djYjksAAAAA6K0I9ST5/U1atnyFlq9YGfF8aXmFJCljz7KlWNsDQHuYpqmfveTT3/7bpNPv82hjBRvr9gVFGZZumaHX7DadTs3Jy1NHb/Fjwj0AAACgz+t3oV4oFFJpWbmqqr/dj8hms+qZ51/W/MefVnlFZbP2Ho9X73/wkQzD0KGTJnSoPQC0x2NLA3r6i6AkaV15WKf+vVFvrw72dLfQS12Zl6dsu/2g3sgJ9wAAAIC+q1fuqRerqupd2rK1ZN+/6xsbJEmr1hQrKWn3vkGZGRkaNLBQNTW1+u0dd2tgUYFuv/Vmac8+eOefe5bmP/607v7r/Zo5Y7qys7O0a1eNPvr4E+2qqdVpp5ygosKCDrUHgLZ8ujmoX77qb3as3i9d8ZhXtx6foFuOT5DFwn583amyIayvd4R17Mje+Vbpslh0e1GRbt20KWqbk9PTtbiuTg2h1nff+7iuTh/X1emolBT9edgwWdn7EQAAAOj1euc3lRitW79RTzz1bIvjC597ad9/T5s6RZdfckHU65gy+RClp6Xq3fc/1CeffaH6unolOBI0qKhQF55/jsaPG3NQ7QEgmnDY1E9f8isQJXe5+90mrdge0r2zXUp1EbZ0hxqPqQsf8mptWVj3XuDUOZPsPd2liI5OTY1YNMMq6fCUFP3f4MFqCIX0VEWFFpSXtxnupdpsBHoAAABAH2EUFxezG3sPGzlyZE93ARGEw2GVbd+q3IKBVCxClyvZFdZVj3u1ckf0ffSGZhl6+DKXRuVau7VvvUV3jckGv6kLH/Loi627HwvDkP54jkOXHJ7QZbd5MEp8Pp23enWzUM9mGHpu7FgVORz7jtUHg62Ge1ZJz40dq4FOZzf1HH0d75NA78F4BHoXxiQO1rp169rVjmcXAPQCRekWvfJ9t84/NPoE6k2Vpk67z6PXvg50a9/6E2/A1JxHvfsCPUkyTenHL/j1wEdNPdq3aA4smmFImpOb2yzQk6Rkm03X5ufrtXHjdF1+vpKszcPhUzMyCPQAAACAPoRQDwB6CZfd0F/Pd+r/znLIFuXV2dMkXbPAp/97069QmInWnakpaOqaJ7xavCnyEtVHP2mSp6l3/s33Fs2QpGy7XXPy8qK2jRTuWSXNbeUye/nCYa2koAYAAADQKxDqAUAvYhiGrpqRoGevcSk7KfreZn//oEkXP+JVdWPvDJn6mmDI1I0LfXq3OHKgV5BmaOFct9wJvXO/OZfFop8VFSk/IUE/KyqSqx3LPPYP9/4wdKiK2jFL74XKSl1RXKybqZYLAAAA9DhCPQDohaYPsemtm9w6tCj6y/Si9SGd8vdGrdzRevEDtC4cNvXjF3x69etgxPM5yYaenetWYVrvfsuclZam18aP16y0tJgul2yz6bh2XMYXDmt+aakkaXFdnebsCfeYuQcAAAD0jN79DQUA+rH8VIteuM6tSw+PXnm1ZJepM//h0fNfss9eR5imqV++6tfCLyIHeuluaeHVLg3J4u3yhcpKVQWb/50W19Xtm7lHuAcAAAB0L76lAEAv5rAZ+uO5Tv3pXIcSohS99QWkGxf69MtXfQqEWI4bi9+/1aSHl0QORJMd0lNXuTU6r39WG97f/rP0IiHcAwAAALofoR4A9AGXHJ6gF69zKz8l+p5u8xYHNHueV5UN4aht8K2//tevv78fuaKt0y49fqVLhxQS6EnSeq9XvnDbzyvCPQAAAKD7EOoBQB9x6ECr3rrJrWmDowdNK7aHVO1htl5b5i1u0h/eihzoJVil+Ze7NG2wrdv71VtNSEzUa+PH65q8PCW2owgH4R4AAADQ9Qj1AKAPyU626NlrXLp6RuR99v52gVMjc5hd1pqnPgvol6/6I56zWqR/XezU0SMI9A6UYrPpewMGEO4BAAAAvQShHgD0MXarod+d5dS9s51y7pc93Xxsgk4bH72oBqSXvwro1hd8Ec8Zxu5Q9JRx/A1bczDh3g82bNAqwr1eYVFNjc5YuVKLamp6uisAAADoIEI9AOijvjvZrpe/71ZhmqFjRlp124kJPd2lXu3t1UHduNAnM8rq5LvOcejcSQR67dWRcO+jujpdvifc2+aPPFsSXc8bDuuOkhLtbGrSHSUl8rZjv0QAAAD0PoR6ANCHTSyw6q2bEnX/hS5ZLdGLaPR3H24I6tonvQpGyS5+dbpDlx5OKNoRHQn3Pquvl6sd7dA1HiktVUVgd9XnikCg1crGAAAA6L34RA0AfVxGoqF0d/sCvWVbQzKjTVWLYw8tDsgfjHzuJyck6LqZBHoHa2+49+r48ZrbRrh3fna2Mu3MiuwJJT6f5peWau+rgClpflmZSnyRl6UDAACg9yLUA4B+4o2VAZ1+v0c/es4nX6B/BXv/vNipE0a3LCBy/Sy7fnQ8gV5nSrXZ9P1Wwj2HYejy3Nwe619/Zpqm7iwpiXx827Z+GfgDAAD0ZYR6ANAPrCsP6eZnds/EWfhFUGf/06NtNf1nHy2n3dBDl7p05oRvK4tcMd2u/znVIcNg2XJXiBbutXeWXtWe5aHoPB/U1mpJfb1CBxwPSVpSV6dFtbU91DMAAAB0BKEeAMS5ep+pqx73qbHp22Mrtod18r0eLd4YZU1qHEqwGfrHRU5dOMWm70626fdnEeh1h/3DvWvy8to1S68mGNQ5q1bphxs2aDXVcjuFNxzWnSUlUT/4WST9gaIZAAAAfQqhHgDEMdM09YNnfdpY0fKLenWjqdkPefXPD5v6zbI7q8XQ3ec59ZfvOmWhsEi3St2z5157Zuk9WV6uxnBYH9bV6bLiYsK9g2CapnY2Nen/bd6s8kBA0SK7MEUzAAAA+hxCPQCIY4Zh6IJDbUpyRD4fCku/ft2v65/2ydPUP4I9i8WQzUqg11vVBIN6ury82THCvY57qLRUZ6xcqXdratpsS9EMAACAvoVQDwDi3Cnj7HrzxkQNz47+kv/SV0Gdeb9Hm6v67tK7ep+pYKh/BJPxbO8svUgI95oLtGOp7FCnM6brDJmm7igp6TezdwEAAPoyQj0A6AeGZ1v05o1unTbOFrXN6tKwTrm3Ue8V97199hr8pi58yKPrn/apKUgY0VcFTFOvVlW12a4/hnveUEhfNjToyfJy/eKbb3TOqlW6rLi4zculWFtWfW6NKWlpfb2eKCsj2AMAAOjlon+7AwDElSSHoXmXOnXv+036w9tNivR9vdYnXTrfq9tPStDNxyT0iUIS3oCpKx71allJWMtKwvIGvHrgEpdc9t7fdzRnNww9PWaMFpSX6+lWZuzt9WFdnT6sq9Os1FRdm5+vMW53t/W1KwXCYa33erXK49Fqj0erGxu1yedrsR+eZU/Y52oluDs0KUl2SbHWEr5nxw69W1urWwoKNDEpqUP3AwAAAF2LUA8A+hHDMHTzsQ6NH2DVDU97VeNt2cY0pT+81aSvtoX1twucSnL03nCsKWhq7hNefbwptO/YO2tDuuwRrx69wqXEXtx3RJZqs+n6AQN0SU5Ou8O9RbW1WlRb26Fwb1FNje7atk23FRZqVlpaJ9yD2IRMU5t8Pq3xeLSqsVGrPR6t93oVaMcsubCktV6vJrcSulksFk1KStJnDQ0x9+3rxkZduW6dTkxL000FBSpwRNmcEwAAAD2C5bcA0A8dN8qmf9+YqLF50d8G3lwV1Kl/92hDhMq5vUEwZOqGhT69VxxqcW7xppBufZ7N/vuyveHeq+PH6+q8PCVa2v7Isqi2VpeuXasfbdyoNR5Pm+294bDuKCnRzqYm3VFSIm879qg7GKZpaqvPpzerq3X3tm26urhYs776SheuWaNfb9mi5yortdrjaVegt1d77ucVeXk6JjVVHY24/1NTo/NWr9bftm9XfajleAMAAEDPINQDgH5qUKZFr17v1jmHRJ+0vaEirFP/3qh/r4p18V7XCodN3fK8T699HXn/v9xkQz89mVlF8WBvuPdKF4R7j5SWqiKw+7ldEQhofmlpp/b9QP+pqdE5q1frfzZv1pPl5Vre2CjfQQaJq9qxp+ARKSn63ZAhyrbbO/zBL2CaerSsTP9v8+YOXgMAAAA6G6EeAPRj7gRD913o1K9Od8ga5R2hwS9d+bhPd73tVzjc8xvnm6apX7zi17PLIgd66W5DC+e6NDiTt7h4knZAuOduZ7j3SV1dxHMlPp/ml5Zq7zPalDS/rEwlvo7N8KwPtl1gprP2/LNIGuZ06qzMTM1KTW3XZVwWi24vKmqxL9/+LsvJUX5CQqvXc3VeXoy9BQAAQFdhTz0A6OcMw9B1MxM0foBF1z3pU1Vj5ODuL+816ZBCq04e23NvHaYp/f6tgOZ/EnnmYLJDevpql0blxlbxE33H3nDv4pwcPVlerqfKy+WJMtst1WrVBdnZLY6bpqk7S0oiH9+2TfcOG9ZqkZj6YHD3Hnh7C1l4PKoKBPThIYfI3krYWJiQoBSrVXUxLmEtcjg01u3WOLdbYxMTNcrlkjvGqraSdHRqqo5ITtan9fXavwdWSYenpOgHBQX6/oABeqq8XA+XlrbYy/C0jAyNS0yM+XYBAADQNQj1AACSpCOH2fTWTW5d/YRXX21rGZLMnmLTSWN6Nix76AuX7l8aOdBz2aUFV7k1sYBArz9oT7h3WW6uEiOEXx/U1mpJfX2L4yFJS+rqtKi2VkfvKZrhDYVU7PVq9X6FLLb6/RH7tMHna3U2nmEYGuN2a2mE294r127XuMREjdkT4o1xu5Vi65yPa4Zh6PaiIp23enXE44ZhyGEYmpOXp7MyM/XPnTv1YmWlwpIchqEbBgzolH4AAACgcxDqAQD2KUiz6KXr3PrZSz49/cW3ywkPKbToD99xtjp7qas9uDig+5dGDkwcNunRK1yaOohAr7/ZP9xbUFampysq5AmHlWq1anaEWXrecFh3lpTIsqd67IEMSf9vyxbNqqlRscejTT5fq0tW97eqsbHNJbbj9gv10m22ZjPwxrrdyrTb23lrHVPkdGpOXp4e3rP02JA0JzdXRQdUts2w2/XzgQM1Oztb92zfrjFut/LaWJorSVt8PuUmJMjZjuXRAAAAODiEegCAZpx2Q3/+rlOTigL65at+JTsNzbvUJae95wK9Jz9r0q9eb4p4zmaRHrjYpZnDeUvrz9JsNt1QUKBLcnO1oKxMmXZ7xCWqe4tjRNsd0pRUHwrp9erqmPuwuh2VaE/OyNDoPSFent3eI0H5lXl5erWqSuWBgLLtds1pZZ+8YS6X7h0+XKF2VOQNmKZu2bhR3nBYNxUU6OT0dFl68IcAAACAeMc3IABAC4Zh6IrpCRqbb1UgZKowredm3by4PKAfvxB5uaNhSPfOduqkHtznD73L3nAvkgOLY3S29oR6w10uDXe5uqgH7eOyWPSzoiLdtW2bbisslKsds+qs7QjnXqys1OY9S5P/Z/NmPVVerlsKCzUpKalT+g0AAIDm+BYEAIgqluWsTUFTCbbOnZXz1uqgbnrGp2iThO4+16nvHNK1yxURH6IVxzhYNsPQCJdLY91uTehDRSRmpaVp1p59AztDfSikf+3c2ezYKo9HV69bpxPS0nRTQYEKD1jiCwAAgINDqAcAOGg7a8M6+58e/fgEhy6Y0jkh26L1QV27wKtQlA3NfnumQxdNJdBD+2z2+SIWx4iFRdIQp7NZIYsRLpcS2D9Oj5SWqiYYjHjunZoafVBbqwuzs3V1Xp6SO6nwBwAAQH/HpyoAwEHxB01ds8Crkl2mfvCsTyu2h/T/TnfIbu34rL1PNwc15zGvmkKRz99+UoLmHtn2pv3AXoOdTh2RnKxP6+sV5WnVgtMwNCs1VeMTEzU2MVGjXK6I+/T1d2HT1KrGxlbbBExTj5eX65WqKn1vwACdk5UlO/vtAQAAHBR+WgYAHJRfvurXF1u/nU730McBnf+gV+X17a0Z2lxVY1iXzffKG4h8/saj7frBsQR6iI1hGLq9qKjd7W2Snh47VncMHapLcnM1OSmJQC8Ki2HonyNG6I4hQzSgjQq5taGQ7iwp0YWrV+vD2lqZ7SjAAQAAgMgI9QAAHfbkZ016fGnL9G3p5pBOvtejL7a2d07UtzITLfrf0xyKNIln9gSvfnpSz1QMRd9X5HRqTl6e2nr2GJLm5OWpiD3g2s0wDJ2Unq7nxo7VzQMGKLGNJcmb/X79cONG3bBhg9a3o8AIAAAAWiLUAwB02DeV0WfZlNaZOvdfHj2+tCnm673k8ATdN9sp637vUhccatNPZnoI9HBQrszLU7bdHvUDkEVStt2uOXl53dyz+OCwWHRFXp5eGjdO383KavOD5tL6el20dq1+u2WLKgNRpucCAAAgIvbUAwB02C9OdWhMvkW3Pu+TL8L38aaQdNuLfv13XUg3HG2PaZ+9qYOteuhSl65d4NVJY2364zkJqirt3P6j/3FZLLq9qEi3btoU8XxY0k+LiuSi+MVBybDb9bOBA3VBdrb+un27FtfVRW1rSnqpqkpv7dqlK3NzdUlurpz8/QEAANpEqAcAOCjnTrJrVI5FVz3h1dbqyDP33lwV1JurIlfGjMZhkz76caJe/r5bY/MsslnYewud4+jU1IhFM6ySDk9J0azU1B7sXXwZ5nLpb8OHa0ldnf6ybZs2+nxR23rDYd2/c6eer6zUbwcP1pTk5G7tKwAAQF/Dz6AAgIM2boBV/74xUUeP6LxCAv6gVN1oalKhVQk2ltyi80QrmrH3OEu8O98RKSl6cswY/WLgQGXYWv9NuSoYVE4bBTcAAABAqAcA6CTpbkMLrnTppmP4Mo7e78CiGYakObm5FMfoQjbD0LlZWXpx3DhdlZurhCjh6YXZ2TwOAAAA7UCoBwDoNFaLoZ+f4tCDlziVSLaHXm5v0QxRHKNbJVmtuqGgQC+MHatT0tObnUu1WjWXxwEAAKBdCPUAAJ3ujAl2vX6DWwVpPd0TIDqXxaKfFRUpPyFBP6M4RrfLdzj0f0OGaP6oUTokMVGSdF1+vpLbWJ7bXotqanTGypVaVFPTKdcHAADQ2/DpFQDQJUblWnXvBa6e7gbQqllpaXpt/HjNSiOB7ikTEhP10MiR+vPQoTo3O7vN9p5QSNetW6dFtbUyzcgFdLzhsO4oKdHOpibdUVIibzjcBT0HAADoWYR6AIAuk+ig4ACAthmGoaPT0mRvR5GSR8vK9HlDg360caOu37BB6zyeFm0eKS1VRSAgSaoIBDS/tLRL+g0AANCTCPUAAADQJ5Q2NenxsrJ9//60vl4Xr12r32zZsi/EK/H5NL+0VHvn8JmS5peVqcTn66FeAwAAdI3O2bQEAAAA6GL379gh/wFLbk1JL1dV6e1du3RFTo6WNTa2uJxpmrpz2zbdO2yYjHbMBgQAAOgLmKkHAACAXm+dx6PXq6ujnveGw/pnaak+ra9X6IBzIUlL6uq0qLa2y/sJAADQXQj1AAAA0OsNc7n0PwMHKrOD1XEtkv5A0QwAABBHCPUAAADQ61kNQ+dkZenFceN0dV6eHDEuow1TNAMAAMQZQj0AAAD0GYlWq64fMEDPjxunU9PTY7qsKWleaal+uXmz3tm1S42hAxfqAgAA9B2EegAAAOhz8hMS9LshQzR/5EglWWL7SPtGdbVu/+YbVe6pmAsAANAXEeoBALpMRqIhRwfrrDtsuy8PAK1JslrV0IF98lKtVg10OFptY5qmzAOq7QIAAPQWHfyqBQBA2wrTLProx4mqboz9S3FGoqHCNH57AtC6wU6njkhOjlj1tjWHJSXJaGNfvmKvVz/YuFGHJiXt+98Qp1OWGPfzAwAA6AqEegCALlWYZlFhWk/3AkC8MgxDtxcV6bzVq2O63JTk5DbbLGtoUGUgoLd37dLbu3ZJe2b4Td4b8iUna6TLJSshHwAA6AGEegAAAOjTipxOzcnL08OlpWprXrDLMOQ1TR2alNTm9X7Z0NDiWG0opPdra/V+ba0kKdFi0aSkpH1B31i3W/YY9/gDAADoCEI9AAAA9HlX5uXp1aoqVQYCirTDnkVSlt2uF8aOVVkg0K799JZFCPUO1BgOa3FdnRbX1UmSHIahCYmJmpKcrMlJSRqfmCgXIR8AAOgChHoAAADo81wWi24vKtKtmzZFPB+W9NOiIrmsVg22Wtu8vm98PtUEgzH3w2+a+ryhQZ/vCQRthqFxbrcmJyXp8ORkTUtJifk6Y7WopkZ3bdum2woLNSuN/Q8AAIhX/GwIAACAuHB0aqqOSE7WgZGdVdIRKSmalZra7uuyG4YuyM7WcKfzoPoUNE191dio+WVleqi09KCuqz284bDuKCnRzqYm3VFSIm8HKgMDAIC+gZl6AAAAiAvRimbsPd5Wtdv9FTmdur2oSJJUEwxqeUODljU06MuGBq31eCIu8W3L5Hbs4xc0TdkOovDGI6WlqggEJEkVgYDml5bq+wMGdPj6AABA70WoBwAAgLhxYNEMQ9Kc3FwVtbGHXmvSbDYdk5amY/YsZW0IhbRiT8i3rKFBqzweBc22SnSoXcU57iop0Wf19ZqclKQpe4pv5Lez7yU+n+bvVyzElDS/rExnZGSo6CBnHAIAgN6HUA8AAABxZW/RjPJAQNl2u+bk5XXq9SdZrZqRmqoZe5bz+sJhrWxs3BfyrWhokP+AkM8qaWJiYpvX/WVDg7b6/drq9+vlqipJUl5Cgg7dU2F3SlKSBjocLWYdmqapO0tKWlyfaZq6c9s23TtsWEwzFQEAQO9HqAcAAIC44rJY9LOion3FIrq6+qzTYtFhyck6LDlZkhQIh7XG49kX8i1vaNAQp1OuNgp07AoEtMnna3G8tKlJb1RX643qaklSps2myXtm8R2alKRhLpcW1dZqSX19i8uGJC2pq9Oi2lodTdEMAADiCqEeAAAA4s6stLQeq/xqt1g0MSlJE5OSNEdSyDRV3Y5Kul82Nrbr+quCQb1TU6N3amokSckWS4uZgfuzSPpDSYkOT0np8oATAAB0H97VAQAAgC5kNQxl2+1ttlsWYaZde9SHw2pqJdQL71c0AwAAxA9CPQAAAKAXODw5WWdkZKggIaHTr3tv0YySCMt7AQBA38TyWwAAAKAX2H/JcGlTk77cW2G3vl6b/f6Dvv69xTTuHT6cohkAAMQBQj0AAACgl8lLSNCpGRk6NSNDklQdCOwL+b5saNA6r1fRF9xGFpK0pL5em30+DXG5uqTfAACg+xDqAQAAAL1cht2u49PTdXx6uiSpPhjUsoYG/WnbNu1oamrXdVglHZ6SosFOZxf3FgAAdAf21AMAAAD6mGSbTUenpen+4cNlbedlDMPQ7UVFLL0FACBOEOoBAAAAfVSR06k5eXlqK6YzJM3JzVWRw9FNPQMAAF2NUA8AAADow67My1O23R71g71FUrbdrjl5ed3cMwAA0JUI9QAAAIA+zGWx6PaiIoWjnA9L+mlRkVwWPvoDABBPeGcHAAAA+rijU1N1RHJyi/31rJKOSEnRrNTUHuoZAADoKoR6AAAAQB+3twhGtOMUxwAAIP4Q6gEAAABx4MCiGRTHAAAgvhHqAQAAAHFib9EMURwDAIC4R6gHAAAAxAmXxaKfFRUpPyFBP6M4BgAAcc3W0x0AAAAA0HlmpaVpVlpaT3cDAAB0MX66AwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgj7H1dAc625Kln+u5F1+Rz+fXb355uzIzM2K6/KZvNuvNt97V5q0lCgZDys7K1BHTpuqYWTNkGEaztqFQSP9dtFiffrZM5RWVslotKiwYoOOPnaWJ48d28j0DAAAAAAAAdoubUK++oUFPLXxBK1ault1u79B1LF+xUvMeeUID8vN05mkny2az6dPPl+m5F19RZVWVzj/3rGbtH3p0gb5asUrjx43RsUcfpWAwqMVLlupf8x7Vheefo5lHTu+kewcAAAAAAAB8K25CvTvvvlehUEjXX3ul3n7nfa3fuCmmy3s8Hi14+jkVDMjXj394/b5gcNrUQ3X3X/+hTd9sls/nl9PpkPYEgF+tWKXDDp2kKy+/aN/1TJt6qH5/1z164eXXNWnieCUnJ3XyPQUAAAAAAEB/Fzd76g0dPFA/v+2HGjtmVIcuv/SzZfJ4vDrj1BObzfSzWq267ZYbdfutN+8L9CRp6adfSJKOP3ZWs+tJSEjQUTOmqampSV8sX9Hh+wMAAAAAAABEEzcz9a664pKDuvzqNcWyWCwaPWqEJMk0TQUCQSUkRF7Ku2nzFtntdhUW5Lc4N3TIoN1tNm3WMTNntHnb4XD4oPqOrrH3ceHxAXoHxiTQuzAmgd6D8Qj0LoxJdJe4CfUO1s7SMqWnpap6V41efPl1rSler2AwqOSkJB0+dbLOOPXkfQGfz+dXQ0OjsrMyZbG0nOyYnp4mSaqorGrXbZdt39rJ9wadqWLntp7uAoD9MCaB3oUxCfQejEegd2FMoqv1ylDvzbffbVe7Y2bOkMvl6pTbbGj0yO126W/3PaBJh0zQVVdcLJ/Pr8VLlurd/36o7dt36sbvz5VhGPL5/ZIkh8MR8bocCbuP+3y+dt12bsHATrkP6FzhcFgVO7cpO78wYngLoHsxJoHehTEJ9B6MR6B3YUziYNVv2NCudr0y1Hvtjbfb1e7wKZM7LdQLhUKqra3Ted85Q8cdM3Pf8alTJumuP9+rtes2aNXqtRo/bkw7rs2UJBmG0a7bZpD3bhaLhccI6EUYk0DvwpgEeg/GI9C7MCbR1XplqHffPXd2+206EhLk9fk09bDJzY5bLBZNP/wwlWx7Res2bNT4cWPkcjolad+MvQPtPe7c0w4AAAAAAADoTETGe2RmZkiSrBFS9JSUZGnPXnqS5HAkKDUlWTU1tRE3vqyq2iVJysnJ6uJeAwAAAAAAoD8i1Ntj2NDBkqSt23a0OFdVvTukS0tN3Xds+LAhCgaD2rK1pEX79Rs2SZJGDh/ahT0GAAAAAABAf9XvQr1QKKTSsvJ9Qd1eM6ZPlWEYevOtd5rNvmtqCmjxx0slSRPGf7uf3owjpkmS3nlvUbPr8Xi8+mjJUiUmujX5kAldfG8AAAAAAADQH/XKPfViVVW9q9mMufrGBknSqjXFSkpKlCRlZmRo0MBC1dTU6rd33K2BRQW6/dab912msGCATjnxOL359rv6230Patrhh8rr9WnJ0s9VUVmlo2fOUFFhwb72o0cO1xHTDtOSpZ/rHw88osmTJsrv9+uDDz9WXV29rp5zSacV8QAAAAAAAAD2Fxeh3rr1G/XEU8+2OL7wuZf2/fe0qVN0+SUXtHo9Z5x2knJysvXBh4v1zPOvyDRN5efl6uLZ5+nIIw5v0f7i2eepsLBAHy/5VE8/+4KsVqsGDxqoi2afqxHDWHoLAAAAAACArmEUFxebPd2J/m7kyJE93QVEEA6HVbZ9q3ILBlKGHOgFGJNA78KYBHoPxiPQuzAmcbDWrVvXrnaEegAAAAAAAEAfQ2QMAAAAAAAA9DGEegAAAAAAAEAfQ6gHAAAAAAAA9DGEegAAAAAAAEAfQ6gHAAAAAAAA9DGEegAAAAAAAEAfQ6gHAAAAAAAA9DGEegAAAAAAAEAfQ6gHAAAAAAAA9DG2nu4A0NU8Hq/ee/9DffX1KlVWVcswpPy8XM2YfrhmTJ8qwzD2tQ2FQvrvosX69LNlKq+olNVqUWHBAB1/7CxNHD+2xXXH2h5AbGMylrZiTAIxi3WM7W9N8Tr9/R8PSZLuu+fOFucZj0DsYh2Tm77ZrDffelebt5YoGAwpOytTR0ybqmNmzeA9EugEsYzJmto6/efd97W2eL2qd+2S0+lUbna2Zs08QpMPmcCYRJcwiouLzZ7uBNBVamrr9Kd77lNtbZ2mTT1Uw4YOkdfr1UcfL1VZeYWOP3amzj37jH3tH3j4MX21YpXGjxujSRPHKxgMavGSpSrZtkMXnn+OZh45vdn1x9oe6O9iGZOxjl8xJoGYdGSM7eXz+fW7O/+sXbtqpCihHuMRiE2sY3L5ipWa98gTGpCfp6NmTJPNZtOnny/T+g2bdMysI3X+uWc1u37GJBCbWMZkWXmF7r7nfjUFAjpqxjQVFQyQ1+/Xp58t05atJTpqxnRddME5za6fMYnOwEw9xLVXXvu3du2q0fnnnqVjZh257/j0ww/Tb+74k957/yOdcNzRSklO1vIVK/XVilU67NBJuvLyi/a1nTb1UP3+rnv0wsuva9LE8UpOTpL2fJCKpT2A2MZkLG3FmARiFusY29+Lr7yuhoZG5eZkq6y8osV5xiMQu1jGpMfj0YKnn1PBgHz9+IfXy263S3vG2N1//Yc2fbNZPp9fTqdDYkwCHRLLmHzrP++p0eNpEcYdOX2qfnvH3fro40904nGzlJWVKTEm0YnYUw9xLT09VZMOGa8Z06c2O+52uzRsyGCZpqkdO8skSUs//UKSdPyxs5q1TUhI0FEzpqmpqUlfLF+x73is7QHENiZjaSvGJBCzWMfYXsXrNmjxkk912sknRAz8xHgEOiSmz62fLZPH49UZp564L9CTJKvVqttuuVG333rzvkBPjEmgQ2IZk5VV1ZKkYUMHN2trt9s1sKhwd5vqXfuOMybRWZiph7h25mknRz3n8XolSW6XS5K0afMW2e12FRbkt2g7dMig3W02bdYxM2d0qD2A2MZkLG3FmARiFusYkySf368FTz+nosICnXDcLK1eUxzx8oxHIHaxjMnVa4plsVg0etQISZJpmgoEgkpIsEe8PGMSiF0sYzI/L08bN21WeXmlBuTnNWtbVV0ti8WivJzsfccYk+gshHrol7bv2KkNG79RTnaWigoHyOfzq6GhUdlZmbJYWk5gTU9PkyRVVFZJe/YSiqU9gNYdOCZjbcuYBDpPa+Px5VffVG1tnb53zZyIY02MR6DTRRqTO0vLlJ6WqupdNXrx5de1pni9gsGgkpOSdPjUyTrj1JP3BXyMSaBzRRqTJ51wjL5euUrPvfiKDMPQoEFF8vv8WvzJUm0t2a4Tjz9GaWmpEmMSnYxQD/3Orl01euChx2QYhi6efZ4Mw5DP75ckORyOiJdxJOw+7vP5dv9/jO0BRBdpTMbaljEJdI7WxuO69Rv14eJPdPopJ7SYhbA/xiPQeaKNyYZGj9xul/523wOadMgEXXXFxfL5/Fq8ZKne/e+H2r59p278/twOfc4FEF20MZmZka6f3HKj5j/+tB54+LF97e12m757zpk69uij9h1jTKIzEeqhX9mydZv+NW++Ghs9mnPZhRoxfGg7L7m7SHRrYcPBtQf6p1jGZMfHrxiTQDu0Nsaampq04OnnNCA/TyedcOxB3hLjEWiP1sZkKBRSbW2dzvvOGTrumJn7jk+dMkl3/flerV23QatWr9X4cWPacUuMSaA9WhuTlZVV+seD81Vf36AzTztZhQX58vn8+urrVXruxVdVWVXdoiJ1dIxJtB+hHvqNz79Yrieefk4JCXbd8L2rNXLEsH3nXE6ntN+vJgfae9y5p12s7QG01NqYjLUtYxI4OG2NsZdefVPVu2p02y03ymq1tnpdjEfg4LU1Jh0JCfL6fJp62ORmxy0Wi6YffphKtr2idRs2avy4MYxJoBO0NSafeOo5lZVX6Cc/ukGDBhbtO37YlElKeDJB7y9arBHDhmrSIeMZk+hUhHroF9557wO9+MobGpCfp+vmXqGszIxm5x2OBKWmJKumplbhcLjF3gZVVbsrFeXkZHWoPYDm2hqTsbZlTAId19YY27DpGy36aIlmHXWEkpIStaumZt+5YDAoSfuOpaelMR6Bg9Se973MzAxt275D1gj7caWk7K5K7fPtXeLHmAQORltj0uf3a8Omb5SZkd4s0Ntr4oSx+uTTz7WmeJ0mHTKeMYlORaiHuLfooyV68ZU3NGbUCM298jI5nZH3Lhg+bIi++HKFtmwt0ZDBg5qdW79hkyRp5H5TrGNtD2C39o7JWNsyJoHYtWeMFRdvkGma+uDDj/XBhx9HvJ7/+dUdkqT77rlTYjwCHdbe971hQwdr2/Yd2rpth0aPHN7sXFX17kAgLTV13zHGJNAx7RmTgUBApmnu+6GrxfmmgLTfD2FiTKITRS5bBsSJTd9s1rMvvKJhQwfrumvmtBoIzDhimiTpnfcWNTvu8Xj10ZKlSkx0a/IhEzrcHkBsYzKWtmJMAjFr7xg7bMokfe+aORH/t7dgxt5/78V4BGIX0+fW6VNlGIbefOsdhcPhfcebmgJa/PFSSdKE8d/up8eYBGLX3jGZnJSknOws1dTWad36jS3OL1u+QtoTxu/FmERnYaYe4tqzL7yqcDisCePG6OuVqyO2yc/LVX5erkaPHK4jph2mJUs/1z8eeESTJ02U3+/XBx9+rLq6el095xK5XK59l4u1PYDYxmQsbcWYBGIWyxjLzcmOeP7dPV9GJhywGT/jEYhdLGOysGCATjnxOL359rv6230Patrhh8rr9WnJ0s9VUVmlo2fOUFFhwb7LMSaB2MUyJr977ln617xH9Y8H5+uoGdNUMCBffr9fK1au1tri9Ro6ZJCmTZ2y73KMSXQWo7i42OzpTgBd5YYf3t5mm9NOPkGnn3qiJCkcDmvR4k/08ZJPVV5RIavVqsGDBuqUk47TiGEtpz/H2h7o72IZk7GOXzEmgZh0ZIwd6J57/6X1GzftW3a7P8YjEJuOjMlPP/9SH3y4WDt2lsk0TeXn5eqoGdN05BGHt7gsYxKITaxjsmTbdr3z3iJt2LhJdfUNstlsysnO0pTJE3Xs0UfJbrc3uyxjEp2BUA8AAAAAAADoY9hTDwAAAAAAAOhjCPUAAAAAAACAPoZQDwAAAAAAAOhjCPUAAAAAAACAPoZQDwAAAAAAAOhjCPUAAAAAAACAPoZQDwAAAAAAAOhjCPUAAAAAAACAPoZQDwAAAAAAAOhjCPUAAAAAAACAPsbW0x0AAABA37dm7TotWfq5Nm/Zqrr6BlmtFqWmpGjwoIGafvgUjRwxrNv68vY772vM6JEqKhzQbbcJAADQ3Qj1AAAA0GF+f5Mee3Khln+1UlmZGZo6ZbJysrMUDAW1Y2eZPvv8Sy397AvNmD5Vs7/7HdlsXfvxs7auXi+/9qaSk5MI9QAAQFwj1AMAAECHPbZgoZavWKmjZkzTBeedLavV2uz8aSefoH899Jg+/uQzJSUl6ewzTunS/mzevLVLrx8AAKC3MIqLi82e7gQAAAD6ntVrinXfvx7W0CGD9KObvieLJfJ2zTW1dXriqWd1yIRxmnnk9H3Hq6qq9e//vKc1a9eprr5BCXa7BgzI16wjp+uwKZOaXceOnaV6+933tWnTZtXW1cvpcCg3N1tHzZiuww+bLEm6595/af3GTc0ud+lF5+uIaYd1yf0HAADoSczUAwAAQId88unnkqQTjjs6aqAnSWmpKbrxe1c3O1ZeUak/3XOfmpqaNHPGdBUVFaqmplaffPq5Hnn8KZWVV+j0U0+U9oR/f/zLfXI5HTp65pHKyEiTx+PVZ198qUefeFoej0fHzDpSp596oj746GN9ufxrzTrqCI0YPlSDBhZ18V8BAACgZxDqAQAAoEM27Vnq2pEiGC+89JoaGz26es4lOnTSxH3HZx41XX/441/17/+8pxnTpyo9PU1ffb1KTU1NuvSi72rK5EP2tT1qxjQ9/OiTqqmplSSNGD5U69Zv1Jf6WgOLCptdLwAAQLyJ/pMqAAAA0IqGhgY5HAlyOZ0xXa6pqUmr1hQrNSW5RfDmcjp12JRJCofD+nrVGknat0/fho3fyDS/3TnGarXqmqsu03fOOq1T7g8AAEBfwkw9AAAAdIjVYlXYDMd8ubLySoXDYeXn50U8n5+bK0kqL6+QJB126CT994OPtOijJVq9dp3GjRmlUSOGa+TIYTEHigAAAPGCUA8AAAAdkpqaorLyCtU3NCg5Kandl/M3+SVJCXZ7xPP2BPuedk2SpMREt26/9SZ98NESfbn8ay36aIk++PBj2Ww2TZk8Ued+5wwlJSZ2yn0CAADoKwj1AAAA0CHDhg5WWXmFVq8u1rTDp7Tadv/gz+lwSJIaGj0R2/r9Tc3aSZLL5dIpJx6nU048TnX19VpbvF4fL/lMSz9bprq6et34/bmdeM8AAAB6P/bUAwAAQIdMP/wwSdJb7/xXgUAgajufz687775Xf7n3nwqFQsrJzpbValV5eYVCoVCL9jt2lkqS8vJyI15fSnKyDj/sUP3gxms1ZNBArSleL6/P12n3CwAAoC8g1AMAAECHDBs6WEcecbjKyiv00KNPyuf3t2jj8Xj0jwcf0a5dNZowfqysVqsSEuyaMH6MGhob9cWXK5q193q9+uzzZbLZbJo4fqwk6YmnntX/3fkXNe1ZjruXYRiy2qyyWCwyDEOSZLHu/njbWsgIAAAQD1h+CwAAgA47/9yzZJqmPv7kM/3qd3fp8MMma0B+vsLhkHbsKNUnny2T3+/X2WecquOPmbnvcueedbo2btqsJxc+rx07dqqwYIDqGxr04eJPVFNbpwvOO1vJybuX644eNUKffPqF7vzzvZo+dYrS0lLl9zdp9dpibdj4jY484vB9S3WzMjMkSR98+LGaAgHl5+Zo3NjRPfTXAQAA6DpGcXGx2dOdAAAAQN+2fuMmfbL0c236Zotq6+pkGIYy0tM1auRwHXnE4cqPsJR2164avfHWO1q9dp3q6urlcDg0aGChjjv6qBZB3KrVa/XBR0u0bdt2NTZ65HK5lJ2dqSOmTdX0w6fIYtk9Qy8YDGr+409r1ZpiOZ0OHX/sLJ1w7Kxu+zsAAAB0F0I9AAAAAAAAoI9hTz0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPqY/w/L7g52QudnKwAAAABJRU5ErkJggg=="
-          },
-          "metadata": {}
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "b42576d5-575c-48d6-b00f-48b48d26dd30",
-        "showInput": true,
-        "customInput": null,
-        "outputsInitialized": false
-      },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Min Cost: 1.0\n",
+      "Max Cost: 121.51041751873485\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "from math import exp\n",
+    "def cost_func(x):\n",
+    "    \"\"\"A simple exponential cost function.\"\"\"\n",
+    "    exp_arg = torch.tensor(4.8, **tkwargs)\n",
+    "    val = torch.exp(exp_arg * x)\n",
+    "    return val\n",
+    "\n",
+    "\n",
+    "# Displaying the min and max costs for this optimization\n",
+    "print(f\"Min Cost: {cost_func(0)}\")\n",
+    "print(f\"Max Cost: {cost_func(1)}\")\n",
+    "\n",
+    "def cost_callable(X: torch.Tensor) -> torch.Tensor:\n",
+    "    r\"\"\"Wrapper for the cost function that takes care of shaping\n",
+    "    input and output arrays for interfacing with cost_func.\n",
+    "    This is passed as a callable function to MOMF.\n",
+    "\n",
+    "    Args:\n",
+    "        X: A `batch_shape x q x d`-dim Tensor\n",
+    "    Returns:\n",
+    "        Cost `batch_shape x q x m`-dim Tensor of cost generated\n",
+    "        from fidelity dimension using cost_func.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    return cost_func(X[..., -1:])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "originalKey": "2f3f70a4-3654-4e65-ab6c-69b1e16ab3d6",
+    "outputsInitialized": false,
+    "showInput": false
+   },
+   "source": [
+    "### Model Initialization \n",
+    "We use a multi-output SingleTaskGP to model the problem with a homoskedastic Gaussian likelihood with an inferred noise level. \n",
+    "The model is initialized with random points, where the fidelity is sampled from a probability distribution with a PDF that is inversely proportional to the cost: $p(s)=C(s)^{-1}$. The initialization is given a budget equivalent to 2 full-fidelity evaluations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false,
+    "customOutput": null,
+    "executionStartTime": 1700239924281,
+    "executionStopTime": 1700239924318,
+    "originalKey": "b35c722b-c75a-4e13-ab18-ff9fd01fad95",
+    "outputsInitialized": false,
+    "requestMsgId": "dcdc2b90-8d52-479b-9aea-e7a69bf194a3"
+   },
+   "outputs": [],
+   "source": [
+    "from botorch.models.gp_regression import SingleTaskGP\n",
+    "from botorch.models.model_list_gp_regression import ModelListGP\n",
+    "from botorch.models.transforms.outcome import Standardize\n",
+    "from gpytorch.kernels import MaternKernel, ScaleKernel\n",
+    "from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood\n",
+    "from gpytorch.priors import GammaPrior\n",
+    "from botorch.utils.transforms import normalize\n",
+    "\n",
+    "\n",
+    "def inv_transform(u):\n",
+    "    # define inverse transform to sample from the probability distribution with\n",
+    "    # PDF proportional to 1/(c(x))\n",
+    "    # u is a uniform(0,1) rv\n",
+    "    return (\n",
+    "        5 / 24 * torch.log(-exp(24 / 5) / (exp(24 / 5) * u - u - exp(24 / 5)))\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def gen_init_data(n: int):\n",
+    "    r\"\"\"\n",
+    "    Generates the initial data. Sample fidelities inversely proportional to cost.\n",
+    "    \"\"\"\n",
+    "    # total cost budget is n\n",
+    "    train_x = torch.empty(\n",
+    "        0, BC.bounds.shape[1], dtype=BC.bounds.dtype, device=BC.bounds.device\n",
+    "    )\n",
+    "    total_cost = 0\n",
+    "    # assume target fidelity is 1\n",
+    "    total_cost_limit = (\n",
+    "        n\n",
+    "        * cost_callable(\n",
+    "            torch.ones(\n",
+    "                1, BC.bounds.shape[1], dtype=BC.bounds.dtype, device=BC.bounds.device\n",
+    "            )\n",
+    "        ).item()\n",
+    "    )\n",
+    "    while total_cost < total_cost_limit:\n",
+    "        new_x = torch.rand(\n",
+    "            1, BC.bounds.shape[1], dtype=BC.bounds.dtype, device=BC.bounds.device\n",
+    "        )\n",
+    "        new_x[:, -1] = inv_transform(new_x[:, -1])\n",
+    "        total_cost += cost_callable(new_x)\n",
+    "        train_x = torch.cat([train_x, new_x], dim=0)\n",
+    "    train_x = train_x[:-1]\n",
+    "    train_obj = BC(train_x)\n",
+    "    return train_x, train_obj\n",
+    "\n",
+    "\n",
+    "def initialize_model(train_x, train_obj, state_dict=None):\n",
+    "    \"\"\"Initializes a ModelList with Matern 5/2 Kernel and returns the model and its MLL.\n",
+    "    \n",
+    "    Note: a batched model could also be used here.\n",
+    "    \"\"\"\n",
+    "    models = []\n",
+    "    for i in range(train_obj.shape[-1]):\n",
+    "        m = SingleTaskGP(\n",
+    "            train_x,\n",
+    "            train_obj[:, i : i + 1],\n",
+    "            train_Yvar=torch.full_like(train_obj[:, i : i + 1], 1e-6),\n",
+    "            outcome_transform=Standardize(m=1),\n",
+    "            covar_module=ScaleKernel(\n",
+    "                MaternKernel(\n",
+    "                    nu=2.5,\n",
+    "                    ard_num_dims=train_x.shape[-1],\n",
+    "                    lengthscale_prior=GammaPrior(2.0, 2.0),\n",
+    "                ),\n",
+    "                outputscale_prior=GammaPrior(2.0, 0.15),\n",
+    "            ),\n",
+    "        )\n",
+    "        models.append(m)\n",
+    "    model = ModelListGP(*models)\n",
+    "    mll = SumMarginalLogLikelihood(model.likelihood, model)\n",
+    "    if state_dict is not None:\n",
+    "        model.load_state_dict(state_dict=state_dict)\n",
+    "    return mll, model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "originalKey": "dcc1666f-f387-40b0-8137-25b133d22dd2",
+    "outputsInitialized": false,
+    "showInput": false
+   },
+   "source": [
+    "### Helper function to optimize acquisition function \n",
+    "This is a helper function that initializes, optimizes the acquisition function MOMF and returns the new_x and new_obj. The problem is called from within this helper function.\n",
+    "\n",
+    "A simple initialization heuristic is used to select the 20 restart initial locations from a set of 1024 random points. Multi-start optimization of the acquisition function is performed using LBFGS-B with exact gradients computed via auto-differentiation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "code_folding": [],
+    "collapsed": false,
+    "customOutput": null,
+    "executionStartTime": 1700239926777,
+    "executionStopTime": 1700239926816,
+    "hidden_ranges": [],
+    "originalKey": "9095cc6a-0e14-4be1-ae9b-e56535e2dcba",
+    "outputsInitialized": false,
+    "requestMsgId": "fe16757e-7f35-462b-a5ca-cd0ddf689f79"
+   },
+   "outputs": [],
+   "source": [
+    "from botorch.acquisition.multi_objective.multi_fidelity import MOMF\n",
+    "from botorch.optim.optimize import optimize_acqf\n",
+    "from botorch.sampling.normal import SobolQMCNormalSampler\n",
+    "from botorch.utils.multi_objective.box_decompositions.non_dominated import (\n",
+    "    FastNondominatedPartitioning,\n",
+    ")\n",
+    "from botorch.utils.transforms import unnormalize\n",
+    "\n",
+    "\n",
+    "dim_y_momf = dim_y + 1  # Output Dimesnion for MOMF optimization\n",
+    "ref_point_momf = torch.zeros(dim_y_momf, **tkwargs)\n",
+    "\n",
+    "def fid_obj(X: torch.Tensor) -> torch.Tensor:\n",
+    "    \"\"\"\n",
+    "    A Fidelity Objective that can be thought of as a trust objective.\n",
+    "    Higher Fidelity simulations are rewarded as being more\n",
+    "    trustworthy. Here we consider just a linear fidelity objective.\n",
+    "    \"\"\"\n",
+    "    fid_obj = 1 * X[..., -1]\n",
+    "    return fid_obj\n",
+    "\n",
+    "\n",
+    "def get_objective_momf(x: torch.Tensor) -> torch.Tensor:\n",
+    "    \"\"\"Wrapper around the Objective function to take care of fid_obj stacking\"\"\"\n",
+    "    y = BC(x)  # The Branin-Currin is called\n",
+    "    fid = fid_obj(x)  # Getting the fidelity objective values\n",
+    "    fid_out = fid.unsqueeze(-1)\n",
+    "    # Concatenating objective values with fid_objective\n",
+    "    y_out = torch.cat([y, fid_out], -1)\n",
+    "    return y_out\n",
+    "\n",
+    "\n",
+    "def optimize_MOMF_and_get_obs(\n",
+    "    model: SingleTaskGP,\n",
+    "    train_obj: torch.Tensor,\n",
+    "    sampler: SobolQMCNormalSampler,\n",
+    "    ref_point: torch.Tensor,\n",
+    "    standard_bounds: torch.Tensor,\n",
+    "    BATCH_SIZE: int,\n",
+    "    cost_call: Callable[[torch.Tensor], torch.Tensor],\n",
+    "):\n",
+    "    \"\"\"\n",
+    "    Wrapper to call MOMF and optimizes it in a sequential greedy\n",
+    "    fashion returning a new candidate and evaluation\n",
+    "    \"\"\"\n",
+    "    partitioning = FastNondominatedPartitioning(\n",
+    "        ref_point=torch.tensor(ref_point, **tkwargs), Y=train_obj\n",
+    "    )\n",
+    "    acq_func = MOMF(\n",
+    "        model=model,\n",
+    "        ref_point=ref_point,  # use known reference point\n",
+    "        partitioning=partitioning,\n",
+    "        sampler=sampler,\n",
+    "        cost_call=cost_call,\n",
+    "    )\n",
+    "    # Optimization\n",
+    "    candidates, vals = optimize_acqf(\n",
+    "        acq_function=acq_func,\n",
+    "        bounds=standard_bounds,\n",
+    "        q=BATCH_SIZE,\n",
+    "        num_restarts=NUM_RESTARTS,\n",
+    "        raw_samples=RAW_SAMPLES,  # used for intialization heuristic\n",
+    "        options={\"batch_limit\": 5, \"maxiter\": 200, \"nonnegative\": True},\n",
+    "        sequential=True,\n",
+    "    )\n",
+    "    # if the AF val is 0, set the fidelity parameter to zero\n",
+    "    if vals.item() == 0.0:\n",
+    "        candidates[:, -1] = 0.0\n",
+    "    # observe new values\n",
+    "    new_x = unnormalize(candidates.detach(), bounds=standard_bounds)\n",
+    "    new_obj = get_objective_momf(new_x)\n",
+    "    return new_x, new_obj"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "f580b5fe-d172-4d7f-a40a-98bc8acdd0f8",
+    "outputsInitialized": false,
+    "showInput": false
+   },
+   "source": [
+    "### Define helper functions for MF-HVKG\n",
+    "\n",
+    "`get_current_value` optimizes the current posterior mean at the full fidelity to determine the hypervolume under the current model.\n",
+    "\n",
+    "`optimize_HVKG_and_get_obs` creates the MF-HVKG acquisition function, optimizes it, and returns the new design and corresponding observation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "executionStartTime": 1700239931973,
+    "executionStopTime": 1700239932009,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "1d61db27-bd71-4e4c-bffc-b8279771e682",
+    "outputsInitialized": false,
+    "requestMsgId": "e3e094aa-d96f-42f2-b499-0bdce21228d6",
+    "showInput": true
+   },
+   "outputs": [],
+   "source": [
+    "from botorch.acquisition.cost_aware import InverseCostWeightedUtility\n",
+    "from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction\n",
+    "from botorch.acquisition.multi_objective.hypervolume_knowledge_gradient import (\n",
+    "    _get_hv_value_function,\n",
+    "    qMultiFidelityHypervolumeKnowledgeGradient,\n",
+    ")\n",
+    "from botorch.acquisition.utils import project_to_target_fidelity\n",
+    "from botorch.models.deterministic import GenericDeterministicModel\n",
+    "from torch import Tensor\n",
+    "\n",
+    "NUM_INNER_MC_SAMPLES = 32\n",
+    "NUM_PARETO = 5 if SMOKE_TEST else 10\n",
+    "NUM_FANTASIES = 2 if SMOKE_TEST else 8\n",
+    "\n",
+    "\n",
+    "def get_current_value(\n",
+    "    model: SingleTaskGP,\n",
+    "    ref_point: torch.Tensor,\n",
+    "    bounds: torch.Tensor,\n",
+    "    normalized_target_fidelities: Dict[int, float],\n",
+    "):\n",
+    "    \"\"\"Helper to get the hypervolume of the current hypervolume\n",
+    "    maximizing set.\n",
+    "    \"\"\"\n",
+    "    fidelity_dims, fidelity_targets = zip(*normalized_target_fidelities.items())\n",
+    "    # optimize\n",
+    "    non_fidelity_dims = list(set(range(dim_x)) - set(fidelity_dims))\n",
+    "    curr_val_acqf = FixedFeatureAcquisitionFunction(\n",
+    "        acq_function=_get_hv_value_function(\n",
+    "            model=model,\n",
+    "            ref_point=ref_point,\n",
+    "            sampler=SobolQMCNormalSampler(\n",
+    "                sample_shape=torch.Size([NUM_INNER_MC_SAMPLES]),\n",
+    "                resample=False,\n",
+    "                collapse_batch_dims=True,\n",
+    "            ),\n",
+    "            use_posterior_mean=True,\n",
+    "        ),\n",
+    "        d=dim_x,\n",
+    "        columns=fidelity_dims,\n",
+    "        values=fidelity_targets,\n",
+    "    )\n",
+    "    # optimize\n",
+    "    _, current_value = optimize_acqf(\n",
+    "        acq_function=curr_val_acqf,\n",
+    "        bounds=bounds[:, non_fidelity_dims],\n",
+    "        q=NUM_PARETO,\n",
+    "        num_restarts=1,\n",
+    "        raw_samples=1024,\n",
+    "        return_best_only=True,\n",
+    "        options={\"nonnegative\": True},\n",
+    "    )\n",
+    "    return current_value\n",
+    "\n",
+    "\n",
+    "normalized_target_fidelities = {}\n",
+    "for idx, fidelity in target_fidelities.items():\n",
+    "    lb = standard_bounds[0, idx].item()\n",
+    "    ub = standard_bounds[1, idx].item()\n",
+    "    normalized_target_fidelities[idx] = (fidelity - lb) / (ub - lb)\n",
+    "project_d = dim_x\n",
+    "\n",
+    "\n",
+    "def project(X: Tensor) -> Tensor:\n",
+    "\n",
+    "    return project_to_target_fidelity(\n",
+    "        X=X,\n",
+    "        d=project_d,\n",
+    "        target_fidelities=normalized_target_fidelities,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def optimize_HVKG_and_get_obs(\n",
+    "    model: SingleTaskGP,\n",
+    "    ref_point: torch.Tensor,\n",
+    "    standard_bounds: torch.Tensor,\n",
+    "    BATCH_SIZE: int,\n",
+    "    cost_call: Callable[[torch.Tensor], torch.Tensor],\n",
+    "):\n",
+    "    \"\"\"Utility to initialize and optimize HVKG.\"\"\"\n",
+    "    cost_model = GenericDeterministicModel(cost_call)\n",
+    "    cost_aware_utility = InverseCostWeightedUtility(cost_model=cost_model)\n",
+    "    current_value = get_current_value(\n",
+    "        model=model,\n",
+    "        ref_point=ref_point,\n",
+    "        bounds=standard_bounds,\n",
+    "        normalized_target_fidelities=normalized_target_fidelities,\n",
+    "    )\n",
+    "\n",
+    "    acq_func = qMultiFidelityHypervolumeKnowledgeGradient(\n",
+    "        model=model,\n",
+    "        ref_point=ref_point,  # use known reference point\n",
+    "        num_fantasies=NUM_FANTASIES,\n",
+    "        num_pareto=NUM_PARETO,\n",
+    "        current_value=current_value,\n",
+    "        cost_aware_utility=cost_aware_utility,\n",
+    "        target_fidelities=normalized_target_fidelities,\n",
+    "        project=project,\n",
+    "    )\n",
+    "    # Optimization\n",
+    "    candidates, vals = optimize_acqf(\n",
+    "        acq_function=acq_func,\n",
+    "        bounds=standard_bounds,\n",
+    "        q=BATCH_SIZE,\n",
+    "        num_restarts=1,\n",
+    "        raw_samples=RAW_SAMPLES,  # used for intialization heuristic\n",
+    "        options={\"batch_limit\": 5},\n",
+    "    )\n",
+    "    # if the AF val is 0, set the fidelity parameter to zero\n",
+    "    if vals.item() == 0.0:\n",
+    "        candidates[:, -1] = 0.0\n",
+    "    # observe new values\n",
+    "    new_x = unnormalize(candidates.detach(), bounds=BC.bounds)\n",
+    "    new_obj = BC(new_x)\n",
+    "    return new_x, new_obj"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "originalKey": "bdb86f2e-6774-4b00-af78-d081948812a5",
+    "outputsInitialized": false,
+    "showInput": false
+   },
+   "source": [
+    "### Define helper functions for MF-HVKG\n",
+    "\n",
+    "We run MOMF to optimize the multi-fidelity versions of the Branin-Currin functions. The optimization loop works in the following sequence. \n",
+    "\n",
+    "1. At the start with an initialization equivalent to 2 full fidelity evaluations.\n",
+    "2. The models are used to generate an acquisition function that is optimized to select new input parameters\n",
+    "3. The objective function is evaluated at the suggested new_x and returns a new_obj.\n",
+    "4. The models are updated with the new points and then are used again to make the next prediction.\n",
+    "\n",
+    "The evaluation budget for the optimization is set to 4 full fidelity evaluations.\n",
+    "\n",
+    "Note: running this takes some time.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "customOutput": null,
+    "executionStartTime": 1700239933421,
+    "executionStopTime": 1700239933474,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "ec218c40-b012-40cc-bc28-ff0b2bedc941",
+    "outputsInitialized": false,
+    "requestMsgId": "e5e1ca9f-350b-4d84-85cc-b5765bd5479e",
+    "showInput": true
+   },
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "from botorch import fit_gpytorch_mll\n",
+    "from gpytorch.utils.warnings import NumericalWarning\n",
+    "\n",
+    "# Ignore warnings that a small jitter is being added to the diagonal for stability\n",
+    "warnings.simplefilter(\"ignore\", category=NumericalWarning)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "code_folding": [],
+    "collapsed": false,
+    "customOutput": null,
+    "executionStartTime": 1700239934173,
+    "executionStopTime": 1700239960450,
+    "hidden_ranges": [],
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "d250edba-f44e-4630-a1d1-90d050115f80",
+    "output": {
+     "id": "339093968712897"
+    },
+    "outputsInitialized": false,
+    "requestMsgId": "a740fdb3-387b-46f7-9715-1247be0f0c7b"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Intializing train_x to zero\n",
+    "verbose = False\n",
+    "torch.manual_seed(0)\n",
+    "train_x_momf, _ = gen_init_data(n_INIT)\n",
+    "train_obj_momf = get_objective_momf(train_x_momf)\n",
+    "# Generate Sampler\n",
+    "momf_sampler = SobolQMCNormalSampler(sample_shape=torch.Size([MC_SAMPLES]))\n",
+    "\n",
+    "# run N_BATCH rounds of BayesOpt after the initial random batch\n",
+    "iteration = 0\n",
+    "total_cost = cost_callable(train_x_momf).sum().item()\n",
+    "while total_cost < EVAL_BUDGET * cost_func(1):\n",
+    "    if verbose:\n",
+    "        print(f\"cost: {total_cost}\")\n",
+    "\n",
+    "    # reinitialize the models so they are ready for fitting on next iteration\n",
+    "    mll, model = initialize_model(normalize(train_x_momf, BC.bounds), train_obj_momf)\n",
+    "\n",
+    "    fit_gpytorch_mll(mll=mll)  # Fit the model\n",
+    "\n",
+    "    # optimize acquisition functions and get new observations\n",
+    "    new_x, new_obj = optimize_MOMF_and_get_obs(\n",
+    "        model=model,\n",
+    "        train_obj=train_obj_momf,\n",
+    "        sampler=momf_sampler,\n",
+    "        ref_point=ref_point_momf,\n",
+    "        standard_bounds=standard_bounds,\n",
+    "        BATCH_SIZE=BATCH_SIZE,\n",
+    "        cost_call=cost_callable,\n",
+    "    )\n",
+    "    # Updating train_x and train_obj\n",
+    "    train_x_momf = torch.cat([train_x_momf, new_x], dim=0)\n",
+    "    train_obj_momf = torch.cat([train_obj_momf, new_obj], dim=0)\n",
+    "    iteration += 1\n",
+    "    total_cost += cost_callable(new_x).sum().item()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "executionStartTime": 1699738891403,
+    "executionStopTime": 1699738891407,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "2e193c2e-f4c4-4d2c-b592-f51a6cc3d5a9",
+    "outputsInitialized": false,
+    "requestMsgId": "2e193c2e-f4c4-4d2c-b592-f51a6cc3d5a9",
+    "showInput": false
+   },
+   "source": [
+    "### Run MF-HVKG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "customOutput": null,
+    "executionStartTime": 1700239960506,
+    "executionStopTime": 1700240950614,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "4a9f3f42-dd1f-45f2-9125-511f72ad337a",
+    "output": {
+     "id": "379210377773864"
+    },
+    "outputsInitialized": false,
+    "requestMsgId": "de9c995c-66dd-49de-b8cf-dc834e52fc38",
+    "showInput": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/botorch/optim/initializers.py:432: BadInitialCandidatesWarning:\n",
+      "\n",
+      "Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/botorch/optim/initializers.py:432: BadInitialCandidatesWarning:\n",
+      "\n",
+      "Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "torch.manual_seed(0)\n",
+    "train_x_kg, train_obj_kg = gen_init_data(n_INIT)\n",
+    "MF_n_INIT = train_x_kg.shape[0]\n",
+    "iteration = 0\n",
+    "total_cost = cost_callable(train_x_kg).sum().item()\n",
+    "while total_cost < EVAL_BUDGET * cost_func(1):\n",
+    "    if verbose:\n",
+    "        print(f\"cost: {total_cost}\")\n",
+    "\n",
+    "    # reinitialize the models so they are ready for fitting on next iteration\n",
+    "    mll, model = initialize_model(normalize(train_x_kg, BC.bounds), train_obj_kg)\n",
+    "\n",
+    "    fit_gpytorch_mll(mll=mll)  # Fit the model\n",
+    "    # optimize acquisition functions and get new observations\n",
+    "    new_x, new_obj = optimize_HVKG_and_get_obs(\n",
+    "        model=model,\n",
+    "        ref_point=ref_point,\n",
+    "        standard_bounds=standard_bounds,\n",
+    "        BATCH_SIZE=BATCH_SIZE,\n",
+    "        cost_call=cost_callable,\n",
+    "    )\n",
+    "    # Updating train_x and train_obj\n",
+    "    train_x_kg = torch.cat([train_x_kg, new_x], dim=0)\n",
+    "    train_obj_kg = torch.cat([train_obj_kg, new_obj], dim=0)\n",
+    "    iteration += 1\n",
+    "    total_cost += cost_callable(new_x).sum().item()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "originalKey": "bc189d13-6ad9-4687-8e67-c506dcc1dad1",
+    "output": {
+     "id": "1977100562657087"
+    },
+    "outputsInitialized": true,
+    "showInput": false
+   },
+   "source": [
+    "### Result:  Evaluating the Pareto front at the highest fidelity using NSGA-II on the posterior mean\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false,
+    "customOutput": null,
+    "executionStartTime": 1700240950637,
+    "executionStopTime": 1700240950639,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "275b1f0b-4d84-4318-99b1-c1a7505bf1a4",
+    "outputsInitialized": false,
+    "requestMsgId": "19199126-7e1c-4adb-88bb-35d42d1f26af"
+   },
+   "outputs": [],
+   "source": [
+    "from botorch.utils.multi_objective.pareto import (\n",
+    "    _is_non_dominated_loop,\n",
+    "    is_non_dominated,\n",
+    ")\n",
+    "from gpytorch import settings\n",
+    "\n",
+    "try:\n",
+    "    from pymoo.algorithms.nsga2 import NSGA2\n",
+    "    from pymoo.model.problem import Problem\n",
+    "    from pymoo.optimize import minimize\n",
+    "    from pymoo.util.termination.max_gen import MaximumGenerationTermination\n",
+    "\n",
+    "    def get_pareto(\n",
+    "        model,\n",
+    "        non_fidelity_indices,\n",
+    "        project,\n",
+    "        population_size=250,\n",
+    "        max_gen=100,\n",
+    "        is_mf_model=True,\n",
+    "    ):\n",
+    "        \"\"\"Optimize the posterior mean using NSGA-II.\"\"\"\n",
+    "        tkwargs = {\n",
+    "            \"dtype\": BC.ref_point.dtype,\n",
+    "            \"device\": BC.ref_point.device,\n",
+    "        }\n",
+    "        dim = len(non_fidelity_indices)\n",
+    "\n",
+    "        class PosteriorMeanPymooProblem(Problem):\n",
+    "            def __init__(self):\n",
+    "                super().__init__(\n",
+    "                    n_var=dim,\n",
+    "                    n_obj=BC.num_objectives,\n",
+    "                    type_var=np.double,\n",
+    "                )\n",
+    "                self.xl = np.zeros(dim)\n",
+    "                self.xu = np.ones(dim)\n",
+    "\n",
+    "            def _evaluate(self, x, out, *args, **kwargs):\n",
+    "                X = torch.from_numpy(x).to(**tkwargs)\n",
+    "                if is_mf_model:\n",
+    "                    X = project(X)\n",
+    "                with torch.no_grad():\n",
+    "                    with settings.cholesky_max_tries(9):\n",
+    "                        # eval in batch mode\n",
+    "                        y = model.posterior(X.unsqueeze(-2)).mean.squeeze(-2)\n",
+    "                out[\"F\"] = -y.cpu().numpy()\n",
+    "\n",
+    "        pymoo_problem = PosteriorMeanPymooProblem()\n",
+    "        algorithm = NSGA2(\n",
+    "            pop_size=population_size,\n",
+    "            eliminate_duplicates=True,\n",
+    "        )\n",
+    "        res = minimize(\n",
+    "            pymoo_problem,\n",
+    "            algorithm,\n",
+    "            termination=MaximumGenerationTermination(max_gen),\n",
+    "            seed=0,  # fix seed\n",
+    "            verbose=False,\n",
+    "        )\n",
+    "        X = torch.tensor(\n",
+    "            res.X,\n",
+    "            **tkwargs,\n",
+    "        )\n",
+    "        # project to full fidelity\n",
+    "        if is_mf_model:\n",
+    "            if project is not None:\n",
+    "                X = project(X)\n",
+    "        # determine Pareto set of designs under model\n",
+    "        with torch.no_grad():\n",
+    "            preds = model.posterior(X.unsqueeze(-2)).mean.squeeze(-2)\n",
+    "        pareto_mask = is_non_dominated(preds)\n",
+    "        X = X[pareto_mask]\n",
+    "        # evaluate Pareto set of designs on true function and compute hypervolume\n",
+    "        if not is_mf_model:\n",
+    "            X = project(X)\n",
+    "        X = unnormalize(X, BC.bounds)\n",
+    "        Y = BC(X)\n",
+    "        # compute HV\n",
+    "        partitioning = FastNondominatedPartitioning(ref_point=BC.ref_point, Y=Y)\n",
+    "        return partitioning.compute_hypervolume().item()\n",
+    "\n",
+    "except ImportError:\n",
+    "    NUM_DISCRETE_POINTS = 100 if SMOKE_TEST else 100000\n",
+    "    CHUNK_SIZE = 512\n",
+    "\n",
+    "    def get_pareto(\n",
+    "        model,\n",
+    "        non_fidelity_indices,\n",
+    "        project,\n",
+    "        population_size=250,\n",
+    "        max_gen=100,\n",
+    "        is_mf_model=True,\n",
+    "    ):\n",
+    "        \"\"\"Optimize the posterior mean over a discrete set.\"\"\"\n",
+    "        tkwargs = {\n",
+    "            \"dtype\": BC.ref_point.dtype,\n",
+    "            \"device\": BC.ref_point.device,\n",
+    "        }\n",
+    "        dim_x = BC.dim\n",
+    "\n",
+    "        discrete_set = torch.rand(NUM_DISCRETE_POINTS, dim_x - 1, **tkwargs)\n",
+    "        if is_mf_model:\n",
+    "            discrete_set = project(discrete_set)\n",
+    "        discrete_set[:, -1] = 1.0  # set to target fidelity\n",
+    "        with torch.no_grad():\n",
+    "            preds_list = []\n",
+    "            for start in range(0, NUM_DISCRETE_POINTS, CHUNK_SIZE):\n",
+    "                preds = model.posterior(\n",
+    "                    discrete_set[start : start + CHUNK_SIZE].unsqueeze(-2)\n",
+    "                ).mean.squeeze(-2)\n",
+    "                preds_list.append(preds)\n",
+    "            preds = torch.cat(preds_list, dim=0)\n",
+    "            pareto_mask = _is_non_dominated_loop(preds)\n",
+    "            pareto_X = discrete_set[pareto_mask]\n",
+    "        if not is_mf_model:\n",
+    "            pareto_X = project(pareto_X)\n",
+    "        pareto_X = unnormalize(pareto_X, BC.bounds)\n",
+    "        Y = BC(pareto_X)\n",
+    "        # compute HV\n",
+    "        partitioning = FastNondominatedPartitioning(ref_point=BC.ref_point, Y=Y)\n",
+    "        return partitioning.compute_hypervolume().item()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "ad70a987-1877-4bc1-a4cd-49fca37dff2b",
+    "outputsInitialized": false,
+    "showInput": false
+   },
+   "source": [
+    "## Evaluate MF-HVKG\n",
+    "\n",
+    "We evaluate performance after every 5 evaluations (this is to speed things up, since there are many observations)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "customOutput": null,
+    "executionStartTime": 1700240950661,
+    "executionStopTime": 1700241053956,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "41ef8566-7400-441c-8087-d5842df6117d",
+    "output": {
+     "id": "1259701838157405"
+    },
+    "outputsInitialized": false,
+    "requestMsgId": "7ff2bd5b-cf9b-4843-9b7b-9fc463b52385",
+    "showInput": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "hvs_kg = []\n",
+    "costs = []\n",
+    "for i in range(MF_n_INIT, train_x_kg.shape[0] + 1, 5):\n",
+    "\n",
+    "    mll, model = initialize_model(\n",
+    "        normalize(train_x_kg[:i], BC.bounds), train_obj_kg[:i]\n",
+    "    )\n",
+    "    fit_gpytorch_mll(mll)\n",
+    "    hypervolume = get_pareto(\n",
+    "        model, project=project, non_fidelity_indices=[0, 1]\n",
+    "    )\n",
+    "    hvs_kg.append(hypervolume)\n",
+    "    costs.append(cost_callable(train_x_kg[:i]).sum().item())"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "executionStartTime": 1699739200762,
+    "executionStopTime": 1699739200768,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "11350000-d066-49a3-b950-f7633e1c507a",
+    "outputsInitialized": false,
+    "requestMsgId": "11350000-d066-49a3-b950-f7633e1c507a",
+    "showInput": false
+   },
+   "source": [
+    "## Evaluate MOMF\n",
+    "\n",
+    "We evaluate performance after every evaluation (there are not as many evaluations since MOMF queries higher fidelities more frequently)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "customOutput": null,
+    "executionStartTime": 1700241054021,
+    "executionStopTime": 1700241163531,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "7770db5f-be4d-40eb-b525-c6d18932c198",
+    "output": {
+     "id": "3721915894755385"
+    },
+    "outputsInitialized": false,
+    "requestMsgId": "89819efc-dd7a-42cf-8144-d9b6480bb5ae",
+    "showInput": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/xarfuse/uid-25744/62360c41-seed-nspid4026534570_cgpid30309810-ns-4026534567/gpytorch/likelihoods/noise_models.py:148: NumericalWarning:\n",
+      "\n",
+      "Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "hvs_momf = []\n",
+    "costs_momf = []\n",
+    "for i in range(MF_n_INIT, train_x_momf.shape[0] + 1):\n",
+    "\n",
+    "    mll, model = initialize_model(\n",
+    "        normalize(train_x_momf[:i], BC.bounds), train_obj_momf[:i, :2]\n",
+    "    )\n",
+    "    fit_gpytorch_mll(mll)\n",
+    "    hypervolume = get_pareto(model, project=project, non_fidelity_indices=[0, 1])\n",
+    "    hvs_momf.append(hypervolume)\n",
+    "    costs_momf.append(cost_callable(train_x_momf[:i]).sum().item())"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "f9e4b24a-6f83-4dd3-b1a4-9a3ebc231813",
+    "outputsInitialized": false,
+    "showInput": false
+   },
+   "source": [
+    "### Plot log inference hypervolume regret (under the model) vs cost\n",
+    "\n",
+    "Log inference hypervolume regret, defined as the logarithm of the difference between the maximum hypervolume dominated by the Pareto frontier and the hypervolume corresponding to the Pareto set identified by each algorithm, is a performance evaluation criterion for multi-information source multi-objective optimization [3]."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "executionStartTime": 1700241163589,
+    "executionStopTime": 1700241164394,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "0f68e995-1461-40bc-b71b-40d66dabefca",
+    "output": {
+     "id": "1783893625394451"
+    },
+    "outputsInitialized": true,
+    "requestMsgId": "0f0468b8-cbaf-47a1-b66a-200ebc3f5d89",
+    "showInput": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7f333f203cd0>"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABPUAAANJCAYAAABkiAl0AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAADz1klEQVR4nOzdeXiU1d3/8c89SzLZQ/Y9hM0NBEVWBUFxt2q11lZbq221tlUfuzxq+7T9tbWt2lZbq9ZqW5da676vdUGQTVQQWUR2skFC9n32+/cHEAkzgWQyk5kk79d1eUnOfWbmOzA3kA/nnK+xadMmUwAAAAAAAACGDEu0CwAAAAAAAADQP4R6AAAAAAAAwBBDqAcAAAAAAAAMMYR6AAAAAAAAwBBDqAcAAAAAAAAMMYR6AAAAAAAAwBBDqAcAAAAAAAAMMYR6AAAAAAAAwBBji3YBkCZMmBDtEhCE3+9XbXWFcgtLZLGQfwPRxj0JxBbuSSB2cD8CsYV7EgO1efPmPs3j0wUAAAAAAAAMMYR6AAAAAAAAwBBDqAcAAAAAAAAMMYR6AAAAAAAAwBBDqAcAAAAAAAAMMYR6AAAAAAAAwBBDqAcAAAAAAAAMMbZoFwAAAAAAAID+8/l8am5uVmdnZ7RLQR9YLBZlZGQoISEhLM9HqAcAAAAAADDE+Hw+VVdXa9SoUcrIyJBhGNEuCYfh8Xi0e/duFRYWymq1Dvj52H4LAAAAAAAwxDQ3N2vUqFFKSUkh0Bsi7Ha7srKy1NDQEJbnI9QDAAAAAAAYYjo7O5WcnBztMtBPCQkJcrlcYXkuQj0AAAAAAIAhiBV6Q084f804Uw8AAAAAAGAEqmr2q7HD7PfjMpIMFaWzTizaCPUAAAAAAABGmKpmv076Y4dc3v4/Nt4mLf1xEsFelPGzDwAAAAAAMMI0dpghBXqS5PIqpBV+CC9W6gEAAAAAACBm/P7Ov+itt9/VGaedoh//4Lqgc375m9u0bPlKff3SS3T5174iSfL7/Xrz7Xf11jvvaseOcjldLmVmZmjKsZN04fnnqqystMdzfO2Kq1W7p043/uh6nXbq/IDX8Pl8+srXv6Xm5hb98bZbNPnYiZKk087+4iHrf/Sh+5WXmzOAn4G+IdQDAAAAAABATHE4HFqydIWu+97Vio+P73Gtvb1DH3y4Wo4Dxr1er355y21at2GjvnLxhfr+Nd9WclKSdu2u0UuvvK7v3/C/+vEN1+qU+XMDXuftdxYHDfVWrV4jpzN4p9rzv3C2Lr3kS0GvpaWlhviu+4dQDwAAAAAAYBg5968dh53T6Q7v9tm/L3XrxbWe7q9f+V7SgJ5v3NgylVdUavn7H2j+yXN6XHtv6XIVFuSpq8vZPfboY09q9cef6E9/vFVHTBjXPZ6Tk60pkyfp7r8+oDv/cq/Gjx+r4qLC7uvHTzlW73/wkerrG5SVldnjdRYuek+TJx2jlR+uCqjP4YhXRsaoAb3HgeJMPQAAAAAAgGFkVYX/sP9trAlvqFfV3PP5B8pisWjmjGl6e+HigGvvvLtYs2ZO7/7a7XbrhZde1Rmnn9oj0DvQt795uWw2m1565fUe42PHlCk7K1MLF73XY7zL6dSyFR9o9qzpilWEegAAAAAAAIg58+acqFWr16ipubl7rK6+XuvWf6r5cz9fvbd5y1Z1dnVpxrSpvT5XgsOhKZMnadXqNQHXTp57UkB4uHzFSjkc8ZoyeVLY3k+4EeoBAAAAAAAg5kw9fopSU1P07qIl3WML312i0aUlPZpe1Nc3Svu22h5Kbk6O6hsaAsYXnHKyduws19ZtO7rH3nn3Pc2be5IsFmuY3k34caYeAAAAAAAAYo7VatW8uSfp7YWLdOEFX5D2nXN3cLMLq21v8Ob3H3pLsd/vl2EErm8rG12qMWNG6+2FizRubJmaW1q0+uNP9PVLL+n1uZ59/mW9+PLrAePJSUl6/NF/9Pk9DgShHgAAAAAAwDAyteTwGzM73WZYz9UrSrf06XX769T5J+v5F19ReUWl/H6/duws1y0n/7THnOx9DS5219Ro3NiyXp+rds8e5WRnBr22YP7Jeua5l3TVNy/XosVLlZuTraOOnKCa2j1B559x2im6+KILAsYtlsHbFEuoBwAAAAAAMIz0pfPs2mqfzri7M2yvedVJcbrqpLiwPd9+R0wYp+LiQr27aIl8Pp8mHnNUwDbb8ePGKj0tVctXfKA5J84K+jxdTqc+WbtB5559RtDr8+fN1T8eelSfrNsQdDXgwZKTk1RYkD+AdzZwnKkHAAAAAACAmHXq/JP1wUer9P4HH+rU+ScHXLdarbrwgvO0cNF7WrtuQ9DnePDhf0umqfPOOTPo9azMDE05dpLefGuhPtu0RafMO3SoFwtYqQcAAAAAAICYder8k/Wvfz8hq8WiOScFX4n35S9doC3btun/fnGLLrn4Qs2eNV3JycnavbtGL7/6hlZ+8JF+cuMPlJub0/vrnDJXd/z5Xo0fN1bFRYURfEfhQaiHkFU1+9XY0f/99xlJhorSWSQKAAAAAAAOLy83R8ccdaSSU5KUmpISdI7VatUvfnqj3nl3sd548x29+PKr6ujsUlZmho4/brL+evcdhw3q5pw4S3ff+4BOmTcnQu8kvIxNmzaF71REhGTChAnRLqHfqpr9OumPHXJ5+//YeJu09MdJMR/s+f1+1VZXKLewZFAPugQQHPckEFu4J4HYwf0IxJbBuicrKytVXFwc8uNHwvf1sepwv3abN2/u0/OwUg8haewwQ7rxJcnl3fv4ovRwVwUAAAAAAPqiKN2ipT9OYgfeEEaoBwAAAAAAMAIVpVtYcDOEEasCAAAAAAAAQwyhHgAAAAAAADDEEOoBAAAAAAAAQwyhHgAAAAAAADDEEOoBAAAAAACg23vNzTp3/Xq919wc7VJwCIR6AAAAAAAAkCR1+f26tbJSu91u3VpZqS6/P9oloReEegAAAAAAAJAkPVRTozqPR5JU5/Ho4ZqaaJeEXhDqAQAAAAAAQJVOpx6uqZG572tT0sO1tap0OqNcGYKxRbsAAAAAAAAARJdpmrq9sjL4eFWV7h47VoZhDEotv7/zL/po1cd66rGHgl7/2hVX66gjj1Bra5uqqnfp0Yf+Josl+Lq1635wkzo6OvTgA/foX/9+Qo/+50m9+sKTiouL657T1tauH974U/n8fv3p979TWlpq97Wqqmo99ewL+viTdWpoaFRcnF052dmaNWOaLr7oAiUnJ0XgZ6BvWKkHAAAAAAAwwi1uadGKtjb5Dhr3SVrR2qr3WlqiVFnvzjpjgfbU1WnNJ+uCXq+orNJnmzbrzNNP7fU5nE6XfvbL36iry6nbf/vLHoHeyg8+0jXX/VB19Q26/vvf0UMP3KO77rhNXzjnTL3+5tv63vU/UlNT9JqJEOoBAAAAAACMYF1+v26vrOw1JLJIui0Gm2acOHuGUlNT9N+3Fga9/tbb78pms+m0BfODXvd6vfr1b2/X7ppa3fbbXyo7K6v7WmNjk373+z9p1ozp+t2vf65pU49Tbm6OSkuK9YVzztRf7rxdHZ2dWrjovYi9v8Nh+y1CkpFkKN4mubz9f2y8be/jAQAAAABA+F2xaVO/5te43d3NMYLxH9A047sFBUHn/GfPHr3Z1NT99cNHHNGvGkJht9t16vyT9dobb6qjo0NJSZ9vhfX7/Xrn3cWaOf0EjUpPD3isaZr6/R1/0cZNm/XH225RUWHP9/XqG2/K5XLpmquvDLrtOC83R0899pCsVmuE3t3hEeohJEXpFi39cZIaO8zuseZOvy75Z+DhmZdOs+kbMz/fq56RZKgonUWiAAAAAABEwrqOjrA/5/6mGedmZKjY4Qi4XuN2R+R1D+esMxbo+Rdf0aL3lumcs07vHl+9Zq3q6ht0w3XfDfq4v97/T614/wPd9ttfauyYsoDra9dt0Jiy0crMyOj1taMZ6IlQDwNRlG5R0QFht2lagq7e8/qkYwuj+0EHAAAAAAADs7+Zxt3jxkW8aUZzc4u+cOFXg15zuVw66si9KwHLRpfqyCMm6M23F/YI9d58a6Gys7N0wtTjAh7/6GNP6oWXXtXRRx2pI48YH/Q1GhobVVJcFLb3EwmEeggbwzBUmG5oe73ZY7y62ez1MQAAAAAAYGjwSVrR1qadTqfKEhIi+lqpKSm6687bgl778U0/7/H1WWecqj/95T5VVlWruKhQHZ2dWv7+Sl180QVBu+K+8ebbuvpb39A/H/63HvjnI/ru1d8MmGOz2uQPcobg967/kSqrdvUYe/m5x0N4hwNHqIewKky3aHt9z1451S2xdZAmAAAAAADoP6uk6ampGh1k+224WawWFRbkB6/D2jOom3/yHP3t7w/pzbcW6ltXfl2L31sqj8erM08L3vX2L3fervz8PBmGofv/8bDGlI3WGaed0mNOVlamdu+uDXjsL392szzevVsUly57X/946F8DeJcDQ6iHsCpMC1x+u6vZlN9vymKhOQYAAAAAAJE26YCGEYfj8vu1uaurT3MNw9BNxcXBG0fExfXrdcMpISFBJ885UW8vXKxvXvE1vf3OYh035Vjl5uYEnZ+ZufecvC9deL42bdmqu+75m4qLC3X0kZ8395h+wvH66/3/VFVVtYqKCrvHc3Kyu3+cnp4W0fd1OIR6CKuCIA0w3D6pvsNUTgqhHgAAAAAAkdbfzrN/3bVLD9bU6FCHZxmSrsjNVXF8fNDrl+bk6NKc4CHaYDjz9AV64813tHT5+9qw8TP99KYf9ulxP/yf76u8vFK/+s3tuveuPyprX+B36vyT9cTTz+kvf31Av/3Vz2S32wMeW1FRGfb30R+0IEVYFaYHD+44Vw8AAAAAgNh0ZV6esu32XkMii6Rsu11X5OUNcmV9d8zRR6q0pFj33Pd3pSQna/bM6X16XILDof/3s5vkdrv1y1tuldvtliSlpCTrZzf/SFu3bdcP//f/tHT5+9pdU6vqXbu1ZNkK/fQXt+jp517UJRd/McLvrHeEegirwiAr9SSpuplz9QAAAAAAiEUJFotuKi5Wb9+5+yXdXFyshCBNJ2LJmaefqsbGJi04dV7QlXW9KSzI180/vkGbt2zTn/5yX/f4xGOO1t/u+ZMmTjxaDz7yb1393f/RNdf+UA//6z/Kz8vVA3/9s7595eURejeHZ2zatIklVFE2YcKEaJcQNlvr/Frwn1qlHV+nltXZcu1OliT9v3Pidc2cuGiX1y9+v1+11RXKLSwJ2i0HwODingRiC/ckEDu4H4HYMlj3ZGVlpYqLi8P2fKZp6rqtW/VBW5sObH+5vznG3WPHBj1LD/13uF+7zZs39+l5ht2ZeitWfqRnnn9JTqdLv/75Td2HH/ZFZ2eXFi5aok/WbVB9Q6MMQ8rPy9XsmdM1e+a0Hh/elR+u1r8ee7LX58rPy9XPbu7b/u3hJCPFVPrUPbIk+JQ+dY/2vJ4o02dhpR4AAAAAADFsfxOMiz79NOg4gV7sGTahXlt7ux5/8jmtXf9pv5ZY7tfc0qo//vletbS0asa043XKvDnq6urS0uUr9Z8nn1Xtnj268Pxzu+d37esMc+r8uRpdGpiuJiREvr1zLHqisVaWBJ8MQ7Ik+JR8ZJPaNmRqF2fqAQAAAAAQ04odDl2Rl9fdNONwzTEQXcMm1Lv9jrvl8/n0vauv1JtvL9KWbdv79fiXXnlDTU3NuvjC8zRv7ond4zOnn6Bf3/pHLVy0VAtOOVmpKSnSvlV9knT0kRN05BHjw/xuhqZKp1MP19Rof3hvGFLyUY3qLE9RdQvbAAAAAAAAiHVX5uXp5YYG7fF4Yr45xkg3bJKWMaNL9NMbb9DRR/WvbfN+o0alacrkiZo9c1qP8cTEBI0tGy3TNLVrd233eOe+lXoJCQkDrHx4ME1Tt1cGtnK2GNLMsxr063NJ9QEAAAAAiHUJFot+Ulys/Lg4/WQINMcYyYbNSr1vfuOyAT3+C2ef0eu1/QFe4gEB3v6VeomJe8f8fr/8fr9stv7/lPr9Q/+8ucUtLVrR1hYwbhrSDrWrI61Nfn9aVGoL1f5fl+Hw6wMMB9yTQGzhngRiB/cjEFsG6540TVOmGZmjruakpWlOWlr36yC8TNMMy+dj2IR6kVK9a7e2btuhnOwsFRcVdI/vD/pWrPxQH69Zp/qGRvn9fmVmZmj2zGk67ZSTZbVa+/QatdUVEat/MDhNU7c2NsuQFOxWNyTdWr5TozPS5RiCB2vW7a6KdgkADsA9CcQW7kkgdnA/ArEl0vek2+WWx+OO6GsgMtwuZ1iyoJgM9V5/850+zZs3Z3ZEt782NTXrgX/+S4Zh6NJLLurR6WX/Sr2PVq3RSbNnKD8/T62tbVq8ZLlefvW/2rmzQt/59jf61B0mt7AkYu9hMNy3e7ca/WbQQE/7gr5Gv6nXrXG6Jj9/kKsLnd/vV93uKmXnF0W0DTmAvuGeBGIL9yQQO7gfgdgyWPfkrl27JBkhNQtF9Ph8PsXFO5RbWNTrnLatW/v0XDEZ6r3y2pt9mjd96nERC/XKK6p0/z8eVkdHp674+lc0ftyYHtfPO+cMOZ1OjR1bpgTH551uZ06fqtvvuFvrNmzU2vWfavKkYw77WkP5D95Kp1OP1Nb2GujtZ0p6ZM8efSEzU8WOodUZ2GKxDOlfI2C44Z4EYgv3JBA7uB+B2BLpezIzM1M1NTXKyspSQkJCnxYVIbp8Pp927dqlnJycsHw2YjLUu/fPt0f19T9atUb/fuIZxcXZ9f1rvqUJ48cGzBk3tizoY61Wq+bNna3HnnhWGz/b3KdQb6jqrTnG4ebfPW4cv9kAAAAAADAACQkJKiwsVENDgxoaGqJdDvooJydHjjAtdorJUC+a3l64WM+/9JoK8vP0nW9/Q1mZGf1+jtSUFElSl9MZgQpjx06nM2hzjN74JK1oa9NOp1NldA0GAAAAAGBArFarcnJyol0GooRQ7wDvLV2h5196TUcdMV7fvvLrcjjig85zudzasPEzWSwWTTl2YsD1mj11kqSMUaMiXnM0jXY4NCslRR+0tcnXh/lWSdNTUzV6iG2/BQAAAAAAiDUj7sAFn8+nmto9amhs6jG+fcdOPf3cSxo7ZrS+c9UVvQZ6kmSzWfXUsy/q4Uef0J66+h7XOju7tGjxUhmGoeOnTIrY+4gFhmHopuLifs9n6y0AAAAAAMDADIuVeg2NTSqv+Pxst7aOdknSho2blJycJEnKzMhQaUmRmptbdMutd6ikuFA3/ej67sc8/dzL8vv9mnTMUVq3/tOgr5Ofl6v8vFxZrVZdfOF5evjRJ3THXX/VnNkzlZ2dpaamZi1d/r6amlt09pkLVFxUGPH3Hm3FDoeuyMvTgzU1h26WYUrebaNUNCVu8IoDAAAAAAAYpoZFqLd5yzb9+/GnA8affOaF7h/PmDZVl1/25V6fo6KySpL0wsuv9zrn7DMW6JyzTpMkTT1uskalp+mdRUv0/oer1Nbaprj4OJUWF+krF39RE485aoDvaui4Mi9PLzc0qM7jCRrsmabk77Jpz5pRajzbVGYSK/UAAAAAAAAGYliEerNmnKBZM07o09zMzIyg3XVD6bg7pmy0xpSN7vfjhpsEi0U3FRfrR9u3B71uGFLz6myZPouqm01lJg16iQAAAAAAAMPKiDtTD5FxclqapiUnB73m7bDJtWtvklfd7B/kygAAAAAAAIYfQj2EhWEY+r+SkqDXfB02SXu33FY3H/LkPQAAAAAAAPQBoR7CptjhUK7dHjBuTfB1/5iVegAAAAAAAANHqIewOiElJWDMmuSRLHtX6LFSDwAAAAAAYOAI9RBWYxyOgDHDsi/YY6UeAAAAAABAWBDqIaxKgoR6kmRLdkus1AMAAAAAAAgLQj2EVUl8fNBxW8relXq1baZcXoI9AAAAAACAgSDUQ1gVxcfv63Pbky3F3f3jmhZCPQAAAAAAgIEg1ENYOSwW5cXFBYzbkj3dP+ZcPQAAAAAAgIEh1EPYBduCu3/7rSRVca4eAAAAAADAgBDqIeyChXrWRK8M694VeqzUAwAAAAAAGBhCPYRdbx1wrfu24O7iTD0AAAAAAIABIdRD2JX22gF3b7MMVuoBAAAAAAAMjC3aBWD4OXD7rcVjlbPFLm+bXf6uvR+3as7UAwAAAAAAGBBCPYRdfny8Hj7iCJXEx+snz3j0/Bpvj+vVzX6ZpinDMKJWIwAAAAAAwFDG9luEnc0wNCkpSWk2mwrTAz9iHW6ppSsqpQEAAAAAAAwLhHqIqKL04KvxOFcPAAAAAAAgdGy/RUQVpltkGFJeiqHCdEOF6RYVphtKcbD1FgAAAAAAIFSEeoiok8dbVf6bZNmthHgAAAAAAADhQqiHiCLMAwAAAAAACD/O1AMAAAAAAACGGEI9AAAAAAAAYIhh+y0ixjRN1Xu9qnA6VeFyqcLplE/SD4uKol0aAAAAAADAkEaoh4j52c6deqOpqcdYosWiHxQWyjA4aw8AAAAAACBUbL9FxBTExQWMdfr9avB6o1IPAAAAAADAcEGoh4gpdjiCjlc4nYNeCwAAAAAAwHDC9ltETGl8fNDx+1d3yFFr05eOt2vOOD6CAAAAAAAA/cVKPURMSS8r9d6t7tJTq71aU+Ub9JoAAAAAAACGA0I9REy61aoUqzVg3JbsliRVN5tRqAoAAAAAAGDoI9RDxBiGoZIgW3BtKR5JUnWzPwpVAQAAAAAADH2Eeoio0iBbcG3JHskwWakHAAAAAAAQIroUIKKKg6zUM6ymrAleVTcbUakJAAAAAABgqGOlHiKqtw64thS3Wp1Sq5PVegAAAAAAAP1FqIeI6q0DrnXfuXq7OFcPAAAAAACg3wj1EFHBGmVo/7l6dMAFAAAAAAAICaEeIirJalWmLfDoRluKW5JU3cJKPQAAAAAAgP4i1EPE9doBl5V6AAAAAAAAISHUQ8QF64BrTfJIFlPVnKkHAAAAAADQb4R6iLhgHXANi2RL8rBSDwAAAAAAIASEeoi4XjvgJrtZqQcAAAAAABACQj1EXK8dcFM82t1iyudntR4AAAAAAEB/EOoh4ori42UEGbeluOX1S3vaCPUAAAAAAAD6g1APERdvsSg/Lq77a7/HIndjvHyddokOuAAAAAAAAP1mi3YBGBluLi7WthrpJ4/75XdapQPW7lU3+3VCqTWq9QEAAAAAAAwlhHoYFCempanA45ff2RFwjZV6AAAAAAAA/cP2Wwya/LRgJ+uJDrgAAAAAAAD9RKiHQeOwG8pO/jzYS4yTxudYNCoxeNgHAAAAAACA4Nh+i0F1/6UOpTgMFaZblJ4gGQaBHgAAAAAAQH8R6mFQzRrDRw4AAAAAAGCg2H4LAAAAAAAADDGEegAAAAAAAMAQw15IDLoWr1cVLpfKnU5VuFz6ek6OUmx8FAEAAAAAAPqKJAWD5t3mZt1SXq4Wn6/H+Jy0NE0i1AMAAAAAAOgztt9i0KRYrQGBniSVO51RqQcAAAAAAGCoItTDoCmJjw86XuFyDXotAAAAAAAAQxmhHgZNtt0uhyXwI/d+bZde/MQTlZoAAAAAAACGIkI9DBrDMFQaZLXemkanbnuT1XoAAAAAAAB9RaiHQVUcJNSzJru1q9kvv9+MSk0AAAAAAABDDaEeBlWpwxEwZrGb8tp9qu8g1AMAAAAAAOgLQj0Mqt6aZdhS3KpuJtQDAAAAAADoC0I9DKreQz2Pqpv9g14PAAAAAADAUESoh0FVEmT7rSTZklmpBwAAAAAA0FeEehhU6TabUq3WgHErK/UAAAAAAAD6jFAPgy7YFlxbsoeVegAAAAAAAH1EqIdBF6wDri3Zo6oWX1TqAQAAAAAAGGoI9TDogq3UM6ymdrk8UakHAAAAAABgqCHUw6DrrQNum8WlLg9bcAEAAAAAAA6HUA+DrtcOuCke7W4h1AMAAAAAADgcQj0Mut5W6llT3HTABQAAAAAA6ANCPQy6RKtVaRZbwDgdcAEAAAAAAPqGUA9RURIXuFrPxko9AAAAAACAPiHUQ1SMTep5rp7pM2R6LKoi1AMAAAAAADiswD2QwCA4IyNDLy2zak+NXb52u3ydNkmGdo1j+y0AAAAAAMDhEOohKqanpKi4zaqqPb4e49V0vwUAAAAAADgstt8iagrTjYCx6ma/TJNgDwAAAAAA4FAI9RA1hemBHz+XV2rqjEo5AAAAAAAAQwbbbxE18yZY5bDHqTDdosJ0Q0XpFuWlGoqzBa7gAwAAAAAAwOcI9RA1M8tsmlnGRxAAAAAAAKC/2H4LAAAAAAAADDGEegAAAAAAAMAQw95HxIROn08VLpcqnE6NTUjQ2ISEaJcEAAAAAAAQswj1EDXNXq9u3L5d5S6X6j2e7vHv5ucT6gEAAAAAABwCoR6iJsVq1ScdHfKaZo/xCpcrajUBAAAAAAAMBZyph6ixGoaK4+MDxgn1AAAAAAAADo1QD1FVEiTU29HlVKfbDDofAAAAAAAAw3D77YqVH+mZ51+S0+nSr39+kzIzM/r82MamJr298D19tmmLGpualZDgUHZWpk6aPUMnHD9FFkvPDNTn8+nd95bpgw9Xa09dvaxWi4oKC3Tq/Lk6duLREXh3w0+CJy5grN3v07IKl04b54hKTQAAAAAAALFu2IR6be3tevzJ57R2/aey2+39fnxFZbXuuvd+yZROnD1DhQX56ujo0LL3P9Aj/35Sn23aossvu6THY/75yGP6ZO0GTTzmKM0/+SR5vV4tW7FS9//jEX3l4i9qzokzw/gOh6dMBYZ6krSh1aXTRKgHAAAAAAAQzLAJ9W6/4275fD597+or9ebbi7Rl2/Z+Pf65F16R0+nSD667RuPGlnWPz5o5TbfceodWfrhaZ55+qnKysyRJa9au1ydrN+iE46foysu/2j1/xrTj9bvf/1nPvfiqphw7USkpyWF8l8PP0WkOqTNwfFuHU1JaNEoCAAAAAACIecPmTL0xo0v00xtv0NFHHRHS46dMmaQLzju7R6AnSQkOh8pKSyRJTU3N3eMrP1glSTp1/twe8+Pi4nTS7Blyu91atWZtSLWMJJNHJQQdr/bQLAMAAAAAAKA3w2al3je/cdmAHj9vzuyg4z6fT7t218hqtSovL7d7fPvOctntdhUV5gc8ZkxZ6d4523f2+rzYKy/eLnkNydazMUajSagHAAAAAADQm2ET6oWT0+mSy+XSnrp6vfnOItU3NOriC89TWmpK9/X29g5lZ2UGNM+QpFGj0iVJdfUNfXo9v98f5ncwtNhdcfLYeoZ4HTZ31H9e9r9+tOsAsBf3JBBbuCeB2MH9CMQW7kkMlpgM9V5/850+zZs3Z7YSEoJv3xyIO/9yn6p37ZYkFRbk6/rvXaXx48Z0X3e69gZQ8fHxQR8fH7d33Ol09un1aqsrwlD10JXotqolqeeYL8Gt3ZXlsliMaJXVrW53VbRLAHAA7kkgtnBPArGD+xGILdyTiLSYDPVeee3NPs2bPvW4iIR6l33lS2rv6FBjY5NWfrBKf/nr33Xm6afonDNP6+Mz7N1Kahh9C6RyC0sGUO3Ql7ejSi0HdcswbKY60vI1LjV4d9zB4Pf7Vbe7Stn5RUFXZAIYXNyTQGzhngRiB/cjEFu4JzFQbVu39mleTIZ69/759qi+fmlJUfePT5o9Q3/7xyN67Y23VVxUqGMnHq0Eh0M6YMXewfaPO/bNO5yRfpOXxMdrU5DxtU0uTUjv289hJFkslhH/awTEEu5JILZwTwKxg/sRiC3ck4g0Pl2HYRiGZk6fKklav2GjJCk+Pk5pqSlqbm4Juke+oaFJkpSTkzXI1Q5N45ODB3eftfVt+zIAAAAAAMBIQ6gnqb6+QT/71a368933B73u8Xikgw65HDe2TF6vV+UVlQHzt2zdLkmacMA5fOjdpF5W4+3o45mEAAAAAAAAI82IC/V8Pp9qaveoobGpeywjY5QsFou2bt+hrdt29Jhvmqbe/2CVJGnc2M9DutmzZkiS3l74Xo/5nZ1dWrpipZKSEnXc5EkRfjfDwxEZcfK5Aj+KNT53VOoBAAAAAACIdTF5pl5/NTQ29Vgx19bRLknasHGTkpP3tlXNzMhQaUmRmptbdMutd6ikuFA3/eh6ad8+90svuUj3PfCQ7r3/QZ00a7oKCwvU1eXUqtVrtKO8QmPHlGna1Cndr3HkhHGaNeMErVj5ke574CEdN+VYuVwuLV6yXK2tbfrWFZdFpInHcJTqkMyOOCm+58q8ZgU/sxAAAAAAAGCkGxah3uYt2/Tvx58OGH/ymRe6fzxj2lRdftmXe32OIyeM0//d9AO9vXCxNmzcpCXLV8owDOXmZOn8c8/S/HknyWq19njMpZdcpKKiQi1f8YGeePo5Wa1WjS4t0VcvuVDjx7L1tq8Mw5DDHSeveoZ6TrtbXtOUrY9dhAEAAAAAAEaKYRHqzZpxgmbNOKFPczMzM3rtrpuTnaVLL7moz69rsVg0b85szZszu8+PQXDpZpzqDx60SLvdbhXHx0enKAAAAAAAgBg14s7UQ2zKswU2yzD90i4nW3ABAAAAAAAONixW6mHoG+dwaOXWNHnb7PK2x8nbZpevw67Cm5KjXRoAAAAAAEDMIdRDTDgqNUEtr+cEjFc3+1WUzoJSAAAAAACAA5GWICYUpgVvhlHdbA56LQAAAAAAALGOUA8xobfVeNXN/kGvBQAAAAAAINax/RYxIS/N0AklFhWkW1SYbqgwbe//jymwRrs0AAAAAACAmEOoh5hgtxp6+XtJ0S4DAAAAAABgSGD7LQAAAAAAADDEEOoBAAAAAAAAQwzbbxGzXH6/qlwueUxTRyYmRrscAAAAAACAmEGoh5jy99279XF7uypcLtW43TIlHZ+crL9PmBDt0gAAAAAAAGIGoR5iytqODq1sa+sxVu50Rq0eAAAAAACAWMSZeogpJfHxAWMNXq86fL6o1AMAAAAAABCLCPUQU4KFepJU4XINei0AAAAAAACxilAPMWVnZfAd4RVswQUAAAAAAOhGqIeY8tL7wT+SrNQDAAAAAAD4HKEeYkqRwy7TZwSME+oBAAAAAAB8jlAPMaUozSpvuz1gnA64AAAAAAAAnyPUQ0wpTDeChno7nS6ZphmVmgAAAAAAAGINoR5iSmG6Rb62uIDxDr9PzT5fVGoCAAAAAACINYR6iCmF6Ya8bYEr9UQHXAAAAAAAgG6EeogphemWoNtvRbMMAAAAAACAboR6iCn5aYa8QbbfipV6AAAAAAAA3Qj1EFMcdkOZNpv8HiPgWjkr9QAAAAAAACRCPcSivVtwA1frVRLqAQAAAAAASIR6iEV7O+AGnqtX4XLJb5pRqQkAAAAAACCWEOoh5uztgBu4Us/p96vO44lKTQAAAAAAALGEUA8xhw64AAAAAAAAh0aoh5jT20o90QEXAAAAAABAItRDLDrUSj064AIAAAAAAEi2aBcAHKwwzZDptsq5K1E+p02+dru8bXG69OhEfX9KSrTLAwAAAAAAiDpCPcSczCRD8TapcWlhj/H2XJviLSwuBQAAAAAAICFBzLFYDBWkGQHj1c1mVOoBAAAAAACINYR6iEmF6YEfzeoWf1RqAQAAAAAAiDVsv0VMKkw3lGCXikZZVJhuqDDdotEZgav3AAAAAAAARiJCPcSk27/o0J++JBkGQR4AAAAAAMDBCPUQk+JthHkAAAAAAAC94Uw9AAAAAAAAYIgh1MOQ4jVNVbtc0S4DAAAAAAAgqth+i5i2uq1Ni1paVOF0qsLlUpXLJb+kpVOmyGEhkwYAAAAAACMToR5i2qednXpsz56A8SqXS+MSEqJSEwAAAAAAQLSx1AkxrcThCDpewRZcAAAAAAAwghHqIaaVxMcHHa9wOge9FgAAAAAAgFjB9lvErOZOU3vqrDIkmQddY6UeAAAAAAAYyViph5j1+EcenX+fU542e8A1Qj0AAAAAADCSEeohZhWmG5Ikb3uQUI/ttwAAAAAAYAQj1EPMKkzf+/H0tsUFXGvwetXu80WhKgAAAAAAgOgj1EPM6l6pF2T7rSRVsgUXAAAAAACMUIR6iFk5yYbsVskXZPutJJWzBRcAAAAAAIxQhHqIWRaLofw0I+j2W9EsAwAAAAAAjGCEeohphWkW+TptMn1GwDWaZQAAAAAAgJGKUA8xbe+5ekbwDris1AMAAAAAACMUoR5i2ucdcANDvXKXS6ZpRqEqAAAAAACA6CLUQ0z7vANu4Ll67T6fmr3eKFQFAAAAAAAQXYR6iGkF+1bq9doBly24AAAAAABgBCLUQ0wrOsRKPXGuHgAAAAAAGKEI9RDTCtJ6P1NPdMAFAAAAAAAjFKEeYlqKw1CaQ/K7rPJ7Aj+urNQDAAAAAAAjUUih3soPVqmpqfmQczZs3KSFi5aEWhfQbW8HXCN4B1xW6gEAAAAAgBEopFDv0cefVnlF1SHn1NTU6u133wu1LqDb/g64nqZ4uRvi1bkzRf4tmfrd6NH69ejR0S4PAAAAAABg0Nn6OrF6125VVe3q/nrz1m1y9bL10e3xaPnKD+VysjUSA7d3pZ5PLatyu8cMQ5p/UbLibEZUawMAAAAAAIiGPod6n27cpBdfeaP76/eWrjjsY46bPCn0yoB99q/UO5BpSrWtpoozCPUAAAAAAMDI0+dQ77RT52nG9KnasaNCf3/oUR03eZLy8nKCzrVarMrKzNBxUwj1MHB7V+oFqmr2qziDXi8AAAAAAGDk6XOoJ0mpKSmafOwxGje2TCfPma1xY8siVxmwz8Er9XJTjKCr9wAAAAAAAEaKfoV6+91w7XfCXwnQi6PzrXr2qgQVpluUl2YonnP0AAAAAADACBdSqCdJnZ2devPtRVr36UY1NTXre1d/s3vl3ruLl+mEqZOVkpwczloxQiXHG5o9NuSPKgAAAAAAwLATUlLS3t6hP/zpHjU0Nslqtcrn88mU2X3t2Rde1qIly/TjG75HsAcAAAAAAACEWUhdBt54a6GaW1p12Ve+pFv+3809riUnJ+mqb35dLS0tevPtReGqE+iV3zTlNc1olwEAAAAAADBoQlqpt37DRs2eOU2zZpygrq6ugOuTJx2j2TOna/2GjbrognPDUScgSWryerWkpUXlTqcqXC5VOJ2qdLn0+zFjdFJaWrTLAwAAAAAAGBQhhXrNLS0qLSk+5JzRpcVasfLDUOsCgqp3u/Wr8vKA8QqXKyr1AAAAAAAARENI22+tVqvcbvch53R0dMlqsYZaFxBUkcMRdLzc6Rz0WgAAAAAAAKIlpFCvsKBAa9au7/V6Z2en3lu6XEWFBQOpDQiQYLEo124PGK9kpR4AAAAAABhBQtp+e/JJs/TQo4/rwUce0+RjJ0qS9uypk8vp0vad5Vq+4kO1d3ToC+ecEe56McJ1uk1lW+JVK0+P8XJCPQAAAAAAMIKEFOpNPX6ydtXU6L9vvavVa9ZJkh5/6vkec8487RQdP+XY8FSJEa/DZWra7R1q6jSVdrxVSeN6Xq9xu+X0++WwhLT4FAAAAAAAYEgJKdSTpC+cfYamHjdZq1Z/ot01tXK5XHI4HCrIz9Pxxx2r/Lzc8FaKES0xTvL4TEmStz1w+60kVblcGpeQMMiVAQAAAAAADL6QQr0up1NxdrsK8vNUcE5e+KsCDmIYhgrTLdpU65e3LXioV+F0EuoBAAAAAIARod97FT1er2786a/00ao1kakI6EVhuiFJ8rbFBb3OuXoAAAAAAGCk6HeoZ7fZlDEqXU3NLZGpCOhFYfrej6uvwy7TH3i9glAPAAAAAACMECF1Fbj4wvO0ZPn7+mj1Gvl8vvBXBQSxf6WeTEO+jsAtuBVO5+AXBQAAAAAAEAUhnan3/oerlJebo0f+/aQee+JZpaelKiHBEWSmoRt/eO3AqwQkFaR9nkF72+yypXh6XGelHgAAAAAAGClCCvXWfLK++8cej0d19Q3hrAkIqnulniRve5ykzh7XG71etfl8SrFao1AdAAAAAADA4Akp1PvVz28KfyXAYRSl91ypF0yl06mjk5IGsSoAAAAAAIDBF1Kol5kxKvyVAIeRl2rIMCTTPHQHXEI9AAAAAAAw3IUU6u2pq5fVapVhHHqexbAoKSlRdnvwVVVAf8TZDOWmGKppNeVrD/6ZolkGAAAAAAAYCUIK9X79uz/2ea5hGBpdWqzzzj1T48eOCeXlgG6F6ftCvU6bTK8hw2b2uF5OswwAAAAAADACWPowJ8DEY47SmLJSaV9ol5uTrbLRpcrLzZGxb/le2egSjR0zWhkZo7RjZ4Xu+es/VF5RGd7qMeIUdp+rZ8gbZLVeJaEeAAAAAAAYAUJaqffli87THXfdpzknztTZZy5QSnJy97WOjk699t+3tX3HTl3//auV4HBox85y3Xv/Q/rvW+/q6m9dHs76A6xY+ZGeef4lOZ0u/frnNykzM6PPj21satLbC9/TZ5u2qLGpWQkJDmVnZeqk2TN0wvFTZLF8noGu/HC1/vXYk70+V35ern528w8H/H7QU88OuHbZ0909rpc7nTJNsztcBgAAAAAAGI5CCvWef/E1jS0r1SVfuiDgWlJSoi6+8Dw99K/H9dIrb+iSL12gstGlmjd3tpYuWxmOmoNqa2/X408+p7XrPw3pDL+Kymrdde/9kimdOHuGCgvy1dHRoWXvf6BH/v2kPtu0RZdfdkn3/K6uLknSqfPnanRpccDzJSQ4BviOEExh2oEdcOMkdfS43uH3q9HrVSbnOAIAAAAAgGEspFBv0+atuuiCcw855+gjJ+jFV9/oDv5yc7K7g7BIuP2Ou+Xz+fS9q6/Um28v0pZt2/v1+OdeeEVOp0s/uO4ajRtb1j0+a+Y03XLrHVr54WqdefqpysnOkiR1du59L0cfOUFHHjE+zO8GvemxUq/NLr/XkK8tTidkOXRCdoJK4uMVbwlpVzkAAAAAAMCQEVKo5/F6VN/YeMg5Tc0t6uzs7P66oaFJSclJobxcn4wZXaKLLzpfKcnJevPtRf1+/JQpk3TMMUf2CPQkKcHhUFlpidasXa+mpubPQ719AWVCQkKY3gH64vMz9aSu8lR17UyVZGj+F+P19YK4qNYGAAAAAAAwWEIK9Qry87Rw0RJNGDdW48cFdrStrNqldxcvVVZmpiRpx85yLVqyTGNGlw684l588xuXDejx8+bMDjru8/m0a3eNrFar8vJyu8f3r9RLTNwb6vn9fvn9ftls/f8p9fv9Idc90uSnHfCF+fmqvaomf9h/Hvc/H78+QGzgngRiC/ckEDu4H4HYwj2JwRJSqHfW6afq/n/+S3fd+4AyMkYpNztLcfFx8nq8qm9oVO2eOknSeeeeKUl65fW31NXZpQWnzA1v9RHidLrkcrm0p65eb76zSPUNjbr4wvOUlprSPWf/Sr0VKz/Ux2vWqb6hUX6/X5mZGZo9c5pOO+VkWa3WPr1ebXVFxN7LcGOaksOWIae3ZyOMbbvbVVvdHpHXrNtdFZHnBRAa7kkgtnBPArGD+xGILdyTiLSQQr2Jxxyla779Db3y+luqrKpWY2NTj+vZWZk6fcE8zZoxTZI05diJOvO0UzSmbHSfnv/1N9/p07x5c2ZHZPvrnX+5T9W7dkuSCgvydf33rgpYkbh/pd5Hq9bopNkzlJ+fp9bWNi1eslwvv/pf7dxZoe98+xt96sKaW1gS9vcwnBWN6tTWOrPHWJsvQbmFfe903Bd+v191u6uUnV/Uo/MxgOjgngRiC/ckEDu4H4HYwj2JgWrburVP80IK9STpmKOP1DFHH6muri7VNzTK5XbLbrMrY1S6UlKSe8ydc+LMfj33K6+92ad506ceF5FQ77KvfEntHR1qbGzSyg9W6S9//bvOPP0UnXPmad1zzjvnDDmdTo0dW6YEx+edbmdOn6rb77hb6zZs1Nr1n2rypGMO+3rc5P3znTlxcnv3nq9XmG6oMN2i9AT1KUANhcVi4dcIiCHck0Bs4Z4EYgf3IxBbuCcRaSGHevslJCSouKgwPNXsc++fbw/r8/VXaUlR949Pmj1Df/vHI3rtjbdVXFSoYyceLUkBDTX2s1qtmjd3th574llt/Gxzn0I99M/XptMQAwAAAAAAjGwhR8adnZ164aXXdMttd+iHN/1cW7ft6L727uJlamuPzPlmg80wDM2cPlWStH7Dxj49JjVl79l7XU5nRGsDAAAAAADAyBTSSr329g794U/3qKGxSVarVT6fT6bM7mvPvvCyFi1Zph/f8D2lJCcf9vmirb6+QX++9wFlZWTohuu+E3Dd4/FIB3Sucbnc2rDxM1ksFk05dmLA/Jp9jUIyRo2KeO0AAAAAAAAYeUJaqffGWwvV3NKqy77yJd3y/27ucS05OUlXffPramlp0ZtvLwpXnWHj8/lUU7tHDQc098jIGCWLxaKt23f0WHEoSaZp6v0PVkmSxo3d2yzDZrPqqWdf1MOPPqE9dfU95nd2dmnR4qUyDEPHT5k0KO9ppPu0o0OvNzbq/l279H87dujrn32mv+7aFe2yAAAAAAAAIiaklXrrN2zU7JnTNGvGCerq6gq4PnnSMZo9c7rWb9ioiy44Nxx1HlJDY5PKKyq7v27r2Lv1d8PGTUpOTpIkZWZkqLSkSM3NLbrl1jtUUlyom350vbTv8MpLL7lI9z3wkO69/0GdNGu6CgsL1NXl1KrVa7SjvEJjx5Rp2tQp0r5z8y6+8Dw9/OgTuuOuv2rO7JnKzs5SU1Ozli5/X03NLTr7zAVhP2sQwf3Ptm1q9Hp7jI2yDfi4SAAAAAAAgJgVUvLR3NKi0pLiQ84ZXVqsFSs/DLWuftm8ZZv+/fjTAeNPPvNC949nTJuqyy/7cq/PceSEcfq/m36gtxcu1oaNm7Rk+UoZhqHcnCydf+5Zmj/vJFmt1u75U4+brFHpaXpn0RK9/+EqtbW2KS4+TqXFRfrKxV/UxGOOisA7RTAl8fEBoV6lyxW1egAAAAAAACItpFDParXK7XYfck5HR5esFush54TLrBknaNaME/o0NzMzo9fuujnZWbr0kov6/LpjykZrTNnoPs9HZJQ4HFrT0dFjrNrlksc0ZTeMqNUFAAAAAAAQKSGdqVdYUKA1a9f3er2zs1PvLV2uosKCgdQG9ElxXFzAmE/SLlbrAQAAAACAYSqklXonnzRLDz36uB585DFN3tf9dc+eOrmcLm3fWa7lKz5Ue0eHvnDOGeGuF5AkPbjcrdfWe1Xd4ld9opQ6K3BOhculUocjGuUBAAAAAABEVEih3tTjJ2tXTY3++9a7Wr1mnSTp8aee7zHnzNNO0fFTjg1PlcBBdjb4tWy7T5Jk89qVGmROhdMppaUNem0AAAAAAACRFnKL0C+cfYamHjdZq1Z/ot01tXK5XHI4HCrIz9Pxxx2r/Lzc8FYKHKAw/fOd4952e9A55Wy/BQAAAAAAw1TIoZ4kFeTnqeCcvPBVA/RRYfoBDTB8Fnk7bLIl0QEXAAAAAACMDCE1yuirlta2SD49RrCi9J4fXV+Q1XrlTucgVgQAAAAAADB4+rVSz+Vy693FS7Vl6zZZLBaNLi3RKfNOUkJCQsDcVas/0VPPvqjbf/uLcNYLSAev1JPkbYtTfG5Xj7Faj0ddfr8SLBHNrgEAAAAAAAZdn0M9j8ejP939N1VV7+oe27hpi1Z88JFu/OG1Sk1JkSR1dnbqiadf0Oo1a2UlTEGEZCYZirdJrn07br1twc/Vq3K5ND5I6AwAAAAAADCU9TnUW7hoqaqqd2n6CcfrpNkzZLNZ9cm6DXrrncV69vlXdOXlX9WGTz/TY08+q9bWNhUXFeiyr3wpstVjxLJYDBWkGdrRYEqSvO1xQedVOJ2EegAAAAAAYNjpc6j38SfrNKZstC6/7MvdYyXFRZIpvfveUj32xDNasfIj2Ww2nXfOmVpwylxZWKmHCCpMt2hHg086xEo9OuACAAAAAIDhqM+pW11dvY6bPDFgfOrxk+V2e7Ri5UcaO2a0fnrjDTp9wTwCPUTcgefq+TrsMv2Bc+iACwAAAAAAhqM+r9Rzud1KS0sNGE/fN3b2GQt09pkLwlsdcAiFB3bANQ35OuyypXh6zKEDLgAAAAAAGI76tZzOYgRON4y9q6XGjx8TvqqAPgjsgBu4BbeClXoAAAAAAGAYYo8shqweK/UkedsCm2U0eb1q83oHsSoAAAAAAIDII9TDkBUQ6rUHb5bBaj0AAAAAADDc9C/UMw516RAXgQgoSDt4+23gSj3RARcAAAAAAAxDfW6UIUn//s/Tevyp53oOmnv/97d/PCKrtWdGaMjQbb/5+cCrBIJIjDM0KtFQU+feD+H+M/UMUxqd4FBJfLxK4uM1Oj4+ypUCAAAAAACEV79CPafLJfWy6MlJl1FEQWH656Gev8um2ldHa+KoOD1zbXK0SwMAAAAAAIiYPod69/zptshWAoSgMN2i9bv8+74y5Ouwaxc7wQEAAAAAwDBHowwMaUXpgQleXbspp8eMSj0AAAAAAACDgVAPQ9rBHXD3291CqAcAAAAAAIavfp2pB8SaI/MsmjfBqsJ0iwrTDBWmW1SUbig3lT24AAAAAABg+CLUw5A2f4JN8yfwMQYAAAAAACML228BAAAAAACAIYZQDwAAAAAAABhi2LeIYafL71eV06lyl0sVLpcqnE55TVO/KSuLdmkAAAAAAABhMaBQb3dNrdZ/+pkaG5s0/+STlJOdJUlqbm5RenpauGoE+uW35eV6vampx1icYehXpimrQQMNAAAAAAAw9IUc6j393EtavGR599fHH3escrKz5PP59Nvf/0nTph6nL190frjqBPqsxOEIGHObpmrdbhXEx0elJgAAAAAAgHAK6Uy9FSs/1OIlyzVubFlAcOfxeDVh3Fi9t3SFVqz8MFx1An1W2ktwV+FyDXotAAAAAAAAkRBSqLf8/Q81pmy0brj2O5o2dUqPaw5HvK765tc1bmyZlq34IFx1An0WbKWeCPUAAAAAAMAwEtL22127a3TeOWcecs7U4ybr5Vf/G2pdQJ/tafPruY+9qmr2q7rZVGW7V5oZOK/c6YxGeQAAAAAAAGEXUqjn8/nk6GU11H5xcXFyezyh1gX0WVOnqV+9duAqPEO5k62yJvh6zKtkpR4AAAAAABgmQtp+Oyo9XZVV1Yecs3b9BmWMSg+1LqDPCtICP8bednvAWDmhHgAAAAAAGCZCCvUmTzpGS5ev1IaNm7rHDBmSpD119XrsiWf0ydoNmnzsxPBVCvQixWEo7aCFo962uIB5u1wuefz+wSsMAAAAAAAgQkLafnvGafO17tONuu+Bh5SYmCBJ+td/npLL6VJHZ6ckKS83R6cvmBfeaoFeFKZb1FLzeWDnawtcqeeXVO12a/Rhto4DAAAAAADEupBW6iUkJOh/b7hWp86fK7t9b3jS2Nikjs5OjUpP14JTTtaPb/i+EghPMEgK040eX3vbA1fqSVIFzTIAAAAAAMAwENJKPUlyOOL1xfPO1hfPO1tdXV1yudxyOBxyOOLDWyHQB4XpFkmfN8bwBlmpJ87VAwAAAAAAw0TIod6BEhISlJCQEI6nAkISuFLPLtOUjJ7DdMAFAAAAAADDQsihXmVVtdau+1Qtra3y+YI3HzAM6WtfvXgg9QF9snel3gH8Fvk6bbIleXsMl7P9FgAAAAAADAMhhXqr16zVQ/96XKZpHnYuoR4Gw8Er9bSvA+7BoV4FK/UAAAAAAMAwEFKo98abCxUfF6fTTp2ngoI8OeI5Rw/RFbBSb38H3LyeY3s8HnX5fEqwWgevOAAAAAAAgDALKdSrq6/XWaefqtMXzA9/RUAIclMMWQzJf8DiUW978GYZlS6XJiQmDl5xAAAAAAAAYRa4vKkPEhMTlZKSEv5qgBDZrIbyUg9qltEWF3QuHXABAAAAAMBQF1KoN/W4Y7X+043hrwYYgIO34Hrbel+pBwAAAAAAMJSFFOp94ZwzZZqm/vnwY/ps0xbtqatXY1NT0P+AwVJ0ULMMX6ddZpDGzHTABQAAAAAAQ11IZ+p1dnTK7XLrs81b9fEn63qdZxiG7r7z1oHUB/RZQLMM05C33S57qkcWSQXx8SqJj9cRnKcHAAAAAACGuJBCvf88+aw+27xVOdlZys/PpfstYkLhQSv1JKn5gzw99NVEzS1MkN0S0sJUAAAAAACAmBNSqLdt+07NmHa8vn7pl8NfERCigJV6kjyNDpkd8QR6AAAAAABgWAkp6TBlasL4ceGvBhiAYCv1JKm6OcjBegAAAAAAAENYSKHeuDFlqt61K/zVAAMQbKWeJFU1m4NeCwAAAAAAQCSFtP32kosv0F/vf0hZmSs0a+Y02W0hPQ0QVqmOvf8lxhkqTDdUmG5RQZqh2WOs0S4NAAAAAAAgrEJK4x5+9EnFxdn11LMv6unnXlJqSrKsQYI9Q9Kvfn5TOOoEDsswDG34ebJs1uDbcAEAAAAAAIaLkEK97Tt2dv/YNE21tLaFsyYgZAR6AAAAAABgJAgp1PvzH34jG1tuAQAAAAAAgKgIKZkj0MNQ4/H7VeV2q9LpVLnLpQqXS9/Lz9couz3apQEAAAAAAPRbRNM5n88nq5UmBYiut5qa9NMdO+Q/aPysUaMI9QAAAAAAwJAUUqh37Q9u7tM8wzB09523hvISQNjk2O0BgZ4klbtcOj4lJQoVAQAAAAAADExIod6o9HQZQfoReH0+te5rmlFYkK+EBMeACwQGqsQR/HNY4XQOei0AAAAAAADhEFKod8v/632lnsfr1fIVH+i9ZSt0xde/OpDagLBIt1qVYrWqzefrMV7hckWtJgAAAAAAgIEI+5l6dptNJ8+Zra4up55/8VVdeTnBHiKvqtmvxg5TkrSr2a/dLab2tPm1p91UXZspTbBLjp6h3uZ2p6qa/SpKt0SpagAAAAAAgNBErFHGhPFj9O57SyP19EC3qma/Tvpjh1ze3uekp9qVOLrndttqt1sn/bFdS3+cTLAHAAAAAACGlIglGR2dXXK7PZF6eqBbY4d5yEBPkrztgV1uDaspb5y3e4UfAAAAAADAUBHSSr3GpqZer3m9PtXuqdMLL7+m7KzMgdQGhI23LS7ouC3FPei1AAAAAAAADFRIod4vfn17n+Z97asXh/L0QNj52gJX6kmSNYXVpAAAAAAAYOgJKdQbN6ZMMoJfs1qtSk9L1ZTJkzTpmKMGWB4QHt52VuoBAAAAAIDhI6RQ74brvhP+SoAIMr0W+bqssib07IBrS2alHgAAAAAAGHpo+YkRI9i5eja23wIAAAAAgCGoTyv1Xnvj7ZCe3DCks85YENJjgXDzttsVn9PVY8ya6JHX9EuyRq0uAAAAAACA/upbqPff0EI9iVAPsSPYSj3DItX53JKCN9IAAAAAAACIRX0K9ehii+Ggtw64NV6XpKRBrwcAAAAAACBUfQr1Zk6fGvlKgAjztvcS6vlcg14LAAAAAADAQITU/fZAtbV1qq2rk9vlVrwjXvm5OcrKygxPdUAYedvtMs29Zz0eqJZQDwAAAAAADDEhh3qfbdqip559UXvq6gOuFRcV6qtf/qJKiosGWh8QPn6LfB022ZK9PYZrvYR6AAAAAABgaAkp1CuvqNR9Dzwkv2lqTNlo5eflKM5ul8vt1q5dNdpZUam77n1AN/7gOuXmZoe/aiBE3va4gFCP7bcAAAAAAGCoCSnUe/PtRbLHxekH131HhQX5Add3llfqr/c/qDfeWqhvfO2ScNQJ9CojyVC8TXJ5Dz/X22aX8j7/2tdlU/Eoh7ymKdvB+3IBAAAAAABiVEih3rYdOzVvzuyggZ4kjS4t1tw5s7Ti/Q8HWh9wWEXpFi39cZIaO8zusd0tfl3xL2fA3DPSMjQ5LV251njl2uKUn2xTUbplkCsGAAAAAAAYmJBCva7OrsNuq83LzVF7e0eodQH9UpRuUVH651+Pzwke1KV7EvStsY7BKwwAAAAAACACQlqi5EhwqLml9ZBzmlta5XAQniA6EuyGRiUGjte2mcGmAwAAAAAADCkhhXqjS0u06L1lampuDnq9salJixYvVVlZ6UDrA0KWmxL48d7dQqgHAAAAAACGvpC23552ysm6694H9Jtb79SkiUerID9XdnucOjo6tLumVus//UwyTZ2xYF74Kwb6KC/N0Ge1e3/ssEv5qYYK02mGAQAAAAAAhr6QQr1xY8t05eVf1ZPPvKCPVq8JuJ6amqKvfvlClY1mpR6i55fnxEvnSHmpFqU6JIPutgAAAAAAYJgIKdSTpOOnHKtjJx6tLdu2q6Zmj1wut+Lj41WQn6txY8tktVrDWynQT0fk8hkEAAAAAADDU0ih3rIVK3X8cZOV4HDoqCMm6KgjJoS/MgAAAAAAAABBhRTqPf7U83rm+Zd17KRjNHPaVB15xHi2NmLI8ZmmatxulbtcqnQ6dUxSkiYmJUW7LAAAAAAAgMMKKdQ7fcE8rfp4rVat/kSrVn+itNQUTZ82VTOmHa+83JzwVwmEUavXq29u3qwql0se8/NuuN/KyyPUAwAAAAAAQ0JIod5555yp8845UzvLK/XRqo+1+pN1euudRXrrnUUaXVKsGdOnaupxk5WYmBD+ig9jxcqP9MzzL8npdOnXP79JmZkZIT/Xxk2bdc99/5Qk3fvn2wOu+3w+vfveMn3w4WrtqauX1WpRUWGBTp0/V8dOPHpA7wORk2K1arfb3SPQk6QKpzNqNQEAAAAAAPRHyI0yJGl0abFGlxbroi9+QZu2bNOq1Wv0ydoNevKZF/TsC6/o2IlH6ZvfuCx81R5CW3u7Hn/yOa1d/6nsdvuAn8/pdOmxJ5495Jx/PvKYPlm7QROPOUrzTz5JXq9Xy1as1P3/eERfufiLmnPizAHXgfAzDEOl8fHa1NXVY7zC5YpaTQAAAAAAAP1hCceTGIahIyeM02Vf+ZJuveVnuuwrX1JCgkOr16wLx9P3ye133K0d5RX63tVXqrS4aMDP9/xLr6q9vUO5OdlBr69Zu16frN2gE46fou9edYVmzThBc06cqR9e/11lZ2XquRdfVVtb+4DrQGQUx8cHjFW4XDIPWr0HAAAAAAAQiwa0Uu9AdfUNWv3xWq1Zu05V1btlmuaAtr7215jRJbr4ovOVkpysN99eNKDn2rR5q5at+EDnnXOmPt24SbV76gLmrPxglSTp1Plze4zHxcXppNkz9PxLr2nVmrWaN2f2gGrBwHl9puraTdW2mqpp9cvjk0qzHAHzuvx+1Xs8yo6Li0qdAAAAAAAAfTWgUK+hsUmr16zV6o8/UWXVLklSYkKCZs+crhnTjtOYstHhqvOwwrXN1+ly6bEnnlFxUaEWnDJXn27cFHTe9p3lstvtKirMD7g2pqx075ztOwn1ouyGp7v09Gqv/AcswMtNMfSbawJX6mnfaj1CPQAAAAAAEOtCCvUWLlqi1R+v1c6KSkmS1WrV5EnHaPoJx2viMUfKarWGu85B8+LLr6ulpVXXXHWFLJbgu5OdTpfa2zuUnZUZdM6oUenSvtWLfeH3+wdYNXrjsKlHoCdJde2m8q3Bz13c6XTquH0dcPf/uvDrA8QG7kkgtnBPArGD+xGILdyTGCwhhXrPvfiqtG9F2rSpx4W90+3rb77Tp3nz5sxWQkL4Xnfzlm1asux9nXPmAhXk5/U6z7mvoUJ8kHPZJCk+bu+4s4/dVGurK0KqF4eXpARJiT3G/Kbk2h08cP2svk61zo4eY3W7qyJaI4D+4Z4EYgv3JBA7uB+B2MI9iUgLKdQ758wFmnbC8cqK0Jl5r7z2Zp/mTZ96XNhCPbfbrceeeEYF+Xk6fcH8AT7b3qVhhmH0aXZuYckAXw+9GVfjkVa6A8YdSUVKc7eqxefrMd5gj+v+9fD7/arbXaXs/KJeV20CGDzck0Bs4Z4EYgf3IxBbuCcxUG1bt/ZpXr9DPbfbo3cXL1NWVmbEQr17/3x7RJ73UF54+XU1NjXrxh9ee9jtwwmOvU0W9q/YO9j+cYcjsBlDMNzkkZOfFvzXck/b3g64LZ2dPcYr3O6AXw+LxcKvERBDuCeB2MI9CcQO7kcgtnBPItL6HerFxdllt9vU1tYemYqiYOv2HXpv6QrNPWmWkpOT1NTc3H3N6/VKUvfYqPR0xcfHKS01Rc3NLfL7/QE3aUNDkyQpJydrUN8HAuWlBl8tWdNqqjTfofUHhXpVLpd8pilrH1dZAgAAAAAARENo22/POl2vvvGWykaXqGx0afirGmSbNm2VaZpavGS5Fi9ZHnTOz355q3TAKsJxY8u06uO1Kq+oDPg52LJ1uyRpwrgxEa8dh5aXGvxfRWpaTZWMDjwT0WOaqnG7VdjLeYkAAAAAAACxIKRQr3ZPnUpLinTnX/6mzIxRysrMkCMhcKupIUPfuuKycNQZNj6fT3X1DbLb7crMGCVJOmHqFJWUFAWd/9Irb2jX7hpdc9UVPcZnz5qhVR+v1dsL39NV3/x693hnZ5eWrlippKREHTd5UoTfDQ4nLWFvB1ynt+d4batfx/cS3JW7XIR6AAAAAAAgpoUU6r3z7nvdP65vaFR9Q2M4a+q3hsYmlVdUdn/d1rF3a/CGjZuUnJwkScrMyFBpSZGam1t0y613qKS4UDf96HpJUm5OtnJzsoM+9zsL977XSccc1WP8yAnjNGvGCVqx8iPd98BDOm7KsXK5XFq8ZLlaW9v0rSsuC2tnXoTGMAzlphoqbzR7jO9uNVXSy5mHFU6nZqemDlKFAAAAAAAA/RdSqPc/3786/JUMwOYt2/Tvx58OGH/ymRe6fzxj2lRdftmXw/q6l15ykYqKCrV8xQd64unnZLVaNbq0RF+95EKNH8vW21iRl2pReWPPLre1raZK4nsJ9XppgAIAAAAAABArQgr1xsfYWXGzZpygWTNO6NPczMyMfnXXveG67/R6zWKxaN6c2Zo3Z3afnw+DL1izjJpWvxKtVmXZ7ar3eHpcI9QDAAAAAACxbkC9lTs6OrV6zVq9vXCxmpo+7xjrdnsO+ThgMAUL9Zq7pC6PqdIgZ+dVOJ2DVBkAAAAAAEBoQlqpJ0kLFy3Ry6/9Vx7P3g4EpaXFGjUqXX6/X7fceodOnjtbC+bPDWetQEh664C7dwtuvFa1t/cY3+12y+33h35zAAAAAAAARFhIK/U+WbdBz734qkalp2vBKSf3uOZ0OpWamqwXXnpNn6zbEK46gZDlBlmpp31bcIM1y/BLqmYLLgAAAAAAiGEhhXqL3lumgvw8/eTGG3T6qfN6XEtMTNQPrrtGRYUFWrxkebjqBEIWbPutDlipd7BRNpuavN5BqAwAAAAAACA0Ie0wrKrepbNOP1V2m01eT+D5eTabTTOnT9Ubby4MR43AgPS2/XZ3q6kZiYm6Oi9PxQ6HSuPjVRIfrxTb3tvC7/cPcqUAAAAAAAB9E1Ko53a5lZycfMg5SUmJcrpoOIDo6237bW2rX3lxDn2noGDQawIAAAAAABiIkLbfpqWlqrZ2zyHnbN6yTampqaHWBYRNYpyhtMCj81TTakajHAAAAAAAgAELKdQ7+qgjtHjpClXv2t09Zmjvaqgup1Ovv/mO3v9glSYefWT4KgUGIC8t8KNOqAcAAAAAAIaqkLbfnnX6qVq7boN+f+c9ys/LkSS98PJr8vn8qqndI4/Ho9TUFJ1x2inhrhcISW6qoU21PcdqWzkzDwAAAAAADE0hhXppaan63x9eq2dfeEXr1n0qSdpZXilJslqtOn7KJH3x/HOUlpoS3mqBEF0y1a6Tx9mUm2ooP9VQbqql1664AAAAAAAAsS6kUE+SRqWn69tXfE0ej0e1e+rkcrnlcMQrJydbdlvITwtExIVT7NEuAQAAAAAAIGwGnL7Z7XYVFRbI6/XKRpgHAAAAAAAARFzIKdyeunq99c4ibd6yTY1NzTJNUxaLRVmZGTr6yAk6df5cjRqVHt5qgQgzTVN1Ho8qXC75/X4VR7sgAAAAAACAIEIK9Soqq3TXPQ/I5XZLkpKSEmW32+V2u7Wnrl576ur1wUcf63+uvVqFBfnhrhkIuz9VVenDtjZVuFzq8u9toDExMVG3JTmiXRoAAAAAAECAkEK9F195Q26PR1++6HxNmzpFCQkJ3dc6Ozv1/ger9PxLr+nFV97Q966+Mpz1AhFR6XJpU1dXj7Fyl0tmYnzUagIAAAAAAOhNSKHezp0VmjdntuaeNCvgWmJiok6ZN0f1DY1a+eGqcNQIRFxpfGB41+bzqdU0lReVigAAAAAAAHpnCeVBpkwVFxceck5JcZFkhloWMLiKHcG32e7y+Qa9FgAAAAAAgMMJKdQryM9TY1PzIefUNzSooIA1Tohdbq+pPW17z88LtlJPknb5/INcFQAAAAAAwOGFtP32nDNP078ff1rHTjxaBfmBwV1N7R4tWfq+Lv/aJeGoEQiLB5e7tXCTVzWtpmpaTTV0mMpPNbT6p8kq6WWlXjUr9QAAAAAAQAwKKdSr3VOnoqJC3fqHuzRubJkKC/LlcMTL4/GqpqZWm7ZsVdnoUpWXV6q8vLL7cYYhnXXGgnDWD/TZZ7V+vbOpZ0i3p92Uz28qy2ZTosWiTn/PlXms1AMAAAAAALEopFDvmedf7v7xlq3btWXr9oA5vY0T6iFa8lKMgDGfX6pvN5WbalFxfHxAB9xqLyv1AAAAAABA7Akp1Pve1VfKZrPJMAJDEiBW5aUF/7zWtJrKTZVKHY6AUG+XzyfTpOMLAAAAAACILSGFerk52crMzAh/NUAE5aYG7wtT02pqsqTiIM0yXJLqPB7lWa2DUCEAAAAAAEDfhBTq/fK3f9AR48dq9qzpmjzpGFkJPDAE5Kf2tlLv0B1wK1wu5fXSSAMAAAAAACAaQgr1iosK9dnmrfps81YlJSVqxrSpmj1zmvJyc8JfIRAmub2EerWte7fX9tYBt8Ll0vSIVgYAAAAAANA/IYV6N/7wWtXXN+jD1Wu0avUnWrhoiRYuWqIxZaN14qzpOn7KJNnt9vBXCwxARqKhOKvkPqj3Rc3+UO8QK/UAAAAAAABiSUihniRlZWXqrNNP1Vmnn6qq6l36aNUarfp4rR79z1N6+rmXNG3qFM2eOV3FRQXhrRgIkWEYyk01VNnUs/HF/u23aTab0qxWtfh6pn6EegAAAAAAINaEHOodqKiwQEWFBbrgvLO1Zdt2vfraW1qy7H0tWfa+xpSN1hmnzdcxRx0RjpcCBiQvaKj3+delDofWdnT0uE6oBwAAAAAAYk3wdqAhaG1r09vvvqfnXnhFW7fvkCSVjS5R7Z49uu+Bh/TgI/+R1+sN18sBIckL0gH3wFAvWAfcardbXtMMGAcAAAAAAIiWAa3U8/v92rBxk1a8/6E2fPqZfH6/EhMSNG/uiTpp9gzl5ebI7Xbrldff1MJFS5WenqYLzz8nfNUD/RSsWUZTpymX11S8zQjaAddrmtrtdgcN/AAAAAAAAKIhpFBvT129Vqz8SCs/XKXW1jZJ0ujSYs2ZPVPHH3dsjyYZcXFxuvD8c9XW1qEPPlxNqIeoyjtEB9ySDKP3DrhOJ6EeAAAAAACIGSGFer/+3R8lSY74eM05caZOmj1DhQX5h3zMUUdO0MefrAutSiBMgm2/1b5mGSUZlkN2wD0xwrUBAAAAAAD0VUihXnFRgU6aPVPTpk5RXFxcnx5TNrpEX7/04lBeDgib3lbq7T9Xr7fVeLvc7ojWBQAAAAAA0B8hhXo3/ej6fj8mOytT2VmZobwcEDa9r9TbG+olWq06PzNTo2w2FcfFKaWtWZMLS5TZx/AaAAAAAABgMPQ51NuybXtILzB+7JiQHgdEQrBGGdq3/Xa/X5SWSvsawdQ6O5Rht8swgj8OAAAAAAAgGvoc6t11zwMhvcA9f7otpMcBkZAcbyg5Xmp39Rzfv1IPAAAAAABgKOhzqDf52GNkqOdqJZ/Pp3UbNmrcmDIlJydFoj4g7PJSLdpa5+8xVkuoBwAAAAAAhpA+h3pXXfn1gLHOzi7d+H+/0jlnn8Y2WwwZeamGttb1HDtw+y0AAAAAAECsC6lRxn4cM4ahaHKRVT6/lJdmKC/VUG6KRcWj+DADAAAAAIChY0ChHjAU/eys+GiXAAAAAAAAMCCWaBcAAAAAAAAAoH8I9YDDME1TTV6v1nd0RLsUAAAAAAAAie23QHDLW1v1WkODtre1andji1p9PknSe5MnK8lqjXZ5AAAAAABghCPUA4KodDr1elNTwHiFy6WjEhOjUhMAAAAAAMB+fQ71nn/ptYAxr9crSVqy9H2t3/BZwHVD0gXnnT3QGoFBV+JwBB2vcDoJ9QAAAAAAQNT1OdR75933er22es3aXq8R6mEoKo0P3iG3wuUa9FoAAAAAAAAO1udQ72tfvTiylQAxJDcuTnbDkMc0e4wT6gEAAAAAgFjQ51Bv5vSpka0EGEQflfu0bpdPNa2malr8qmkzJVN68tt7t9ZaDUNF8fHa4XT2eFz5QV8DAAAAAABEA40yMCI9scqjxz7w9BizWSS/35TFYkj7tuAeHOpVuFwyTVOGYQxqvQAAAAAAAAeyRLsAIBryUwNDOa9fauz8fLttcZBz9dp8PjX7fBGvDwAAAAAA4FAI9TAi5QYJ9SRpd8vnoV5Jb80y2IILAAAAAACijFAPI1JeavCPfm3b4UO9cpplAAAAAACAKCPUw4iU18tKvZpWf/ePewv1KlmpBwAAAAAAooxQDyNSr6HeAdtvM202JQSZxko9AAAAAAAQbQMO9dra21VeUSWnk6ADQ0dGoiG7NXC85oDtt4ZhqMAaOKmCUA8AAAAAAESZLdQHbt9Rrmeef1kVlVWSpP+59mqNHztGkvT3hx7V/LknadzYsvBVCoSRxWIoJ8VQdbPZY7ymxd/j60KrVdu8PbvdVjid8pumLEbw1X4AAAAAAACRFtJKvepdu/WXv/5d1bt2q2x0aY9r7e0d2rRpq+69/0FVVe8KV51A2OUH2YJb29oz5Cu0Bt4iLtNUnccT0doAAAAAAAAOJaRQ779vLZQjPl4//d8b9N2rruhxLTk5ST+96QYlOOL11juLw1UnEHa5QTrgHrj9VlLQ7bfiXD0AAAAAABBlIYV6W7fv1JwTZyo3N1vBdiBmjBqlOSfO1NbtO8JQIhAZwZpl1Lebcns/D/Z6C/Uq6IALAAAAAACiKKRQr6O9Q9nZWYeck5WVqfb2jlDrAiKutw64e9o/D/WCbb8VzTIAAAAAAECUhRTqJSQkqLW19ZBz9uypV0KCI9S6gIgLtv1WkmpaPg/1ki0WpQfrgMtKPQAAAAAAEEUhhXpjxpRq2YoP5Ha7g17fum2H3l28VGPHjB5ofUDEBGuUIUk1rT074JY4AsNpVuoBAAAAAIBosoXyoDMWnKI77/qrfvf7P+voo46QJK1a/YnWrd+oHTvLtWNnhaxWq85YcEq46wXCJreXUO/gDrhTk5OVarWq1OFQSXz83v+CBH0AAAAAAACDJaRQr7SkSFd/63I99uSzem/pCknS0uUru6+npaXq0ksuUklxYfgqBcIsr7fttweFet/Lz5fFEtKiVgAAAAAAgIgIKdSTpGOOPlK3/OJmbdm2Q7t318jlcsvhiFdBfp7GjS0jBEHMS3EYSoqTOg7aRX7w9lsAAAAAAIBYE3KoJ0lWq1VHThinIyeM6x7z+XwEehgy8lINbavvuTLv4JV6AAAAAAAAsSbk9O2zTVt02x/v0q7dNT3GV364Sr+57U5t3rItHPUBERVsCy6hHgAAAAAAiHUhhXo7dlbovgce0q7dtfJ6vT2uJScnq76hQff+7Z8qr6gMV51AROxvlpHqkMbnWDR3nFUnjrVGuywAAAAAAIBDCmn77RtvvqP0Uem6/rvfVmZmRo9rx048Wr/62U368z3367X/vqPvXnVFuGoFwu6WLzj0hwulxLjgnXABAAAAAABiUUgr9corqzRvzokBgd5+aWmpmnvSLFVUVg20PiCiMpIMAj0AAAAAADDkhBTqOZ0uxcfHHXJOUlKiurqcodYFxLx2n09OP51yAQAAAADA4Atp+212VqY+27RZs2dO63XOmrXrlZ2VOZDagJhR7/HolYYGVbhce/9zOtXg9eoPY8bolPT0aJcHAAAAAABGmJBCveknHKcXX3lDCQnPaca0qcrOzpTdbpfL6dKumhotXbZSa9d9qvO/cFb4KwaioN3n0927dgWMVzhZjQoAAAAAAAZfSKHeKfPmaEd5hZat+EDLVnwQdM6xk47WqfPmDLQ+ICYUxsXJKsl30HiFyxWligAAAAAAwEgWUqhntVp19Tcv1yfrNmj1mrWqqdkjl8ul+Ph45efl6vjjjtWxE48Of7VAlNgtFhXEx6vyoBCPUA8AAAAAAERDSKHefpMnHaPJk44JXzVADCsJFuqx/RYAAAAAAETBgEI9YDhweU3taTW1u9Wv2lZTu1tNdbpNXT/P3mNeSXy8lh302AavV+0+n5Kt1kGtGQAAAAAAjGwhh3pLlr2v1WvWqrm5RT6/P+gcQ9Kvfn7TQOoDIu6nL7j0n488PcbsVum6k3veHiUOR9DHV7pcOioxMaI1AgAAAAAAHCikUO/dxUv17AuvhL8aIApyU42AMY9PaursOVYSHx/08W80NhLqAQAAAACAQRVSqLd0+UrlZGfpa1/9koqLCmW32/vwKCA2BQv1JGl3q19ZB3xd2kuo93x9va4pKFCCxRKhCgEAAAAAAHoKKYVoaGzS/JNP0piy0QR6GPLyU4PfBrWtZo+vc+PiFGcEBoAdfr8erqmJWH0AAAAAAAAHCynUS0pMkM1GYwAMD72t1Ks5KNSzGIaKe1mt93BtrSrphAsAAAAAAAZJSNtvJx87Ues//UyzZkwLf0XAIMtPCx7q1baaUkHPseK4OG0LEt6Zpqnbq6p099ixMoKs5gNGuveam/X7qirdWFSkuenp0S4HQD9VNfvV2NHzH7tMv18NdVbtkU+GxQz6uIwkQ0XpHE8BAAAQCSGFehd84Szd/89/6fGnntP8uScqOztLVisr9zA0ZSYZslok30FNnHe3Bn6D0ltg55O0orVV77W06GQCC6CHLr9ft1ZWao/Ho1srKzUtNZUzKIEhpKrZr5P+2CGXN9jVdEm9r1SPt0lLf5xEsAcAABABIYV6v7n9TzL9pjZt3qplKz7odZ5hGLr7zlsHUh8QcVaLoZxkIyDEq23r+XWX36+P2tt7fR6LpNsqKzWdwALo4aGaGtV5PJKkOo9HD9fU6LsFBYd9HIDY0Nhh9hLoHZ7Lu/fxRfx7FwAAQNiFFOp5PB7ZrDZljOJvaBge8tKChHoHff1QTY3afb5en8NPYAEEqHQ69XBNjfbfTea+MyjPzchQscMR5eoAAAAAYOgKKdS79dc/C38lYbJi5Ud65vmX5HS69Ouf36TMzIyQn2vjps26575/SpLu/fPtPa6t/HC1/vXYk70+Nj8vVz+7+YchvzYGV26KZV8s97kDG2UcHEz0hsAC+Jxpmrq9sjL4OGdQAgAAAMCAhBTqxaK29nY9/uRzWrv+U9nt9gE/n9Pp0mNPPNvr9a6uLknSqfPnanRpccD1hAQCnaEkWLOM+g5THl/vwURv9s+/e9w4AguMaItbWrSirS1gnDMoAQAAAGDgBhTqbfj0M63/9DM1NjbpvHPPVGFBviSpvKJSpSWBQVck3X7H3fL5fPre1VfqzbcXacu27QN6vudfelXt7R3KzclW7Z66gOudnXtDvaOPnKAjjxg/oNdC9OWmBoZvpik1dFrkcbmCBhO98Ula0damnU6nyhISwlwpMDR0+f26vbJSgWtg9+IMSgAAAAAYmJC+k/L7/br/H4/ovr8/rCXL3teGjZvUuW/lmtvt1p/vuV9/+/vD8vuDfSsXGWNGl+inN96go486YsDPtb8ByNlnLFBqSkrQOfvfbwKhzbCQnxr8VqjrsGh0fLxmpaSor/2drZJmpaZqNNtvMYLtb47R258CB55BCQAAAADov5BW6i1cvFTrNmzU9BOO03GTJ+n+f/7rgKuGTpw1Q4veW6ZF7y3TKfPmhK/aQ/jmNy4Ly/M4XS499sQzKi4q1IJT5urTjZuCztu/Ui8xcW+o5/f75ff7ZbP1/6d0MMNPBJeTHHy8rtMi0zT1v0VFunjjxj49l2EYurGwUKZpyjQPdwofMPxUulz9OoPy7FGjVBwff9jn3f97Jb9nAoPLHOA9Z/r98vs5jgKIJP6MBGIL9yQGS0ih3ker1mjiMUfp8ssu6T5bbr+4OLu+9MUvqLGpSR98tHrQQr1wefHl19XS0qprrrpClkNsCdu/Um/Fyg/18Zp1qm9olN/vV2ZmhmbPnKbTTjlZVmvf1nbVVleErX6ExtZllRR4tteedovqdlcpTtKXEh16qtN5yKDCkPSlhHjZ62tVG9GKgdhkmqZ+09J22EBvP79p6jdbt+hXaSl9PoOybnfVgGoE0D8NdcH/jOz742tUq967xwMIH/6MBGIL9yQiLaRQb09dnU6cNf2QcyYefaSee+HVkIp6/c13+jRv3pzZYd3+unnLNi1Z9r7OOXOBCvLzDjl3/0q9j1at0UmzZyg/P0+trW1avGS5Xn71v9q5s0Lf+fY3+vRNam5hSdjeA0LjyDAldQaM13UYys4vksVi0bV+vxZu3KiGXrYUWiRl2e36/rgJcnBGGEaoHU6nVtc39Xm+X9Jqj1ddWbkqO8yWdb/fr7rdVd33JIDBsUc+Sc6QH5+Znafcwr4eYgEgFPwZCcQW7kkMVNvWrX2aF1Ko5/ebh91mahiGfP7Q/lX2ldfe7NO86VOPC1uo53a79dgTz6ggP0+nL5h/2PnnnXOGnE6nxo4tU8IB34jOnD5Vt99xt9Zt2Ki16z/V5EnHHPa5uMmjLz3RlMMuOT09x+s6LLJY9v6XaLHo5uJi/Wh78CYsfkk3FxcrMYQt2MBw8Vlnp4x9W2v7wippemqqxiQk9Hml3v57EsDgKG8a2Co7g3sWGDT8GQnEFu5JRFpI6UN2Vqa2bd+hWTNO6HXOBx99rOysrJCKuvfPt4f0uIF44eXX1djUrBt/eG2fts2OG1sWdNxqtWre3Nl67IlntfGzzX0K9RB9hmEoP9XQjoaeUURdR8/fgE9OS9OslBR90NbWYyPR/mBiblpa0Off4XSqxu3WrNTUiNQPRJvb79edVVV6ur6+X48zDEM3FRf3OdADMLi21/t18wuhr9IDAABA5IQUGU89frJWfrhaS5a9L5fLLUkyZMjlcmvjps26+69/15at23XC8VPCXW9EbN2+Q+8tXaE5J85UcnKSmpqbu//zer2S1P11X+zvmNvl5C/BQ0lukA64B4d6+wOIgx0qmNjjduvarVv1P1u36rXGxjBXDUTfbrdb3968uf+BnqQrcnP71CQDwOCravbry//oVFPg6RQAAACIASGt1Fswf64+27RFTz7zgp585gVJ0j1/+2d3ACZJ48eN0anzh0aTjE2btso0TS1eslyLlywPOudnv7xV2reK0OVya8PGz2SxWDTl2IkBc2v21EmSMkaNinDlCKe81MBAzu0LHCt2OHRFXp4e3Nfd81DBRKvXq2u3blWNe2/4/fOdO9Xk8eiy3NwIvQtgcL3f2qqf7tihFl//tuftP4PyirxDn18KIDr2tPn15b93qrqZLu4AAACxKqRQz2az6frvXaWly1fqw1VrtLumVi6XS4kJCSrIz9PU4yfrxFnTY3LvuM/nU119g+x2uzIz9oZuJ0ydopKSoqDzX3rlDe3aXaNrrrqie8xms+qpZ1+U0+nST2+8QTnZn28z7uzs0qLFS2UYho6fMmkQ3hHC5Rsz7Tr7GJtyUw3lp1qUlWyqubZSUuCW2Svz8vRyQ4P2eDzK7iWYcPr9+sG2bdp20IrNO6ur1eD16rqCArYcYsjym6YerKnR33bv7vP5eT0ev+8MyoQY/HMCGOkaO0xd8o+ugCMpQhFvkzKS+LMOAAAgEkI+0d9isWjuSbM096RZ4a0oBA2NTSqvqOz+uq2jXZK0YeMmJScnSZIyMzJUWlKk5uYW3XLrHSopLtRNP7pekpSbk63cnOygz/3OwvckSZOOOap7zGq16uILz9PDjz6hO+76q+bMnqns7Cw1NTVr6fL31dTcorPPXKDiosKIvm+E18yynreD3x+sx+1eCRaLflJcrN9XVenGoqKgwcRLDQ1a09ER9PGP1NaqwePRz0pLZSfYwxDT6vXq5zt3amlra69zHBaL/q+4WK81Nvb7DEoA0dPmNHXpQ536rDb4n4FH5Rm69XyHEuIMmX6/GupqlJmdJ6OXgD4jyVBROuE9AABAJPQ71HO7PbrzL/fprDNOjZkmEJu3bNO/H386YHz/1mBJmjFtqi6/7Mthe82px03WqPQ0vbNoid7/cJXaWtsUFx+n0uIifeXiL2riASEghqe56emam57e6/WLs7JU63br4draoNdfaWxUs9er28aMYbUShoyNnZ26cft27dq3pTyY0vh4/WHMGI1NSNCkpCRd9OmnPa7THAOITW6vqa8/3KVPqoIHehPzLXr6qkSlJ+69d/1+Q7XyKbfQetjdGbta/MpPNbjvAQAAwqjfoV5cnF1NTc1qael9hcZgmzXjhEN24j1QZmZGv7rr3nDdd3q9NqZstMaUje7zc2FkMQxD1xUWKtNu1x1VVUHnLG1t1Xe3bNGfx45Vui3khbPAoHihvl63V1bKbfa+Je/U9HT9orRUyfu6iPflDEqP3y+XaXY/BkB02K3SyeOtWrkz8IzMcdkWPf6thO5Ar6/8flMPv+/RLa+7dNv5Dl1ygj2MFQMAAIxsIS0PmnfyiVr03jI1NfWtGywwkl2ak6PfjB4tWy+rE9Z1dOjbmzd3N9MAYpHPNPVqY2OvgZ5V0g8KC3V7WVlAOHdlXp6y7Xu/kT/wDMomr1f/3L1b527YoH/u3j0I7wLAoRiGoR+cGq9fnduz8VNJhqGnvp2grOT+/bVxV4tfX32wS//3kktOj/Szl52qbOr9aAsAAAD0T0hLg5ISE1WQn6df/vYPGjdmtDIzM5SQkBAwz5B0wXlnh6NOYEg7KyND6Tab/nf7dnUFOatvh9Opb27apLvHjdPYIPcSEG1Ww9Dvysp02caNajig07kkZdpsun3MGB2XnBz0sQefQVnjcuk/dXV6taFBrn0h4XMNDboqP1+JrNYDou7qk+KUFCf97/Mu5aYYevrbicpP61+g98o6j370rFOtB/SKandJNzzt1NPfTpDFwjZcAACAgQop1Hvq2Re7f7xpyzZpy7Ze5xLqAXvNSk3V/ePH6/pt29R8UCgiSbUej769ebP+PHasJvcSjgDRlG2367ayMl2zZUt344vjk5N1a1mZsuyH3lJ34BmUP9mxQ282NfW43u7z6eWGBl2SkxOx+gH03WXT45TiMHRknkUlGf3f2GGzqEegt9/y7T79fZlH35kTF55CAQAARrCQQr2vffXi8FcCjADHJCXpwQkTdO3WrUEbDbT6fPruli26razskE04gGg5PiVF1xUW6s/V1fp6To6uLSzsdWt5by7NyQkI9STp8bo6fSk7W1YO0gdiwnnHhn7+3ZnH2PWVqV49sSrwH7Fu/a9L8yZYdUQuK3MBAAAGIqRQb+b0qeGvBIgxnW5TFc0WVfl8mjY6fN1pSx0OPXjEEbpu61Zt6eoKuO4yTf14+3b9rLRU52Vmhu11gXD5Wk6Ojk1KCnlF6aSkJE1OStInHR09xitdLi1padE8Am1gWPj1Fxxauq1DVc09z+J0eaVrn3Tq1e8lKs5GiA8AABCqASUVfr9f5RWVWr1mrdra28NXFRAl973n1tw7O3TEL9s0/peduuCxUbr4H06Zh+j2GYpsu11/nzBBU3sJRXySflVerodqasL+2kBvPu3oUJcvsOvlwQzDGPAW8Ut72Wb7nz17BvS8AA7vyY88qm2NfMOKFIehu77sULDFt+t3+fWnhTSIAgAAGIiQQ73Va9bq57+6VX/407168JH/qKb282/Efn/n3Vr18SfhqhEYNC1dprbs8fc4B8jllZo6w/9aKVar7h43TqccYlXSPbt26Y6qKvkJ9hBBpmnqqbo6Xbl5s35XWTkoQfK89HTlxwWeqbWqvV2fdUbghgMgSfrXSrdueMapC+7vHJROtLPH2HT1icG38f7lXbdWVRz+HxIAAAAQXEih3tZtO/TQvx6X1+fT1OMm97jW3tGh9o5OPfzoE9qybXu46gQGRX5a8G1AtW2R+cYn3mLRbWVluigrq9c577a0qCVIYw0gHLp8Pv1s507dXlkpr2nqtcZGPVNfH/HXtRmGvpKdHfQaq/WAyHjmY49ufsElSdrZYOqCv3VqW13kg72bz4jXhJzAv3L6Ten6p7rU6eYfrgAAAEIRUqj31sLFyhiVrp/f/CNd8qULelxLTkrSzT+6XpkZo/TOu0vCVScwKHJTgod6u1si9w2H1TD0k+JiXZ2XF3AtzWrVPePGadRhOosCodjpdOobmzbpjYOaVvyxqkrrDzrvLhLOz8pSoiXwj6H/NjWpzuOJ+OsDI8lr6z264WmnDlyIu6vF1Bfv79TGmsiulnPYDd1ziUO2IH/r3F5v6jevuyL6+gAAAMNVSKHezvIKnThrhpKTk4Kek5KYmKATZ89QRUVlGEoEBk9eWvBborY1sqsIDMPQdwoK9JPiYu2/pRwWi+4aN05lDkdEXxsj09tNTfr6Z59pm9MZcM1rmrpx+/aIrxBNsVp1fpBmMF7T1NN1dRF9bWAkeXezV9c87pQvyKK8unZTH5ZHfgvspEKrfrQgcMu9JD20wqNFm1mRDgAA0F8hhXrOLqdGjUo75JxRaWnq6Azs7AnEsrzUXlbqDcKB4pL0pexs3V5WpgSLRX8oK9OkpKRBeV2MHB7T1J+qqnTTjh3q9Pf+uf5CZqaSrdaI1/OVnBwFu+ueqauT8xD1AeibFdu9+uajXfL0ktv99Mw4XT4jeNgWbteeHKepJcH/6vmDZ5xq7mQbLgAAQH+EFOolJSepvqHxkHPKK6uUnEwggaElK8mQJUjCEOmVegc6ddQovTxxomanHTo4B/qrzuPRd7ds0b8PcWZditWqP48dq+8WFMgabCl2mBXFx2t+kGYxLT6fXms89J8zAA5tTaVPlz/SJWcvu9mvnx+n6+bFD1o9Nquhv3w5QQlBTpSoaTX10xcDVw4DAACgdyGFehPGj9WSpSvU0tIacM00TX3w0WotWbZCR4wfF44agUFjsxrKCXKu3mCGepI0ymYb1NfD8Le6rU2Xbdyoj9vbe51zREKCHjvySM0Z5ED50pycoOOP1dbS+RkI0cYan776YKfaezmu7luz7br59MFZoXegMVkW/eLs4EHi85949eInnKcJAADQVyElB2efsUDr12/Ub2//k8aOGS1JenfxUi1+b7l2VlSqublFDodDZ55+SrjrBSIuN9VQzUEh3mBtv+2vf9fWKi8uTgtGjYp2KYhRpmnq0T17dE91tQ51atYFmZm6sbhY8UEaV0TalKQkHZ2YqE87O3uM73S5tKK1VSeyahXol211fl3yjy4193IKyldPsOvX58bLGITVuMF8Y6Zd/93o1aLNgb8r3fyCUzPKrMpLHfzfiwAAAIaakP7GlJOdpeu/f7WysjK0bsNGSdLadZ9qzdr1am5uUWlJkf7n+1cpJzsr3PUCERfsG4nBXqnXFy83NOhP1dW6eccOmgogqDafTzfu2KG7DhHoxRmGflFSop+XlkYl0NO+RjG9rtY7xFZhAIEqm/z68j86Vdce/M+t84+16Q8XxssS7KyJQWIYhu68yKH0hMBrzV3SD59xymSVLgAAwGGFvMevpLhQN/7wOtXVN2jX7hq5XG4lOOJVkJ+nzMyM8FYJDKJgzTLq2k15faZs1uh9E3SgJS0tuqW8XJJkSrqtslINHo++k58ftZUXiC1bu7r0v9u3q8LVy947SYVxcfr9mDE6MjFxUGsLZsGoUfpLdbX2eHpuvVvZ1qatXV0alxDku38APdS27g30drUED8ROP8qquy9xyBrFQG+//DSLbr3Aoe8+HniO3rubfVq506eZZRxFAQAAcCh9WpbxwD//pY2bNnd/fde9D2jrth2SpOysTE2edIymn3CcJk08mkAPQ15ukDP1/KZ6XfUw2NZ1dOim7dsDVl79vaZGv6uslI/VDSPea42N+samTYcM9E5KTdW/jzwyJgI9SbIbhr6cnR302n9YrQccVkOHX5f8s0s7G4L/GTBnnFX3X5oge4z845QkXTDZrvOP7Rnc5aUa+s83Ewj0AAAA+qBPod6GjZtUV9fQ/fWWrdvV3t4RybqAqMlPC35bxMoW3KUtLXL1Etw9V1+vm7Zvl8sfm2cAIrLcfr9uq6jQz3fulLOXz4BF0vcLCvSnsWOVGmMNWS7MypIjyBbg1xsb1ejh8HygN61OU5c+2KVNtcHv+2mlFj309QQ57LET6O136wWO7n9Mu2CyTQtvSNL8CbH1exMAAECs6tPfmjJGpevFl1/X5i3bFB+/t2PZ4qXLu8/T641hSF/76sXhqRQYJLlBtt9qX7OMKbIOej0HuyY/XwkWi+7etSvo9XdbWnTt1q26c8wYpcRYaIPIqvd49HpTU6/X0202/W70aM1ITR3UuvoqzWbTuRkZeqa+vse4xTC0sbNTs1JSolYbEKs63aa+9lCX1lYHD/QmFlj06BWJSoqPvUBPkkYlGrrryw41dZq6YLI92uUAAAAMKX36jv/cs07Xv594WmvWru8e27J1e59egFAPQ01+L6FerKzUMwxDV+TlKcNu12/Ky4M2QFjd3q5vb96se8aNU3ZcXBSqRDQUxMfr16Wl+uH2wN+fJyYm6vYxY5QX45+HS3NyukO9XLtdl2Rn64tZWUq12eRnBSrQg9Nj6spHu/RhefBWOONzLHr8mwlKS4jNQG+/k8fzD1AAAACh6NPfoqYeP1lHHzVBe+rq5XK59Ze//l3nnLlA48aOiXyFwCDLDdL9VpJ2x0iot995mZlKt9l08/btQbfjbnU6deXmzbp33DiVOhxRqRGD7+T0dF2Zm6uHamu7xy7JztYPCgtlj1J32/4odTj0jdxcHZGQoFNGjZKdxi9Aryqa/FpXHTzQK80w9NS3E5SVHPv3PQAAAELT538aTUhIUGlJsSRp3NgyjR83VuPGlkWyNiAq0hMkh01yenuO17bG3iqhuWlp+tv48fqfbdvU6gv8xm63261vbt6su8aO1cSkpKjUiMF3TUGB1nd2al1Hh/6vpERnZwytBkbXFxZGuwRgSJiQY9WzVyfqkn909WjmlJ9q6OlvJyqvl3+kAgAAwPAQ0t/2brj2OwR6GLYMwwh6rl5NjK3U2+/Y5GT9c8IE5dqDn0XU7PXqmi1btLy1ddBrQ3TYDEO/Gz1ajxxxxJAL9AD0z1F5Vj3/nUQVpO39cysr2dBTVyWqOGP4BXp+f2z+OQwAABAtIR9ismt3jT5Zu15NzS3y+YKvYKJRBoaq3FSLyht7rnyL1VBPksYkJOjBI47QdVu3arvTGXC9y+/XDVu36pejRxPyDHHrOjo0qQ+rLjPsdmX0EvQCGF7GZlv0wjWJuvqxLv3xQofGZQ+vQM80TT25yqu/L3XrhWsSleJgWz4AAIBCDfU2frZZ9/394T4dWk6oh6EoWLOMWNx+e6C8uDj9Y8IE/WDbNn3S0RFw3Sfp5zt3qsnj0WW5uVGpEaFz+v36fWWlXmxo0K1lZTp91KholwQghhSPsui17yfKGGbnUNa3+/Xj51z676d7z8T4f6+4dOeXOCcWAABAoYZ6r7z+puw2m05bME/FRYWKYzUIhpnZY62Ks0kpRqvGFqQrP90yJM4mSrPZdO/48frJ9u1a0st22zurq9Xg9eq6goJh983fcFXlcunG7du1qatLknRLebnGOxwqS0iIdmkAYshw+z39jQ0e/fg5lxo6Pl8p//hHHp1+lFVnHsPfPQEAAEIK9Wpq9+iM0+br9AXzw18REAMunxGnr03zq7a6S7mF2bIMga6h+yVYLPrj2LH6bUWFXmpoCDrnkdpa1Xs8+kVpqWzD7JvA4ea9lhb9YudOtR3QCKXT79f/7tihfx1xhBKt1qjWFw3NXq/irFYlj8D3jpGpqtmvovSh8+dQOJimqQeWenoEevv9+DmXTii10tkXAACMeCH9bchqsSo9PT381eD/t3ff4W1Wd//HP7eGNby3HdvZe5EQQkIgYe9VoBA2AQK0rLbQQsfT59f1lEJLS0uhLQQII0DYm0KBQiCEMEIIWc4iiTO846lhjfv3RwZxLNmW4ym/X9fVq+S+j6QjS0fjo3POF+gUNsPQ/w4cqCtbWWbrtFhEJNJ7hUxT9+/YoR9t3Ngs0NvrG59Pv926tUf61lM2+3y6r75RZ6xapWcqKnq6O0C3eOaLgGb8sVEvLg/0dFe6lWEY+uv5TiUmtDxX1WjqJy/4ZZq9d69bAACA7tChUG/48CEqKdnW+b0B0GkMw9CNBQW6tbCwxbnj0tJ0e1FR3C3Vihe7AgHduGGDHiotjdom0WLRCf3kx5VP6+p084YNOn/tWr3p88tvmnqmokKBduzrCvRlr30d0I+e8ykQkm5Y6NOCT5t6ukvdqijDot+eGXn/vH+vDurZZcFu7xMAAEBv0qFQ79yzTteXK1bq82XLO79HADrVxTk5+r/Bg/cts52SlKTfDR4sK4Fer/R1Y6MuWbtWn9bXR20zzOnU46NH6/h+Uizj0bIyLT5gj8iKQED/qanpsT4BXe3d4qCuf9qn8J7JaKa5e9npAx/1r2DvwsNsOnlM5N1ifvGKTyW7CPcBAED/1aE99d58+z0NyM/T/Mef1vMvvaaszAzZbJGv6gc3XHuwfQRwkE7JyFCazaYHdu7U3cOGydGH9gjsL0zT1LOVlbp72zYFW1lSdkp6uv5n4EC5+tF+cpfk5OiTCCHnk+XlOjU9nRmniDsfbwpq7uNeBVquvNf/e82vQ4usOmxQ/3gNMAxDfzzXoc/vCbXYX6/BL/3wWZ+eneuSxcLrAAAA6H86FOot/eyLff9dX9+g+vqGzuwTgC4wPSVF05KTCUB6IW8opN9t3ap/79oVtY3NMHRrYaHOz8rqd4/hESkpGuJ06hufr9nxNR6Pljc2anJSUo/1DehsX5aEdPl8r3xRVpb+8LiEfhPo7ZWdbNEfz3Xoqsd9Lc59vCmkBxcHdN3MCJvvAQAAxLkOhXq//NmtslmtUj/7Ygn0de0Ng0KmyfLcbrLZ59NtmzZpo6/ll9W9cu123Tl0qCYkJnZr33oLwzB2LyOPUBhkQVkZoR7ixuqdIV38sEeNUVbYXnOkXbed2D/Dq1PH2TV7SlALv2iZdt7xll/HjLRqVG7/CjsBAAA6tAYvNydbmZkZysxIb/N/APqWhlBIVxYX6+XKyp7uStx7d9cuXb52bauB3rTkZC0YPbrfBnp7nZaRodQIS47fr63VNr+/R/oEdKYNFWHNfsirGm/k8xdPtevXZzj63Uzd/f3mTKcK0lref39QuukZn5qCVMMFAAD9CxtrAVG8vy6ovyx264anfTr3Xx4d+acGjf9tg8xW9jvr65rCYf1k0yat8nj0m61b9XBpaVzf354SME39Zds23fbNN2pspYLr1Xl5unf4cKXb7d3av97IabHovKysFsdNSU+Xl/dIn4DOUlId1ux5HlU2RH69PecQm+46p38HepKU4jT0t/MjV8P9entY97zXv4qIAAAAtHv57aKPlnToBmYddUSHLgf0tCXfhPX4cpek5juV1/mkVFePdavLhE1T/7t5c7Oqq/ft2KGqQEC3FhbK0s+/THaWikBAP/vmG33ZEH0v0mSrVb8dPFgzU1O7tW+93flZWXqsrEwHLr57uapK1w0YoOR+VDwE8aO0Lqzz53m0ozZyoHfyGJv+eoFTVgpBSJJmDLPp2qPseuCjQItzf3u/SSeMtunQgbwWAACA/qHdod4zz7/coRsg1ENflZcS+QtUaV1Yqa74+sJgmqb+tG2b/lNT0+Lc0xUVqg4G9etBg5RA1dyD9lldXauB3iiXS38cOlQFDke39qsvyLLbNcuRoPf8zWfjeMJhvVRZqctyc3usb0BHVDWGNXueV1uqIwd6s4Zb9c+LnbJbCfT297OTHXp/XUjrypvPdA6FpZue8eo/NyfKncDfDAAAxL92h3qnnnS8xOcj9CPRQz1To+IwO0izRX85eHvXLtUGg/rj0KFKZDbUQTktM1PLGhr0YlVVi3NnZ2bq9qIiOQhPo/qO29ki1NOe8PminBzZmFGKPqLWa+rCh7wtgqm9pg6y6pHLXXLaeU4fyGk3dO9sp06/z6PgAX++TZWmfvemX78/O/IyXQAAgHjS7lDv9FNP7NqeAL1MbpRQr6wu/vaYMwxD1+bnK9Nm0x9KShTpK+bS+npdu26d7h0+XBns8XZQflJUpLVer9Z4PJKkBMPQ7UVF+k6EPePQ3FCbTVOSkvTFAbMdS5ua9N+aGp2YToEm9H6eJlOXzfdo5Y7Igd6EAoueuNLFbLNWTCyw6pbjE3TXf1qG/I8sCeikMTYdM7LdH3MBAAD6JKaDAFHkJkf+MrWzLnphg77uvOxs3TlkiBKizHZa6/XqqnXrqDZ6kBwWi+4aMkQpVqsKEhL0yKhRBHoxuCg7O+LxJymYgT7AFzA15zGvPtsS+b1kZI5FT13lUoqTQK8tNx2ToEOLIn+UveU5nzxN8fcjHAAAwP4I9YAocpINGWr5hSAeZ+rt77j0dP19+HAlRlkCWuL366riYhXvmWWGjhngcOhvw4fridGjNdrt7unu9CkzU1JUFGHPwRWNjfq6sbFH+gS0RyBk6ronvfpwQyji+cGZhp6Z61JmIh/P2sNmNfS3C1xyHjB5PCPR0O/OcjDTEQAAxD0+NQJR2K2GMlwtA7ydUSoUxpMpycmaN3KkMqPss1cVDOqadev02X6VcrFbUzisDV5vu9pOSExUSit7GSIyi2EwWw990j8/bNLbayIHegNSDT0z163cFD6axWJYtkX/e9q3If9JY6x6/4dunTaebSIAAED845Mj0IrspJbLo8rq43f57f5Gut16ZNQoDYxShbUxHNZNGzbonV27ur1vvVVpU5OuWbdO165bp51NLfd5Quc5MzNTyRGKtry7axd/e/Ra1xyZoJPGtHzeZiftDvSK0vlY1hFzptt1+nib7j7PofmXu5SdzN8RAAD0D3zqAVqRndgywCvtBzP19ipwOPTwyJEaG2V5aMA09dNvvtEzFRXd3rfeZmldnS5Zu1YrPR7VhkK6fdMmNYX7RwDcE9xWq86NsA9hSNJCZuuhl3LaDc271KWzJ347QzfNJS2c69KwbD6SdZRh7P67Xjw1QQYVsAEAQD/CJ0igFdnulqFMeYOpULj/BHvpdrv+NWKEpicnRzxvSrqzpET/2LFDptl//i57hU1TD+3cqRs2bFBNMLjv+CqPR3/etq1H+xbvLsjOVss5T9KLVVXyhCIvcQR6mt1q6L4LnbroMLsSE6Qnr3JrTF6kZzIAAADQOkI9oBU5EZbfhsJSVWP/Cq/cVqvuGTZMp6SnR20zr7RUvy8pUbAfBXt1waB+tHGj7t+5M0JJFenZykq9UVXVAz3rH/ISEnRChOek22LRFio0oxezWgz96VyH3ropUZOLCPQAAADQMR3aof2V1/8tq9UqQ60vcbBYLEpKStSIYUOVmxt5U3OgN4u0/FZ7imXkRJ64FrfsFot+O3iwMuz2qMUIXqisVFM4rF8PHtzt/etuazwe3b5pk7a3sn/bIIdDI6ls26UuzsnRW3v2dRzrduvinBydkJ4uO0vw0MtZLIaGZfM87SrbasKq7sAPcBmJhgrT+M0bAAD0DR0K9d5+5/2YLzNj+lRdPPu8jtwc0GNyooR6ZXX9Zzba/iyGoVsKCpRls+lvO3a0OJ9gGDo7M7NH+tadXqqs1J0lJWpqZVbi8Wlp+t9Bg5QUoZgDOs/4xERdlZurGampmpSYyH5aALStJqyj/tQof7AdjQ/gsEkf/TiRYA8AAPQJHQr1rrnyMn3x5XJ9+dVKjR0zSsOHDpbb7ZbX69XGTZu1ak2xjph2mAYPKlJNbZ2+WPaVPv7kMxUMyNfRM2d0/r0AukjUmXp1/bcAgmEYuiIvT+l2u363ZYv27lxmkfT7IUN0aJS99+KBLxzWXSUlermVJbVWSTcVFOjSnBwCpm5yQ0FBT3cB2Oe1rwN6fWVQfz3fqQQbrwE9obrR7FCgJ0n+4O7LF6Z1dq8AAAA6X4dCPdM0taZ4vW79wfUaPKio2bkTjjtaW7Zu0z8efETTph6qI6ZN1cknHKs/3XO/Pvn0C0I99CnRQr3+OlNvf2dlZirdZtPtmzbJb5r62cCBOjYtfr8FbfP7ddumTSr2eqO2ybTZ9Ic4DzYBRPfu2qCuf9qnQEiq93n14KUuuewEewAAAOgaHVpb8NY7/9Wxs45qEejtNWhgoWYeOV2vvfmf3TdisejwqYeqLMo+XEBvleY0ZY+wepJQb7eZqan654gR+mFBgc7Nyurp7nSZRbW1unTt2lYDvclJSVowZgyBHtBPfbwxqLlPeBXYM3353eKQLnvEqwY/7xcAAADoGh0K9XaWlik9PbXVNhnp6dqytWTfv11Op/pRUUzECcOQcpNbzrLoz8tvDzQxKUmX5eb2dDe6RMg0df+OHfrRxo2qD4WitrssJ0f/GDFC2XZ7t/YPQO+wbGtIlz/qle+AJZ+LN4V04UMeeQN8AAIAAEDn61Co53AkaPWada222bBxU7N/F6/boLTUlI7cHNCj8lJahnrM1OuY0lYqxfY2uwIB3bRhgx4qLY3aJtFi0V1DhuiHhYVUWwX6qVU7Qrr4YY8ao7y8TR1klbNDm50AAAAAretQqDdm1Eh9+dXXevzJZ7Rh4zeqq6+Xz+9XQ0OjNm8p0XMvvqqlny3T0CGDJUmvvvGWPv18mSaMH9vZ/Qe6XG6EUG8noV7MltbV6ZxVq/REWVlPd6VNXzc26pK1a7W0vj5qm2FOpx4bPVrHp6d3a98Qu80+n7xhZtei860vD2n2Q17V+iKfv2yaXf97moOiOQAAAOgSHfrt+DtnnaZvtmzV0s+WaelnyyK2SXS7de7Zp0uSSkvLlZ+Xq1NOPPbgegv0gPxUQ5mJhvJSdv8vN8Wi/BRDpmnyRa2d1ng8+vGmTWoyTf1l+3ZVBQK6uaCg1/79niovV1kgEPX8Kenp+p+BA+WyRthwEb2CaZr6rL5eC8rL9VFdnX5eVKTzsrN7uluII1urw5o9z6uqxsg/8pw7yaY/nE2gBwAAgK7ToVAvLTVFv7jtR1qy9DMVr9ugyqpq+ZuaZLfZlJ6epuFDh+jIIw5XUlKiJOnM005SdnaWrHwBRh/0q9MS9Nszee52VInPp5s3bJBnv5lSj5WXqyoY1C8HDeqVy1Z/PnCg1no82uL3NztuMwzdWlio87Oy+KLeS4VNU69VV+vJ8nKt36+wyYLycp2TlSULjxs6wc7asC6Y54k6a/uUsTb99XynLBaebwAAAOg6Hd7lJSHBrqNnztDRM2e02TYvLz430Uf/QHjTcZ5QSDds2KDqYLDFuderq1UTDOrOIUN63Yy3JKtVdw0dqiuKi+XbE0bm2u26c+hQTUhM7OnuoRWGpOcqKpoFepK0xe/Xx3V1Oiq19SJPQFsqG8K6YJ5XW6ojB3pHj7Dqnxc7ZbPy3gEAAICu1aE99fZXVlahFStX6/MvluvrVWtUWVnVOT0D0Oe5rVZdmJMT9fziujp9b/161UQI/XracJdLvxg4UJI0LTlZC0aPJtDrAwzD0MVRnnNPlpd3e38QX2q9pi56yKsNFZH3aJw22KqHL3PJYSPQAwAAQNfr8Ey9tcXr9czzL6u8orLFuaLCAl10wTkaWFR4sP0D0MddnJOjTJtN/7tli4Jmy5ktKz0eXV1crL+PGKH8hIQe6WM0p2VkKMli0ZGpqbIyY7PPOD49XX/bvr3FvohL6+u13uvVCJerx/qGvqvRb+rSRzxauTNyoHdIoUWPz3HJncBrRV8XCFEMCwAA9A0dmqm3ZWuJ/vHAI6qorNLQIYN15BGH69hZR2rG9KkaPLBIJdu266/3PaCysorO7zGAPufkjAz9ddgwuS2RX3I2+/26qrhYGw5YMtlVKgIB7Wrn7MBZaWkEen2M3TB0QZSiGE8xWw8d4AuYmvOYV59vjRzojc616Mkr3Up28loRD+77IHqhJAAAgN6kQzP13n7nfdkTEvSjm65TwYD8Fuc3bynR/f96WP/+z3u64tLZndFPAH3c9JQU/WvECN28cWPEQK08ENDcdev0l2HDNDkpqcv6say+Xj/95huNcLn0t+HDCezi1LlZWXqwtHTfnoh7vVldrRsHDFCG3d5jfUPf0hQ0dc0Crz7aGIp4fkimoYVzXcpI5LUkXry5KqjHljbp8mm9a/Y4AADAgTo0U2/jN5t1zMwZEQM9SRo8qEizZh6hdes3HGz/AMSRsYmJenjkSBVEWWZbHwrphvXr9UFNTafftmmaerysTN9bv15VwaA+qa/Xgzt3dvrtoHdIsdl0ZkZGi+NNpqnnKltuGwFEEgqbuukZn95ZGznQK0gz9Mw1buUkH/QWxehEGYmGHB3eYGa3X7zs19LNvW+/VwAAgP116COP1+NVbm7kpU175eXmqKGhsaP9AhCnBjqdemjUKN28YYPWRVhu6zdN/XjTJv1i4EB9JyurU26zIRTSr7ds0XsHhIUPlpZqfGIiFVHj1EU5OXquslIH7o71TEWFrsjNlSPKcnBgr9te8OuVFZGDnewkQ8/MdaswjedRb1OYZtFHP05UdWPbe+NtrgrrB8/45DvgYQ6GpblP+PTWTW4NSOUxBgAAvVOHQj2ny6ma2rpW29TU1snpdHa0X0CvUloX1saKsErrTJXVmdpZF1ZVo6n7ZjtlsHwzZtl2ux4YOVK3btyoLxoaWpwPS/rt1q2qDgZ1ZW7uQf2NN3i9+smmTdrq90c8/8vNm7Vg9GgNcDg6fBvonQY5nZqZmqpFtbXNju8KBvXv6mqd3UmhMeLXYYOseuqLgA6s8ZPulp6Z69LQLMKe3qowzaLCtLbbTSywymrZHeAdqM5r6qttIUI9AADQa3XoU8rgQQP1/qLF2hVliVz1rl16/4OPNGTIoIPtH9ArPLQ4oO8+6NWNC3367Zt+zVsc0IvLg6qPnBOhHZKtVt07fLiOT4v+reu+HTv0x23bFI5QNXdRTY3OWLlSi1pZqvtGdbWuKC6OGuhJ0sTERCVZrR24B+gLLs7JiXj8yfJymRGeV8D+Lppq1/0XOmXb79NSkkN68iq3RufxuhEvTh9v14+Oa74tRG6yoeevdevUcey/CQAAeq8OzdQ78bij9df7HtDv7vizJowfqwH5ubLbE9TY2KidpWVauXqtZJo6+YRjOr/HQA/IS4k8U6y0LqwUJ1/sOsphseiOIUN0V0lJ1H3OFlZUqDoQ0G8GD1bCnuWS3nBYd5SUqDwQ0B0lJZqakiLXfkspA+Gw/rx9u56piF6B2yLp+wMGaE5urizMtoxbhyUlaaTL1WKp9wafT5/W12taSkqP9Q19w3cOscttN3Ttk14ZhvT4HJcmFfK6H29+fEKCVu0M6e01IU0ZaNG8S13KS2GGHgAA6N06FOoNHzZEV15+kRY+95I+X7a8xfmUlGRddMG5GjKYmXqID7lRQr2yOlMjI08EQjtZDUM/LSpSpt2uf0UpXPGfmhoNKS3VdQMGSJIeKS1VRSAgSaoIBDS/tFTf33OutKlJt2/apJUeT9TbTLPZ9PvBgwl0+gHDMHRxTo5+tWVLi3MLyst5DqBdThpr0+NzXAqFpelDDrICA3oli8XQ32e79I9FTfrBcQly2PixBwAA9H4d/mR66KSJmjh+rNZv3KTS0nL5/U1yOBwakJ+r4cOGyMpyNsSRaL/W76xl+V5nMAxD1+bnK9Nm0x9KShQ+4PyExERdnpcnSSrx+TS/tHRf8QNT0vyyMp2RkaEdTU36+ebNqglGr1g43u3WnUOHKi9KBV7En5PT03Xv9u2qOuB5sbiuTt/4fBrC/q9oh5nDCfPiXbLT0G0nsb8qAADoOw7qE6rNZtOYUSM1ZtTIzusR0AvlpUaZqVd/YPyEg3FedrbSbTb9YvNmNe3Z72yI06l7hg2Ty2KRaZq6s6SkxeVM09RNGzeqpJW98yRpdna2flRQIDtVT/uVBItF52dn658RZoI+VV6unw8c2CP9AgAAAICD0WXfbL9euVo/+fmvuurqgW6VkxRlTz1m6nW649LT9ffhw5VosSjXbtffhw9Xmm337w8f1NZqSX29QgdcJiS1Gug5LRb9dvBg3VZURKDXT303K0uOCHsnvlZV1erMTsS/94qDWl9+4KsKAAAA0Pt12bfbYCgkr9fXVVcPdKsEm6GsCMFeaR2hXleYkpysh0aO1L3Dh+9bJusNh3VnSUnML1qDHA49OmqUTsvI6JK+om9It9sjPgf8pqkXohRpQfz7aENQVz3u1Tn/8mrVDoI9tM/HG4N6aHFTT3cDAACg60I9IN7kJbcM9Vh+23VGuN0a5nLt+/fe4hix/MWPS0vTY6NHa/h+14P+6+KcyFVtFlZUKBBmLPc3n28J6YrHvPIHpapGU+c94NEXWwn2EJ1pmnr44yZd8JBXv3zNr3fXMssXAAD0LEI9oJ0iVcClUEb3OLA4Rlsskn5YUKC7hgxREkV7sMdQl0tHRKh2m22376umjP7h6+0hXfKIR579JlvV+qQL5nn08UaCGrTkC5i69Xm/fvGKX6GwZJrS9U97tbGCHwQAAEDPIdQD2ikvteVwKa83FQ4T7HWlaMUxWjPG7dalOTkyIuyhhv5t72w9Q9KxqamaN3KkHh81SgMcVLzsL9aVh3Thw17VRdghxNMkvbGKUA/NhcKmLpjn1VOfNw//63zSnMe8qvfxOQAAAPSMg6p+C/QnkZbfBsO7l21lRziHzrHZ59OS+vqYLrPK49Fmn09DWHaLAxyRnKzv5+frlIwMFRLk9TtbqsKaPc+r6sbIIcx5k236zRk8L9Cc1WLo9PE2fbal5fLsDRVhXT7fo1+d7pBhaf2zQEaiocI0fk8HAKCjttWEo36Oa008vwcT6gHtlJcapQJunans5G7vTr8x2OnUEcnJ+jRC1dtIrJIOT0nRYKezG3qHvsYwDM3Nz+/pbqAH7KgN64KHPFELHJ06zqZ7vuuUpY1gBv3TtUfZ9fWOkJ7/suVMzk82h3XKfd42r8Nhkz76cWLcfqkAAKArbasJ66g/NcrfgUUV8fwe3O5Qb978J2K64trauo70B+i18lIivwCU1pmaUNDt3ek3DMPQ7UVFOm/16pjas/QWwF6VDWFdMM+rrdWRA71jRlr1j4ucsll53UBkhmHoj+c69dW2Rm2o6NhyW39Qqm40VZjW6d0DACDuVTeaHQr0FOfvwe0O9ZZ/tbJrewL0crlRltiW1rFJdlcrcjo1Jy9PD7dRLMOQNCc3V0UsqwSwR43H1IUPRS9oMH2IVQ9d6pLDRqCH1rnshn51ukOXzo+wISMAAEAPaHeo94Mbru3angC9XH6U5bdlUZZyoXNdmZenV6uqVBkIKNJXc4ukLLtdc/LyeqB3AHqjBr+pS+d7tGpn5EBvUqFFj13hkjuBQA/tk53ctct2QmFT3v3qcez/zIw2AX3/45Ha2yy79wVs63abXWdrt8FMeAAAeo12h3ojhg/t2p4AvVyG25DdKgUO2NhtJ6Fet3BZLLq9qEi3btoU8XxY0k+LiuSyxN8+CQBi5w2YmvOoV19sjRzojc61aMGVbiU7CSjQe2yoCOuYv3g69TrvPs+hi6cmtNrmkke8+mB9e3aubd3evG9kjkXv/yix1bYfrA/qsvnf7kUYLcBsNkLbCDAfvsylo0e0/vXmtPsam83cjXQ9RpQbjdSvGUOteuCS1gtzvbA8oF+/7m/1Nls7rgjHF17t1rDs1j/zHH9PoxqbzHbfTvO7bbQ4fvp4m356cuurIeYvadL8T75NpmO9r5H+9C9d51aiI/prdaPf1Hcf/HbcxHo7kR7vCw+ztTlu7vvAr3fXfjtuDnzMWns8I/XFlWBo/uWtP5dKdoV1+4vfzhY+mPtq7Dlz5Qx7m+Pmz+/6tWrHfuOmHfcnYrs9/5+fauj/nd76/terd4Z03wdNMd1GW8evm5mg0XnWVm/3j//xq6z+2+93rf7IEeW4JMk05WlM1CFDArr6yNbHzedbQnrpq/3GzcHc1z3//f2ZCW3+EPWn//jl3++lvz2PXWvnJhRYdOo4e6u3+fGmoD7ZFPlG27pPrJCLjEIZQDtZLIZykg1tr2ke4pXx4tJtjk5NjVg0Y29xjFmpqT3YO8QD0zS1rKFBhyQlycZslD6rKWjqmie8WrwpckgxNMvQwrkuZSTyGAOdyTSb/39rwmbLH0oPVrgdt9vgl+piWkHd+pXW+dq+UW+TqfL6zv0RONiOO7t1V1gN/jabRdHy+ivacR8qG0wVl3XuZ+O27mrIlJZv69zbnDW89eBHkjZWmFryTec9iZPbsXuMp8nUf9d17sA5aWzb9/XTzaFOCf73Gplj0f87vfU2ZfWmXljewQ3UojjrELtGt7Go59Wvg1pf3lnPJ6fK/SFdfWTrrYrLQnro40DrjWI0e4q9zWKO//qo6SBeI1q6+DB726HexpDufrep1TaIDVNagBjkpbT8AhitkiI6394iGNGOsyQIHdUUDuvVqipdvHatrl2/Xu/V1PR0l9BBwZCpGxf69G5x5C8fBWmGFs51K6eLl1ECHdGeMKxLbrcnbrMffXzqqbvaE3/jfvSwAkCvwEw9IAa7K+A2/+WGUK97HVg0g+IYOBj+cFiPlZXp2YoKVQW//TX4yfJynZSe3qN9Q+zCYVM/fsGnV7+O/Mt+TrKhZ+e6VZhGoIf+w2ixeKwbbrOHfmPriZvtV78n9tTj2kv/xmYPpKYE//GJ4B8Hg0+1QAz2n6lnMXb/uyjdaLHBNLrWlXl5yrbvntqdTXEMHAS7YeiN6upmgZ4kfd3YqK8bG3usX4idaZr65at+LfwicqCX7pYWXu3SkCw++gAAWtdbg8SuQPAff7fZY/rVne09mKkHxOCqGQn67mS78lINZSUasll55eoJLotFPysq0l3btum2wkKKY6DDLIahi3JydGdJSYtzC8rK9IehFInqK6oaTb21JnKgl+yQnrrK3ebm2EBPy0w0dMvxuzfn338Gxf4/HcZ6fEx+2++RZ06wadyeds2up43binb7Ocltfz4qSDM0Z/q3ey+15760dS4/te3bPXWcTVOKwlFvM9a/9Zi8tv++gzIsOnvit1+7OnRfDziZ1ErhiL2OH22TPyCZ+13zwTyvRuW2777u3Y8ulvsT7Ta154f01lgNaeqgva/vnXNfcyNsuXOggjSLxg+wtLyiNu5PtHPu1utySJISbIaG7ymQ0uxq97uiWO9rUjsWu2QlGipIM1pc9kDtfT5ntmNP2wTrt+2i/z2jPN5R+mFrx1cGl/3bxyLi9cTwvDJNU+35mmLs9zxv7bkDRGIUFxfH1VNlydLP9dyLr8jn8+s3v7xdmZkZ7brc0s+W6bEFC6Oez8/L1f/89JZmx0KhkP67aLE+/WyZyisqZbVaVFgwQMcfO0sTx49td59HjhzZ7rboPuFwWGXbtyq3YKAshEZAj+uqMekNhXTaypWqCzXfg80i6ZVx45TP0u4+Y3tNWBfM82hT5bcfbZx26emrXZo2mN8xO1t/fJ9csT2kk+/teHXat25ya2IB4TI6X38cj0Bv1pVjcv+l39ECTIuhNvcb9wfNVq8jWqgYrb3VIrnsrd+mN2CqKdj69TQ//u0/Vu0IafZDMVU6aqavvQevW7euXe3i5hNufUODnlr4glasXC27vfWKK5F4vV5J0vHHztLgQS034ne5WpbcfujRBfpqxSqNHzdGxx59lILBoBYvWap/zXtUF55/jmYeOb2D9wYA0F1cVqvOycrSo2VlzY6HJT1dUaEfFRb2WN8Qm4I0i168zq3Z87xaWxZWglWafzmBHgAAiB/7h3UHs5TZYev+VWcuuyFXTHHNt31Mc8fVfLROEzefcu+8+16FQiFdf+2Vevud97V+46aYLu/x7A71xo4eqdGjRrTZfvmKlfpqxSoddugkXXn5RfuOT5t6qH5/1z164eXXNWnieCUnJ3Xg3gAAutPs7Gw9UVamA+ulvlhZqWvz85Vo7Tu/6vV3OckWvXCdW1c86tH1sxJ09Ii4+agDAAAANBM3c7OHDh6on9/2Q40dM6pDl/fsmanncrna1X7pp19Ie2b27S8hIUFHzZimpqYmfbF8RYf6AgDoXrkJCTohQrXbxnBYr1RV9Uif0HHpbkMvXefWKeNin7kPAAAA9BVxE+pddcUlSk7q+Ky4vTP13O7doV44HFYwGHnDbUnatHmL7Ha7CgvyW5wbOmTQ7jabNne4PwCA7nVJTk7E40+VlyvETsV9jqWtndWBDshINOTo4ORPh2335QEAQOx4D46MNSl77J2pt2TpZ/py+deqrKpWOBxWZmaGZkyfqhOPO1rWPcuvfD6/GhoalZ2VGXHTy/T0NElSRWX7ZneEw+FOvS/oHHsfFx4foHfo6jE5xuXSIYmJ+qqxsdnx7U1N+mDXLh2TltYlt4vYlNaFlZcSN79J9mn98X1yQIr04S0uVTfGHvRnJBoakNK//l7oPv1xPAK9GWOy8/EeHFmvDPXefPvddrU7ZuaMdi+XbcvemXqff7FcR82Ypvz8PNXV1euDDz/Wq6+/pc2bt+q6uVfIMAz5/H5JkiNKRURHwu7jPl/7KrOUbd/aKfcBXaNi57ae7gKA/XTlmDzNauirCMcf3b5NYxrruux20T7Ld9p0wyspuu5wjy6f3PHqZ+hc/e190iYp8rzeNjRKZY3taAcchP42HoHejjHZuXgPbqlXhnqvvfF2u9odPmVyp4V6Z51+snw+n4YNGyKX89tKt9MPn6I7775XX69aoxUrV+uQCePacW27k+O2SkjvlVswsMP9RtcJh8Oq2LlN2fmFLWZkmqapWp9UVmeqrM5UeUNY353M3k1AV2ptTHaWs01Tj65Zox1NTc2OrwwEVZ2epTFud5fcLtr29faQfvC6T96gdM/HibI403TL8fZ2v9ei83XHmATQPoxHoHdhTOJg1W/Y0K52vTLUu++eO7v9NocPGxLxuNVq1TGzZmjB089rzdp1OmTCuH2h394Zewfae9y5XzjYGgZ572axWJo9Rve+79ef322SL9C83WnjE5Tk4Msl0NUOHJOdet2SLsrJ0d3bWv6q+lRFhX43JPJ7BbpWcVlIFz3iV/1+b7t/fi+gxibp/53uINjrYV05JgHEhvEI9C6MSXQ1nl3tkJKcLEny7llO63AkKDUlWTU1tRHXZFdV7ZIk5eRkdXNP0R0cNqNFoCftnrUHoO87KzNTiRE+fL29a5fKD5jBh663uSqs2fO82uVp+Rr7r48CenZZ9KJWAAAAQDwj1JPk9zdp2fIVWr5iZcTzpeUVkqSM9PR9x4YPG6JgMKgtW0tatF+/YZMkaeTwoV3WZ/ScvJTIM0JK6+Jv002gP0qyWvWdrJY/yoQkPVNR0SN96q+214R1/oMeldVH/tHk9PE2nTupVy46AAAAALpcvwv1QqGQSsvKVVW9a98xm82qZ55/WfMff1rlFZXN2ns8Xr3/wUcyDEOHTpqw7/iMI6ZJkt55b1GL9h8tWarERLcmHzJBiD/RQz1m6gHx4sLs7IhvkC9UVsobh1WzeqOK+rBmz/NoW03k19bjRll1/4VO2awsvQUAAED/FBc/b1dV72o2Y66+sUGStGpNsZKSEiVJmRkZGjSwUDU1tfrtHXdrYFGBbr/1ZmnPvnnnn3uW5j/+tO7+6/2aOWO6srOztGtXjT76+BPtqqnVaaecoKLCgn23MXrkcB0x7TAtWfq5/vHAI5o8aaL8fr8++PBj1dXV6+o5l3RaEQ/0LnkpkbNwZuoB8WOAw6Fj09L0bk1Ns+O1oZBer6rSd7Oze6xv/cEuj6kLH/JqY2XkQO+IIVbNu9SlBBuBHgAAAPqvuAj11q3fqCeeerbF8YXPvbTvv6dNnaLLL7kg6nVMmXyI0tNS9e77H+qTz75QfV29EhwJGlRUqAvPP0fjx41pcZmLZ5+nwsICfbzkUz397AuyWq0aPGigLpp9rkYMY+ltvMplph7QL1yck9Mi1JOkJ8vLdW5WliwUZ+gSDX5Tlzzi0erSyD+UHFpk0WNzXHLZ+fsDAACgf4uLUO+IaYfpiGmHtattZmZG1Oq6Q4cM1tAhg9t9uxaLRcfMnKFjZs5o92XQ9zlshtLdRotN2ymUAcSXQxITNc7t1iqPZ98xQ9Jgp1MNoZBSbHHxFtqreJpMXT7fqy9LIgd6Y/MsWnClm0rjAAAAQH/cUw/oDPkRZuux/BaIL4Zh6JKcHEmSy2LR7OxsvTh2rP48bBiBXhdoCpq6ZoFXS74JRTw/LMvQ01e7lOYm0AMAAAAULzP1gO6Wm2JodWnzYyy/BeLPcenp+kkwqNMzMpRMkNdlgiFT1z/t03vFkQO9onRDz1zjVnYyv0UCAAAAe/ENBeiA/BSLpOZfPsvqTJmmKYN9toC4YTcMXbhnth66Rjhs6pbnfXp9ZTDi+dxkQ8/MdWtAKoEeAAAAsD8+IQMdEKlYRlNIqvYwWw8A2ss0Tf38Fb+eXRY50MtINLRwrkuDM/m4AgAAAByIT8lAB+SlRp6NR7EMAGgf0zT1f/9u0qOfBCKeT3ZIT13l0qhca7f3DQAAAOgLCPWADsiLsq/TTkI9AGiXN1cFdd8HTRHPuezSgqvcmlhAoAcAAABEQ6gHdECk5beSVEYFXABol5PH2nTJ4fYWxx026dErXJo6iEAPAAAAaA2hHtAB+VGW35bWMlMP6E+awmG9s2uXTJOxHyurxdAfz3Ho2qO+DfZsFumBi12aOZw6XgAAAEBb+NQMdEBmoiGrRQodMDGvtJ4v9kB/sCsY1PMVFXqmokJVwaDuGz5c01NSerpbfY5hGPrV6Q4lOQzd816T/j7bqZPG8tEEAAAAaA8+OQMdYLUYyk02tOOAmXmltSy/BeJZbTCoe7dv1xvV1fLvNzvvyfJyQr0OMgxDPznRoTMn2DQ6jyW3AAAAQHux/BbooEj76jFTD4hvbotFi2prmwV6krS4rk7feL091q94QKAHAAAAxIZQD+igvJSWw6eM6rdAXLNbLLogOzviuacqKrq9PwAAAAD6L0I9oIPyIszUq2gwFQgR7AHx7LzsbDmMluP/taoq7QoGe6RPvdVX20K64lGPGvy8LgIAAACdjT31gA46frRNmYmGclMM5adYlJtiKC/FkI2oHIhr6TabTs/M1AuVlc2O+01TL1RU6Or8/B7rW2+ytjSkix72aJdHumCeRwuudCvdHblyOAAAAIDYET8AHXT8KJtuPcGhSw9P0PGjbRo/wKqsJIuMCDN4AMSXi6MswX2mslKBMAVzNlWGNfshr3Z5dv/7y5KwznvAo4p6/jYAAABAZyHUAwAgRkNcLs2IUO22MhDQ27t29UifeottNWFdMM+j8gMKB60pDeucf3lUTrAHAAAAdApCPQAAOuDinJyIxxeUl8s0++cecuX1Yc2e59H2msj3f0iWRWkuZjMDAAAAnYFQDwCADpienKxhTmeL48Ver5Y1NPRIn3pSdaOp2fO82lQZOdA7cqhVD1ziUoKNUA8AAADoDIR6AAB0gGEYuqiV2Xr9Sb3P1MWPeLS2LPLS2ikDLZp/hUsuO4EeAAAA0FkI9QAA6KBTMzKUZmtZSH5Rba1KfL4e6VN38zSZumy+V19tixzojc+36Ik5biU5CPQAAACAzkSoBwBABzktFp2fldXiuCnpqYqKHulTd/IHTV39hFdLN4cinh+ebdFTV7uU5ibQAwAAADoboR7QicJhU5UNVHYE+pPzs7NlN1qGVq9UVak+GOyRPnWHYMjU95/y6f11kQO9gRmGnpnrUlYSHzUAAACArtByzRCAdvv3qoCeXx5UaW1YpXWmyupNBULSxt8kyZ3AzBSgP8i023VKerpera5udtwbDuvFqipdnpvbY33rKuGwqR8+59ObqyKHlnkphp6d61Z+KoEeAAAA0FX4tA0chM3Vpl77OqjPt4a1rWZ3oCdJpXWRqz8CiE8XRymY8XR5uYJmfL0emKapn77s1/NfRg70MhINLZzr0sAMPmIAAAAAXYlP3MBByE+JPBuvtI4luEB/MtLt1tTk5BbHywIBvbdrV4/0qSuYpqnfvOHX40sDEc+nOqWFV7s0Msfa7X0DAAAA+htCPeAg5EYN9eJrZg6AtkWbrbegvLzb+9JV/vxuk/75YeRAz50gLbjKrfEDCPQAAACA7kCoBxyEvJTIQ6iMUA/od45KSdEgh6PZMZfFonGJiQqE+/7s3X992KQ/vdMU8ZzDJj16uUtTBhLoAQAAAN2FQhnAQYg+U6/vf4EHEBuLYeiinBz9oaREuXa7LszJ0TmZmUq2xcdb7fBsi5w2yXfAVno2izTvUpeOGh4f9xMAAADoK/gEDhwEl91Qmkuq8TY/zvJboH86IyNDqTabjk1Lk92IrwrYx4+26YkrXbr8Ua88eybsWQzpvgudOmE0HycAAACA7sbyW+AgRVqCS6gH9E8uq1UnpafHXaC315HDbHpmrlupzt3//vN5Tp010d7T3QIAAAD6JX5aBw5SboqhtWXNj7H8FkC8mjLQqueudWv5tpBmH0agBwAAAPQUQj3gIOVH2FevrM6UaZoy4nS2DoD+bfwAK1VuAQAAgB5GqAccpNwIy2/9wd377KW7e6RLPW5bTVjVjbEvQc5INFSYxq4AAAAAAAC0hVAPOEh5rVTATXf3v5ks22rCOupPjfIH29H4AA6b9NGPEwn2gB6ytjSkBr902KD+99oFAAAA9DV8cwYOUvRQr38Wy6huNDsU6GnPDMeOzPAD+oqaYFCvVFX1dDci2lQZ1gXzvJr9kEcfbejgIAYAAADQbZipBxykSNVvJam0lnAKwG7f+Hx6qrxcr1VVyW+aGu50amxiYk93a59tNWGd/6BHFQ27X7cune/Vg5e4dOIYPiYAAAAAvRUz9YCDlJcaffktgP5th9+vmzds0HdXr9bzlZXym7tDswXl5T3dtX3K6sK64EGPduz3Q4Q/KF31uFevrAj0aN8AAAAAREeoBxykrERDlgi5Xlk9M/WA/i7VZtPyhoYWx/+za5fKm5p6pE/7q240Nfshr76pavl6FQxLCz4LyDR5LQMAAAB6I0I94CDZrIayk1qmeiy/BZBoteo7WVktjockLayo6JE+7VXnM3XRwx4Vl0WeVXzYQIsevtQlw4g8GxkAAABAzyLUAzpBpCW4pfX9b/ltg9/Uf4vZYB/Y34XZ2RHfbF+orJQ3FOqBHkmeJlOXzfdqxfbIr1PjB1j0xJVuJToI9AAAAIDeih2wgU6Ql2zRV2r+5bi/zNRr9Jv6z9qgXlkR1H+Lg/KR6QHNDHA4dGxamt6tqWl2vC4U0mvV1To/O7tb++MPmrryca8+3Rw5UByRY9FTV7mU6iLQAwAAAHozQj2gE0SaqVfRYCoYMmWzxt8X40a/qXf2BHnvEeQBbbokJ6dFqCdJT5WX67ysLFm6aYlrIGTquid9WrQ+cqA3KMPQwqtdykpiIj8AAADQ2xHqAZ1gRLZFkwotykuxKC/FUG6KofwUi8JxNFnP0/RtkPducVC+LiqK+dnmkCYWWLvmyoEeMjExUePcbq3yeJod3+L3a3FdnWampnZ5H0JhUz941qe3VkdO4fNTDD071638VAI9AAAAoC8g1AM6wdVHJujqIxN6uhudztNk6t21Qb3ydVDvrO26IG9///OqXw1Npm4+JoEN+hE3DMPQpTk5+tnmzS3OLSgv7/JQzzRN3f6SXy8ujxzoZSYaWjjXpaIMAj0AAACgryDUA9DM3iDv1T1BnrcbgrwD/eGtJn21Lay/nu9UspNgD/HhuPR05W7frrJA80H1WX291nk8Gul2d8ntmqapX73u14JPIw/mVKe08GqXRuQwQxYAAADoS/hJHoAk6a3VQV33pFfjf9uga5/06dWvYw/0hmUZunhq5/xW8OaqoE67z6MNFf2vijDik80wdGFOTsRzT5aXd9nt/umdJj3wUeTBnJggPXmVW+MGEOgBAAAAfQ2hHgBJ0sIvAnplRexB3tAsQz84NkHv/sCtD29N1BXTO28Z8oaKsE79e6P+vaoHpgsCXeCczEy5LC3fev+9a5cqA53/PL//gyb9+d2miOecNumxK1w6dCCBHgAAANAXEeoBkCSdNbH9M+yGZBq6+dgEvXOzWx/dmqifnuzQ2HyrDMNQRqIhRycu7G/wS1c+7tOdb/sViqfKI+iXkm02nZWZ2eJ4wDT1XEVFp97Wo5806bdv+iOes1uleZe6NGMYu3AAAAAAfRWf5oE45w2YWlcW1iGFrc/GOXG0TU6b5Iu8j76GZBo6Y4JdZ020aVy+JWoRi8I0iz76caKqG2ML4FZsC+n//u1XjTfy+Xvea9KK7SHdN9ulNDf77KHvuig7W89UVOjAEfJcZaWuzMuTI8JMvlgFQqaeWBp55p/FkO6/0KnjR/MRAAAAAOjL+EQPxCFvwNR/i4N67eug3l4TlM0irfifJCXYoodhiQ5Dx42y6Y1V36Z6g/cGeRNsGj8gepB3oMI0iwrTYuvzxAKrjh1l09VPePXVtsj76L1XHNKp9zXq4ctcGpPHkkH0TUVOp2alpuqD2tpmx3cFg3qzulrfyco66NuwWw09c41blz7i0bKS5uPpL9916owJ9oO+DQAAAAA9i1APiBO+gKn/rgvq1RW7g7zGA7bR+nBDqM2ZOWdOtGnVzpDOnGDXmRNtmhBDkNcZCtIseuk6t372kk9PfxF5yuDmKlOn3+fRPec7ddZEggn0TRfn5LQI9bSnYMbZmZmdMu7S3YYWznXrike9+nhTSJJ0x9kOXTCFcQMAAADEA0I9oJOsLw/p8y1hldaFVVZvqrTOVGldWC9e55bL3jXBmC9g6v11Qb3ydVD/WRNUQ+TtsyRJr34daDvUm2DT2RNt3RrkHchpN/Tn7zo1qSigX77qVyDUso03IF33pE/Lt4X085MdsllZjou+ZUpSkka5XCr2Nl9vvtHn0yf19ToiJaVTbifJYeiJK12a+4RXM4ZaNeeIzitkAwAAAKBnEeoBneTdtSH9+o2WqVp5nalBmZ0XOvkCpj5YH9IrKwJ6u40gb39vrgrqrnPMVpfgWi29IxwzDENXTE/Q2Hyr5j7hVXl95P35Xlwe1PWzEpSV1Dv6DbSXYRi6JCdH/7tlS4tzT5aXd1qoJ0kuu6HHrnD1mvENAAAAoHNQ/RboJLkpkb8w76yLvD9cLPxBU2+vDurGhV5N/F2D5jzm1QvL2x/oSVKdT1q8KcK0t15s6iCr3r7JramDWr5U7a3emZXEyxj6ppPS05Vlb74UNsdu19TkZJlm51Z6JtADAAAA4g8z9YBOkhcl1Cur69iXc3/Q1KI9M/LeWh1UfQwB3v4K0wydNdGmMyfYdUhh3wvAclMseu4at/7fa37N/+Tbap7/d5ZDUwZSLAN9l91i0QVZWbp/506Nc7t1cU6Ojk9Plz2G5e+VDWFlJho9umQeAAAAQM8g1AMOwraasKobd4d2td7I4d2ykpCGZDUP0zISDRWmtR6wff8pn95cFblYRFsK9gvyJhV2b7GLrpBgM3THd5w6pNCqn77k03mT7bpsGnuDoe87LztbU5KTdUhiYszjtGRXWN/5p0enjbfpN2c4+vw4BwAAABAbQj2gg7bVhHXUnxrlbyN3e+CjgB74KNDsmMMmffTjxFaDvRNH22IK9QrSDJ05YXeQN7mo7wd5kVx4mF0TBlg0PKfvzTgEIkmz2TQpKSnmy5XVhXXBPI921Jqatzggj1+661wHy2wBAACAfoRQD+ig6kazzUAvGn9w9+UL06K3OWWcTbe9KAVb2ZJvQOruIO+sifEb5B1o3ID2Lbk1TVPfVJkamkUAiPhS1RjWBfO82lz17ezgJz8PqLHJ1L2znbJTDRoAAADoFwj1gB4SDre+116629DM4Vb9d13z4hYDUg2dsTfIK7TIwsyciOYtDuh3b/r1u7McLNVF3KjzmbroYa/WlbdM+19eEdTgzCb99GRHj/QNAAAAQPci1AN6yModYU0qar3NWRPt+u+60L4g78wJdh1aRJDXlo83BfXrN/wKhaXbXvTrq+1h/d9ZDjls/N3Qd3maTF36iFdfb488fXdCgUXXH02ADQAAAPQXhHpAD1m0IaRLp7Xe5rTxNg3LdmsKQV677agN67onfQrtl3ss+DSgNTtDevBSlwakshwXfY8vYOrKx7z6bEso4vmRORY9dZVLKU5eJwAAAID+gm+3QA/5cENQoTaW4KY4DU0dZCXQayd/0NTcJ7yqbGj5d11WEtbJ93q0ZFMHN0IEesA3Pp+eLivX9570adGGyIHe4ExDC+e6lJnIWzoAAADQn/ANAOghNV7pk28if0lHx9gs0lHDok9ArmwwdcE8r+YtbpJpth6oAj3FNE0travTzRs26LurV+uP27bpnRJPxLYDUg09c7VbeSm8nQMAAAD9Dd8CgB5y9kSbcvki3qmsFkM/P8WhBy9xKjHK1mLBsPTLV/26+RmfvAGCPfQuazweXbhmja7fsEGL6+p2HzSkpBE1LdpmJRl6Zq5bRRm8jgAAAAD9Ed8EgB5y/dEJGp7NEOwKZ0yw6/Ub3BqaFX3Z8nNfBnXWPzwqqY5cdADoCTl2u7b4/S2Ou4bUybB/O7M3zSUtvNqlYbyGAAAAAP0W3wYAxKVRuVa9eWOiThpjjdpm5Y6wTv67R4vWs88eeodMu12nZmS0OG6xmUocWitJSkyQnrzKrbH50Z/bAAAAAOIfoR6AuJXiNPTIZS795IQoa3El7fKYuuhhr+7/gH320DtYtqZFPJ44olZOu6nH5rg0uYhADwAAAOjvCPUAxDWLxdAtJzj02BUupTgjtwmb0m/f9Ot7T/nU6CfYQ8+Zv6RJ979ukb/M1eKc1R3UTRc2acbQ6MVgAAAAAPQfhHoA+oUTx9j05o2JGpkT/WXvlRVBnXG/R99Uss8eut8zXwT0s5d376fXsC49Ypvl1kpmlAIAAACQCPUA9CdDsyx64wa3zpgQfabT2rKwTvl7o95Zyz576D5rSkP60XO+ff/273QrUGdv0W6Vx6MVjY3d3DsAAAAAvRGhHtBBGYmGHB1cBeew7b48ul+iw9ADFzv1i1MSZInyENT5pCse9TJjD91mdK5Ftzbb+9FQ4/rIe+stKC/vtn4BAAAA6L3YmAfooMI0iz76caKqG2NfCpeRaKgwjUy9pxiGoRuPcWhCgVXff8qrXZ6WbW45PkFDsniM0D0Mw9AtxzvkTjD069d3L8H1bk5R7qHV8huhZm3/W1Oj7X6/ChyOHuotAAAAgN6AUA84CIVpFhVGnkyDPuDoETb9+8ZEXf24Vyt3fjsr76QxVv3ouOgVc4Gu8r2ZCUpMkG5/ya8fHu2UOy9Lj5SVNWsTlrSwokK3FBb2WD8BAAAA9DymoQDo1wZmWPTy9906d9Lu3ziGZhm6d7ZLlmhrc4Eudtm0BL15g1s/OTFBF2RnyxqhzUuVlWoIhSKcAQAAANBfEOoB6PfcCYb+Ptup353p0MOXuZTiJNBDzzqk0CrDMJSTkKCT0ltWwm0Mh/VKVVWP9A0AAABA70CoBwB79jS7+sgEjcqNNC+qpXA49r0UgY64JDc34vGny8sVMnkeAgAAAP0VoR4AxGhtaUgn/s2j1TtZ/oj2K60La86jXpXXx1ZVeYzbrclJSS2Ob29q0gc1NZ3YQwAAAAB9CaEeAMSg1mvqqse9Wl0a1hn3e/TSV4Ge7hL6gMqGsC6Y59Vba4L6zj89KtkVW7B3cU5OxOMLyss7qYcAAAAA+hpCPQBop3DY1A1Pe/VN1e4lj96A9P2nfPrVaz4FQyyDRGS1XlMXPezV+vLdQd43Vaa+80+PNlW2P9g7OjVVBQktKzIvb2zUqsbGTu0vAAAAgL6BUA8A2unud5v0bnHLJbf/+iigCx/yqrIhttlXiH+NflOXzfdo5Y7mz40dtbuDveKy9i3hthqGLmK2HgAAAID9EOoBQDsEQqYWb4wewCzeFNLJ93q0fBv77GE3X8DUnMe8+mxL5LA3I9FQdlL734bPysxUoqV5+7Fut45JSzvovgIAAADoewj1AKAd7FZDz8x16aoj7FHb7J19tfBz9tnr7wIhU9c96dVHUYLgIZmGFl7tUkai0e7rTLRadU5WliySjktL07yRI/XYqFE6KT29E3sOAAAAoK8g1AOAdkqwGfq/s5366/lOOWyR2/iD0g+f8+lnL/nUFGSfvf4oFDZ100Kf3l4TOdAbkGpo4Vy3clNifwu+PDdXL40bpz8OHarJSUkyjG9DwUU1NTpj5UotoiIuAAAA0C8Q6gFAjC6YYtfL33OrIC36LKv5nwT03Qe9Kqtjn73+JBw29ZMX/Hp5RTDi+ewkQ89e41ZResfefjPtdhU4HC2Oe8Nh3VFSop1NTbqjpETeMM87AAAAIN4R6gFABxxSaNW/b3TrqGHWqG0+27J7n73PtrDPXn9gmqb+9zW/noqy/DrdLS2c69LQrM5/632ktFQVgd23WxEIaH5paaffBgAAAIDeJcoCsr5rydLP9dyLr8jn8+s3v7xdmZkZ7brc0s+W6bEFC6Oez8/L1f/89JYOtwcQf7KSLHrqKpd+/5Zf/1gUOcgpqzd13gMe/fZMhy6fZm+2XBLx5c63m/TQx5GfB0kO6ckr3RqTFz0E7qgSn0/zS0u1d7G3KWl+WZnOyMhQkdPZ6bcHAAAAoHeIm1CvvqFBTy18QStWrpbdHn0j+2i8Xq8k6fhjZ2nwoKIW510u50G1BxCfbFZD/3uaUxMLrLrlOZ+8ETKdQEj66Ut+fbUtrN+f7ZDTTrAXb+5936+//rcp4jmnXXp8jkuTijo/0DNNU3eWlEQ+vm2b7h02jCAZAAAAiFNxE+rdefe9CoVCuv7aK/X2O+9r/cZNMV3e49kd0o0dPVKjR43o9PYA4tt3DrFrZI5FVz3u1ZbqyAUynvo8oDWlIc271KWCNHY/iBcPf9yk3/87cqCXYJUevsyl6UO65u32g9paLamvb3E8JGlJXZ0W1dbq6LS0LrltAAAAAD0rbr5VDh08UD+/7YcaO2ZUhy7v2TPzzuVydUl7APFvbL5V/74xUceNij4ja/m2sE6+16PiMvbZiwcLPw/oF6/4I56zWqR/XOTUsSO7JtDzhsO6s6Qk6hu5RdIfKJoBAAAAxK24CfWuuuISJScldfjye2feud27Q7pwOKxgMHL1wo60B9A/pLkNPXaFSz84NiFqm8GZhgZnxs3Lb7/16oqAbnneF/GcYUj3nO/UaeNj3w6ivfYWx4gW2YUpmgEAAADEtbhZfnuw9s68W7L0M325/GtVVlUrHA4rMzNDM6ZP1YnHHS2r1drh9q0JM4uiV9r7uPD4IFaGpNtOtGtigaEfPOtXw34TuXKSDT1wsUN2i6lwOPIyXUTWm8bku8VBXf+0X9Eewj+cnaBzD7F2WV9L/P5mxTGi2Vs047T0dBU5HF3SF/RfvWlMAv0d4xHoXRiT6C69MtR78+1329XumJkzOm35696Zd59/sVxHzZim/Pw81dXV64MPP9arr7+lzZu36rq5V+zbcDzW9q0p2761U+4DukbFzm093QX0UZNTpUfPs+jWN1K0ucYqm8XUHSfUyqgPqqzlNmhop14xJhttctuTVedvOePyRzMadWJBlcq2d81Nm6ap39XWtxno7RU2Tf1uw3r9OjWZohnoEr1iTAKQGI9Ar8OYRFfrlaHea2+83a52h0+Z3Gmh3lmnnyyfz6dhw4bI5fy2cu30w6fozrvv1der1mjFytU6ZMK4DrVvTW7BwE65D+hc4XBYFTu3KTu/UBYLSyXRMbkF0r+Hm/rhc37NHGbVKVMH9HSX+qzeNCZzC6Tn88O66GGvKhu/PX7LcXbdekJOl972Nz6fllXuanf7sKRlgaCWJ6bolPT0Lu0b+pfeNCaB/o7xCPQujEkcrPoNG9rVrleGevfdc2e33+bwYUMiHrdarTpm1gwtePp5rVm7bl9IF2v71jDIezeLxcJjhIOS6t5dAVUSM6U6QW8Zk+MLLHrpe4m6YJ5HO2pNfW+mXT8+0dHlj/FQl0tHJCfr0/p6xVJu5ZdbtuiNXbt0XX6+JiQmdmEP0d/0ljEJgPEI9DaMSXQ1nl3tkJKcLEny+iJviH6w7QHEP8Mw2hX2+AKm7njLrwY/++31BcOyLXrpOrduPT5B/3ta1wd62vNcur2oqEOXXVJXpznFxbppwwZ93djYjksAAAAA6K0I9ST5/U1atnyFlq9YGfF8aXmFJCljz7KlWNsDQHuYpqmfveTT3/7bpNPv82hjBRvr9gVFGZZumaHX7DadTs3Jy1NHb/Fjwj0AAACgz+t3oV4oFFJpWbmqqr/dj8hms+qZ51/W/MefVnlFZbP2Ho9X73/wkQzD0KGTJnSoPQC0x2NLA3r6i6AkaV15WKf+vVFvrw72dLfQS12Zl6dsu/2g3sgJ9wAAAIC+q1fuqRerqupd2rK1ZN+/6xsbJEmr1hQrKWn3vkGZGRkaNLBQNTW1+u0dd2tgUYFuv/Vmac8+eOefe5bmP/607v7r/Zo5Y7qys7O0a1eNPvr4E+2qqdVpp5ygosKCDrUHgLZ8ujmoX77qb3as3i9d8ZhXtx6foFuOT5DFwn583amyIayvd4R17Mje+Vbpslh0e1GRbt20KWqbk9PTtbiuTg2h1nff+7iuTh/X1emolBT9edgwWdn7EQAAAOj1euc3lRitW79RTzz1bIvjC597ad9/T5s6RZdfckHU65gy+RClp6Xq3fc/1CeffaH6unolOBI0qKhQF55/jsaPG3NQ7QEgmnDY1E9f8isQJXe5+90mrdge0r2zXUp1EbZ0hxqPqQsf8mptWVj3XuDUOZPsPd2liI5OTY1YNMMq6fCUFP3f4MFqCIX0VEWFFpSXtxnupdpsBHoAAABAH2EUFxezG3sPGzlyZE93ARGEw2GVbd+q3IKBVCxClyvZFdZVj3u1ckf0ffSGZhl6+DKXRuVau7VvvUV3jckGv6kLH/Loi627HwvDkP54jkOXHJ7QZbd5MEp8Pp23enWzUM9mGHpu7FgVORz7jtUHg62Ge1ZJz40dq4FOZzf1HH0d75NA78F4BHoXxiQO1rp169rVjmcXAPQCRekWvfJ9t84/NPoE6k2Vpk67z6PXvg50a9/6E2/A1JxHvfsCPUkyTenHL/j1wEdNPdq3aA4smmFImpOb2yzQk6Rkm03X5ufrtXHjdF1+vpKszcPhUzMyCPQAAACAPoRQDwB6CZfd0F/Pd+r/znLIFuXV2dMkXbPAp/97069QmInWnakpaOqaJ7xavCnyEtVHP2mSp6l3/s33Fs2QpGy7XXPy8qK2jRTuWSXNbeUye/nCYa2koAYAAADQKxDqAUAvYhiGrpqRoGevcSk7KfreZn//oEkXP+JVdWPvDJn6mmDI1I0LfXq3OHKgV5BmaOFct9wJvXO/OZfFop8VFSk/IUE/KyqSqx3LPPYP9/4wdKiK2jFL74XKSl1RXKybqZYLAAAA9DhCPQDohaYPsemtm9w6tCj6y/Si9SGd8vdGrdzRevEDtC4cNvXjF3x69etgxPM5yYaenetWYVrvfsuclZam18aP16y0tJgul2yz6bh2XMYXDmt+aakkaXFdnebsCfeYuQcAAAD0jN79DQUA+rH8VIteuM6tSw+PXnm1ZJepM//h0fNfss9eR5imqV++6tfCLyIHeuluaeHVLg3J4u3yhcpKVQWb/50W19Xtm7lHuAcAAAB0L76lAEAv5rAZ+uO5Tv3pXIcSohS99QWkGxf69MtXfQqEWI4bi9+/1aSHl0QORJMd0lNXuTU6r39WG97f/rP0IiHcAwAAALofoR4A9AGXHJ6gF69zKz8l+p5u8xYHNHueV5UN4aht8K2//tevv78fuaKt0y49fqVLhxQS6EnSeq9XvnDbzyvCPQAAAKD7EOoBQB9x6ECr3rrJrWmDowdNK7aHVO1htl5b5i1u0h/eihzoJVil+Ze7NG2wrdv71VtNSEzUa+PH65q8PCW2owgH4R4AAADQ9Qj1AKAPyU626NlrXLp6RuR99v52gVMjc5hd1pqnPgvol6/6I56zWqR/XezU0SMI9A6UYrPpewMGEO4BAAAAvQShHgD0MXarod+d5dS9s51y7pc93Xxsgk4bH72oBqSXvwro1hd8Ec8Zxu5Q9JRx/A1bczDh3g82bNAqwr1eYVFNjc5YuVKLamp6uisAAADoIEI9AOijvjvZrpe/71ZhmqFjRlp124kJPd2lXu3t1UHduNAnM8rq5LvOcejcSQR67dWRcO+jujpdvifc2+aPPFsSXc8bDuuOkhLtbGrSHSUl8rZjv0QAAAD0PoR6ANCHTSyw6q2bEnX/hS5ZLdGLaPR3H24I6tonvQpGyS5+dbpDlx5OKNoRHQn3Pquvl6sd7dA1HiktVUVgd9XnikCg1crGAAAA6L34RA0AfVxGoqF0d/sCvWVbQzKjTVWLYw8tDsgfjHzuJyck6LqZBHoHa2+49+r48ZrbRrh3fna2Mu3MiuwJJT6f5peWau+rgClpflmZSnyRl6UDAACg9yLUA4B+4o2VAZ1+v0c/es4nX6B/BXv/vNipE0a3LCBy/Sy7fnQ8gV5nSrXZ9P1Wwj2HYejy3Nwe619/Zpqm7iwpiXx827Z+GfgDAAD0ZYR6ANAPrCsP6eZnds/EWfhFUGf/06NtNf1nHy2n3dBDl7p05oRvK4tcMd2u/znVIcNg2XJXiBbutXeWXtWe5aHoPB/U1mpJfb1CBxwPSVpSV6dFtbU91DMAAAB0BKEeAMS5ep+pqx73qbHp22Mrtod18r0eLd4YZU1qHEqwGfrHRU5dOMWm70626fdnEeh1h/3DvWvy8to1S68mGNQ5q1bphxs2aDXVcjuFNxzWnSUlUT/4WST9gaIZAAAAfQqhHgDEMdM09YNnfdpY0fKLenWjqdkPefXPD5v6zbI7q8XQ3ec59ZfvOmWhsEi3St2z5157Zuk9WV6uxnBYH9bV6bLiYsK9g2CapnY2Nen/bd6s8kBA0SK7MEUzAAAA+hxCPQCIY4Zh6IJDbUpyRD4fCku/ft2v65/2ydPUP4I9i8WQzUqg11vVBIN6ury82THCvY57qLRUZ6xcqXdratpsS9EMAACAvoVQDwDi3Cnj7HrzxkQNz47+kv/SV0Gdeb9Hm6v67tK7ep+pYKh/BJPxbO8svUgI95oLtGOp7FCnM6brDJmm7igp6TezdwEAAPoyQj0A6AeGZ1v05o1unTbOFrXN6tKwTrm3Ue8V97199hr8pi58yKPrn/apKUgY0VcFTFOvVlW12a4/hnveUEhfNjToyfJy/eKbb3TOqlW6rLi4zculWFtWfW6NKWlpfb2eKCsj2AMAAOjlon+7AwDElSSHoXmXOnXv+036w9tNivR9vdYnXTrfq9tPStDNxyT0iUIS3oCpKx71allJWMtKwvIGvHrgEpdc9t7fdzRnNww9PWaMFpSX6+lWZuzt9WFdnT6sq9Os1FRdm5+vMW53t/W1KwXCYa33erXK49Fqj0erGxu1yedrsR+eZU/Y52oluDs0KUl2SbHWEr5nxw69W1urWwoKNDEpqUP3AwAAAF2LUA8A+hHDMHTzsQ6NH2DVDU97VeNt2cY0pT+81aSvtoX1twucSnL03nCsKWhq7hNefbwptO/YO2tDuuwRrx69wqXEXtx3RJZqs+n6AQN0SU5Ou8O9RbW1WlRb26Fwb1FNje7atk23FRZqVlpaJ9yD2IRMU5t8Pq3xeLSqsVGrPR6t93oVaMcsubCktV6vJrcSulksFk1KStJnDQ0x9+3rxkZduW6dTkxL000FBSpwRNmcEwAAAD2C5bcA0A8dN8qmf9+YqLF50d8G3lwV1Kl/92hDhMq5vUEwZOqGhT69VxxqcW7xppBufZ7N/vuyveHeq+PH6+q8PCVa2v7Isqi2VpeuXasfbdyoNR5Pm+294bDuKCnRzqYm3VFSIm879qg7GKZpaqvPpzerq3X3tm26urhYs776SheuWaNfb9mi5yortdrjaVegt1d77ucVeXk6JjVVHY24/1NTo/NWr9bftm9XfajleAMAAEDPINQDgH5qUKZFr17v1jmHRJ+0vaEirFP/3qh/r4p18V7XCodN3fK8T699HXn/v9xkQz89mVlF8WBvuPdKF4R7j5SWqiKw+7ldEQhofmlpp/b9QP+pqdE5q1frfzZv1pPl5Vre2CjfQQaJq9qxp+ARKSn63ZAhyrbbO/zBL2CaerSsTP9v8+YOXgMAAAA6G6EeAPRj7gRD913o1K9Od8ga5R2hwS9d+bhPd73tVzjc8xvnm6apX7zi17PLIgd66W5DC+e6NDiTt7h4knZAuOduZ7j3SV1dxHMlPp/ml5Zq7zPalDS/rEwlvo7N8KwPtl1gprP2/LNIGuZ06qzMTM1KTW3XZVwWi24vKmqxL9/+LsvJUX5CQqvXc3VeXoy9BQAAQFdhTz0A6OcMw9B1MxM0foBF1z3pU1Vj5ODuL+816ZBCq04e23NvHaYp/f6tgOZ/EnnmYLJDevpql0blxlbxE33H3nDv4pwcPVlerqfKy+WJMtst1WrVBdnZLY6bpqk7S0oiH9+2TfcOG9ZqkZj6YHD3Hnh7C1l4PKoKBPThIYfI3krYWJiQoBSrVXUxLmEtcjg01u3WOLdbYxMTNcrlkjvGqraSdHRqqo5ITtan9fXavwdWSYenpOgHBQX6/oABeqq8XA+XlrbYy/C0jAyNS0yM+XYBAADQNQj1AACSpCOH2fTWTW5d/YRXX21rGZLMnmLTSWN6Nix76AuX7l8aOdBz2aUFV7k1sYBArz9oT7h3WW6uEiOEXx/U1mpJfX2L4yFJS+rqtKi2VkfvKZrhDYVU7PVq9X6FLLb6/RH7tMHna3U2nmEYGuN2a2mE294r127XuMREjdkT4o1xu5Vi65yPa4Zh6PaiIp23enXE44ZhyGEYmpOXp7MyM/XPnTv1YmWlwpIchqEbBgzolH4AAACgcxDqAQD2KUiz6KXr3PrZSz49/cW3ywkPKbToD99xtjp7qas9uDig+5dGDkwcNunRK1yaOohAr7/ZP9xbUFampysq5AmHlWq1anaEWXrecFh3lpTIsqd67IEMSf9vyxbNqqlRscejTT5fq0tW97eqsbHNJbbj9gv10m22ZjPwxrrdyrTb23lrHVPkdGpOXp4e3rP02JA0JzdXRQdUts2w2/XzgQM1Oztb92zfrjFut/LaWJorSVt8PuUmJMjZjuXRAAAAODiEegCAZpx2Q3/+rlOTigL65at+JTsNzbvUJae95wK9Jz9r0q9eb4p4zmaRHrjYpZnDeUvrz9JsNt1QUKBLcnO1oKxMmXZ7xCWqe4tjRNsd0pRUHwrp9erqmPuwuh2VaE/OyNDoPSFent3eI0H5lXl5erWqSuWBgLLtds1pZZ+8YS6X7h0+XKF2VOQNmKZu2bhR3nBYNxUU6OT0dFl68IcAAACAeMc3IABAC4Zh6IrpCRqbb1UgZKowredm3by4PKAfvxB5uaNhSPfOduqkHtznD73L3nAvkgOLY3S29oR6w10uDXe5uqgH7eOyWPSzoiLdtW2bbisslKsds+qs7QjnXqys1OY9S5P/Z/NmPVVerlsKCzUpKalT+g0AAIDm+BYEAIgqluWsTUFTCbbOnZXz1uqgbnrGp2iThO4+16nvHNK1yxURH6IVxzhYNsPQCJdLY91uTehDRSRmpaVp1p59AztDfSikf+3c2ezYKo9HV69bpxPS0nRTQYEKD1jiCwAAgINDqAcAOGg7a8M6+58e/fgEhy6Y0jkh26L1QV27wKtQlA3NfnumQxdNJdBD+2z2+SIWx4iFRdIQp7NZIYsRLpcS2D9Oj5SWqiYYjHjunZoafVBbqwuzs3V1Xp6SO6nwBwAAQH/HpyoAwEHxB01ds8Crkl2mfvCsTyu2h/T/TnfIbu34rL1PNwc15zGvmkKRz99+UoLmHtn2pv3AXoOdTh2RnKxP6+sV5WnVgtMwNCs1VeMTEzU2MVGjXK6I+/T1d2HT1KrGxlbbBExTj5eX65WqKn1vwACdk5UlO/vtAQAAHBR+WgYAHJRfvurXF1u/nU730McBnf+gV+X17a0Z2lxVY1iXzffKG4h8/saj7frBsQR6iI1hGLq9qKjd7W2Snh47VncMHapLcnM1OSmJQC8Ki2HonyNG6I4hQzSgjQq5taGQ7iwp0YWrV+vD2lqZ7SjAAQAAgMgI9QAAHfbkZ016fGnL9G3p5pBOvtejL7a2d07UtzITLfrf0xyKNIln9gSvfnpSz1QMRd9X5HRqTl6e2nr2GJLm5OWpiD3g2s0wDJ2Unq7nxo7VzQMGKLGNJcmb/X79cONG3bBhg9a3o8AIAAAAWiLUAwB02DeV0WfZlNaZOvdfHj2+tCnm673k8ATdN9sp637vUhccatNPZnoI9HBQrszLU7bdHvUDkEVStt2uOXl53dyz+OCwWHRFXp5eGjdO383KavOD5tL6el20dq1+u2WLKgNRpucCAAAgIvbUAwB02C9OdWhMvkW3Pu+TL8L38aaQdNuLfv13XUg3HG2PaZ+9qYOteuhSl65d4NVJY2364zkJqirt3P6j/3FZLLq9qEi3btoU8XxY0k+LiuSi+MVBybDb9bOBA3VBdrb+un27FtfVRW1rSnqpqkpv7dqlK3NzdUlurpz8/QEAANpEqAcAOCjnTrJrVI5FVz3h1dbqyDP33lwV1JurIlfGjMZhkz76caJe/r5bY/MsslnYewud4+jU1IhFM6ySDk9J0azU1B7sXXwZ5nLpb8OHa0ldnf6ybZs2+nxR23rDYd2/c6eer6zUbwcP1pTk5G7tKwAAQF/Dz6AAgIM2boBV/74xUUeP6LxCAv6gVN1oalKhVQk2ltyi80QrmrH3OEu8O98RKSl6cswY/WLgQGXYWv9NuSoYVE4bBTcAAABAqAcA6CTpbkMLrnTppmP4Mo7e78CiGYakObm5FMfoQjbD0LlZWXpx3DhdlZurhCjh6YXZ2TwOAAAA7UCoBwDoNFaLoZ+f4tCDlziVSLaHXm5v0QxRHKNbJVmtuqGgQC+MHatT0tObnUu1WjWXxwEAAKBdCPUAAJ3ujAl2vX6DWwVpPd0TIDqXxaKfFRUpPyFBP6M4RrfLdzj0f0OGaP6oUTokMVGSdF1+vpLbWJ7bXotqanTGypVaVFPTKdcHAADQ2/DpFQDQJUblWnXvBa6e7gbQqllpaXpt/HjNSiOB7ikTEhP10MiR+vPQoTo3O7vN9p5QSNetW6dFtbUyzcgFdLzhsO4oKdHOpibdUVIibzjcBT0HAADoWYR6AIAuk+ig4ACAthmGoaPT0mRvR5GSR8vK9HlDg360caOu37BB6zyeFm0eKS1VRSAgSaoIBDS/tLRL+g0AANCTCPUAAADQJ5Q2NenxsrJ9//60vl4Xr12r32zZsi/EK/H5NL+0VHvn8JmS5peVqcTn66FeAwAAdI3O2bQEAAAA6GL379gh/wFLbk1JL1dV6e1du3RFTo6WNTa2uJxpmrpz2zbdO2yYjHbMBgQAAOgLmKkHAACAXm+dx6PXq6ujnveGw/pnaak+ra9X6IBzIUlL6uq0qLa2y/sJAADQXQj1AAAA0OsNc7n0PwMHKrOD1XEtkv5A0QwAABBHCPUAAADQ61kNQ+dkZenFceN0dV6eHDEuow1TNAMAAMQZQj0AAAD0GYlWq64fMEDPjxunU9PTY7qsKWleaal+uXmz3tm1S42hAxfqAgAA9B2EegAAAOhz8hMS9LshQzR/5EglWWL7SPtGdbVu/+YbVe6pmAsAANAXEeoBALpMRqIhRwfrrDtsuy8PAK1JslrV0IF98lKtVg10OFptY5qmzAOq7QIAAPQWHfyqBQBA2wrTLProx4mqboz9S3FGoqHCNH57AtC6wU6njkhOjlj1tjWHJSXJaGNfvmKvVz/YuFGHJiXt+98Qp1OWGPfzAwAA6AqEegCALlWYZlFhWk/3AkC8MgxDtxcV6bzVq2O63JTk5DbbLGtoUGUgoLd37dLbu3ZJe2b4Td4b8iUna6TLJSshHwAA6AGEegAAAOjTipxOzcnL08OlpWprXrDLMOQ1TR2alNTm9X7Z0NDiWG0opPdra/V+ba0kKdFi0aSkpH1B31i3W/YY9/gDAADoCEI9AAAA9HlX5uXp1aoqVQYCirTDnkVSlt2uF8aOVVkg0K799JZFCPUO1BgOa3FdnRbX1UmSHIahCYmJmpKcrMlJSRqfmCgXIR8AAOgChHoAAADo81wWi24vKtKtmzZFPB+W9NOiIrmsVg22Wtu8vm98PtUEgzH3w2+a+ryhQZ/vCQRthqFxbrcmJyXp8ORkTUtJifk6Y7WopkZ3bdum2woLNSuN/Q8AAIhX/GwIAACAuHB0aqqOSE7WgZGdVdIRKSmalZra7uuyG4YuyM7WcKfzoPoUNE191dio+WVleqi09KCuqz284bDuKCnRzqYm3VFSIm8HKgMDAIC+gZl6AAAAiAvRimbsPd5Wtdv9FTmdur2oSJJUEwxqeUODljU06MuGBq31eCIu8W3L5Hbs4xc0TdkOovDGI6WlqggEJEkVgYDml5bq+wMGdPj6AABA70WoBwAAgLhxYNEMQ9Kc3FwVtbGHXmvSbDYdk5amY/YsZW0IhbRiT8i3rKFBqzweBc22SnSoXcU57iop0Wf19ZqclKQpe4pv5Lez7yU+n+bvVyzElDS/rExnZGSo6CBnHAIAgN6HUA8AAABxZW/RjPJAQNl2u+bk5XXq9SdZrZqRmqoZe5bz+sJhrWxs3BfyrWhokP+AkM8qaWJiYpvX/WVDg7b6/drq9+vlqipJUl5Cgg7dU2F3SlKSBjocLWYdmqapO0tKWlyfaZq6c9s23TtsWEwzFQEAQO9HqAcAAIC44rJY9LOion3FIrq6+qzTYtFhyck6LDlZkhQIh7XG49kX8i1vaNAQp1OuNgp07AoEtMnna3G8tKlJb1RX643qaklSps2myXtm8R2alKRhLpcW1dZqSX19i8uGJC2pq9Oi2lodTdEMAADiCqEeAAAA4s6stLQeq/xqt1g0MSlJE5OSNEdSyDRV3Y5Kul82Nrbr+quCQb1TU6N3amokSckWS4uZgfuzSPpDSYkOT0np8oATAAB0H97VAQAAgC5kNQxl2+1ttlsWYaZde9SHw2pqJdQL71c0AwAAxA9CPQAAAKAXODw5WWdkZKggIaHTr3tv0YySCMt7AQBA38TyWwAAAKAX2H/JcGlTk77cW2G3vl6b/f6Dvv69xTTuHT6cohkAAMQBQj0AAACgl8lLSNCpGRk6NSNDklQdCOwL+b5saNA6r1fRF9xGFpK0pL5em30+DXG5uqTfAACg+xDqAQAAAL1cht2u49PTdXx6uiSpPhjUsoYG/WnbNu1oamrXdVglHZ6SosFOZxf3FgAAdAf21AMAAAD6mGSbTUenpen+4cNlbedlDMPQ7UVFLL0FACBOEOoBAAAAfVSR06k5eXlqK6YzJM3JzVWRw9FNPQMAAF2NUA8AAADow67My1O23R71g71FUrbdrjl5ed3cMwAA0JUI9QAAAIA+zGWx6PaiIoWjnA9L+mlRkVwWPvoDABBPeGcHAAAA+rijU1N1RHJyi/31rJKOSEnRrNTUHuoZAADoKoR6AAAAQB+3twhGtOMUxwAAIP4Q6gEAAABx4MCiGRTHAAAgvhHqAQAAAHFib9EMURwDAIC4R6gHAAAAxAmXxaKfFRUpPyFBP6M4BgAAcc3W0x0AAAAA0HlmpaVpVlpaT3cDAAB0MX66AwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgj7H1dAc625Kln+u5F1+Rz+fXb355uzIzM2K6/KZvNuvNt97V5q0lCgZDys7K1BHTpuqYWTNkGEaztqFQSP9dtFiffrZM5RWVslotKiwYoOOPnaWJ48d28j0DAAAAAAAAdoubUK++oUFPLXxBK1ault1u79B1LF+xUvMeeUID8vN05mkny2az6dPPl+m5F19RZVWVzj/3rGbtH3p0gb5asUrjx43RsUcfpWAwqMVLlupf8x7Vheefo5lHTu+kewcAAAAAAAB8K25CvTvvvlehUEjXX3ul3n7nfa3fuCmmy3s8Hi14+jkVDMjXj394/b5gcNrUQ3X3X/+hTd9sls/nl9PpkPYEgF+tWKXDDp2kKy+/aN/1TJt6qH5/1z164eXXNWnieCUnJ3XyPQUAAAAAAEB/Fzd76g0dPFA/v+2HGjtmVIcuv/SzZfJ4vDrj1BObzfSzWq267ZYbdfutN+8L9CRp6adfSJKOP3ZWs+tJSEjQUTOmqampSV8sX9Hh+wMAAAAAAABEEzcz9a664pKDuvzqNcWyWCwaPWqEJMk0TQUCQSUkRF7Ku2nzFtntdhUW5Lc4N3TIoN1tNm3WMTNntHnb4XD4oPqOrrH3ceHxAXoHxiTQuzAmgd6D8Qj0LoxJdJe4CfUO1s7SMqWnpap6V41efPl1rSler2AwqOSkJB0+dbLOOPXkfQGfz+dXQ0OjsrMyZbG0nOyYnp4mSaqorGrXbZdt39rJ9wadqWLntp7uAoD9MCaB3oUxCfQejEegd2FMoqv1ylDvzbffbVe7Y2bOkMvl6pTbbGj0yO126W/3PaBJh0zQVVdcLJ/Pr8VLlurd/36o7dt36sbvz5VhGPL5/ZIkh8MR8bocCbuP+3y+dt12bsHATrkP6FzhcFgVO7cpO78wYngLoHsxJoHehTEJ9B6MR6B3YUziYNVv2NCudr0y1Hvtjbfb1e7wKZM7LdQLhUKqra3Ted85Q8cdM3Pf8alTJumuP9+rtes2aNXqtRo/bkw7rs2UJBmG0a7bZpD3bhaLhccI6EUYk0DvwpgEeg/GI9C7MCbR1XplqHffPXd2+206EhLk9fk09bDJzY5bLBZNP/wwlWx7Res2bNT4cWPkcjolad+MvQPtPe7c0w4AAAAAAADoTETGe2RmZkiSrBFS9JSUZGnPXnqS5HAkKDUlWTU1tRE3vqyq2iVJysnJ6uJeAwAAAAAAoD8i1Ntj2NDBkqSt23a0OFdVvTukS0tN3Xds+LAhCgaD2rK1pEX79Rs2SZJGDh/ahT0GAAAAAABAf9XvQr1QKKTSsvJ9Qd1eM6ZPlWEYevOtd5rNvmtqCmjxx0slSRPGf7uf3owjpkmS3nlvUbPr8Xi8+mjJUiUmujX5kAldfG8AAAAAAADQH/XKPfViVVW9q9mMufrGBknSqjXFSkpKlCRlZmRo0MBC1dTU6rd33K2BRQW6/dab912msGCATjnxOL359rv6230Patrhh8rr9WnJ0s9VUVmlo2fOUFFhwb72o0cO1xHTDtOSpZ/rHw88osmTJsrv9+uDDz9WXV29rp5zSacV8QAAAAAAAAD2Fxeh3rr1G/XEU8+2OL7wuZf2/fe0qVN0+SUXtHo9Z5x2knJysvXBh4v1zPOvyDRN5efl6uLZ5+nIIw5v0f7i2eepsLBAHy/5VE8/+4KsVqsGDxqoi2afqxHDWHoLAAAAAACArmEUFxebPd2J/m7kyJE93QVEEA6HVbZ9q3ILBlKGHOgFGJNA78KYBHoPxiPQuzAmcbDWrVvXrnaEegAAAAAAAEAfQ2QMAAAAAAAA9DGEegAAAAAAAEAfQ6gHAAAAAAAA9DGEegAAAAAAAEAfQ6gHAAAAAAAA9DGEegAAAAAAAEAfQ6gHAAAAAAAA9DGEegAAAAAAAEAfQ6gHAAAAAAAA9DG2nu4A0NU8Hq/ee/9DffX1KlVWVcswpPy8XM2YfrhmTJ8qwzD2tQ2FQvrvosX69LNlKq+olNVqUWHBAB1/7CxNHD+2xXXH2h5AbGMylrZiTAIxi3WM7W9N8Tr9/R8PSZLuu+fOFucZj0DsYh2Tm77ZrDffelebt5YoGAwpOytTR0ybqmNmzeA9EugEsYzJmto6/efd97W2eL2qd+2S0+lUbna2Zs08QpMPmcCYRJcwiouLzZ7uBNBVamrr9Kd77lNtbZ2mTT1Uw4YOkdfr1UcfL1VZeYWOP3amzj37jH3tH3j4MX21YpXGjxujSRPHKxgMavGSpSrZtkMXnn+OZh45vdn1x9oe6O9iGZOxjl8xJoGYdGSM7eXz+fW7O/+sXbtqpCihHuMRiE2sY3L5ipWa98gTGpCfp6NmTJPNZtOnny/T+g2bdMysI3X+uWc1u37GJBCbWMZkWXmF7r7nfjUFAjpqxjQVFQyQ1+/Xp58t05atJTpqxnRddME5za6fMYnOwEw9xLVXXvu3du2q0fnnnqVjZh257/j0ww/Tb+74k957/yOdcNzRSklO1vIVK/XVilU67NBJuvLyi/a1nTb1UP3+rnv0wsuva9LE8UpOTpL2fJCKpT2A2MZkLG3FmARiFusY29+Lr7yuhoZG5eZkq6y8osV5xiMQu1jGpMfj0YKnn1PBgHz9+IfXy263S3vG2N1//Yc2fbNZPp9fTqdDYkwCHRLLmHzrP++p0eNpEcYdOX2qfnvH3fro40904nGzlJWVKTEm0YnYUw9xLT09VZMOGa8Z06c2O+52uzRsyGCZpqkdO8skSUs//UKSdPyxs5q1TUhI0FEzpqmpqUlfLF+x73is7QHENiZjaSvGJBCzWMfYXsXrNmjxkk912sknRAz8xHgEOiSmz62fLZPH49UZp564L9CTJKvVqttuuVG333rzvkBPjEmgQ2IZk5VV1ZKkYUMHN2trt9s1sKhwd5vqXfuOMybRWZiph7h25mknRz3n8XolSW6XS5K0afMW2e12FRbkt2g7dMig3W02bdYxM2d0qD2A2MZkLG3FmARiFusYkySf368FTz+nosICnXDcLK1eUxzx8oxHIHaxjMnVa4plsVg0etQISZJpmgoEgkpIsEe8PGMSiF0sYzI/L08bN21WeXmlBuTnNWtbVV0ti8WivJzsfccYk+gshHrol7bv2KkNG79RTnaWigoHyOfzq6GhUdlZmbJYWk5gTU9PkyRVVFZJe/YSiqU9gNYdOCZjbcuYBDpPa+Px5VffVG1tnb53zZyIY02MR6DTRRqTO0vLlJ6WqupdNXrx5de1pni9gsGgkpOSdPjUyTrj1JP3BXyMSaBzRRqTJ51wjL5euUrPvfiKDMPQoEFF8vv8WvzJUm0t2a4Tjz9GaWmpEmMSnYxQD/3Orl01euChx2QYhi6efZ4Mw5DP75ckORyOiJdxJOw+7vP5dv9/jO0BRBdpTMbaljEJdI7WxuO69Rv14eJPdPopJ7SYhbA/xiPQeaKNyYZGj9xul/523wOadMgEXXXFxfL5/Fq8ZKne/e+H2r59p278/twOfc4FEF20MZmZka6f3HKj5j/+tB54+LF97e12m757zpk69uij9h1jTKIzEeqhX9mydZv+NW++Ghs9mnPZhRoxfGg7L7m7SHRrYcPBtQf6p1jGZMfHrxiTQDu0Nsaampq04OnnNCA/TyedcOxB3hLjEWiP1sZkKBRSbW2dzvvOGTrumJn7jk+dMkl3/flerV23QatWr9X4cWPacUuMSaA9WhuTlZVV+seD81Vf36AzTztZhQX58vn8+urrVXruxVdVWVXdoiJ1dIxJtB+hHvqNz79Yrieefk4JCXbd8L2rNXLEsH3nXE6ntN+vJgfae9y5p12s7QG01NqYjLUtYxI4OG2NsZdefVPVu2p02y03ymq1tnpdjEfg4LU1Jh0JCfL6fJp62ORmxy0Wi6YffphKtr2idRs2avy4MYxJoBO0NSafeOo5lZVX6Cc/ukGDBhbtO37YlElKeDJB7y9arBHDhmrSIeMZk+hUhHroF9557wO9+MobGpCfp+vmXqGszIxm5x2OBKWmJKumplbhcLjF3gZVVbsrFeXkZHWoPYDm2hqTsbZlTAId19YY27DpGy36aIlmHXWEkpIStaumZt+5YDAoSfuOpaelMR6Bg9Se973MzAxt275D1gj7caWk7K5K7fPtXeLHmAQORltj0uf3a8Omb5SZkd4s0Ntr4oSx+uTTz7WmeJ0mHTKeMYlORaiHuLfooyV68ZU3NGbUCM298jI5nZH3Lhg+bIi++HKFtmwt0ZDBg5qdW79hkyRp5H5TrGNtD2C39o7JWNsyJoHYtWeMFRdvkGma+uDDj/XBhx9HvJ7/+dUdkqT77rlTYjwCHdbe971hQwdr2/Yd2rpth0aPHN7sXFX17kAgLTV13zHGJNAx7RmTgUBApmnu+6GrxfmmgLTfD2FiTKITRS5bBsSJTd9s1rMvvKJhQwfrumvmtBoIzDhimiTpnfcWNTvu8Xj10ZKlSkx0a/IhEzrcHkBsYzKWtmJMAjFr7xg7bMokfe+aORH/t7dgxt5/78V4BGIX0+fW6VNlGIbefOsdhcPhfcebmgJa/PFSSdKE8d/up8eYBGLX3jGZnJSknOws1dTWad36jS3OL1u+QtoTxu/FmERnYaYe4tqzL7yqcDisCePG6OuVqyO2yc/LVX5erkaPHK4jph2mJUs/1z8eeESTJ02U3+/XBx9+rLq6el095xK5XK59l4u1PYDYxmQsbcWYBGIWyxjLzcmOeP7dPV9GJhywGT/jEYhdLGOysGCATjnxOL359rv6230Patrhh8rr9WnJ0s9VUVmlo2fOUFFhwb7LMSaB2MUyJr977ln617xH9Y8H5+uoGdNUMCBffr9fK1au1tri9Ro6ZJCmTZ2y73KMSXQWo7i42OzpTgBd5YYf3t5mm9NOPkGnn3qiJCkcDmvR4k/08ZJPVV5RIavVqsGDBuqUk47TiGEtpz/H2h7o72IZk7GOXzEmgZh0ZIwd6J57/6X1GzftW3a7P8YjEJuOjMlPP/9SH3y4WDt2lsk0TeXn5eqoGdN05BGHt7gsYxKITaxjsmTbdr3z3iJt2LhJdfUNstlsysnO0pTJE3Xs0UfJbrc3uyxjEp2BUA8AAAAAAADoY9hTDwAAAAAAAOhjCPUAAAAAAACAPoZQDwAAAAAAAOhjCPUAAAAAAACAPoZQDwAAAAAAAOhjCPUAAAAAAACAPoZQDwAAAAAAAOhjCPUAAAAAAACAPoZQDwAAAAAAAOhjCPUAAAAAAACAPsbW0x0AAABA37dm7TotWfq5Nm/Zqrr6BlmtFqWmpGjwoIGafvgUjRwxrNv68vY772vM6JEqKhzQbbcJAADQ3Qj1AAAA0GF+f5Mee3Khln+1UlmZGZo6ZbJysrMUDAW1Y2eZPvv8Sy397AvNmD5Vs7/7HdlsXfvxs7auXi+/9qaSk5MI9QAAQFwj1AMAAECHPbZgoZavWKmjZkzTBeedLavV2uz8aSefoH899Jg+/uQzJSUl6ewzTunS/mzevLVLrx8AAKC3MIqLi82e7gQAAAD6ntVrinXfvx7W0CGD9KObvieLJfJ2zTW1dXriqWd1yIRxmnnk9H3Hq6qq9e//vKc1a9eprr5BCXa7BgzI16wjp+uwKZOaXceOnaV6+933tWnTZtXW1cvpcCg3N1tHzZiuww+bLEm6595/af3GTc0ud+lF5+uIaYd1yf0HAADoSczUAwAAQId88unnkqQTjjs6aqAnSWmpKbrxe1c3O1ZeUak/3XOfmpqaNHPGdBUVFaqmplaffPq5Hnn8KZWVV+j0U0+U9oR/f/zLfXI5HTp65pHKyEiTx+PVZ198qUefeFoej0fHzDpSp596oj746GN9ufxrzTrqCI0YPlSDBhZ18V8BAACgZxDqAQAAoEM27Vnq2pEiGC+89JoaGz26es4lOnTSxH3HZx41XX/441/17/+8pxnTpyo9PU1ffb1KTU1NuvSi72rK5EP2tT1qxjQ9/OiTqqmplSSNGD5U69Zv1Jf6WgOLCptdLwAAQLyJ/pMqAAAA0IqGhgY5HAlyOZ0xXa6pqUmr1hQrNSW5RfDmcjp12JRJCofD+nrVGknat0/fho3fyDS/3TnGarXqmqsu03fOOq1T7g8AAEBfwkw9AAAAdIjVYlXYDMd8ubLySoXDYeXn50U8n5+bK0kqL6+QJB126CT994OPtOijJVq9dp3GjRmlUSOGa+TIYTEHigAAAPGCUA8AAAAdkpqaorLyCtU3NCg5Kandl/M3+SVJCXZ7xPP2BPuedk2SpMREt26/9SZ98NESfbn8ay36aIk++PBj2Ww2TZk8Ued+5wwlJSZ2yn0CAADoKwj1AAAA0CHDhg5WWXmFVq8u1rTDp7Tadv/gz+lwSJIaGj0R2/r9Tc3aSZLL5dIpJx6nU048TnX19VpbvF4fL/lMSz9bprq6et34/bmdeM8AAAB6P/bUAwAAQIdMP/wwSdJb7/xXgUAgajufz687775Xf7n3nwqFQsrJzpbValV5eYVCoVCL9jt2lkqS8vJyI15fSnKyDj/sUP3gxms1ZNBArSleL6/P12n3CwAAoC8g1AMAAECHDBs6WEcecbjKyiv00KNPyuf3t2jj8Xj0jwcf0a5dNZowfqysVqsSEuyaMH6MGhob9cWXK5q193q9+uzzZbLZbJo4fqwk6YmnntX/3fkXNe1ZjruXYRiy2qyyWCwyDEOSZLHu/njbWsgIAAAQD1h+CwAAgA47/9yzZJqmPv7kM/3qd3fp8MMma0B+vsLhkHbsKNUnny2T3+/X2WecquOPmbnvcueedbo2btqsJxc+rx07dqqwYIDqGxr04eJPVFNbpwvOO1vJybuX644eNUKffPqF7vzzvZo+dYrS0lLl9zdp9dpibdj4jY484vB9S3WzMjMkSR98+LGaAgHl5+Zo3NjRPfTXAQAA6DpGcXGx2dOdAAAAQN+2fuMmfbL0c236Zotq6+pkGIYy0tM1auRwHXnE4cqPsJR2164avfHWO1q9dp3q6urlcDg0aGChjjv6qBZB3KrVa/XBR0u0bdt2NTZ65HK5lJ2dqSOmTdX0w6fIYtk9Qy8YDGr+409r1ZpiOZ0OHX/sLJ1w7Kxu+zsAAAB0F0I9AAAAAAAAoI9hTz0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPoYQj0AAAAAAACgjyHUAwAAAAAAAPqY/w/L7g52QudnKwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1500x1000 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(\n",
+    "    costs_momf,\n",
+    "    np.log10(BC.max_hv - np.array(hvs_momf)),\n",
+    "    \"--\",\n",
+    "    marker=\"s\",\n",
+    "    ms=10,\n",
+    "    label=\"MOMF\",\n",
+    ")\n",
+    "plt.plot(\n",
+    "    costs, np.log10(BC.max_hv - np.array(hvs_kg)), \"--\", marker=\"d\", ms=10, label=\"HVKG\"\n",
+    ")\n",
+    "plt.ylabel(\"Log Inference Hypervolume Regret\")\n",
+    "plt.xlabel(\"Cost\")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "customInput": null,
+    "originalKey": "b42576d5-575c-48d6-b00f-48b48d26dd30",
+    "outputsInitialized": false,
+    "showInput": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": [],
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": [],
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "position": {
+    "height": "423.4px",
+    "left": "858.8px",
+    "right": "20px",
+    "top": "120px",
+    "width": "350px"
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
## Motivation

This tutorial was taking too long to run. This brings the runtime down from 76s to 40s on a Macbook.

* Change NUM_PARETO from 10 to 5 in smoke test mode
* Change NUM_FANTASIES from 8 to 2 in smoke test mode
* Change RAW_SAMPLES from 4 to 2 in smoke test mode

Also
* Remove an unused import
* Silence a numerical error

## Test Plan

Ran the notebook: `python scripts/run_tutorials.py -p ~/repos/botorch -s -n Multi_objective_multi_fidelity_BO.ipynb
`
