### PR TITLE
Add support for multitask models to ModelListGP

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -36,9 +36,11 @@ from botorch.models.utils import (
 )
 from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
+from botorch.utils.multitask import separate_mtmvn
 from botorch.utils.transforms import is_ensemble
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
 from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
+from linear_operator.operators import BlockDiagLinearOperator, CatLinearOperator
 from torch import Tensor
 
 if TYPE_CHECKING:
@@ -101,6 +103,7 @@ class GPyTorchModel(Model, ABC):
                     "following error would have been raised with strict enforcement: "
                     f"{message}",
                     BotorchTensorDimensionWarning,
+                    stacklevel=2,
                 )
         # Yvar may not have the same batch dimensions, but the trailing dimensions
         # of Yvar should be the same as the trailing dimensions of Y.
@@ -559,7 +562,8 @@ class ModelListGPyTorchModel(ModelList, GPyTorchModel, ABC):
     r"""Abstract base class for models based on multi-output GPyTorch models.
 
     This is meant to be used with a gpytorch ModelList wrapper for independent
-    evaluation of submodels.
+    evaluation of submodels. Those submodels can themselves be multi-output
+    models, in which case the task covariances will be ignored.
 
     :meta private:
     """
@@ -582,7 +586,7 @@ class ModelListGPyTorchModel(ModelList, GPyTorchModel, ABC):
             )
             try:
                 broadcast_shape = torch.broadcast_shapes(*batch_shapes)
-                warnings.warn(msg + ". Broadcasting batch shapes.")
+                warnings.warn(msg + ". Broadcasting batch shapes.", stacklevel=2)
                 return broadcast_shape
             except RuntimeError:
                 raise NotImplementedError(msg + " that are not broadcastble.")
@@ -598,6 +602,9 @@ class ModelListGPyTorchModel(ModelList, GPyTorchModel, ABC):
         **kwargs: Any,
     ) -> Union[GPyTorchPosterior, PosteriorList]:
         r"""Computes the posterior over model outputs at the provided points.
+        If any model returns a MultitaskMultivariateNormal posterior, then that
+        will be split into individual MVNs per task, with inter-task covariance
+        ignored.
 
         Args:
             X: A `b x q x d`-dim Tensor, where `d` is the dimension of the
@@ -648,20 +655,41 @@ class ModelListGPyTorchModel(ModelList, GPyTorchModel, ABC):
         )
         if not returns_untransformed:
             mvns = [p.distribution for p in posterior.posteriors]
-            # Combining MTMVNs into a single MTMVN is currently not supported.
-            if not any(isinstance(m, MultitaskMultivariateNormal) for m in mvns):
-                # Return the result as a GPyTorchPosterior/GaussianMixturePosterior.
+            if any(isinstance(m, MultitaskMultivariateNormal) for m in mvns):
+                mvn_list = []
+                for mvn in mvns:
+                    if len(mvn.event_shape) == 2:
+                        # We separate MTMVNs into independent-across-task MVNs for
+                        # the convenience of using BlockDiagLinearOperator below.
+                        # (b x q x m x m) -> list of m (b x q x 1 x 1)
+                        mvn_list.extend(separate_mtmvn(mvn))
+                    else:
+                        mvn_list.append(mvn)
+                mean = torch.stack([mvn.mean for mvn in mvn_list], dim=-1)
+                covars = CatLinearOperator(
+                    *[mvn.lazy_covariance_matrix.unsqueeze(-3) for mvn in mvn_list],
+                    dim=-3,
+                )  # List of m (b x q x 1 x 1) -> (b x q x m x 1 x 1)
+                mvn = MultitaskMultivariateNormal(
+                    mean=mean,
+                    covariance_matrix=BlockDiagLinearOperator(covars, block_dim=-3).to(
+                        X
+                    ),  # (b x q x m x 1 x 1) -> (b x q x m x m)
+                    interleaved=False,
+                )
+            else:
                 mvn = (
                     mvns[0]
                     if len(mvns) == 1
                     else MultitaskMultivariateNormal.from_independent_mvns(mvns=mvns)
                 )
-                if any(is_ensemble(m) for m in self.models):
-                    # Mixing fully Bayesian and other GP models is currently
-                    # not supported.
-                    posterior = GaussianMixturePosterior(distribution=mvn)
-                else:
-                    posterior = GPyTorchPosterior(distribution=mvn)
+            # Return the result as a GPyTorchPosterior/GaussianMixturePosterior.
+            if any(is_ensemble(m) for m in self.models):
+                # Mixing fully Bayesian and other GP models is currently
+                # not supported.
+                posterior = GaussianMixturePosterior(distribution=mvn)
+            else:
+                posterior = GPyTorchPosterior(distribution=mvn)
         if posterior_transform is not None:
             return posterior_transform(posterior)
         return posterior

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, List
 
+import torch
+
 from botorch.exceptions.errors import BotorchTensorDimensionError
 from botorch.models.gpytorch import GPyTorchModel, ModelListGPyTorchModel
 from botorch.models.model import FantasizeMixin
@@ -87,14 +89,12 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel, FantasizeMixin):
                 f"{Y.shape[-1]} observation outputs, but model has "
                 f"{self.num_outputs} outputs."
             )
-        targets = [Y[..., i] for i in range(Y.shape[-1])]
-        for i, model in enumerate(self.models):
-            if hasattr(model, "outcome_transform"):
-                noise = kwargs.get("noise")
-                targets[i], noise = model.outcome_transform(targets[i], noise)
-
-        # This should never trigger, posterior call would fail.
-        assert len(targets) == len(X)
+        if len(X) != self.num_outputs:
+            raise BotorchTensorDimensionError(
+                "Incorrect number of inputs for observations. Received "
+                f"{len(X)} observation inputs, but model has "
+                f"{self.num_outputs} outputs."
+            )
         if "noise" in kwargs:
             noise = kwargs.pop("noise")
             if noise.shape != Y.shape[-noise.dim() :]:
@@ -102,19 +102,43 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel, FantasizeMixin):
                     "The shape of observation noise does not agree with the outcomes. "
                     f"Received {noise.shape} noise with {Y.shape} outcomes."
                 )
-            kwargs_ = {**kwargs, "noise": [noise[..., i] for i in range(Y.shape[-1])]}
+
         else:
-            kwargs_ = kwargs
-        return super().get_fantasy_model(X, targets, **kwargs_)
+            noise = None
+        targets = []
+        inputs = []
+        noises = []
+        i = 0
+        for model in self.models:
+            j = i + model.num_outputs
+            y_i = torch.cat([Y[..., k] for k in range(i, j)], dim=-1)
+            X_i = torch.cat([X[k] for k in range(i, j)], dim=-2)
+            if noise is None:
+                noise_i = None
+            else:
+                noise_i = torch.cat([noise[..., k] for k in range(i, j)], dim=-1)
+            if hasattr(model, "outcome_transform"):
+                y_i, noise_i = model.outcome_transform(y_i, noise_i)
+                if noise_i is not None:
+                    noise_i = noise_i.squeeze(0)
+            targets.append(y_i)
+            inputs.append(X_i)
+            noises.append(noise_i)
+            i += model.num_outputs
+
+        kwargs_ = {**kwargs, "noise": noises} if noise is not None else kwargs
+        return super().get_fantasy_model(inputs, targets, **kwargs_)
 
     def subset_output(self, idcs: List[int]) -> ModelListGP:
-        r"""Subset the model along the output dimension.
+        r"""Subset the model along the submodel dimension.
 
         Args:
-            idcs: The output indices to subset the model to.
+            idcs: The indices of submodels to subset the model to.
 
         Returns:
-            The current model, subset to the specified output indices.
+            The current model, subset to the specified submodels. If each model
+            is single-output, this will correspond to that subset of the
+            outputs.
         """
         return self.__class__(*[deepcopy(self.models[i]) for i in idcs])
 

