### PR TITLE
Support different noise levels for different outputs in test functions 

### DIFF
--- a/botorch/test_functions/base.py
+++ b/botorch/test_functions/base.py
@@ -35,9 +35,9 @@ class BaseTestProblem(Module, ABC):
         r"""Base constructor for test functions.
 
         Args:
-            noise_std: Standard deviation of the observation noise. If a list is provided,
-                specifies separate noise standard deviations for each objective in a
-                multiobjective problem.
+            noise_std: Standard deviation of the observation noise. If a list is
+                provided, specifies separate noise standard deviations for each
+                objective in a multiobjective problem.
             negate: If True, negate the function.
         """
         super().__init__()
@@ -163,8 +163,9 @@ class MultiObjectiveTestProblem(BaseTestProblem):
         r"""Base constructor for multi-objective test functions.
 
         Args:
-            noise_std: Standard deviation of the observation noise. If a list is provided,
-                specifies separate noise standard deviations for each objective.
+            noise_std: Standard deviation of the observation noise. If a list is
+                provided, specifies separate noise standard deviations for each
+                objective in a multiobjective problem.
             negate: If True, negate the objectives.
         """
         if isinstance(noise_std, list) and len(noise_std) != len(self._ref_point):

--- a/botorch/test_functions/base.py
+++ b/botorch/test_functions/base.py
@@ -11,7 +11,7 @@ Base class for test functions for optimization benchmarks.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Optional, Tuple, Union
+from typing import List, Tuple, Union
 
 import torch
 
@@ -35,7 +35,9 @@ class BaseTestProblem(Module, ABC):
         r"""Base constructor for test functions.
 
         Args:
-            noise_std: Standard deviation of the observation noise.
+            noise_std: Standard deviation of the observation noise. If a list is provided,
+                specifies separate noise standard deviations for each objective in a
+                multiobjective problem.
             negate: If True, negate the function.
         """
         super().__init__()
@@ -161,11 +163,15 @@ class MultiObjectiveTestProblem(BaseTestProblem):
         r"""Base constructor for multi-objective test functions.
 
         Args:
-            noise_std: Standard deviation of the observation noise.
+            noise_std: Standard deviation of the observation noise. If a list is provided,
+                specifies separate noise standard deviations for each objective.
             negate: If True, negate the objectives.
         """
         if isinstance(noise_std, list) and len(noise_std) != len(self._ref_point):
-            raise InputDataError("If specified as a list, length of noise_std must match the number of objectives")
+            raise InputDataError(
+                f"If specified as a list, length of noise_std ({len(noise_std)}) "
+                f"must match the number of objectives ({len(self._ref_point)})"
+            )
         super().__init__(noise_std=noise_std, negate=negate)
         ref_point = torch.tensor(self._ref_point, dtype=torch.float)
         if negate:

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -76,7 +76,7 @@ from __future__ import annotations
 import math
 from abc import ABC, abstractmethod
 from math import pi
-from typing import Optional
+from typing import List, Optional, Union
 
 import torch
 from botorch.exceptions.errors import UnsupportedError
@@ -116,7 +116,11 @@ class BraninCurrin(MultiObjectiveTestProblem):
     _ref_point = [18.0, 6.0]
     _max_hv = 59.36011874867746  # this is approximated using NSGA-II
 
-    def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
+    def __init__(
+        self,
+        noise_std: Optional[Union[float, List[float]]] = None,
+        negate: bool = False,
+    ) -> None:
         r"""
         Args:
             noise_std: Standard deviation of the observation noise.
@@ -174,7 +178,7 @@ class DH(MultiObjectiveTestProblem, ABC):
     def __init__(
         self,
         dim: int,
-        noise_std: Optional[float] = None,
+        noise_std: Optional[Union[float, List[float]]] = None,
         negate: bool = False,
     ) -> None:
         r"""
@@ -334,7 +338,7 @@ class DTLZ(MultiObjectiveTestProblem):
         self,
         dim: int,
         num_objectives: int = 2,
-        noise_std: Optional[float] = None,
+        noise_std: Optional[Union[float, List[float]]] = None,
         negate: bool = False,
     ) -> None:
         r"""
@@ -600,7 +604,7 @@ class GMM(MultiObjectiveTestProblem):
 
     def __init__(
         self,
-        noise_std: Optional[float] = None,
+        noise_std: Optional[Union[float, List[float]]] = None,
         negate: bool = False,
         num_objectives: int = 2,
     ) -> None:
@@ -926,7 +930,7 @@ class ZDT(MultiObjectiveTestProblem):
         self,
         dim: int,
         num_objectives: int = 2,
-        noise_std: Optional[float] = None,
+        noise_std: Optional[Union[float, List[float]]] = None,
         negate: bool = False,
     ) -> None:
         r"""
