### PR TITLE
Add ability to not deduplicate points in `_is_non_dominated_loop`

### DIFF
--- a/botorch/utils/multi_objective/pareto.py
+++ b/botorch/utils/multi_objective/pareto.py
@@ -13,7 +13,11 @@ from torch import Tensor
 MAX_BYTES = 5e6
 
 
-def is_non_dominated(Y: Tensor, deduplicate: bool = True) -> Tensor:
+def is_non_dominated(
+    Y: Tensor,
+    maximize: bool = True,
+    deduplicate: bool = True,
+) -> Tensor:
     r"""Computes the non-dominated front.
 
     Note: this assumes maximization.
@@ -26,6 +30,7 @@ def is_non_dominated(Y: Tensor, deduplicate: bool = True) -> Tensor:
 
     Args:
         Y: A `(batch_shape) x n x m`-dim tensor of outcomes.
+        maximize: If True, assume maximization (default).
         deduplicate: A boolean indicating whether to only return
             unique points on the pareto frontier.
 
@@ -38,11 +43,14 @@ def is_non_dominated(Y: Tensor, deduplicate: bool = True) -> Tensor:
         return torch.zeros(Y.shape[:-1], dtype=torch.bool, device=Y.device)
     el_size = 64 if Y.dtype == torch.double else 32
     if n > 1000 or n**2 * Y.shape[:-2].numel() * el_size / 8 > MAX_BYTES:
-        return _is_non_dominated_loop(Y)
+        return _is_non_dominated_loop(Y, maximize=maximize, deduplicate=deduplicate)
 
     Y1 = Y.unsqueeze(-3)
     Y2 = Y.unsqueeze(-2)
-    dominates = (Y1 >= Y2).all(dim=-1) & (Y1 > Y2).any(dim=-1)
+    if maximize:
+        dominates = (Y1 >= Y2).all(dim=-1) & (Y1 > Y2).any(dim=-1)
+    else:
+        dominates = (Y1 <= Y2).all(dim=-1) & (Y1 < Y2).any(dim=-1)
     nd_mask = ~(dominates.any(dim=-1))
     if deduplicate:
         # remove duplicates
@@ -54,7 +62,11 @@ def is_non_dominated(Y: Tensor, deduplicate: bool = True) -> Tensor:
     return nd_mask
 
 
-def _is_non_dominated_loop(Y: Tensor, maximize: bool = True) -> Tensor:
+def _is_non_dominated_loop(
+    Y: Tensor,
+    maximize: bool = True,
+    deduplicate: bool = True,
+) -> Tensor:
     r"""Determine which points are non-dominated.
 
     Compared to `is_non_dominated`, this method is significantly
@@ -63,7 +75,9 @@ def _is_non_dominated_loop(Y: Tensor, maximize: bool = True) -> Tensor:
 
     Args:
         Y: A `(batch_shape) x n x m` Tensor of outcomes.
-        maximize: A boolean indicating if the goal is maximization.
+        maximize: If True, assume maximization (default).
+        deduplicate: A boolean indicating whether to only return unique points on
+            the pareto frontier.
 
     Returns:
         A `(batch_shape) x n`-dim Tensor of booleans indicating whether each point is
@@ -87,7 +101,22 @@ def _is_non_dominated_loop(Y: Tensor, maximize: bool = True) -> Tensor:
                 # Set all elements in all batches where Y[..., i, :] is not
                 # efficient to False
                 is_efficient2[~i_is_efficient] = False
-            # Only include elements from in_efficient from the batches
+            # Only include elements from is_efficient from the batches
             # where Y[..., i, :] is efficient
             is_efficient[is_efficient2] = update[is_efficient2]
+
+    if not deduplicate:
+        # Doing another pass over the data to remove duplicates. There may be a
+        # more efficient way to do this. One could broadcast this as in
+        # `is_non_dominated`, but we loop here to avoid high memory usage.
+        is_efficient_dedup = is_efficient.clone()
+        for i in range(Y.shape[-2]):
+            i_is_efficient = is_efficient[..., i]
+            if i_is_efficient.any():
+                vals = Y[..., i : i + 1, :]
+                duplicate = (vals == Y).all(dim=-1) & i_is_efficient.unsqueeze(-1)
+                if duplicate.any():
+                    is_efficient_dedup[duplicate] = True
+        return is_efficient_dedup
+
     return is_efficient

--- a/test/utils/multi_objective/test_pareto.py
+++ b/test/utils/multi_objective/test_pareto.py
@@ -61,7 +61,7 @@ class TestPareto(BotorchTestCase):
             ]
         )
         expected_nondom_Y3b = expected_nondom_Y3[1:]
-        for dtype in (torch.float, torch.double):
+        for dtype, maximize in product((torch.float, torch.double), (True, False)):
             tkwargs["dtype"] = dtype
             Y = Y.to(**tkwargs)
             expected_nondom_Y = expected_nondom_Y.to(**tkwargs)
@@ -72,26 +72,31 @@ class TestPareto(BotorchTestCase):
             Y3b = Y3b.to(**tkwargs)
             expected_nondom_Y3b = expected_nondom_Y3b.to(**tkwargs)
 
+            test_Y = Y if maximize else -Y
+
             # test 2d
-            nondom_Y = Y[is_non_dominated(Y)]
+            nondom_Y = Y[is_non_dominated(test_Y, maximize=maximize)]
             self.assertTrue(torch.equal(expected_nondom_Y, nondom_Y))
             # test deduplicate=False
             expected_nondom_Y_no_dedup = torch.cat(
                 [expected_nondom_Y, expected_nondom_Y[-1:]], dim=0
             )
