### PR TITLE
Removing Python as runtime dependency

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -17,7 +17,6 @@ requirements:
     - setuptools
     - setuptools_scm
   run:
-    - python
     - pytorch >=1.13.1
     - gpytorch ==1.11
     - linear_operator ==0.5.1


### PR DESCRIPTION
Summary:
Context: Nightly chron has been failing ever since we introduced python as a runtime dependency. D52833880 tried to remedy this by removing the version specification, which got rid of the error in local testing, but the error is still present in the GitHub actions.

This commit removes python as a runtime dependency completely, in the hope that this will get rid of the nightly chron failures. Once a new Conda version is released later this year, we can try adding the requirement back in, since the dependency resolution solver is bound for an update.

Reviewed By: Balandat

Differential Revision: D53087603


