### PR TITLE
Don't allow unused keyword arguments in Model.construct_inputs

### DIFF
--- a/botorch/models/contextual.py
+++ b/botorch/models/contextual.py
@@ -47,7 +47,6 @@ class SACGP(SingleTaskGP):
         cls,
         training_data: SupervisedDataset,
         decomposition: Dict[str, List[int]],
-        **kwargs: Any,
     ) -> Dict[str, Any]:
         r"""Construct `Model` keyword arguments from a dict of `SupervisedDataset`.
 
@@ -56,7 +55,7 @@ class SACGP(SingleTaskGP):
             decomposition: Dictionary of context names and their indexes of the
                 corresponding active context parameters.
         """
-        base_inputs = super().construct_inputs(training_data=training_data, **kwargs)
+        base_inputs = super().construct_inputs(training_data=training_data)
         return {
             **base_inputs,
             "decomposition": decomposition,
@@ -127,7 +126,6 @@ class LCEAGP(SingleTaskGP):
         embs_feature_dict: Optional[Dict] = None,
         embs_dim_list: Optional[List[int]] = None,
         context_weight_dict: Optional[Dict] = None,
-        **kwargs: Any,
     ) -> Dict[str, Any]:
         r"""Construct `Model` keyword arguments from a dict of `SupervisedDataset`.
 
@@ -147,7 +145,7 @@ class LCEAGP(SingleTaskGP):
                 dimension is set to 1 for each categorical variable.
             context_weight_dict: Known population weights of each context.
         """
-        base_inputs = super().construct_inputs(training_data=training_data, **kwargs)
+        base_inputs = super().construct_inputs(training_data=training_data)
         index_decomp = {
             c: [training_data.feature_names.index(i) for i in v]
             for c, v in decomposition.items()

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -167,7 +167,6 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         cls,
         training_data: SupervisedDataset,
         fidelity_features: List[int],
-        **kwargs,
     ) -> Dict[str, Any]:
         r"""Construct `Model` keyword arguments from a dict of `SupervisedDataset`.
 
@@ -175,7 +174,7 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
             training_data: Dictionary of `SupervisedDataset`.
             fidelity_features: Index of fidelity parameter as input columns.
         """
-        inputs = super().construct_inputs(training_data=training_data, **kwargs)
+        inputs = super().construct_inputs(training_data=training_data)
         inputs["data_fidelities"] = fidelity_features
         return inputs
 

--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -187,7 +187,6 @@ class MixedSingleTaskGP(SingleTaskGP):
         training_data: SupervisedDataset,
         categorical_features: List[int],
         likelihood: Optional[Likelihood] = None,
-        **kwargs: Any,
     ) -> Dict[str, Any]:
         r"""Construct `Model` keyword arguments from a dict of `SupervisedDataset`.
 
@@ -196,7 +195,7 @@ class MixedSingleTaskGP(SingleTaskGP):
             categorical_features: Column indices of categorical features.
             likelihood: Optional likelihood used to constuct the model.
         """
-        base_inputs = super().construct_inputs(training_data=training_data, **kwargs)
+        base_inputs = super().construct_inputs(training_data=training_data)
         return {
             **base_inputs,
             "cat_dims": categorical_features,

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -186,7 +186,6 @@ class Model(Module, ABC):
     def construct_inputs(
         cls,
         training_data: SupervisedDataset,
-        **kwargs: Any,
     ) -> Dict[str, Union[BotorchContainer, Tensor]]:
         """
         Construct `Model` keyword arguments from a `SupervisedDataset`.
@@ -194,7 +193,6 @@ class Model(Module, ABC):
         Args:
             training_data: A `SupervisedDataset`, with attributes `train_X`,
                 `train_Y`, and, optionally, `train_Yvar`.
-            kwargs: Ignored.
 
         Returns:
             A dict of keyword arguments that can be used to initialize a `Model`,

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -334,7 +334,6 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
         task_covar_prior: Optional[Prior] = None,
         prior_config: Optional[dict] = None,
         rank: Optional[int] = None,
-        **kwargs,
     ) -> Dict[str, Any]:
         r"""Construct `Model` keyword arguments from a dataset and other args.
 
@@ -367,9 +366,8 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
                 raise ValueError(f"eta must be a real number, your eta was {eta}.")
             task_covar_prior = LKJCovariancePrior(num_tasks, eta, sd_prior)
 
-        base_inputs = super().construct_inputs(
-            training_data=training_data, task_feature=task_feature, **kwargs
-        )
+        # Call Model.construct_inputs to parse training data
+        base_inputs = super().construct_inputs(training_data=training_data)
         if isinstance(training_data, MultiTaskDataset):
             all_tasks = list(range(len(training_data.datasets)))
             base_inputs["all_tasks"] = all_tasks

--- a/botorch/models/pairwise_gp.py
+++ b/botorch/models/pairwise_gp.py
@@ -781,7 +781,6 @@ class PairwiseGP(Model, GP, FantasizeMixin):
     def construct_inputs(
         cls,
         training_data: SupervisedDataset,
-        **kwargs: Any,
     ) -> Dict[str, Tensor]:
         r"""
         Construct `Model` keyword arguments from a `RankingDataset`.
@@ -789,7 +788,6 @@ class PairwiseGP(Model, GP, FantasizeMixin):
         Args:
             training_data: A `RankingDataset`, with attributes `train_X`,
                 `train_Y`, and, optionally, `train_Yvar`.
-            kwargs: Ignored.
 
         Returns:
             A dict of keyword arguments that can be used to initialize a


### PR DESCRIPTION
Summary: BoTorch changes to go with the subsequent Ax diff. This will eventually need to be landed with this diff going before the Ax diff.

Differential Revision: D53086323


