### PR TITLE
[Very easy] Fix docstring indentation

### DIFF
--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -69,7 +69,8 @@ def repeat_to_match_aug_dim(target_tensor: Tensor, reference_tensor: Tensor) -> 
                 [2, 2],
                 [0, 0],
                 [1, 1],
-                [2, 2]])"""
+                [2, 2]])
+    """
 
     augmented_sample_num, remainder = divmod(
         reference_tensor.shape[0], target_tensor.shape[0]


### PR DESCRIPTION
## Motivation

flake8 is failing because a docstring is under-indented.

## Test Plan

I ran flake8 and will make sure the CI passes as well.
