### PR TITLE
Reap requires_grad_ctx

### DIFF
--- a/botorch/__init__.py
+++ b/botorch/__init__.py
@@ -16,11 +16,7 @@ from botorch import (
     test_functions,
 )
 from botorch.cross_validation import batch_cross_validation
-from botorch.fit import (
-    fit_fully_bayesian_model_nuts,
-    fit_gpytorch_mll,
-    fit_gpytorch_model,
-)
+from botorch.fit import fit_fully_bayesian_model_nuts, fit_gpytorch_mll
 from botorch.generation.gen import (
     gen_candidates_scipy,
     gen_candidates_torch,
@@ -58,7 +54,6 @@ __all__ = [
     "exceptions",
     "fit_fully_bayesian_model_nuts",
     "fit_gpytorch_mll",
-    "fit_gpytorch_model",
     "gen_candidates_scipy",
     "gen_candidates_torch",
     "get_best_candidates",

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -319,7 +319,7 @@ class SaasFullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel):
     with a Matern-5/2 kernel is used by default.
 
     You are expected to use `fit_fully_bayesian_model_nuts` to fit this model as it
-    isn't compatible with `fit_gpytorch_model`.
+    isn't compatible with `fit_gpytorch_mll`.
 
     Example:
         >>> saas_gp = SaasFullyBayesianSingleTaskGP(train_X, train_Y)

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -172,7 +172,7 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
     kernel by default.
 
     You are expected to use `fit_fully_bayesian_model_nuts` to fit this model as it
-    isn't compatible with `fit_gpytorch_model`.
+    isn't compatible with `fit_gpytorch_mll`.
 
     Example:
         >>> X1, X2 = torch.rand(10, 2), torch.rand(20, 2)

--- a/botorch/models/pairwise_gp.py
+++ b/botorch/models/pairwise_gp.py
@@ -66,17 +66,10 @@ def _check_strict_input(
             expected_attr = getattr(t_input, attr, None)
             found_attr = getattr(input_, attr, None)
             if expected_attr != found_attr:
-                msg = (
-                    "Cannot modify {attr} of {t_or_i} "
-                    "(expected {e_attr}, found {f_attr})."
+                raise RuntimeError(
+                    f"Cannot modify {attr} of {target_or_inputs} "
+                    f"(expected {expected_attr}, found {found_attr})."
                 )
-                msg = msg.format(
-                    attr=attr,
-                    e_attr=expected_attr,
-                    f_attr=found_attr,
-                    t_or_i=target_or_inputs,
-                )
-                raise RuntimeError(msg)
 
 
 def _scaled_psd_safe_cholesky(
@@ -836,7 +829,7 @@ class PairwiseGP(Model, GP, FantasizeMixin):
                 `comparisons` or `datapoints` is `None`, construct a prior-only
                 model.
             strict: `strict` argument as in gpytorch.models.exact_gp for compatibility
-                when using fit_gpytorch_model with input_transform.
+                when using fit_gpytorch_mll with input_transform.
             update_model: True if we want to refit the model (see _update) after
                 re-setting the data.
         """

--- a/botorch/utils/context_managers.py
+++ b/botorch/utils/context_managers.py
@@ -45,24 +45,6 @@ def delattr_ctx(
 
 
 @contextmanager
-def requires_grad_ctx(
-    module: Module, assignments: Dict[str, bool]
-) -> Generator[None, None, None]:
-    r"""Contextmanager for temporarily setting the requires_grad field of a module's
-    parameters."""
-    try:
-        cache = {}
-        for name, mode in assignments.items():
-            parameter = module.get_parameter(name)
-            cache[name] = parameter.requires_grad
-            parameter.requires_grad_(mode)
-        yield
-    finally:
-        for name, mode in cache.items():
-            module.get_parameter(name).requires_grad_(mode)
-
-
-@contextmanager
 def parameter_rollback_ctx(
     parameters: Dict[str, Tensor],
     checkpoint: Optional[Dict[str, TensorCheckpoint]] = None,

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -24,11 +24,7 @@ from botorch.optim.closures import get_loss_closure_with_grads
 from botorch.optim.fit import fit_gpytorch_mll_scipy, fit_gpytorch_mll_torch
 from botorch.optim.utils import get_data_loader
 from botorch.settings import debug
-from botorch.utils.context_managers import (
-    module_rollback_ctx,
-    requires_grad_ctx,
-    TensorCheckpoint,
-)
+from botorch.utils.context_managers import module_rollback_ctx, TensorCheckpoint
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.kernels import MaternKernel
 from gpytorch.mlls import ExactMarginalLogLikelihood, VariationalELBO
@@ -169,9 +165,7 @@ class TestFitFallback(BotorchTestCase):
         ]
         for should_fail in (True, False):
             optimizer.call_count = 0
-            with catch_warnings(), requires_grad_ctx(
-                module=mll, assignments={"model.mean_module.constant": False}
-            ), module_rollback_ctx(mll, checkpoint=ckpt):
+            with catch_warnings(), module_rollback_ctx(mll, checkpoint=ckpt):
                 try:
                     fit._fit_fallback(
                         mll,

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -15,6 +15,7 @@ import torch
 from botorch import fit
 from botorch.exceptions.errors import ModelFittingError, UnsupportedError
 from botorch.exceptions.warnings import OptimizationWarning
+from botorch.fit import fit_gpytorch_mll
 from botorch.models import SingleTaskGP, SingleTaskVariationalGP
 from botorch.models.transforms.input import Normalize
 from botorch.models.transforms.outcome import Standardize
@@ -88,7 +89,7 @@ class TestFitAPI(BotorchTestCase):
     def test_fit_gpytorch_mll(self):
         # Test that `optimizer` is only passed when non-None
         with patch.object(fit, "FitGPyTorchMLL") as mock_dispatcher:
-            fit.fit_gpytorch_mll(self.mll, optimizer=None)
+            fit_gpytorch_mll(self.mll, optimizer=None)
             mock_dispatcher.assert_called_once_with(
                 self.mll,
                 type(self.mll.likelihood),
@@ -98,7 +99,7 @@ class TestFitAPI(BotorchTestCase):
                 optimizer_kwargs=None,
             )
 
-            fit.fit_gpytorch_mll(self.mll, optimizer="foo")
+            fit_gpytorch_mll(self.mll, optimizer="foo")
             mock_dispatcher.assert_called_with(
                 self.mll,
                 type(self.mll.likelihood),
@@ -108,68 +109,6 @@ class TestFitAPI(BotorchTestCase):
                 optimizer="foo",
                 optimizer_kwargs=None,
             )
-
-    def test_fit_gyptorch_model(self):
-        r"""Test support for legacy API"""
-
-        # Test `option` argument
-        options = {"foo": 0}
-        with catch_warnings(), patch.object(
-            fit,
-            "fit_gpytorch_mll",
-            new=lambda mll, optimizer_kwargs=None, **kwargs: optimizer_kwargs,
-        ):
-            self.assertEqual(
-                {"options": options, "bar": 1},
-                fit.fit_gpytorch_model(
-                    self.mll,
-                    options=options,
-                    optimizer_kwargs={"bar": 1},
-                ),
-            )
-
-        # Test `max_retries` argument
-        with catch_warnings(), patch.object(
-            fit,
-            "fit_gpytorch_mll",
-            new=lambda mll, max_attempts=None, **kwargs: max_attempts,
-        ):
-            self.assertEqual(100, fit.fit_gpytorch_model(self.mll, max_retries=100))
-
-        # Test `exclude` argument
-        self.assertTrue(self.mll.model.mean_module.constant.requires_grad)
-        with catch_warnings(), patch.object(
-            fit,
-            "fit_gpytorch_mll",
-            new=lambda mll, **kwargs: mll.model.mean_module.constant.requires_grad,
-        ):
-            self.assertFalse(
-                fit.fit_gpytorch_model(
-                    self.mll,
-                    options=options,
-                    exclude=["model.mean_module.constant"],
-                )
-            )
-        self.assertTrue(self.mll.model.mean_module.constant.requires_grad)
-
-        # Test collisions
-        with catch_warnings(record=True) as ws, self.assertRaises(SyntaxError):
-            fit.fit_gpytorch_model(
-                self.mll,
-                options=options,
-                optimizer_kwargs={"options": {"bar": 1}},
-            )
-            self.assertTrue(any("marked for deprecation" in str(w.message) for w in ws))
-
-        # Test that ModelFittingErrors are rethrown as warnings
-        def mock_fit_gpytorch_mll(*args, **kwargs):
-            raise ModelFittingError("foo")
-
-        with catch_warnings(record=True) as ws, patch.object(
-            fit, "fit_gpytorch_mll", new=mock_fit_gpytorch_mll
-        ):
-            fit.fit_gpytorch_model(self.mll)
-        self.assertTrue(any("foo" in str(w.message) for w in ws))
 
 
 class TestFitFallback(BotorchTestCase):

--- a/test/utils/test_context_managers.py
+++ b/test/utils/test_context_managers.py
@@ -13,7 +13,6 @@ from botorch.utils.context_managers import (
     delattr_ctx,
     module_rollback_ctx,
     parameter_rollback_ctx,
-    requires_grad_ctx,
     TensorCheckpoint,
     zero_grad_ctx,
 )
@@ -46,18 +45,6 @@ class TestContextManagers(BotorchTestCase):
         with self.assertRaisesRegex(ValueError, "Attribute .* missing"):
             with delattr_ctx(self.module, "z", enforce_hasattr=True):
                 pass  # pragma: no cover
-
-    def test_requires_grad_ctx(self):
-        # Test temporary setting of requires_grad field
-        with requires_grad_ctx(self.module, assignments={"a": False, "b": True}):
-            self.assertTrue(not self.module.a.requires_grad)
-            self.assertTrue(self.module.b.requires_grad)
-            self.assertTrue(self.module.c.requires_grad)
-
-        # Test that requires_grad fields get restored
-        self.assertTrue(self.module.a.requires_grad)
-        self.assertTrue(not self.module.b.requires_grad)
-        self.assertTrue(self.module.c.requires_grad)
 
     def test_parameter_rollback_ctx(self):
         # Test that only unfiltered parameters get rolled back


### PR DESCRIPTION
Summary: This may be controversial, as `requires_grad_ctx` could be useful. However, it is no longer used outside tests after reaping `fit_gpytorch_mll`, and users will not make use of this unless we highlight it in tutorials or other worked examples.

Reviewed By: saitcakmak

Differential Revision: D55027020


