### PR TITLE
`get_acquisition_function` for fully bayesian GPs

### DIFF
--- a/botorch/acquisition/factory.py
+++ b/botorch/acquisition/factory.py
@@ -107,6 +107,11 @@ def get_acquisition_function(
         # Since these are the non-noisy variants, use the posterior mean at the observed
         # inputs directly to compute the best feasible value without sampling.
         Y = model.posterior(X_observed, posterior_transform=posterior_transform).mean
+        # in case of a fully bayesian GP, one has to take also the mean over the
+        # individual sets of hyperparams
+        if len(Y.shape) == 3:
+            Y = Y.mean(dim=0)
+
         obj = objective(samples=Y, X=X_observed)
         best_f = compute_best_feasible_objective(
             samples=Y,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

I encountered a bug when using `get_acquisition_function` together with a fully bayesian GP when trying to instantiate `qEI`, which seems also a newer bug as it was  definitly working in the past. The origin is the computation of `Y`, when we have a fully bayesian GP one also has to take also the mean over the individual predictions which is currently missing. This should be in principle also the case for `qLogEI`, but there it is working ...

I added a quick fix, but I am not sure if this is ok in the way I did it, or if I am introducing other bugs by my fix.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

In principle unit tests but not yet implemented as I am not sure if the proposed solution is valid.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
