### PR TITLE
Increase eval budget of Multi_objective_multi_fidelity_BO smoke test

### DIFF
--- a/tutorials/Multi_objective_multi_fidelity_BO.ipynb
+++ b/tutorials/Multi_objective_multi_fidelity_BO.ipynb
@@ -147,7 +147,7 @@
     "\n",
     "BATCH_SIZE = 1  # For batch optimization, BATCH_SIZE should be greater than 1\n",
     "# This evaluation budget is set to be very low to make the notebook run fast. This should be much higher.\n",
-    "EVAL_BUDGET = 1.05 if SMOKE_TEST else 2.05  # in terms of the number of full-fidelity evaluations\n",
+    "EVAL_BUDGET = 2.05  # in terms of the number of full-fidelity evaluations\n",
     "n_INIT = 2  # Initialization budget in terms of the number of full-fidelity evaluations\n",
     "# Number of Monte Carlo samples, used to approximate MOMF\n",
     "MC_SAMPLES = 2 if SMOKE_TEST else 128\n",


### PR DESCRIPTION
The change in #2207 made it such that MOMF wasn't actually properly tested in smoke test. This rectifies this behavior.