### PR TITLE
remap task values in MTGP if they are not contiguous integers starting from zero

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -710,6 +710,39 @@ class MultiTaskGPyTorchModel(GPyTorchModel, ABC):
     :meta private:
     """
 
+    def _map_tasks(self, task_values: Tensor) -> Tensor:
+        """Map raw task values to the task indices used by the model.
+
+        Args:
+            task_values: A tensor of task values.
+
+        Returns:
+            A tensor of task indices with the same shape as the input
+                tensor.
+        """
+        if self._task_mapper is None:
+            if not (
+                torch.all(0 <= task_values) and torch.all(task_values < self.num_tasks)
+            ):
+                raise ValueError(
+                    "Expected all task features in `X` to be between 0 and "
+                    f"self.num_tasks - 1. Got {task_values}."
+                )
+        else:
+            task_values = task_values.long()
+
+            unexpected_task_values = set(task_values.unique().tolist()).difference(
+                self._expected_task_values
+            )
+            if len(unexpected_task_values) > 0:
+                raise ValueError(
+                    "Received invalid raw task values. Expected raw value to be in"
+                    f" {self._expected_task_values}, but got unexpected task values:"
+                    f" {unexpected_task_values}."
+                )
+            task_values = self._task_mapper[task_values]
+        return task_values
+
     def posterior(
         self,
         X: Tensor,
@@ -729,9 +762,9 @@ class MultiTaskGPyTorchModel(GPyTorchModel, ABC):
                 model produces outputs for tasks in in `self._output_tasks` (specified
                 as `output_tasks` while constructing the model), which can overwritten
                 using `output_indices`.
-            output_indices: A list of indices, corresponding to the tasks over
-                which to compute the posterior. Only used if `X` does not include the
-                task feature. If omitted, defaults to `self._output_tasks`.
+            output_indices: A list of task values over which to compute the posterior.
+                Only used if `X` does not include the task feature. If omitted,
+                defaults to `self._output_tasks`.
             observation_noise: If True, add observation noise from the respective
                 likelihoods. If a Tensor, specifies the observation noise levels
                 to add.
@@ -746,35 +779,26 @@ class MultiTaskGPyTorchModel(GPyTorchModel, ABC):
         """
         includes_task_feature = X.shape[-1] == self.num_non_task_features + 1
         if includes_task_feature:
-            # Make sure all task feature values are valid.
-            task_features = X[..., self._task_feature].unique()
-            if not (
-                (task_features >= 0).all() and (task_features < self.num_tasks).all()
-            ):
-                raise ValueError(
-                    "Expected all task features in `X` to be between 0 and "
-                    f"self.num_tasks - 1. Got {task_features}."
-                )
             if output_indices is not None:
                 raise ValueError(
                     "`output_indices` must be None when `X` includes task features."
                 )
+            task_features = X[..., self._task_feature].unique()
             num_outputs = 1
             X_full = X
         else:
             # Add the task features to construct the full X for evaluation.
