### PR TITLE
Remove deprecated botorch/generation/gen/minimize

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -283,7 +283,9 @@ def gen_candidates_scipy(
                 candidates = torch.from_numpy(x0).to(candidates).reshape(shapeX)
                 warnings.warn(
                     "SLSQP failed to converge to a solution the satisfies the "
-                    "non-linear constraints. Returning the feasible starting point."
+                    "non-linear constraints. Returning the feasible starting point.",
+                    OptimizationWarning,
+                    stacklevel=2,
                 )
                 break
 
@@ -462,6 +464,7 @@ def _process_scipy_result(res: OptimizeResult, options: Dict[str, Any]) -> None:
                 "Optimization failed within `scipy.optimize.minimize` with no "
                 "status returned to `res.`",
                 OptimizationWarning,
+                stacklevel=3,
             )
     elif not res.success:
         if (
@@ -486,16 +489,5 @@ def _process_scipy_result(res: OptimizeResult, options: Dict[str, Any]) -> None:
                     f"Optimization failed within `scipy.optimize.minimize` with status "
                     f"{res.status} and message {res.message}.",
                     OptimizationWarning,
+                    stacklevel=3,
                 )
-
-
-def minimize(*args, **kwargs):
-    """Deprecated, use `botorch.generation.gen.minimize_with_timeout`."""
-    # TODO: Reap this after the next stable Ax release.
-    warnings.warn(
-        "`botorch.generation.gen.minimize` is an alias for "
-        "`botorch.generation.gen.minimize_with_timeout` and will "
-        "be removed in a future release.",
-        DeprecationWarning,
-    )
-    return minimize_with_timeout(*args, **kwargs)

--- a/botorch/sampling/base.py
+++ b/botorch/sampling/base.py
@@ -10,9 +10,8 @@ The base class for sampler modules to be used with MC-evaluated acquisition func
 
 from __future__ import annotations
 
-import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 
 import torch
 from botorch.exceptions.errors import InputDataError
@@ -49,7 +48,6 @@ class MCSampler(Module, ABC):
         self,
         sample_shape: torch.Size,
         seed: Optional[int] = None,
-        **kwargs: Any,
     ) -> None:
         r"""Abstract base class for samplers.
 
@@ -57,37 +55,13 @@ class MCSampler(Module, ABC):
             sample_shape: The `sample_shape` of the samples to generate. The full shape
                 of the samples is given by `posterior._extended_shape(sample_shape)`.
             seed: An optional seed to use for sampling.
-            **kwargs: Catch-all for deprecated kwargs.
         """
         super().__init__()
         if not isinstance(sample_shape, torch.Size):
-            if isinstance(sample_shape, int):
-                sample_shape = torch.Size([sample_shape])
-                warnings.warn(
-                    "The first positional argument of samplers, `num_samples`, has "
-                    "been deprecated and replaced with `sample_shape`, which expects "
-                    "a `torch.Size` object.",
-                    DeprecationWarning,
-                )
-            else:
-                raise InputDataError(
-                    "Expected `sample_shape` to be a `torch.Size` object, "
-                    f"got {sample_shape}."
-                )
-        for k, v in kwargs.items():
-            if k == "resample":
-                if v is True:
-                    raise RuntimeError(KWARG_ERR_MSG.format(k, "StochasticSampler"))
-                else:
-                    warnings.warn(KWARGS_DEPRECATED_MSG.format(k), DeprecationWarning)
-            elif k == "collapse_batch_dims":
-                if v is False:
-                    raise RuntimeError(KWARG_ERR_MSG.format(k, "ForkedRNGSampler"))
-                else:
-                    warnings.warn(KWARGS_DEPRECATED_MSG.format(k), DeprecationWarning)
-            else:
-                raise RuntimeError(f"Recevied an unknown argument {k}: {v}.")
-
+            raise InputDataError(
+                "Expected `sample_shape` to be a `torch.Size` object, "
+                f"got {sample_shape}."
+            )
         self.sample_shape = sample_shape
         self.seed = seed if seed is not None else torch.randint(0, 1000000, (1,)).item()
         self.register_buffer("base_samples", None)

--- a/test/generation/test_gen.py
+++ b/test/generation/test_gen.py
@@ -371,16 +371,3 @@ class TestRandomRestartOptimization(TestBaseCandidateGeneration):
                 batch_candidates=batch_candidates, batch_values=batch_acq_values
             )
             self.assertTrue(-EPS <= candidates <= 1 + EPS)
-
-
-class TestDeprecateMinimize(BotorchTestCase):
-    def test_deprecate_minimize(self):
-        from botorch.generation.gen import minimize
-
-        with self.assertWarnsRegex(
-            DeprecationWarning, "botorch.generation.gen.minimize_with_timeout"
-        ):
-            try:
-                minimize(None, None)
-            except Exception:
-                pass

--- a/test/sampling/test_base.py
+++ b/test/sampling/test_base.py
@@ -36,21 +36,9 @@ class TestBaseMCSampler(BotorchTestCase):
         # Default seed.
         sampler = NonAbstractSampler(sample_shape=torch.Size([4]))
         self.assertIsInstance(sampler.seed, int)
-        # Deprecated args & error handling.
-        with self.assertWarnsRegex(DeprecationWarning, "positional argument"):
-            NonAbstractSampler(4)
+        # Error handling.
         with self.assertRaisesRegex(InputDataError, "sample_shape"):
             NonAbstractSampler(4.5)
-        with self.assertWarnsRegex(DeprecationWarning, "resample"):
-            NonAbstractSampler(sample_shape=torch.Size([4]), resample=False)
-        with self.assertRaisesRegex(RuntimeError, "StochasticSampler"):
-            NonAbstractSampler(sample_shape=torch.Size([4]), resample=True)
-        with self.assertWarnsRegex(DeprecationWarning, "collapse_batch"):
-            NonAbstractSampler(sample_shape=torch.Size([4]), collapse_batch_dims=True)
-        with self.assertRaisesRegex(RuntimeError, "ForkedRNGSampler"):
-            NonAbstractSampler(sample_shape=torch.Size([4]), collapse_batch_dims=False)
-        with self.assertRaisesRegex(RuntimeError, "unknown argument"):
-            NonAbstractSampler(sample_shape=torch.Size([4]), dummy_arg=True)
 
     def test_batch_range(self):
         posterior = MockPosterior()

--- a/tutorials/Multi_objective_multi_fidelity_BO.ipynb
+++ b/tutorials/Multi_objective_multi_fidelity_BO.ipynb
@@ -501,8 +501,6 @@
     "            ref_point=ref_point,\n",
     "            sampler=SobolQMCNormalSampler(\n",
     "                sample_shape=torch.Size([NUM_INNER_MC_SAMPLES]),\n",
-    "                resample=False,\n",
-    "                collapse_batch_dims=True,\n",
     "            ),\n",
     "            use_posterior_mean=True,\n",
     "        ),\n",

--- a/tutorials/risk_averse_bo_with_input_perturbations.ipynb
+++ b/tutorials/risk_averse_bo_with_input_perturbations.ipynb
@@ -224,7 +224,7 @@
         "    acqf = qNoisyExpectedImprovement(\n",
         "        model=model,\n",
         "        X_baseline=train_X,\n",
-        "        sampler=SobolQMCNormalSampler(128),\n",
+        "        sampler=SobolQMCNormalSampler(sample_shape=torch.Size([128])),\n",
         "        objective=risk_measure,\n",
         "        prune_baseline=True,\n",
         "    )\n",


### PR DESCRIPTION
Summary: This has been deprecated since #1352.

Differential Revision: D54280813


