### PR TITLE
Reap base_samples argument of GPyTorchPosterior.rsample

### DIFF
--- a/botorch/posteriors/posterior_list.py
+++ b/botorch/posteriors/posterior_list.py
@@ -154,19 +154,13 @@ class PosteriorList(Posterior):
         """
         return self._reshape_and_cat(tensors=[p.variance for p in self.posteriors])
 
-    def rsample(
-        self,
-        sample_shape: Optional[torch.Size] = None,
-    ) -> Tensor:
+    def rsample(self, sample_shape: Optional[torch.Size] = None) -> Tensor:
         r"""Sample from the posterior (with gradients).
 
         Args:
             sample_shape: A `torch.Size` object specifying the sample shape. To
                 draw `n` samples, set to `torch.Size([n])`. To draw `b` batches
                 of `n` samples each, set to `torch.Size([b, n])`.
-            base_samples: An (optional) Tensor of `N(0, I)` base samples of
-                appropriate dimension, typically obtained from a `Sampler`.
-                This is used for deterministic optimization. Deprecated.
 
         Returns:
             Samples from the posterior, a tensor of shape

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -298,16 +298,11 @@ class MockPosterior(Posterior):
     def rsample(
         self,
         sample_shape: Optional[torch.Size] = None,
-        base_samples: Optional[Tensor] = None,
     ) -> Tensor:
         """Mock sample by repeating self._samples. If base_samples is provided,
         do a shape check but return the same mock samples."""
         if sample_shape is None:
             sample_shape = torch.Size()
-        if sample_shape is not None and base_samples is not None:
-            # check the base_samples shape is consistent with the sample_shape
-            if base_samples.shape[: len(sample_shape)] != sample_shape:
-                raise RuntimeError("sample_shape disagrees with base_samples.")
         return self._samples.expand(sample_shape + self._samples.shape)
 
     def rsample_from_base_samples(
@@ -315,7 +310,12 @@ class MockPosterior(Posterior):
         sample_shape: torch.Size,
         base_samples: Tensor,
     ) -> Tensor:
-        return self.rsample(sample_shape, base_samples)
+        if base_samples.shape[: len(sample_shape)] != sample_shape:
+            raise RuntimeError(
+                "`sample_shape` disagrees with shape of `base_samples`. "
+                f"Got {sample_shape=} and {base_samples.shape=}."
+            )
+        return self.rsample(sample_shape)
 
 
 @GetSampler.register(MockPosterior)

--- a/test/utils/test_testing.py
+++ b/test/utils/test_testing.py
@@ -8,9 +8,8 @@ import torch
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
 
 
-class TestMock(BotorchTestCase):
-    def test_MockPosterior(self):
-        # test basic logic
+class TestMockPosterior(BotorchTestCase):
+    def test_basic_logic(self) -> None:
         mp = MockPosterior()
         self.assertEqual(mp.device.type, "cpu")
         self.assertEqual(mp.dtype, torch.float32)
@@ -18,7 +17,8 @@ class TestMock(BotorchTestCase):
         self.assertEqual(
             MockPosterior(variance=torch.rand(2))._extended_shape(), torch.Size([2])
         )
-        # test passing in tensors
+
+    def test_passing_tensors(self) -> None:
         mean = torch.rand(2)
         variance = torch.eye(2)
         samples = torch.rand(1, 2)
@@ -31,10 +31,17 @@ class TestMock(BotorchTestCase):
         self.assertTrue(
             torch.all(mp.rsample(torch.Size([2])) == samples.repeat(2, 1, 1))
         )
-        with self.assertRaises(RuntimeError):
-            mp.rsample(sample_shape=torch.Size([2]), base_samples=torch.rand(3))
 
-    def test_MockModel(self):
+    def test_rsample_from_base_samples(self) -> None:
+        mp = MockPosterior()
+        with self.assertRaisesRegex(
+            RuntimeError, "`sample_shape` disagrees with shape of `base_samples`."
+        ):
+            mp.rsample_from_base_samples(torch.zeros(2, 2), torch.zeros(3))
+
+
+class TestMockModel(BotorchTestCase):
+    def test_basic(self) -> None:
         mp = MockPosterior()
         mm = MockModel(mp)
         X = torch.empty(0)


### PR DESCRIPTION
Summary:
The `base_samples` argument to GPyTorchPosterior.rsample was deprecated in BoTorch 8.0.0
- reaped the deprecated code
- removed the corresponding unit tests
- Removed `base_samples` argument from `MockPosterior.rsample` used for testing, since the base Posterior class also does not permit `base_samples` in `rsample`. Moved an exception in `MockPosterior` so that invalid `base_samples` will still be checked.
- stopped TRBO from using the deprecated code; reshaped samples to match legacy behavior
- fixed a docstring in PosteriorList

Differential Revision: D55038429


