### PR TITLE
Release restriction in `OneHotToNumeric` that the categoricals are the trailing dimensions

### DIFF
--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -1470,8 +1470,6 @@ class OneHotToNumeric(InputTransform, Module):
             sorted(categorical_features.items(), key=lambda x: x[0])
         )
         if len(self.categorical_features) > 0:
-            self.categorical_start_idx = min(self.categorical_features.keys())
-            #
             self.onehot_idx = [
                 list(range(start, start + card))
                 for start, card in self.categorical_features.items()
@@ -1512,15 +1510,10 @@ class OneHotToNumeric(InputTransform, Module):
             X_numeric = X[..., : self.numeric_dim].clone()
             # copy the numerical dims over
             X_numeric[..., self.new_numerical_idx] = X[..., self.numerical_idx]
-            # idx = self.categorical_start_idx
-            for i in range(
-                len(self.categorical_features)
-            ):  # start, card in self.categorical_features.items():
-                # start, card = self.categorical_features[i]
+            for i in range(len(self.categorical_features)):
                 X_numeric[..., self.ordinal_idx[i]] = X[..., self.onehot_idx[i]].argmax(
                     dim=-1
                 )
-                # idx += 1
             return X_numeric
         return X
 
@@ -1548,26 +1541,6 @@ class OneHotToNumeric(InputTransform, Module):
                     num_classes=len(self.onehot_idx[i]),
                 ).to(X_onehot)
             return X_onehot
-
-            # one_hot_categoricals = [
-            #     # note that self.categorical_features is sorted by the starting index
-            #     # in one-hot representation
-            #     one_hot(
-            #         X[..., self.ordinal_idx[i]].long(),
-            #         num_classes=len(self.onehot_idx[i]),
-            #     )
-            #     for i in range(
-            #         len(self.categorical_features)
-            #     )  # idx, cardinality in enumerate(self.categorical_features.values())
-            # ]
-
-            # X = torch.cat(
-            #     [
-            #         X[..., : self.categorical_start_idx],
-            #         *one_hot_categoricals,
-            #     ],
-            #     dim=-1,
-            # )
         return X
 
     def equals(self, other: InputTransform) -> bool:

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -1429,10 +1429,7 @@ class InputPerturbation(InputTransform, Module):
 
 
 class OneHotToNumeric(InputTransform, Module):