-            if output_indices is None:
-                output_indices = self._output_tasks
-            num_outputs = len(output_indices)
-            if not all(0 <= i < self.num_tasks for i in output_indices):
-                raise ValueError(
-                    "Expected `output_indices` to be between 0 and self.num_tasks - 1. "
-                    f"Got {output_indices}."
-                )
-            X_full = _make_X_full(
-                X=X, output_indices=output_indices, tf=self._task_feature
+            task_features = torch.tensor(
+                self._output_tasks if output_indices is None else output_indices,
+                dtype=torch.long,
+                device=X.device,
             )
-
+            num_outputs = len(task_features)
+            X_full = _make_X_full(
+                X=X, output_indices=task_features.tolist(), tf=self._task_feature
+            )
+        # Make sure all task feature values are valid.
+        task_features = self._map_tasks(task_values=task_features)
         self.eval()  # make sure model is in eval mode
         # input transforms are applied at `posterior` in `eval` mode, and at
         # `model.forward()` at the training time

--- a/botorch/utils/test_helpers.py
+++ b/botorch/utils/test_helpers.py
@@ -12,7 +12,7 @@ should be defined here to avoid relative imports.
 from __future__ import annotations
 
 import math
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 from botorch.acquisition.objective import PosteriorTransform
@@ -66,14 +66,16 @@ def standardize_moments(
 
 
 def gen_multi_task_dataset(
-    yvar: Optional[float] = None, **tkwargs
+    yvar: Optional[float] = None, task_values: Optional[List[int]] = None, **tkwargs
 ) -> Tuple[MultiTaskDataset, Tuple[Tensor, Tensor, Tensor]]:
     """Constructs a multi-task dataset with two tasks, each with 10 data points."""
     X = torch.linspace(0, 0.95, 10, **tkwargs) + 0.05 * torch.rand(10, **tkwargs)
     X = X.unsqueeze(dim=-1)
     Y1 = torch.sin(X * (2 * math.pi)) + torch.randn_like(X) * 0.2
     Y2 = torch.cos(X * (2 * math.pi)) + torch.randn_like(X) * 0.2
-    train_X = torch.cat([pad(X, (1, 0), value=i) for i in range(2)])
+    if task_values is None:
+        task_values = [0, 1]
+    train_X = torch.cat([pad(X, (1, 0), value=i) for i in task_values])
     train_Y = torch.cat([Y1, Y2])
 
     Yvar1 = None if yvar is None else torch.full_like(Y1, yvar)

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -15,11 +15,12 @@ from botorch.exceptions import OptimizationWarning
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.multitask import (
     FixedNoiseMultiTaskGP,
+    get_task_value_remapping,
     KroneckerMultiTaskGP,
     MultiTaskGP,
 )
-from botorch.models.transforms.input import Normalize
-from botorch.models.transforms.outcome import Standardize
+from botorch.models.transforms.input import InputTransform, Normalize
+from botorch.models.transforms.outcome import OutcomeTransform, Standardize
 from botorch.posteriors import GPyTorchPosterior
 from botorch.posteriors.transformed import TransformedPosterior
 from botorch.utils.test_helpers import gen_multi_task_dataset
@@ -48,11 +49,14 @@ from gpytorch.settings import max_cholesky_size, max_root_decomposition_size
 def _gen_model_and_data(
     task_feature: int = 0,
     output_tasks: Optional[List[int]] = None,
-    input_transform=None,
-    outcome_transform=None,
+    task_values: Optional[List[int]] = None,
+    input_transform: Optional[InputTransform] = None,
+    outcome_transform: Optional[OutcomeTransform] = None,
     **tkwargs
 ):
-    datasets, (train_X, train_Y, _) = gen_multi_task_dataset(**tkwargs)
+    datasets, (train_X, train_Y, _) = gen_multi_task_dataset(
+        task_values=task_values, **tkwargs
+    )
     model = MultiTaskGP(
         train_X,
         train_Y,
@@ -177,9 +181,9 @@ def _gen_kronecker_model_and_data(model_kwargs=None, batch_shape=None, **tkwargs
 
 class TestMultiTaskGP(BotorchTestCase):
     def test_MultiTaskGP(self):
-        bounds = torch.tensor([[-1.0, 0.0], [1.0, 1.0]])
-        for dtype, use_intf, use_octf in itertools.product(
-            (torch.float, torch.double), (False, True), (False, True)
+        bounds = torch.tensor([[0.0, 0.0], [1.0, 1.0]])
+        for dtype, use_intf, use_octf, task_values in itertools.product(
+            (torch.float, torch.double), (False, True), (False, True), [None, [0, 2]]
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
             octf = Standardize(m=1) if use_octf else None
@@ -190,7 +194,10 @@ class TestMultiTaskGP(BotorchTestCase):
                 else None
             )
             model, datasets, (train_X, train_Y) = _gen_model_and_data(
-                input_transform=intf, outcome_transform=octf, **tkwargs
+                task_values=task_values,
+                input_transform=intf,
+                outcome_transform=octf,
+                **tkwargs,
             )
             self.assertIsInstance(model, MultiTaskGP)
             self.assertEqual(model.num_outputs, 2)
@@ -246,7 +253,7 @@ class TestMultiTaskGP(BotorchTestCase):
 
             # test posterior w/ bad output index
             with self.assertRaises(ValueError):
-                model.posterior(test_x, output_indices=[2])
+                model.posterior(test_x, output_indices=[3])
 
             # test posterior (batch eval)
             test_x = torch.rand(3, 2, 1, **tkwargs)
@@ -272,7 +279,15 @@ class TestMultiTaskGP(BotorchTestCase):
             # test invalid task feature in X.
             invalid_x = test_x.clone()
             invalid_x[0, 0, 0] = 3
-            with self.assertRaisesRegex(ValueError, "task features in `X`"):
+            if task_values is None:
+                msg = "task features in `X`"
+            else:
+                msg = (
+                    r"Received invalid raw task values. Expected raw value to be in"
+                    r" \{0, 2\}, but got unexpected task values:"
+                    r" \{3\}."
+                )
+            with self.assertRaisesRegex(ValueError, msg):
                 model.posterior(invalid_x)
 
             # test that unsupported batch shape MTGPs throw correct error
@@ -297,6 +312,32 @@ class TestMultiTaskGP(BotorchTestCase):
                 model.outcome_transform = tmp_tf
                 expected_var = tmp_tf.untransform_posterior(p_utf).variance
                 self.assertAllClose(posterior_f.variance, expected_var)
+
+            if task_values is not None:
+                test_x = torch.rand(2, 1, **tkwargs)
+                test_x_task = torch.zeros_like(test_x)
+                test_x_task[1, 0] = 2.0
+                test_x = torch.cat([test_x_task, test_x], dim=-1)
+                expected_task_mapper_non_nan = torch.tensor(
+                    [0.0, 1.0], dtype=dtype, device=self.device
+                )
+                self.assertTrue(
+                    torch.equal(
+                        model._task_mapper[[0, 2]], expected_task_mapper_non_nan
+                    )
+                )
+                self.assertTrue(torch.isnan(model._task_mapper[1]))
+
+                # test split inputs
+                _, task_idcs = model._split_inputs(test_x)
+                self.assertTrue(
+                    torch.equal(
+                        task_idcs,
+                        torch.tensor([[0.0], [1.0]], dtype=dtype, device=self.device),
+                    )
+                )
+            else:
+                self.assertIsNone(model._task_mapper)
 
     def test_MultiTaskGP_single_output(self):
         for dtype in (torch.float, torch.double):
@@ -836,3 +877,15 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
             self.assertIsInstance(posterior_f.distribution, MultitaskMultivariateNormal)
             self.assertEqual(posterior_f.mean.shape, torch.Size([3, 2, 2]))
             self.assertEqual(posterior_f.variance.shape, torch.Size([3, 2, 2]))
+
+
+class TestMultiTaskUtils(BotorchTestCase):
+    def test_get_task_value_remapping(self) -> None:
+        for dtype in (torch.float, torch.double):
+            task_values = torch.tensor([1, 3], dtype=torch.long, device=self.device)
+            expected_mapping_no_nan = torch.tensor(
+                [0.0, 1.0], dtype=dtype, device=self.device
+            )
+            mapping = get_task_value_remapping(task_values, dtype)
+            self.assertTrue(torch.equal(mapping[[1, 3]], expected_mapping_no_nan))
+            self.assertTrue(torch.isnan(mapping[[0, 2]]).all())


### PR DESCRIPTION
Summary: see title. This handles cases where the task values are e.g. {0,2}.

Reviewed By: saitcakmak

Differential Revision: D54121693


