### PR TITLE
Set seed in test_learned_preference_objective to stop it from flaking

### DIFF
--- a/test/acquisition/test_objective.py
+++ b/test/acquisition/test_objective.py
@@ -454,6 +454,8 @@ class TestLearnedObjective(BotorchTestCase):
         return pref_model
 
     def test_learned_preference_objective(self) -> None:
+        seed = torch.randint(low=0, high=10, size=torch.Size([1]))
+        torch.manual_seed(seed)
         pref_model = self._get_pref_model(dtype=torch.float64)
 
         og_sample_shape = 3
@@ -492,7 +494,7 @@ class TestLearnedObjective(BotorchTestCase):
             with self.assertRaisesRegex(
                 ValueError, "samples should have at least 3 dimensions."
             ):
-                pref_obj(torch.rand(q, self.x_dim))
+                pref_obj(torch.rand(q, self.x_dim, dtype=torch.float64))
 
         # test when sampler has multiple preference samples
         with self.subTest("Multiple samples"):


### PR DESCRIPTION
## Motivation

* The test was flaky due to a varying amount of numerical error depending on random inputs, so I set a seed to a random number between 0 and 10
* Changed some data to double precision to avoid a warning


## Test Plan

*  checked that the test passes for each seed between 0 and 10
*  I confirmed that there are seeds that do cause it to fail
* Increased the number of samples a lot to confirm that numerical error because small when the number of samples is large -- in other words, the error is due to a low number of samples