-    r"""Transform categorical parameters from a one-hot to a numeric representation.
-
-    This assumes that the categoricals are the trailing dimensions.
-    """
+    r"""Transform categorical parameters from a one-hot to a numeric representation."""
 
     def __init__(
         self,

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Union
 from warnings import warn
+import itertools
 
 import torch
 from botorch.exceptions.errors import BotorchTensorDimensionError
@@ -258,6 +259,7 @@ class ReversibleInputTransform(InputTransform, ABC):
 
     :meta private:
     """
+
     reverse: bool
 
     def transform(self, X: Tensor) -> Tensor:
@@ -1469,26 +1471,32 @@ class OneHotToNumeric(InputTransform, Module):
         )
         if len(self.categorical_features) > 0:
             self.categorical_start_idx = min(self.categorical_features.keys())
-            # check that the trailing dimensions are categoricals
-            end = self.categorical_start_idx
-            err_msg = (
-                f"{self.__class__.__name__} requires that the categorical "
-                "parameters are the rightmost elements."
-            )
+            #
+            self.onehot_idx = [
+                list(range(start, start + card))
+                for start, card in self.categorical_features.items()
+            ]
+            idx = list(itertools.chain.from_iterable(self.onehot_idx))
+            if len(idx) != len(set(idx)):
+                raise ValueError("Categorical features overlap.")
+            if max(idx) >= dim:
+                raise ValueError("Categorical features exceed the provided dimension.")
+            self.numerical_idx = list(set(range(dim)) - set(idx))
+
+            offset = 0
+            self.ordinal_idx = []
             for start, card in self.categorical_features.items():
-                # the end of one one-hot representation should be followed
-                # by the start of the next
-                if end != start:
-                    raise ValueError(err_msg)
-                # This assumes that the categoricals are the trailing
-                # dimensions
-                end = start + card
-            if end != dim:
-                # check end
-                raise ValueError(err_msg)
-            # the numeric representation dimension is the total number of parameters
-            # (continuous, integer, and categorical)
-            self.numeric_dim = self.categorical_start_idx + len(categorical_features)
+                self.ordinal_idx.append(start - offset)
+                offset += card - 1
+
+            reduced_dim = len(self.ordinal_idx) + len(self.numerical_idx)
+            self.new_numerical_idx = list(
+                set(range(reduced_dim)) - set(self.ordinal_idx)
+            )
+
+            self.numeric_dim = len(self.new_numerical_idx) + len(
+                self.categorical_features
+            )
 
     def transform(self, X: Tensor) -> Tensor:
         r"""Transform the categorical inputs into integer representation.
@@ -1502,10 +1510,17 @@ class OneHotToNumeric(InputTransform, Module):
         """
         if len(self.categorical_features) > 0:
             X_numeric = X[..., : self.numeric_dim].clone()
-            idx = self.categorical_start_idx
-            for start, card in self.categorical_features.items():
-                X_numeric[..., idx] = X[..., start : start + card].argmax(dim=-1)
-                idx += 1
+            # copy the numerical dims over
+            X_numeric[..., self.new_numerical_idx] = X[..., self.numerical_idx]
+            # idx = self.categorical_start_idx
+            for i in range(
+                len(self.categorical_features)
+            ):  # start, card in self.categorical_features.items():
+                # start, card = self.categorical_features[i]
+                X_numeric[..., self.ordinal_idx[i]] = X[..., self.onehot_idx[i]].argmax(
+                    dim=-1
+                )
+                # idx += 1
             return X_numeric
         return X
 
@@ -1521,23 +1536,38 @@ class OneHotToNumeric(InputTransform, Module):
             have been transformed to one-hot representation.
         """
         if len(self.categorical_features) > 0:
-            self.numeric_dim
-            one_hot_categoricals = [
-                # note that self.categorical_features is sorted by the starting index
-                # in one-hot representation
-                one_hot(
-                    X[..., idx - len(self.categorical_features)].long(),
-                    num_classes=cardinality,
-                )
-                for idx, cardinality in enumerate(self.categorical_features.values())
-            ]
-            X = torch.cat(
-                [
-                    X[..., : self.categorical_start_idx],
-                    *one_hot_categoricals,
-                ],
-                dim=-1,
+            s = list(X.shape)
+            s[-1] = len(self.numerical_idx) + len(
+                list(itertools.chain.from_iterable(self.onehot_idx))
             )
+            X_onehot = torch.zeros(size=s).to(X)
+            X_onehot[..., self.numerical_idx] = X[..., self.new_numerical_idx]
+            for i in range(len(self.categorical_features)):
+                X_onehot[..., self.onehot_idx[i]] = one_hot(
+                    X[..., self.ordinal_idx[i]].long(),
+                    num_classes=len(self.onehot_idx[i]),
+                ).to(X_onehot)
+            return X_onehot
+
+            # one_hot_categoricals = [
+            #     # note that self.categorical_features is sorted by the starting index
+            #     # in one-hot representation
+            #     one_hot(
+            #         X[..., self.ordinal_idx[i]].long(),
+            #         num_classes=len(self.onehot_idx[i]),
+            #     )
+            #     for i in range(
+            #         len(self.categorical_features)
+            #     )  # idx, cardinality in enumerate(self.categorical_features.values())
+            # ]
+
+            # X = torch.cat(
+            #     [
+            #         X[..., : self.categorical_start_idx],
+            #         *one_hot_categoricals,
+            #     ],
+            #     dim=-1,
+            # )
         return X
 
     def equals(self, other: InputTransform) -> bool:

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -15,12 +15,12 @@ method.
 """
 from __future__ import annotations
 
-import itertools
-
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Union
 from warnings import warn
+
+import numpy as np
 
 import torch
 from botorch.exceptions.errors import BotorchTensorDimensionError
@@ -1468,10 +1468,11 @@ class OneHotToNumeric(InputTransform, Module):
         )
         if len(self.categorical_features) > 0:
             self.onehot_idx = [
-                list(range(start, start + card))
+                np.arange(start, start + card)
                 for start, card in self.categorical_features.items()
             ]
-            idx = list(itertools.chain.from_iterable(self.onehot_idx))
+            idx = np.concatenate(self.onehot_idx)
+
             if len(idx) != len(set(idx)):
                 raise ValueError("Categorical features overlap.")
             if max(idx) >= dim:
@@ -1527,9 +1528,7 @@ class OneHotToNumeric(InputTransform, Module):
         """
         if len(self.categorical_features) > 0:
             s = list(X.shape)
-            s[-1] = len(self.numerical_idx) + len(
-                list(itertools.chain.from_iterable(self.onehot_idx))
-            )
+            s[-1] = len(self.numerical_idx) + len(np.concatenate(self.onehot_idx))
             X_onehot = torch.zeros(size=s).to(X)
             X_onehot[..., self.numerical_idx] = X[..., self.new_numerical_idx]
             for i in range(len(self.categorical_features)):

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -15,11 +15,12 @@ method.
 """
 from __future__ import annotations
 
+import itertools
+
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Union
 from warnings import warn
-import itertools
 
 import torch
 from botorch.exceptions.errors import BotorchTensorDimensionError
@@ -1229,7 +1230,6 @@ class AppendFeatures(InputTransform, Module):
 
 
 class FilterFeatures(InputTransform, Module):
-
     r"""A transform that filters the input with a given set of features indices.
 
     As an example, this can be used in a multiobjective optimization with `ModelListGP`


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR refactors the `OneHotToNumeric` `InputTransform` in a way that it is not needed anymore that the categoricals are the trailing dimensions. Thus, making the input transform more flexible.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.


