### PR TITLE
Test (some) constrained MOO test functions with non-zero noise on constraints

### DIFF
--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -1241,6 +1241,7 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
     def __init__(
         self,
         noise_std: Union[None, float, List[float]] = None,
+        constraint_noise_std: Union[None, float, List[float]] = None,
         negate: bool = False,
     ) -> None:
         r"""
@@ -1251,6 +1252,7 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
         super().__init__(noise_std=noise_std, negate=negate)
         con_bounds = torch.tensor(self._con_bounds, dtype=torch.float).transpose(-1, -2)
         self.register_buffer("con_bounds", con_bounds)
+        self.constraint_noise_std = constraint_noise_std
 
     def evaluate_slack_true(self, X: Tensor) -> Tensor:
         X_tf = unnormalize(X, self.con_bounds)
@@ -1346,6 +1348,7 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
         self,
         dim: int,
         noise_std: Union[None, float, List[float]] = None,
+        constraint_noise_std: Union[None, float, List[float]] = None,
         negate: bool = False,
     ) -> None:
         r"""
@@ -1359,6 +1362,7 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
         self.dim = dim
         self._bounds = [(0.0, 1.0) for _ in range(self.dim)]
         super().__init__(noise_std=noise_std, negate=negate)
+        self.constraint_noise_std = constraint_noise_std
 
     def LA2(self, A, B, C, D, theta):
         return A * torch.sin(B * theta.pow(C)).pow(D)

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -1246,7 +1246,9 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
     ) -> None:
         r"""
         Args:
-            noise_std: Standard deviation of the observation noise.
+            noise_std: Standard deviation of the observation noise of the objectives.
+            constraint_noise_std: Standard deviation of the observation noise of the
+                constraint.
             negate: If True, negate the function.
         """
         super().__init__(noise_std=noise_std, negate=negate)
@@ -1354,7 +1356,9 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
         r"""
         Args:
             dim: The (input) dimension of the function. Must be at least 2.
-            noise_std: Standard deviation of the observation noise.
+            noise_std: Standard deviation of the observation noise of the objectives.
+            constraint_noise_std: Standard deviation of the observation noise of the
+                constraints.
             negate: If True, negate the function.
         """
         if dim < 2:

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -196,8 +196,8 @@ class ConstrainedTestProblemTestCaseMixin:
                     bounds=f.bounds,
                 )
                 slack_true = f.evaluate_slack_true(X)
-                # Mock out the random generator to ensure that the noise realizations are
-                # sizable and we don't run into any floating point comparison issues.
+                # Mock out the random generator to ensure that noise realizations are
+                # sizable so we don't run into any floating point comparison issues.
                 with mock.patch(
                     "botorch.test_functions.base.torch.randn_like",
                     side_effect=lambda y: y,

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -11,7 +11,7 @@ import warnings
 from abc import abstractproperty
 from collections import OrderedDict
 from typing import Any, List, Optional, Tuple, Union
-from unittest import TestCase
+from unittest import mock, TestCase
 
 import torch
 from botorch import settings
@@ -196,7 +196,14 @@ class ConstrainedTestProblemTestCaseMixin:
                     bounds=f.bounds,
                 )
                 slack_true = f.evaluate_slack_true(X)
-                slack_observed = f.evaluate_slack(X)
+                # Mock out the random generator to ensure that the noise realizations are
+                # sizable and we don't run into any floating point comparison issues.
+                with mock.patch(
+                    "botorch.test_functions.base.torch.randn_like",
+                    side_effect=lambda y: y,
+                ):
+                    slack_observed = f.evaluate_slack(X)
+
                 self.assertEqual(slack_true.shape, torch.Size([1, f.num_constraints]))
                 self.assertEqual(
                     slack_observed.shape, torch.Size([1, f.num_constraints])
@@ -208,14 +215,9 @@ class ConstrainedTestProblemTestCaseMixin:
                     )
                 elif isinstance(f.constraint_noise_std, list):
                     for i, noise_std in enumerate(f.constraint_noise_std):