@@ -1234,7 +1238,11 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
     _ref_point = [80.0, 12.0]
     _max_hv = 608.4004237022673  # from NSGA-II with 90k evaluations
 
-    def __init__(self, noise_std: Optional[float] = None, negate: bool = False) -> None:
+    def __init__(
+        self,
+        noise_std: Optional[Union[float, List[float]]] = None,
+        negate: bool = False,
+    ) -> None:
         r"""
         Args:
             noise_std: Standard deviation of the observation noise.
@@ -1337,7 +1345,7 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     def __init__(
         self,
         dim: int,
-        noise_std: Optional[float] = None,
+        noise_std: Optional[Union[float, List[float]]] = None,
         negate: bool = False,
     ) -> None:
         r"""

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -76,7 +76,7 @@ from __future__ import annotations
 import math
 from abc import ABC, abstractmethod
 from math import pi
-from typing import List, Optional, Union
+from typing import List, Union
 
 import torch
 from botorch.exceptions.errors import UnsupportedError
@@ -118,7 +118,7 @@ class BraninCurrin(MultiObjectiveTestProblem):
 
     def __init__(
         self,
-        noise_std: Optional[Union[float, List[float]]] = None,
+        noise_std: Union[None, float, List[float]] = None,
         negate: bool = False,
     ) -> None:
         r"""
@@ -178,7 +178,7 @@ class DH(MultiObjectiveTestProblem, ABC):
     def __init__(
         self,
         dim: int,
-        noise_std: Optional[Union[float, List[float]]] = None,
+        noise_std: Union[None, float, List[float]] = None,
         negate: bool = False,
     ) -> None:
         r"""
@@ -338,7 +338,7 @@ class DTLZ(MultiObjectiveTestProblem):
         self,
         dim: int,
         num_objectives: int = 2,
-        noise_std: Optional[Union[float, List[float]]] = None,
+        noise_std: Union[None, float, List[float]] = None,
         negate: bool = False,
     ) -> None:
         r"""
@@ -604,7 +604,7 @@ class GMM(MultiObjectiveTestProblem):
 
     def __init__(
         self,
-        noise_std: Optional[Union[float, List[float]]] = None,
+        noise_std: Union[None, float, List[float]] = None,
         negate: bool = False,
         num_objectives: int = 2,
     ) -> None:
@@ -930,7 +930,7 @@ class ZDT(MultiObjectiveTestProblem):
         self,
         dim: int,
         num_objectives: int = 2,
-        noise_std: Optional[Union[float, List[float]]] = None,
+        noise_std: Union[None, float, List[float]] = None,
         negate: bool = False,
     ) -> None:
         r"""
@@ -1240,7 +1240,7 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
 
     def __init__(
         self,
-        noise_std: Optional[Union[float, List[float]]] = None,
+        noise_std: Union[None, float, List[float]] = None,
         negate: bool = False,
     ) -> None:
         r"""
@@ -1345,7 +1345,7 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     def __init__(
         self,
         dim: int,
-        noise_std: Optional[Union[float, List[float]]] = None,
+        noise_std: Union[None, float, List[float]] = None,
         negate: bool = False,
     ) -> None:
         r"""

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -50,6 +50,7 @@ import math
 from typing import List, Optional, Tuple, Union
 
 import torch
+from botorch.exceptions.errors import InputDataError
 from botorch.test_functions.base import BaseTestProblem, ConstrainedBaseTestProblem
 from botorch.test_functions.utils import round_nearest
 from torch import Tensor
@@ -804,7 +805,57 @@ class ThreeHumpCamel(SyntheticTestFunction):
 #  ------------ Constrained synthetic test functions ----------- #
 
 