-            nondom_Y = Y[is_non_dominated(Y, deduplicate=False)]
+            nondom_Y = Y[is_non_dominated(test_Y, maximize=maximize, deduplicate=False)]
             self.assertTrue(torch.equal(expected_nondom_Y_no_dedup, nondom_Y))
 
             # test batch
             batch_Y = torch.stack([Y, Yb], dim=0)
-            nondom_mask = is_non_dominated(batch_Y)
+            test_batch_Y = batch_Y if maximize else -batch_Y
+            nondom_mask = is_non_dominated(test_batch_Y, maximize=maximize)
             self.assertTrue(torch.equal(batch_Y[0][nondom_mask[0]], expected_nondom_Y))
             self.assertTrue(torch.equal(batch_Y[1][nondom_mask[1]], expected_nondom_Yb))
             # test deduplicate=False
             expected_nondom_Yb_no_dedup = torch.cat(
                 [expected_nondom_Yb[:-1], expected_nondom_Yb[-2:]], dim=0
             )
-            nondom_mask = is_non_dominated(batch_Y, deduplicate=False)
+            nondom_mask = is_non_dominated(
+                test_batch_Y, maximize=maximize, deduplicate=False
+            )
             self.assertTrue(
                 torch.equal(batch_Y[0][nondom_mask[0]], expected_nondom_Y_no_dedup)
             )
@@ -100,17 +105,21 @@ class TestPareto(BotorchTestCase):
             )
 
             # test 3d
-            nondom_Y3 = Y3[is_non_dominated(Y3)]
+            test_Y3 = Y3 if maximize else -Y3
+            nondom_Y3 = Y3[is_non_dominated(test_Y3, maximize=maximize)]
             self.assertTrue(torch.equal(expected_nondom_Y3, nondom_Y3))
             # test deduplicate=False
             expected_nondom_Y3_no_dedup = torch.cat(
                 [expected_nondom_Y3[:3], expected_nondom_Y3[2:]], dim=0
             )
-            nondom_Y3 = Y3[is_non_dominated(Y3, deduplicate=False)]
+            nondom_Y3 = Y3[
+                is_non_dominated(test_Y3, maximize=maximize, deduplicate=False)
+            ]
             self.assertTrue(torch.equal(expected_nondom_Y3_no_dedup, nondom_Y3))
             # test batch
             batch_Y3 = torch.stack([Y3, Y3b], dim=0)
-            nondom_mask3 = is_non_dominated(batch_Y3)
+            test_batch_Y3 = batch_Y3 if maximize else -batch_Y3
+            nondom_mask3 = is_non_dominated(test_batch_Y3, maximize=maximize)
             self.assertTrue(
                 torch.equal(batch_Y3[0][nondom_mask3[0]], expected_nondom_Y3)
             )
@@ -118,7 +127,9 @@ class TestPareto(BotorchTestCase):
                 torch.equal(batch_Y3[1][nondom_mask3[1]], expected_nondom_Y3b)
             )
             # test deduplicate=False
-            nondom_mask3 = is_non_dominated(batch_Y3, deduplicate=False)
+            nondom_mask3 = is_non_dominated(
+                test_batch_Y3, maximize=maximize, deduplicate=False
+            )
             self.assertTrue(
                 torch.equal(batch_Y3[0][nondom_mask3[0]], expected_nondom_Y3_no_dedup)
             )
@@ -159,8 +170,7 @@ class TestPareto(BotorchTestCase):
             tkwargs["dtype"] = dtype
             Y = torch.rand(batch_shape + torch.Size([n, m]), **tkwargs)
             pareto_mask = _is_non_dominated_loop(
-                # this is so that we can assume maximization in the test
-                # code
+                # this is so that we can assume maximization in the test code
                 Y=Y if maximize else -Y,
                 maximize=maximize,
             )
@@ -219,3 +229,48 @@ class TestPareto(BotorchTestCase):
                                     )
                                 best_obj_mask[k] = False
                         point_mask[j] = False
+
+    def test_is_non_dominated_loop_no_dedup(self):
+        not_dom_expected_dedup = torch.tensor(
+            [
+                [True, False, False, False, True, False],
+                [False, True, True, False, False, False],
+            ],
+            device=self.device,
+        )
+        not_dom_expected_no_dedup = torch.tensor(
+            [
+                [True, False, True, False, True, False],
+                [False, True, True, False, False, True],
+            ],
+            device=self.device,
+        )
+
+        for dtype, maximize, deduplicate in product(
+            (torch.float, torch.double), (True, False), (True, False)
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            y1 = torch.tensor([1.0, 0.75], **tkwargs)
+            y2 = torch.tensor([0.75, 1.0], **tkwargs)
+            y3 = torch.tensor([1.0, 0.3], **tkwargs)
+            # 0.5 ensures all points are dominated by y1/y2
+            Y = 0.5 * torch.rand(2, 6, 2, **tkwargs)
+
+            Y[0, 0] = y1
+            Y[0, 2] = y1
+            Y[0, 4] = y2
+            Y[0, 3] = y3  # weakly Pareto optimal, dominated by y1
+
+            Y[1, 1] = y1
+            Y[1, 2] = y2
+            Y[1, 5] = y2
+
+            Y = Y if maximize else -Y
+            not_dom = _is_non_dominated_loop(
+                Y, maximize=maximize, deduplicate=deduplicate
+            )
+
+            if deduplicate:
+                self.assertTrue(torch.equal(not_dom, not_dom_expected_dedup))
+            else:
+                self.assertTrue(torch.equal(not_dom, not_dom_expected_no_dedup))


### PR DESCRIPTION
This was previously unsupported. With this ability we can now also pass the `deduplicate` kwarg down to `_is_non_dominated_loop`. In addition, this PR adds the `maximize` argument to `is_non_dominated` for convenience.

Fixes #2201