### PR TITLE
Avoid writing a "|" file in `run_tutorials` when runnnig a tutorial

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -53,7 +53,7 @@ def run_script(
     if env is not None:
         env = {**os.environ, **env}
     run_out = subprocess.run(
-        ["papermill", tutorial, "|"],
+        ["papermill", tutorial],
         capture_output=True,
         text=True,
         env=env,


### PR DESCRIPTION
I don't think this is necessary, and it creates a "|" file upon running tutorials that's annoying to deal with in git.