-class ConstrainedGramacy(ConstrainedBaseTestProblem, SyntheticTestFunction):
+class ConstrainedSyntheticTestFunction(
+    ConstrainedBaseTestProblem, SyntheticTestFunction
+):
+    r"""Base class for constrained synthetic test functions."""
+
+    def __init__(
+        self,
+        noise_std: Union[None, float, List[float]] = None,
+        constraint_noise_std: Union[None, float, List[float]] = None,
+        negate: bool = False,
+        bounds: Optional[List[Tuple[float, float]]] = None,
+    ) -> None:
+        r"""
+        Args:
+            noise_std: Standard deviation of the observation noise. If a list is
+                provided, specifies separate noise standard deviations for each
+                objective in a multiobjective problem.
+            constraint_noise_std: Standard deviation of the constraint noise.
+                If a list is provided, specifies separate noise standard
+                deviations for each constraint.
+            negate: If True, negate the function.
+            bounds: Custom bounds for the function specified as (lower, upper) pairs.
+        """
+        self.setup_constraint_noise(constraint_noise_std)
+        SyntheticTestFunction.__init__(
+            self, noise_std=noise_std, negate=negate, bounds=bounds
+        )
+
+    def setup_constraint_noise(self, constraint_noise_std):
+        """
+        Validates that constraint_noise_std has length equal to
+        the number of constraints, if given as a list
+
+        Args:
+            constraint_noise_std: Standard deviation of the constraint noise.
+                If a list is provided, specifies separate noise standard
+                deviations for each constraint.
+        """
+        if (
+            isinstance(constraint_noise_std, list)
+            and len(constraint_noise_std) != self.num_constraints
+        ):
+            raise InputDataError(
+                f"If specified as a list, length of constraint_noise_std "
+                f"({len(constraint_noise_std)}) must match the "
+                f"number of constraints ({self.num_constraints})"
+            )
+        self.constraint_noise_std = constraint_noise_std
+
+
+class ConstrainedGramacy(ConstrainedSyntheticTestFunction):
     r"""Constrained Gramacy test function.
 
     This problem comes from [Gramacy2016]_. The problem is defined
@@ -837,7 +888,7 @@ class ConstrainedGramacy(ConstrainedBaseTestProblem, SyntheticTestFunction):
         return torch.cat([-c1, -c2], dim=-1)
 
 
-class ConstrainedHartmann(Hartmann, ConstrainedBaseTestProblem):
+class ConstrainedHartmann(Hartmann, ConstrainedSyntheticTestFunction):
     r"""Constrained Hartmann test function.
 
     This is a constrained version of the standard Hartmann test function that
@@ -845,11 +896,34 @@ class ConstrainedHartmann(Hartmann, ConstrainedBaseTestProblem):
     """
     num_constraints = 1
 
+    def __init__(
+        self,
+        dim: int = 6,
+        noise_std: Union[None, float] = None,
+        constraint_noise_std: Union[None, float, List[float]] = None,
+        negate: bool = False,
+        bounds: Optional[List[Tuple[float, float]]] = None,
+    ) -> None:
+        r"""
+        Args:
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            constraint_noise_std: Standard deviation of the constraint noise.
+                If a list is provided, specifies separate noise standard
+                deviations for each constraint.
+            negate: If True, negate the function.
+            bounds: Custom bounds for the function specified as (lower, upper) pairs.
+        """
+        self.setup_constraint_noise(constraint_noise_std)
+        Hartmann.__init__(
+            self, dim=dim, noise_std=noise_std, negate=negate, bounds=bounds
+        )
+
     def evaluate_slack_true(self, X: Tensor) -> Tensor:
         return -X.norm(dim=-1, keepdim=True) + 1
 
 
-class ConstrainedHartmannSmooth(Hartmann, ConstrainedBaseTestProblem):
+class ConstrainedHartmannSmooth(Hartmann, ConstrainedSyntheticTestFunction):
     r"""Smooth constrained Hartmann test function.
 
     This is a constrained version of the standard Hartmann test function that
@@ -857,11 +931,34 @@ class ConstrainedHartmannSmooth(Hartmann, ConstrainedBaseTestProblem):
     """
     num_constraints = 1
 
+    def __init__(
+        self,
+        dim: int = 6,
+        noise_std: Union[None, float] = None,
+        constraint_noise_std: Union[None, float, List[float]] = None,
+        negate: bool = False,
+        bounds: Optional[List[Tuple[float, float]]] = None,
+    ) -> None:
+        r"""
+        Args:
+            dim: The (input) dimension.
+            noise_std: Standard deviation of the observation noise.
+            constraint_noise_std: Standard deviation of the constraint noise.
+                If a list is provided, specifies separate noise standard
+                deviations for each constraint.
+            negate: If True, negate the function.
+            bounds: Custom bounds for the function specified as (lower, upper) pairs.
+        """
+        self.setup_constraint_noise(constraint_noise_std)
+        Hartmann.__init__(
+            self, dim=dim, noise_std=noise_std, negate=negate, bounds=bounds
+        )
+
     def evaluate_slack_true(self, X: Tensor) -> Tensor:
         return -X.pow(2).sum(dim=-1, keepdim=True) + 1
 
 
-class PressureVessel(SyntheticTestFunction, ConstrainedBaseTestProblem):
+class PressureVessel(ConstrainedSyntheticTestFunction):
     r"""Pressure vessel design problem with constraints.
 
     The four-dimensional pressure vessel design problem with four black-box
