### PR TITLE
Don't allow data_fidelities=[] in SingleTaskMultiFidelityGP

### DIFF
--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -124,9 +124,11 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
             "nu": nu,
             "outcome_transform": outcome_transform,
         }
-        if iteration_fidelity is None and data_fidelities is None:
+        if iteration_fidelity is None and (
+            data_fidelities is None or len(data_fidelities) == 0
+        ):
             raise UnsupportedError(
-                "SingleTaskMultiFidelityGP requires at least one fidelity parameter."
+                f"{self.__class__.__name__} requires at least one fidelity parameter."
             )
         with torch.no_grad():
             transformed_X = self.transform_inputs(

--- a/test/models/test_gp_regression_fidelity.py
+++ b/test/models/test_gp_regression_fidelity.py
@@ -91,13 +91,20 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
         model = SingleTaskMultiFidelityGP(**model_kwargs)
         return model, model_kwargs
 
-    def test_init_error(self):
+    def test_init_error(self) -> None:
         train_X = torch.rand(2, 2, device=self.device)
         train_Y = torch.rand(2, 1)
         for lin_truncated in (True, False):
-            with self.assertRaises(UnsupportedError):
+            no_fidelity_msg = (
+                "SingleTaskMultiFidelityGP requires at least one fidelity parameter."
+            )
+            with self.assertRaisesRegex(UnsupportedError, no_fidelity_msg):
                 SingleTaskMultiFidelityGP(
                     train_X, train_Y, linear_truncated=lin_truncated
+                )
+            with self.assertRaisesRegex(UnsupportedError, no_fidelity_msg):
+                SingleTaskMultiFidelityGP(
+                    train_X, train_Y, linear_truncated=lin_truncated, data_fidelities=[]
                 )
         with self.assertRaises(ValueError):
             SingleTaskMultiFidelityGP(
@@ -108,7 +115,7 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
                 train_X, train_Y, data_fidelity=1, linear_truncated=False
             )
 
-    def test_gp(self):
+    def test_gp(self) -> None:
         for (iteration_fidelity, data_fidelities) in self.FIDELITY_TEST_PAIRS:
             num_dim = 1 + (iteration_fidelity is not None)
             if data_fidelities is not None:


### PR DESCRIPTION
Summary:
`data_fidelities=[]` will lead to the construction of an invalid degenerate kernel and eventually lead to an ugly GPyTorch error upon trying to construct a covariance.

Also, changed error message to reference `self.__class__.__name__` rather than `SingleTaskMultiFidelityGP` to account for subclasses.

Differential Revision: D53619175


