### PR TITLE
Fixing conda build test by relaxing python version run requirement

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - setuptools
     - setuptools_scm
   run:
-    - python >=3.9
+    - python
     - pytorch >=1.13.1
     - gpytorch ==1.11
     - linear_operator ==0.5.1


### PR DESCRIPTION
Summary: The last successful “Test Conda build” was during the [Nightly Cron starting on Sun, 24 Dec 2023 10:33:54 GMT](https://github.com/pytorch/botorch/actions/runs/7314058005/job/19926281495), which coincided with the landing of #2148. While meant to ensure that the conda build works correctly, this addition actually caused the failures. Either removing the version requirement or the python run requirement completely makes the [`build_and_verify_conda_package`](https://github.com/pytorch/botorch/blob/main/scripts/build_and_verify_conda_package.sh) workflow succeed locally.

Differential Revision: D52833880


