### PR TITLE
Reap deprecated `mvn` argument to GPyTorchPosterior

### DIFF
--- a/botorch/posteriors/gpytorch.py
+++ b/botorch/posteriors/gpytorch.py
@@ -10,8 +10,6 @@ Posterior module to be used with GPyTorch models.
 
 from __future__ import annotations
 
-import warnings
-
 from contextlib import ExitStack
 from typing import Optional, Tuple, TYPE_CHECKING, Union
 
@@ -39,32 +37,13 @@ class GPyTorchPosterior(TorchPosterior):
 
     distribution: MultivariateNormal
 
-    def __init__(
-        self,
-        distribution: Optional[MultivariateNormal] = None,
-        mvn: Optional[MultivariateNormal] = None,
-    ) -> None:
+    def __init__(self, distribution: MultivariateNormal) -> None:
         r"""A posterior based on GPyTorch's multi-variate Normal distributions.
 
         Args:
             distribution: A GPyTorch MultivariateNormal (single-output case) or
                 MultitaskMultivariateNormal (multi-output case).
-            mvn: Deprecated.
         """
-        if mvn is not None:
-            if distribution is not None:
-                raise RuntimeError(
-                    "Got both a `distribution` and an `mvn` argument. "
-                    "Use the `distribution` only."
-                )
-            warnings.warn(
-                "The `mvn` argument of `GPyTorchPosterior`s has been renamed to "
-                "`distribution` and will be removed in a future version.",
-                DeprecationWarning,
-            )
-            distribution = mvn
-        if distribution is None:
-            raise RuntimeError("GPyTorchPosterior must have a distribution specified.")
         super().__init__(distribution=distribution)
         self._is_mt = isinstance(distribution, MultitaskMultivariateNormal)
 

--- a/botorch/posteriors/posterior_list.py
+++ b/botorch/posteriors/posterior_list.py
@@ -154,19 +154,13 @@ class PosteriorList(Posterior):
         """
         return self._reshape_and_cat(tensors=[p.variance for p in self.posteriors])
 
-    def rsample(
-        self,
-        sample_shape: Optional[torch.Size] = None,
-    ) -> Tensor:
+    def rsample(self, sample_shape: Optional[torch.Size] = None) -> Tensor:
         r"""Sample from the posterior (with gradients).
 
         Args:
             sample_shape: A `torch.Size` object specifying the sample shape. To
                 draw `n` samples, set to `torch.Size([n])`. To draw `b` batches
                 of `n` samples each, set to `torch.Size([b, n])`.
-            base_samples: An (optional) Tensor of `N(0, I)` base samples of
-                appropriate dimension, typically obtained from a `Sampler`.
-                This is used for deterministic optimization. Deprecated.
 
         Returns:
             Samples from the posterior, a tensor of shape

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -298,16 +298,11 @@ class MockPosterior(Posterior):
     def rsample(
         self,
         sample_shape: Optional[torch.Size] = None,
-        base_samples: Optional[Tensor] = None,
     ) -> Tensor:
         """Mock sample by repeating self._samples. If base_samples is provided,
         do a shape check but return the same mock samples."""
         if sample_shape is None:
             sample_shape = torch.Size()
-        if sample_shape is not None and base_samples is not None:
-            # check the base_samples shape is consistent with the sample_shape
-            if base_samples.shape[: len(sample_shape)] != sample_shape:
-                raise RuntimeError("sample_shape disagrees with base_samples.")
         return self._samples.expand(sample_shape + self._samples.shape)
 
     def rsample_from_base_samples(
@@ -315,7 +310,12 @@ class MockPosterior(Posterior):
         sample_shape: torch.Size,
         base_samples: Tensor,
     ) -> Tensor:
-        return self.rsample(sample_shape, base_samples)
+        if base_samples.shape[: len(sample_shape)] != sample_shape:
+            raise RuntimeError(
+                "`sample_shape` disagrees with shape of `base_samples`. "
+                f"Got {sample_shape=} and {base_samples.shape=}."
+            )
+        return self.rsample(sample_shape)
 
 
 @GetSampler.register(MockPosterior)

