### PR TITLE
Fix non-None constraint noise levels in some constrained test problems

### DIFF
--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -772,11 +772,7 @@ class SixHumpCamel(SyntheticTestFunction):
 
     def evaluate_true(self, X: Tensor) -> Tensor:
         x1, x2 = X[..., 0], X[..., 1]
-        return (
-            (4 - 2.1 * x1**2 + x1**4 / 3) * x1**2
-            + x1 * x2
-            + (4 * x2**2 - 4) * x2**2
-        )
+        return (4 - 2.1 * x1**2 + x1**4 / 3) * x1**2 + x1 * x2 + (4 * x2**2 - 4) * x2**2
 
 
 class StyblinskiTang(SyntheticTestFunction):

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -772,7 +772,11 @@ class SixHumpCamel(SyntheticTestFunction):
 
     def evaluate_true(self, X: Tensor) -> Tensor:
         x1, x2 = X[..., 0], X[..., 1]
-        return (4 - 2.1 * x1**2 + x1**4 / 3) * x1**2 + x1 * x2 + (4 * x2**2 - 4) * x2**2
+        return (
+            (4 - 2.1 * x1**2 + x1**4 / 3) * x1**2
+            + x1 * x2
+            + (4 * x2**2 - 4) * x2**2
+        )
 
 
 class StyblinskiTang(SyntheticTestFunction):
@@ -848,11 +852,11 @@ class ConstrainedSyntheticTestFunction(
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
         """
-        self.constraint_noise_std = self._validate_constraint_noise(
-            constraint_noise_std
-        )
         SyntheticTestFunction.__init__(
             self, noise_std=noise_std, negate=negate, bounds=bounds
+        )
+        self.constraint_noise_std = self._validate_constraint_noise(
+            constraint_noise_std
         )
 
     def _validate_constraint_noise(
@@ -939,9 +943,11 @@ class ConstrainedHartmann(Hartmann, ConstrainedSyntheticTestFunction):
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
         """
-        self._validate_constraint_noise(constraint_noise_std)
         Hartmann.__init__(
             self, dim=dim, noise_std=noise_std, negate=negate, bounds=bounds
+        )
+        self.constraint_noise_std = self._validate_constraint_noise(
+            constraint_noise_std
         )
 
     def evaluate_slack_true(self, X: Tensor) -> Tensor:
@@ -975,9 +981,11 @@ class ConstrainedHartmannSmooth(Hartmann, ConstrainedSyntheticTestFunction):
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
         """
-        self._validate_constraint_noise(constraint_noise_std)
         Hartmann.__init__(
             self, dim=dim, noise_std=noise_std, negate=negate, bounds=bounds
+        )
+        self.constraint_noise_std = self._validate_constraint_noise(
+            constraint_noise_std
         )
 
     def evaluate_slack_true(self, X: Tensor) -> Tensor:


### PR DESCRIPTION
This was inadvertently overridden / nnot properly set in some constructors.

We currently don't properly test that this attribute is correctly assigned upon instantiation. It's not straightforward to figure out how to easily do this in the current test setup; we can figure that out in a follow-up.
