### PR TITLE
Adding `posterior_transform` to `qMaxValueEntropySearch`'s input constructor

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -1103,6 +1103,7 @@ def construct_inputs_qMES(
     model: Model,
     training_data: MaybeDict[SupervisedDataset],
     bounds: List[Tuple[float, float]],
+    posterior_transform: Optional[PosteriorTransform] = None,
     candidate_size: int = 1000,
     maximize: bool = True,
     # TODO: qMES also supports other inputs, such as num_fantasies
@@ -1115,6 +1116,7 @@ def construct_inputs_qMES(
     _bounds = torch.as_tensor(bounds, **_kw).transpose(0, 1)
     return {
         "model": model,
+        "posterior_transform": posterior_transform,
         "candidate_set": _bounds[0] + (_bounds[1] - _bounds[0]) * _rvs,
         "maximize": maximize,
     }

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -1116,11 +1116,12 @@ class TestMultiObjectiveAcquisitionFunctionInputConstructors(
 
     def test_construct_inputs_mes(self) -> None:
         func = get_acqf_input_constructor(qMaxValueEntropy)
-        model = SingleTaskGP(train_X=torch.ones((3, 2)), train_Y=torch.zeros((3, 1)))
+        n, d, m = 5, 2, 1
+        model = SingleTaskGP(train_X=torch.ones((n, d)), train_Y=torch.zeros((n, m)))
         kwargs = func(
             model=model,
             training_data=self.blockX_blockY,
-            objective=LinearMCObjective(torch.rand(2)),
+            posterior_transform=ScalarizedPosteriorTransform(torch.rand(m)),
             bounds=self.bounds,
             candidate_size=17,
             maximize=False,


### PR DESCRIPTION
Summary:
This diff adds `posterior_transform` to the input constructor of the `qMaxValueEntropySearch` acquisition function. This can be used to transform the posterior distribution before computing the maximum entropy search, a property that Ax relies on to encode whether an objective is to be maximized or minimized, instead of passing the `minimize` keyword, which is not accepted by  all acquisition functions.

This solves https://github.com/facebook/Ax/issues/2133.

Differential Revision: D53101380


