### PR TITLE
Remove (Identity)AnalyticMultiOutputObjective

### DIFF
--- a/botorch/acquisition/multi_objective/__init__.py
+++ b/botorch/acquisition/multi_objective/__init__.py
@@ -22,8 +22,6 @@ from botorch.acquisition.multi_objective.monte_carlo import (
 )
 from botorch.acquisition.multi_objective.multi_fidelity import MOMF
 from botorch.acquisition.multi_objective.objective import (
-    AnalyticMultiOutputObjective,
-    IdentityAnalyticMultiOutputObjective,
     IdentityMCMultiOutputObjective,
     MCMultiOutputObjective,
     UnstandardizeMCMultiOutputObjective,
@@ -44,9 +42,7 @@ __all__ = [
     "qNoisyExpectedHypervolumeImprovement",
     "MOMF",
     "qMultiObjectiveMaxValueEntropy",
-    "AnalyticMultiOutputObjective",
     "ExpectedHypervolumeImprovement",
-    "IdentityAnalyticMultiOutputObjective",
     "IdentityMCMultiOutputObjective",
     "MCMultiOutputObjective",
     "MultiObjectiveAnalyticAcquisitionFunction",

--- a/botorch/acquisition/multi_objective/objective.py
+++ b/botorch/acquisition/multi_objective/objective.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 from abc import abstractmethod
 from typing import List, Optional
 
@@ -15,7 +13,6 @@ import torch
 from botorch.acquisition.objective import GenericMCObjective, MCAcquisitionObjective
 from botorch.exceptions.errors import BotorchError, BotorchTensorDimensionError
 from botorch.models.model import Model
-from botorch.posteriors import GPyTorchPosterior
 from botorch.utils import apply_constraints
 from botorch.utils.transforms import normalize_indices
 from torch import Tensor

--- a/botorch/acquisition/multi_objective/objective.py
+++ b/botorch/acquisition/multi_objective/objective.py
@@ -255,27 +255,3 @@ class UnstandardizeMCMultiOutputObjective(IdentityMCMultiOutputObjective):
     def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
         samples = super().forward(samples=samples)
         return samples * self.Y_std + self.Y_mean
-
-
-class AnalyticMultiOutputObjective(torch.nn.Module):
-    r"""Abstract base class for multi-output analytic objectives.
-
-    DEPRECATED - This will be removed in the next version.
-
-    """
-
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize objective."""
-        warnings.warn("AnalyticMultiOutputObjective is deprecated.", DeprecationWarning)
-        super().__init__(*args, **kwargs)
-
-
-class IdentityAnalyticMultiOutputObjective(AnalyticMultiOutputObjective):
-    """DEPRECATED - This will be removed in the next version."""
-
-    def __init__(self):
-        """Initialize objective."""
-        super().__init__()
-
-    def forward(self, posterior: GPyTorchPosterior) -> GPyTorchPosterior:
-        return posterior

--- a/test/acquisition/multi_objective/test_objective.py
+++ b/test/acquisition/multi_objective/test_objective.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
-import warnings
 
 import torch
 from botorch.acquisition.multi_objective.multi_output_risk_measures import (

--- a/test/acquisition/multi_objective/test_objective.py
+++ b/test/acquisition/multi_objective/test_objective.py
@@ -143,13 +143,6 @@ class TestFeasibilityWeightedMCMultiOutputObjective(BotorchTestCase):
 
 class TestUnstandardizeMultiOutputObjective(BotorchTestCase):
     def test_unstandardize_mo_objective(self):
-        warnings.filterwarnings(
-            "ignore",
-            message=(
-                "UnstandardizeAnalyticMultiOutputObjective is deprecated. "
-                "Use UnstandardizePosteriorTransform instead."
-            ),
-        )
         Y_mean = torch.ones(2)
         Y_std = torch.ones(2)
         with self.assertRaises(BotorchTensorDimensionError):


### PR DESCRIPTION
This has been deprecated for a while now. It's not on a clear deprecation schedule but this is a rarely used feature so should be fine to remove.
