### PR TITLE
Restricting `mpmath <= 1.3`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 multipledispatch
 scipy
+mpmath>=0.19,<=1.3
 torch>=1.13.1
 pyro-ppl>=1.8.4
 gpytorch==1.11


### PR DESCRIPTION
This commit restricts `mpmath` to versions `<=1.3`, since the latest alpha release breaks `sympy` -> `pytorch` -> `gpytorch` -> `botorch`.

See also https://github.com/sympy/sympy/issues/26273 and [the commit removing `rational` from `mpmath`](https://github.com/mpmath/mpmath/commit/721e2571eb3f911a5a904dd94f8c87c48dddc7ca).

Differential Revision: D54214691