--- a/test/posteriors/test_gpytorch.py
+++ b/test/posteriors/test_gpytorch.py
@@ -12,7 +12,7 @@ from unittest import mock
 import torch
 from botorch.exceptions import BotorchTensorDimensionError
 from botorch.posteriors.gpytorch import GPyTorchPosterior, scalarize_posterior
-from botorch.utils.testing import _get_test_posterior, BotorchTestCase, MockPosterior
+from botorch.utils.testing import _get_test_posterior, BotorchTestCase
 from gpytorch import settings as gpt_settings
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
 from linear_operator.operators import to_linear_operator
@@ -25,18 +25,7 @@ ROOT_DECOMP_PATH = (
 
 
 class TestGPyTorchPosterior(BotorchTestCase):
-    def test_GPyTorchPosterior(self):
-        # Test init & mvn property.
-        mock_mvn = MockPosterior()
-        with self.assertWarnsRegex(DeprecationWarning, "The `mvn` argument of"):
-            posterior = GPyTorchPosterior(mvn=mock_mvn)
-        self.assertIs(posterior.mvn, mock_mvn)
-        self.assertIs(posterior.distribution, mock_mvn)
-        with self.assertRaisesRegex(RuntimeError, "Got both a `distribution`"):
-            GPyTorchPosterior(mvn=mock_mvn, distribution=mock_mvn)
-        with self.assertRaisesRegex(RuntimeError, "GPyTorchPosterior must have"):
-            GPyTorchPosterior()
-
+    def test_GPyTorchPosterior(self) -> None:
         for dtype in (torch.float, torch.double):
             n = 3
             mean = torch.rand(n, dtype=dtype, device=self.device)

--- a/test/utils/test_testing.py
+++ b/test/utils/test_testing.py
@@ -8,9 +8,8 @@ import torch
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
 
 
-class TestMock(BotorchTestCase):
-    def test_MockPosterior(self):
-        # test basic logic
+class TestMockPosterior(BotorchTestCase):
+    def test_basic_logic(self) -> None:
         mp = MockPosterior()
         self.assertEqual(mp.device.type, "cpu")
         self.assertEqual(mp.dtype, torch.float32)
@@ -18,7 +17,8 @@ class TestMock(BotorchTestCase):
         self.assertEqual(
             MockPosterior(variance=torch.rand(2))._extended_shape(), torch.Size([2])
         )
-        # test passing in tensors
+
+    def test_passing_tensors(self) -> None:
         mean = torch.rand(2)
         variance = torch.eye(2)
         samples = torch.rand(1, 2)
@@ -31,10 +31,17 @@ class TestMock(BotorchTestCase):
         self.assertTrue(
             torch.all(mp.rsample(torch.Size([2])) == samples.repeat(2, 1, 1))
         )
-        with self.assertRaises(RuntimeError):
-            mp.rsample(sample_shape=torch.Size([2]), base_samples=torch.rand(3))
 
-    def test_MockModel(self):
+    def test_rsample_from_base_samples(self) -> None:
+        mp = MockPosterior()
+        with self.assertRaisesRegex(
+            RuntimeError, "`sample_shape` disagrees with shape of `base_samples`."
+        ):
+            mp.rsample_from_base_samples(torch.zeros(2, 2), torch.zeros(3))
+
+
+class TestMockModel(BotorchTestCase):
+    def test_basic(self) -> None:
         mp = MockPosterior()
         mm = MockModel(mp)
         X = torch.empty(0)


### PR DESCRIPTION
Summary: All internal calls to this have been updated to use `distribution` instead, including in subclasses (`HigherOrderGPPosterior`, `GaussianMixturePosterior`, `MultiTaskGPPosterior`, `FullyBayesianPosterior`)

Differential Revision: D55092855