@@ -896,7 +993,7 @@ class PressureVessel(SyntheticTestFunction, ConstrainedBaseTestProblem):
         )
 
 
-class WeldedBeamSO(SyntheticTestFunction, ConstrainedBaseTestProblem):
+class WeldedBeamSO(ConstrainedSyntheticTestFunction):
     r"""Welded beam design problem with constraints (single-outcome).
 
     The four-dimensional welded beam design proble problem with six
@@ -952,7 +1049,7 @@ class WeldedBeamSO(SyntheticTestFunction, ConstrainedBaseTestProblem):
         return -torch.stack([g1, g2, g3, g4, g5, g6], dim=-1)
 
 
-class TensionCompressionString(SyntheticTestFunction, ConstrainedBaseTestProblem):
+class TensionCompressionString(ConstrainedSyntheticTestFunction):
     r"""Tension compression string optimization problem with constraints.
 
     The three-dimensional tension compression string optimization problem with
@@ -983,7 +1080,7 @@ class TensionCompressionString(SyntheticTestFunction, ConstrainedBaseTestProblem
         return -constraints.clamp_max(100)
 
 
-class SpeedReducer(SyntheticTestFunction, ConstrainedBaseTestProblem):
+class SpeedReducer(ConstrainedSyntheticTestFunction):
     r"""Speed Reducer design problem with constraints.
 
     The seven-dimensional speed reducer design problem with eleven black-box

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -828,12 +828,16 @@ class ConstrainedSyntheticTestFunction(
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
         """
-        self.constraint_noise_std = self._validate_constraint_noise(constraint_noise_std)
+        self.constraint_noise_std = self._validate_constraint_noise(
+            constraint_noise_std
+        )
         SyntheticTestFunction.__init__(
             self, noise_std=noise_std, negate=negate, bounds=bounds
         )
 
-    def _validate_constraint_noise(self, constraint_noise_std) -> Union[None, float, List[float]]:
+    def _validate_constraint_noise(
+        self, constraint_noise_std
+    ) -> Union[None, float, List[float]]:
         """
         Validates that constraint_noise_std has length equal to
         the number of constraints, if given as a list
@@ -914,7 +918,7 @@ class ConstrainedHartmann(Hartmann, ConstrainedSyntheticTestFunction):
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
         """
-        self.setup_constraint_noise(constraint_noise_std)
+        self._validate_constraint_noise(constraint_noise_std)
         Hartmann.__init__(
             self, dim=dim, noise_std=noise_std, negate=negate, bounds=bounds
         )
@@ -949,7 +953,7 @@ class ConstrainedHartmannSmooth(Hartmann, ConstrainedSyntheticTestFunction):
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
         """
-        self.setup_constraint_noise(constraint_noise_std)
+        self._validate_constraint_noise(constraint_noise_std)
         Hartmann.__init__(
             self, dim=dim, noise_std=noise_std, negate=negate, bounds=bounds
         )

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -47,7 +47,7 @@ References:
 from __future__ import annotations
 
 import math
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import torch
 from botorch.test_functions.base import BaseTestProblem, ConstrainedBaseTestProblem
@@ -64,13 +64,15 @@ class SyntheticTestFunction(BaseTestProblem):
 
     def __init__(
         self,
-        noise_std: Optional[float] = None,
+        noise_std: Union[None, float, List[float]] = None,
         negate: bool = False,
         bounds: Optional[List[Tuple[float, float]]] = None,
     ) -> None:
         r"""
         Args:
-            noise_std: Standard deviation of the observation noise.
+            noise_std: Standard deviation of the observation noise. If a list is provided,
+                specifies separate noise standard deviations for each objective in a
+                multiobjective problem.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
         """

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -828,12 +828,12 @@ class ConstrainedSyntheticTestFunction(
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
         """
-        self.setup_constraint_noise(constraint_noise_std)
+        self.constraint_noise_std = self._validate_constraint_noise(constraint_noise_std)
         SyntheticTestFunction.__init__(
             self, noise_std=noise_std, negate=negate, bounds=bounds
         )
 
-    def setup_constraint_noise(self, constraint_noise_std):
+    def _validate_constraint_noise(self, constraint_noise_std) -> Union[None, float, List[float]]:
         """
         Validates that constraint_noise_std has length equal to
         the number of constraints, if given as a list
@@ -848,11 +848,11 @@ class ConstrainedSyntheticTestFunction(
             and len(constraint_noise_std) != self.num_constraints
         ):
             raise InputDataError(
-                f"If specified as a list, length of constraint_noise_std "
+                "If specified as a list, length of constraint_noise_std "
                 f"({len(constraint_noise_std)}) must match the "
                 f"number of constraints ({self.num_constraints})"
             )
-        self.constraint_noise_std = constraint_noise_std
+        return constraint_noise_std
 
 
 class ConstrainedGramacy(ConstrainedSyntheticTestFunction):

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -70,9 +70,9 @@ class SyntheticTestFunction(BaseTestProblem):
     ) -> None:
         r"""
         Args:
-            noise_std: Standard deviation of the observation noise. If a list is provided,
-                specifies separate noise standard deviations for each objective in a
-                multiobjective problem.
+            noise_std: Standard deviation of the observation noise. If a list is
+                provided, specifies separate noise standard deviations for each
+                objective in a multiobjective problem.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
         """

--- a/test/test_functions/test_multi_objective.py
+++ b/test/test_functions/test_multi_objective.py
@@ -75,7 +75,9 @@ class TestBaseTestMultiObjectiveProblem(BotorchTestCase):
                     self.assertTrue(torch.equal(f_X, expected_f_X))
                 with self.assertRaises(NotImplementedError):
                     f.gen_pareto_front(1)
-            with self.assertRaises(InputDataError):
+            with self.assertRaisesRegex(
+                InputDataError, "must match the number of objectives"
+            ):
                 f = DummyMOProblem(noise_std=[1.0, 2.0, 3.0], negate=negate)
 
 

--- a/test/test_functions/test_multi_objective.py
+++ b/test/test_functions/test_multi_objective.py
@@ -63,7 +63,7 @@ class DummyMOProblem(MultiObjectiveTestProblem):
 class TestBaseTestMultiObjectiveProblem(BotorchTestCase):
     def test_base_mo_problem(self):
         for negate in (True, False):
-            for noise_std in (None, 1.0):
+            for noise_std in (None, 1.0, [1.0, 2.0]):
                 f = DummyMOProblem(noise_std=noise_std, negate=negate)
                 self.assertEqual(f.noise_std, noise_std)
                 self.assertEqual(f.negate, negate)
@@ -155,6 +155,7 @@ class TestDTLZ(
             DTLZ4(dim=5, num_objectives=2),
             DTLZ5(dim=5, num_objectives=2),
             DTLZ7(dim=5, num_objectives=2),
+            DTLZ7(dim=5, num_objectives=2, noise_std=[0.1, 0.2]),
         ]
 
     def test_init(self):
@@ -216,7 +217,10 @@ class TestGMM(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [GMM(num_objectives=4)]
+        return [
+            GMM(num_objectives=4),
+            GMM(num_objectives=4, noise_std=[0.0, 0.1, 0.2, 0.3]),
+        ]
 
     def test_init(self):
         f = self.functions[0]
@@ -269,7 +273,7 @@ class TestMW7(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [MW7(dim=3)]
+        return [MW7(dim=3), MW7(dim=3, noise_std=[0.1, 0.2])]
 
     def test_init(self):
         for f in self.functions:
@@ -290,6 +294,8 @@ class TestZDT(
             ZDT1(dim=3, num_objectives=2),
             ZDT2(dim=3, num_objectives=2),
             ZDT3(dim=3, num_objectives=2),
+            ZDT3(dim=3, num_objectives=2, noise_std=0.1),
+            ZDT3(dim=3, num_objectives=2, noise_std=[0.1, 0.2]),
         ]
 
     def test_init(self):
@@ -362,7 +368,7 @@ class TestCarSideImpact(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [CarSideImpact()]
+        return [CarSideImpact(), CarSideImpact(noise_std=[0.1, 0.2, 0.3, 0.4])]
 
 
 class TestPenicillin(
@@ -372,7 +378,7 @@ class TestPenicillin(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [Penicillin()]
+        return [Penicillin(), Penicillin(noise_std=[0.1, 0.2, 0.3])]
 
 
 class TestToyRobust(
@@ -382,7 +388,7 @@ class TestToyRobust(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [ToyRobust()]
+        return [ToyRobust(), ToyRobust(noise_std=[0.1, 0.2])]
 
 
 class TestVehicleSafety(
@@ -392,7 +398,7 @@ class TestVehicleSafety(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [VehicleSafety()]
+        return [VehicleSafety(), VehicleSafety(noise_std=[0.1, 0.2, 0.3])]
 
 
 # ------------------ Constrained Multi-objective test problems ------------------ #
@@ -406,7 +412,7 @@ class TestBNH(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [BNH()]
+        return [BNH(), BNH(noise_std=[0.1, 0.2])]
 
 
 class TestSRN(
@@ -417,7 +423,7 @@ class TestSRN(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [SRN()]
+        return [SRN(), SRN(noise_std=[0.1, 0.2])]
 
 
 class TestCONSTR(
@@ -428,7 +434,7 @@ class TestCONSTR(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [CONSTR()]
+        return [CONSTR(), CONSTR(noise_std=[0.1, 0.2])]
 
 
 class TestConstrainedBraninCurrin(
@@ -439,7 +445,10 @@ class TestConstrainedBraninCurrin(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [ConstrainedBraninCurrin()]
+        return [
+            ConstrainedBraninCurrin(),
+            ConstrainedBraninCurrin(noise_std=[0.1, 0.2]),
+        ]
 
 
 class TestC2DTLZ2(
@@ -450,7 +459,11 @@ class TestC2DTLZ2(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [C2DTLZ2(dim=3, num_objectives=2)]
+        return [
+            C2DTLZ2(dim=3, num_objectives=2),
+            C2DTLZ2(dim=3, num_objectives=2, noise_std=0.1),
+            C2DTLZ2(dim=3, num_objectives=2, noise_std=[0.1, 0.2]),
+        ]
 
     def test_batch_exception(self):
         f = C2DTLZ2(dim=3, num_objectives=2)
@@ -466,7 +479,7 @@ class TestDiscBrake(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [DiscBrake()]
+        return [DiscBrake(), DiscBrake(noise_std=[0.1, 0.2])]
 
 
 class TestWeldedBeam(
@@ -477,7 +490,7 @@ class TestWeldedBeam(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [WeldedBeam()]
+        return [WeldedBeam(), WeldedBeam(noise_std=[0.1, 0.2])]
 
 
 class TestOSY(
@@ -488,4 +501,4 @@ class TestOSY(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [OSY()]
+        return [OSY(), OSY(noise_std=[0.1, 0.2])]

--- a/test/test_functions/test_multi_objective.py
+++ b/test/test_functions/test_multi_objective.py
@@ -8,7 +8,7 @@ import math
 from typing import List
 
 import torch
-from botorch.exceptions.errors import UnsupportedError
+from botorch.exceptions.errors import InputDataError, UnsupportedError
 from botorch.test_functions.base import BaseTestProblem
 from botorch.test_functions.multi_objective import (
     BNH,
@@ -75,6 +75,8 @@ class TestBaseTestMultiObjectiveProblem(BotorchTestCase):
                     self.assertTrue(torch.equal(f_X, expected_f_X))
                 with self.assertRaises(NotImplementedError):
                     f.gen_pareto_front(1)
+            with self.assertRaises(InputDataError):
+                f = DummyMOProblem(noise_std=[1.0, 2.0, 3.0], negate=negate)
 
 
 class TestBraninCurrin(

--- a/test/test_functions/test_synthetic.py
+++ b/test/test_functions/test_synthetic.py
@@ -134,7 +134,9 @@ class TestConstraintNoise(BotorchTestCase):
     ]
 
     def test_constraint_noise_length_validation(self):
-        with self.assertRaises(InputDataError):
+        with self.assertRaisesRegex(
+            InputDataError, "must match the number of constraints"
+        ):
             DummyConstrainedSyntheticTestFunction(constraint_noise_std=[0.1, 0.2])
 
 


### PR DESCRIPTION
Adds support for different noise levels for different objectives in a multiobjective test function

Closes #2135 

Modifies `BaseTestProblem` class to allow for `noise_std` to be a list of floats, where the length should be the number of objectives in a `MultiObjectiveTestProblem`. This way each component of the objective function can be subject to a separate noise level.

