### PR TITLE
Consistent signature for BoTorch `get_objective_weights_transform`

### DIFF
--- a/botorch/utils/objective.py
+++ b/botorch/utils/objective.py
@@ -43,9 +43,6 @@ def get_objective_weights_transform(
         >>> weights = torch.tensor([0.75, 0.25])
         >>> transform = get_objective_weights_transform(weights)
     """
-    # if no weights provided, just extract the single output
-    if weights is None:
-        return lambda Y: Y.squeeze(-1)
 
     def _objective(Y: Tensor, X: Optional[Tensor] = None):
         r"""Evaluate objective.
@@ -55,10 +52,14 @@ def get_objective_weights_transform(
 
         Args:
             Y: A `... x b x q x m` tensor of function values.
+            X: Ignored.
 
         Returns:
             A `... x b x q`-dim tensor of objective values.
         """
+        # if no weights provided, just extract the single output
+        if weights is None:
+            return Y.squeeze(-1)
         return torch.einsum("...m, m", [Y, weights])
 
     return _objective

--- a/test/utils/test_objective.py
+++ b/test/utils/test_objective.py
@@ -251,19 +251,23 @@ class TestApplyConstraints(BotorchTestCase):
 
 
 class TestGetObjectiveWeightsTransform(BotorchTestCase):
-    def test_NoWeights(self):
+    def test_NoWeights(self) -> None:
         Y = torch.ones(5, 2, 4, 1)
         objective_transform = get_objective_weights_transform(None)
         Y_transformed = objective_transform(Y)
         self.assertTrue(torch.equal(Y.squeeze(-1), Y_transformed))
+        Y_transformed_X_None = objective_transform(Y, X=None)
+        self.assertTrue(torch.equal(Y.squeeze(-1), Y_transformed_X_None))
 
-    def test_OneWeightBroadcasting(self):
+    def test_OneWeightBroadcasting(self) -> None:
         Y = torch.ones(5, 2, 4, 1)
         objective_transform = get_objective_weights_transform(torch.tensor([0.5]))
         Y_transformed = objective_transform(Y)
         self.assertTrue(torch.equal(0.5 * Y.sum(dim=-1), Y_transformed))
+        Y_transformed_X_None = objective_transform(Y, X=None)
+        self.assertTrue(torch.equal(0.5 * Y.sum(dim=-1), Y_transformed_X_None))
 
-    def test_IncompatibleNumberOfWeights(self):
+    def test_IncompatibleNumberOfWeights(self) -> None:
         Y = torch.ones(5, 2, 4, 3)
         objective_transform = get_objective_weights_transform(torch.tensor([1.0, 2.0]))
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
Summary: `get_objective_weights_transform` sometimes returns a function that accepts a second argument and sometimes doesn't. Its docstring and type annotation are incorrect. This will become more problematic when we reap support for passing an `objective` with one argument to `GenericMCObjective` in https://github.com/pytorch/botorch/pull/2199

Differential Revision: D53706138


