### PR TITLE
flake8 config to ignore E701

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # E203: black and flake8 disagree on whitespace before ':'
 # W503: black and flake8 disagree on how to place operators
 # D: Don't run any docstring checks, except those specified in extend-select
-ignore = E203, W503, D
+ignore = E203, E701, W503, D
 # D107: Missing docstring in public method `__init__`
 # D417: Missing argument descriptions in the docstring
 # D3*: Quotes issues


### PR DESCRIPTION
Summary:
Triggered by black 2024 style on `test/acquisition/test_input_constructors.py`:

```
class Foo: ...
```

simpsons_bandaid

Differential Revision: D54459865


