### PR TITLE
Remove sphinx version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ if os.environ.get("ALLOW_LATEST_GPYTORCH_LINOP"):
 # Read in pinned versions of the formatting tools
 FMT_REQUIRES += read_deps_from_file("requirements-fmt.txt")
 # Dev is test + formatting + docs generation
-DEV_REQUIRES = TEST_REQUIRES + FMT_REQUIRES + ["sphinx<=7.1.2"]
+DEV_REQUIRES = TEST_REQUIRES + FMT_REQUIRES + ["sphinx"]
 
 # read in README.md as the long description
 with open(os.path.join(root_dir, "README.md"), "r") as fh:


### PR DESCRIPTION
Sphinx 7.2.0 caused issues in the past (see #1990), but things appear to work just fine on the latest sphinx version (7.2.6)