### PR TITLE
Circumvent conda install bug in >= 23.10.0

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -82,6 +82,8 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
+        # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
+        conda config --set solver classic
         conda install -y setuptools_scm conda-build conda-verify anaconda-client
         conda install -y scipy sphinx pytest flake8 multipledispatch
         conda install -y -c pytorch pytorch cpuonly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -106,6 +106,8 @@ jobs:
       # Don't need most deps for conda build, but need them for testing
       # We do need setuptools_scm though to properly parse the version
       run: |
+        # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
+        conda config --set solver classic
         conda install -y scipy multipledispatch setuptools_scm conda-build conda-verify
         conda config --set anaconda_upload no
         conda install -y -c pytorch-nightly pytorch cpuonly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,8 @@ jobs:
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
+        # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
+        conda config --set solver classic
         conda install pytorch torchvision -c pytorch
         conda install -y pip scipy sphinx pytest flake8
         pip install git+https://github.com/cornellius-gp/linear_operator.git

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -45,6 +45,8 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
+        # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
+        conda config --set solver classic
         conda install -y -c pytorch pytorch cpuonly
         conda install -y pip scipy pytest
         conda install -y -c gpytorch gpytorch


### PR DESCRIPTION
In newer conda versions, some packages end up not being installed correctly: https://github.com/conda/conda/issues/13412

Selecting the classic solver fixes this issue. This does this for all conda github workflows. Once this is fixed in conda itself we can remove this setting again.