--- a/botorch/utils/multitask.py
+++ b/botorch/utils/multitask.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+Helpers for multitask modeling.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import torch
+from gpytorch.distributions import MultitaskMultivariateNormal
+from gpytorch.distributions.multivariate_normal import MultivariateNormal
+from linear_operator import to_linear_operator
+
+
+def separate_mtmvn(mvn: MultitaskMultivariateNormal) -> List[MultivariateNormal]:
+    """
+    Separate a MTMVN into a list of MVNs, where covariance across data within each task are
+    preserved, while covariance across task are dropped.
+    """
+    # TODO T150340766 Upstream this into a class method on gpytorch MultitaskMultivariateNormal.
+    full_covar = mvn.lazy_covariance_matrix
+    num_data, num_tasks = mvn.mean.shape[-2:]
+    if mvn._interleaved:
+        data_indices = torch.arange(
+            0, num_data * num_tasks, num_tasks, device=full_covar.device
+        ).view(-1, 1, 1)
+        task_indices = torch.arange(num_tasks, device=full_covar.device)
+    else:
+        data_indices = torch.arange(num_data, device=full_covar.device).view(-1, 1, 1)
+        task_indices = torch.arange(
+            0, num_data * num_tasks, num_data, device=full_covar.device
+        )
+    slice_ = (data_indices + task_indices).transpose(-1, -3)
+    data_covars = full_covar[..., slice_, slice_.transpose(-1, -2)]
+    mvns = []
+    for c in range(num_tasks):
+        mvns.append(
+            MultivariateNormal(
+                mvn.mean[..., c], to_linear_operator(data_covars[..., c, :, :])
+            )
+        )
+    return mvns


### PR DESCRIPTION
Summary: This upstreams behavior from MixedOutputModelListGP to enable computing a posterior on a model list that is a mix of single- and multi-task models. The ability to do this is necessary for using models that are multi-task across outcomes, such as LCE-M.

Reviewed By: saitcakmak

Differential Revision: D51906858


