### PR TITLE
unify ModelList and ModelListGP subset_output behavior

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -21,7 +21,11 @@ from typing import Any, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
 from botorch.acquisition.objective import PosteriorTransform
-from botorch.exceptions.errors import BotorchTensorDimensionError, InputDataError
+from botorch.exceptions.errors import (
+    BotorchTensorDimensionError,
+    InputDataError,
+    UnsupportedError,
+)
 from botorch.exceptions.warnings import (
     _get_single_precision_warning,
     BotorchTensorDimensionWarning,
@@ -828,3 +832,16 @@ class MultiTaskGPyTorchModel(GPyTorchModel, ABC):
         if posterior_transform is not None:
             return posterior_transform(posterior)
         return posterior
+
+    def subset_output(self, idcs: List[int]) -> MultiTaskGPyTorchModel:
+        r"""Returns a new model that only outputs a subset of the outputs.
+
+        Args:
+            idcs: A list of output indices, corresponding to the outputs to keep.
+
+        Returns:
+            A new model that only outputs the requested outputs.
+        """
+        raise UnsupportedError(
+            "Subsetting outputs is not supported by `MultiTaskGPyTorchModel`."
+        )

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from copy import deepcopy
 from typing import (
     Any,
     Callable,
@@ -576,10 +575,12 @@ class ModelList(Model):
         the model `m1` subset to its second output.
         """
         group_indices = self._get_group_subset_indices(idcs=idcs)
-        subset_models = [
-            deepcopy(self.models[grp_idx].subset_output(idcs=sub_idcs))
-            for grp_idx, sub_idcs in group_indices.items()
-        ]
+        subset_models = []
+        for grp_idx, sub_idcs in group_indices.items():
+            subset_model = self.models[grp_idx]
+            if sub_idcs is not None and subset_model.num_outputs != len(sub_idcs):
+                subset_model = subset_model.subset_output(idcs=sub_idcs)
+            subset_models.append(subset_model)
         if len(subset_models) == 1:
             return subset_models[0]
         return self.__class__(*subset_models)

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -10,7 +10,6 @@ Model List GP Regression models.
 
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import Any, List
 
 import torch
@@ -128,19 +127,6 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel, FantasizeMixin):
 
         kwargs_ = {**kwargs, "noise": noises} if noise is not None else kwargs
         return super().get_fantasy_model(inputs, targets, **kwargs_)
-
-    def subset_output(self, idcs: List[int]) -> ModelListGP:
-        r"""Subset the model along the submodel dimension.
-
-        Args:
-            idcs: The indices of submodels to subset the model to.
-
-        Returns:
-            The current model, subset to the specified submodels. If each model
-            is single-output, this will correspond to that subset of the
-            outputs.
-        """
-        return self.__class__(*[deepcopy(self.models[i]) for i in idcs])
 
     def _set_transformed_inputs(self) -> None:
         r"""Update training inputs with transformed inputs."""

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 import torch
 from botorch.acquisition.objective import ScalarizedPosteriorTransform
 from botorch.exceptions import OptimizationWarning
+from botorch.exceptions.errors import UnsupportedError
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.multitask import (
     FixedNoiseMultiTaskGP,
@@ -312,6 +313,9 @@ class TestMultiTaskGP(BotorchTestCase):
                 model.outcome_transform = tmp_tf
                 expected_var = tmp_tf.untransform_posterior(p_utf).variance
                 self.assertAllClose(posterior_f.variance, expected_var)
+            msg = "Subsetting outputs is not supported by `MultiTaskGPyTorchModel`."
+            with self.assertRaisesRegex(UnsupportedError, msg):
+                model.subset_output(idcs=[0])
 
             if task_values is not None:
                 test_x = torch.rand(2, 1, **tkwargs)


### PR DESCRIPTION
Summary:
`ModelList` and `ModelListGP` have different `subset_output` methods. This is bug prone and is bug in SEBO.

`ModelList.subset_output` considers that `Model`s in the list may themselves be multi-output, and considers that when splitting the input argument `idcs` across models in the list---idcs is used to index into outputs

`ModelListGP.subset_output` does not consider that sub models may be multi-output and instead applies `idcs` is used to index into models.

A significant issue here is that `MultitaskGP` has the number of outputs equal to the number of tasks. This causes issues for typical uses cases where all tasks refer to the same Ax outcome e.g. the real metric and a proxy of it. This is not an issue with the current use of `ModelListGP`, but it is with `Modellist`.

To fix this, this diff unifies the `subset_output` behavior for `ModelListGP` and `Modellist` and prepares the appropriate arguments in Ax.

Ax-side diff will follow.

Reviewed By: saitcakmak, Balandat

Differential Revision: D54203833


