### PR TITLE
Exclude .conda and .eggs folder from flake8 linting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ ignore = E203, W503, D
 extend-select = D107, D417, D3, D207, D208, D214, D215
 max-line-length = 88
 exclude =
-  build, dist, tutorials, website
+  build, dist, tutorials, website, .conda, .eggs
 
 [coverage:report]
 omit =


### PR DESCRIPTION
Previously, flake8 would lint files generated during packaging in a local checkout, which increased runtime and could cause a large number of "errors". This ignores some of these build folders in the setup.cfg.