-                        # NOTE: We can run into floating point precision issues here if
-                        # the slack value is extremely large so that adding noise to the
-                        # outcome may not result in a different (floating point) number.
-                        # TODO: Find a more principled way for testing this.
-                        if slack_true[:, i].abs() < 1e8:
-                            self.assertEqual(
-                                is_equal[:, i].item(), noise_std in (0.0, None)
-                            )
+                        self.assertEqual(
+                            is_equal[:, i].item(), noise_std in (0.0, None)
+                        )
                 else:
                     self.assertTrue(is_equal.all().item())
 

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -187,7 +187,7 @@ class ConstrainedTestProblemTestCaseMixin:
         for f in self.functions:
             self.assertTrue(hasattr(f, "num_constraints"))
 
-    def test_evaluate_slack_true(self):
+    def test_evaluate_slack(self):
         for dtype in (torch.float, torch.double):
             for f in self.functions:
                 f.to(device=self.device, dtype=dtype)
@@ -195,8 +195,13 @@ class ConstrainedTestProblemTestCaseMixin:
                     torch.rand(1, f.dim, device=self.device, dtype=dtype),
                     bounds=f.bounds,
                 )
-                slack = f.evaluate_slack_true(X)
-                self.assertEqual(slack.shape, torch.Size([1, f.num_constraints]))
+                slack_true = f.evaluate_slack_true(X)
+                slack_observed = f.evaluate_slack(X)
+                self.assertEqual(slack_true.shape, torch.Size([1, f.num_constraints]))
+                self.assertEqual(slack_observed.shape, torch.Size([1, f.num_constraints]))
+                if isinstance(f.constraint_noise_std, float):
+                    is_equal = torch.equal(slack_true, slack_observed)
+                    self.assertEqual(is_equal, f.constraint_noise_std == 0.0)
 
 
 class MockPosterior(Posterior):

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -198,7 +198,9 @@ class ConstrainedTestProblemTestCaseMixin:
                 slack_true = f.evaluate_slack_true(X)
                 slack_observed = f.evaluate_slack(X)
                 self.assertEqual(slack_true.shape, torch.Size([1, f.num_constraints]))
-                self.assertEqual(slack_observed.shape, torch.Size([1, f.num_constraints]))
+                self.assertEqual(
+                    slack_observed.shape, torch.Size([1, f.num_constraints])
+                )
                 if isinstance(f.constraint_noise_std, float):
                     is_equal = torch.equal(slack_true, slack_observed)
                     self.assertEqual(is_equal, f.constraint_noise_std == 0.0)

--- a/test/test_functions/test_multi_objective.py
+++ b/test/test_functions/test_multi_objective.py
@@ -277,7 +277,11 @@ class TestMW7(
 ):
     @property
     def functions(self) -> List[BaseTestProblem]:
-        return [MW7(dim=3), MW7(dim=3, noise_std=[0.1, 0.2])]
+        return [
+            MW7(dim=3),
+            MW7(dim=3, noise_std=[0.1, 0.2]),
+            MW7(dim=3, constraint_noise_std=[0.05, 0.025]),
+        ]
 
     def test_init(self):
         for f in self.functions:
@@ -452,6 +456,7 @@ class TestConstrainedBraninCurrin(
         return [
             ConstrainedBraninCurrin(),
             ConstrainedBraninCurrin(noise_std=[0.1, 0.2]),
+            ConstrainedBraninCurrin(constraint_noise_std=0.1),
         ]
 
 


### PR DESCRIPTION
Previously, we did not properly test the case when a constrained MOO funciton had non-zero noise for the constraint outcomes. This closes that gap (only adds the ability to specify this to `ConstrainedBraninCurrin` and `MW7`, can add this to others as well if needed).