### PR TITLE
Move MacOS CI to M1 runners

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
+        exclude:
+          - os: "macos-14"
+            python-version: "3.9"  # not available for macos-14
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
+        exclude:
+        - os: "macos-14"
+          python-version: "3.9"  # not available for macos-14
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,16 @@ on:
 jobs:
 
   tests-and-coverage-pip:
-    name: Tests and coverage (pip, Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Tests+coverage (pip, py${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
+        exclude:
+          - os: "macos-14"
+            python-version: "3.9"  # not available for macos-14
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -47,6 +50,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
+        exclude:
+        - os: "macos-14"
+          python-version: "3.9"  # not available for macos-14
     steps:
     - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v2
@@ -58,6 +64,7 @@ jobs:
       shell: bash -l {0}
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true
+      if: $!{{ runner.os == 'macOS' && matrix.python-version == 3.9 }}
       run: |
         # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
         conda config --set solver classic
@@ -68,5 +75,6 @@ jobs:
         pip install .[test]
     - name: Unit tests
       shell: bash -l {0}
+      if: $!{{ runner.os == 'macOS' && matrix.python-version == 3.9 }}
       run: |
         pytest -ra

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,6 @@ jobs:
       shell: bash -l {0}
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true
-      if: $!{{ runner.os == 'macOS' && matrix.python-version == 3.9 }}
       run: |
         # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
         conda config --set solver classic
@@ -75,6 +74,5 @@ jobs:
         pip install .[test]
     - name: Unit tests
       shell: bash -l {0}
-      if: $!{{ runner.os == 'macOS' && matrix.python-version == 3.9 }}
       run: |
         pytest -ra

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
+        exclude:
+          - os: "macos-14"
+            python-version: "3.9"  # not available for macos-14
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -35,6 +38,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
+        exclude:
+          - os: "macos-14"
+            python-version: "3.9"  # not available for macos-14
     steps:
     - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v2
@@ -65,6 +71,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-14"]
         python-version: ["3.9", "3.11"]
+        exclude:
+        - os: "macos-14"
+          python-version: "3.9"  # not available for macos-14
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-14"]
         python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         # HACK around the fact that pytorch does not offer a mac binary for 1.13.1 for py3.11 - TODO: Remove when bumping torch to 2.0.1
-        min_torch_version="$(if ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-latest' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
+        min_torch_version="$(if ${{ matrix.python-version == '3.11' }} && ${{ matrix.os == 'macos-14' }}; then echo "2.0.1"; else echo "${min_torch_version}"; fi)"
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"

--- a/test/acquisition/test_objective.py
+++ b/test/acquisition/test_objective.py
@@ -387,8 +387,8 @@ class TestLinearMCObjective(BotorchTestCase):
             weights = torch.rand(3, device=self.device, dtype=dtype)
             obj = LinearMCObjective(weights=weights)
             samples = torch.randn(4, 2, 3, device=self.device, dtype=dtype)
-            atol = 1e-8 if dtype == torch.double else 3e-8
-            rtol = 1e-5 if dtype == torch.double else 4e-5
+            atol = 1e-7 if dtype == torch.double else 3e-7
+            rtol = 1e-4 if dtype == torch.double else 4e-4
             self.assertAllClose(obj(samples), samples @ weights, atol=atol, rtol=rtol)
             samples = torch.randn(5, 4, 2, 3, device=self.device, dtype=dtype)
             self.assertAllClose(


### PR DESCRIPTION
Pytorch is planning to stop nightly builds for Intel Macs: https://github.com/pytorch/pytorch/issues/114602

This PR updates the mac runners to `macos-14`, which is the only public GHA runner for Mac M1s: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories

Note: Python 3.9 is not available on the `macos-14` runners, so testing on py3.9 is disabled on those by excluding that combo from the test matrix. Once we bump up the minimum supported python version to 3.10 we can remove this added complexity.