### PR TITLE
speed up decoupled mobo smoke test

### DIFF
--- a/tutorials/decoupled_mobo.ipynb
+++ b/tutorials/decoupled_mobo.ipynb
@@ -597,7 +597,7 @@
         "warnings.filterwarnings(\"ignore\", category=RuntimeWarning)\n",
         "\n",
         "MC_SAMPLES = 128 if not SMOKE_TEST else 16\n",
-        "COST_BUDGET = 90 if not SMOKE_TEST else 60\n",
+        "COST_BUDGET = 90 if not SMOKE_TEST else 54\n",
         "torch.manual_seed(0)\n",
         "verbose = True\n",
         "N_INIT = 2 * problem.dim + 1\n",


### PR DESCRIPTION
Summary: Drop the cost budget from 60 to 54. The initialization cost budget has cost 52, so this does at most 2 iterations.

Reviewed By: esantorella

Differential Revision: D51590942


