### PR TITLE
Hotfix/non linear q

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -233,7 +233,7 @@ def gen_candidates_scipy(
 
     if nonlinear_inequality_constraints:
         # Make sure `batch_limit` is 1 for now.
-        if not (len(shapeX) == 3 and shapeX[:2] == torch.Size([1, 1])):
+        if not (len(shapeX) == 3 and shapeX[0] == 1):
             raise ValueError(
                 "`batch_limit` must be 1 when non-linear inequality constraints "
                 "are given."

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -1039,7 +1039,7 @@ def optimize_acqf_discrete(
             be passed to different acquisition functions without raising an error.
 
     Returns:
-        A three-element tuple containing
+        A two-element tuple containing
 
         - a `q x d`-dim tensor of generated candidates.
         - an associated acquisition value.

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -79,7 +79,11 @@ class SquaredAcquisitionFunction(AcquisitionFunction):
         super().__init__(model=model)
 
     def forward(self, X):
-        return torch.linalg.norm(X, dim=-1).squeeze(-1)
+        # we take the norm and sum over the q-batch dim
+        if len(X.shape) > 2:
+            return torch.linalg.norm(X, dim=-1).sum(-1)
+        else:
+            return torch.linalg.norm(X, dim=-1).squeeze(-1)
 
 
 class MockOneShotEvaluateAcquisitionFunction(MockOneShotAcquisitionFunction):
@@ -852,6 +856,7 @@ class TestOptimizeAcqf(BotorchTestCase):
             def nlc4(x):
                 return x[..., 2] - 1
 
+            # test it with q=1
             with torch.random.fork_rng():
                 torch.manual_seed(0)
                 batch_initial_conditions = 1 + 0.33 * torch.rand(
@@ -878,6 +883,38 @@ class TestOptimizeAcqf(BotorchTestCase):
             )
             self.assertTrue(
                 torch.allclose(acq_value, torch.tensor(2.45, **tkwargs), atol=1e-3)
+            )
+
+            # test it with q=2
+            with torch.random.fork_rng():
+                torch.manual_seed(0)
+                batch_initial_conditions = 1 + 0.33 * torch.rand(
+                    num_restarts, 2, 3, **tkwargs
+                )
+            candidates, acq_value = optimize_acqf(
+                acq_function=mock_acq_function,
+                bounds=bounds,
+                q=2,
+                nonlinear_inequality_constraints=[
+                    (nlc1, True),
+                    (nlc2, True),
+                    (nlc3, True),
+                    (nlc4, True),
+                ],
+                batch_initial_conditions=batch_initial_conditions,
+                num_restarts=num_restarts,
+                return_best_only=True,
+            )
+
+            for i in range(2):
+                self.assertTrue(
+                    torch.allclose(
+                        torch.sort(candidates[i]).values,
+                        torch.tensor([[1, 1, 2]], **tkwargs),
+                    )
+                )
+            self.assertTrue(
+                torch.allclose(acq_value, torch.tensor(2.45 * 2, **tkwargs), atol=1e-3)
             )
 
             with torch.random.fork_rng():

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -906,11 +906,11 @@ class TestOptimizeAcqf(BotorchTestCase):
                 return_best_only=True,
             )
 
-            for i in range(2):
+            for candidate in candidates:
                 self.assertTrue(
                     torch.allclose(
-                        torch.sort(candidates[i]).values,
-                        torch.tensor([[1, 1, 2]], **tkwargs),
+                        torch.sort(candidate).values,
+                        torch.tensor([[1.0, 1.0, 2.0]], **tkwargs),
                     )
                 )
             self.assertTrue(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

When implementing the possibility to use `q>1` for nonlinear constraints in PR https://github.com/pytorch/botorch/pull/1793, I forgot to update the `batch_limit` check when commenting the check back in. Thus, the feature is still not usable. Here, it is fixed and it is actually tested that it is working with `q>1`.

Before, only the lower level methods were tested with `q>1`, but not `optimize_acqf`. This demonstrates again, that one cannot write to less tests :D

cc: @Balandat


### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.
