### PR TITLE
ConstantKernel

### DIFF
--- a/botorch/models/kernels/__init__.py
+++ b/botorch/models/kernels/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from botorch.models.kernels.categorical import CategoricalKernel
+from botorch.models.kernels.constant import ConstantKernel
 from botorch.models.kernels.downsampling import DownsamplingKernel
 from botorch.models.kernels.exponential_decay import ExponentialDecayKernel
 from botorch.models.kernels.linear_truncated_fidelity import (
@@ -14,6 +15,7 @@ from botorch.models.kernels.linear_truncated_fidelity import (
 
 __all__ = [
     "CategoricalKernel",
+    "ConstantKernel",
     "DownsamplingKernel",
     "ExponentialDecayKernel",
     "LinearTruncatedFidelityKernel",

--- a/botorch/models/kernels/constant.py
+++ b/botorch/models/kernels/constant.py
@@ -1,0 +1,121 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Optional
+
+import torch
+
+from gpytorch.constraints import Interval, Positive
+from gpytorch.kernels.kernel import Kernel
+from gpytorch.priors import Prior
+
+
+class ConstantKernel(Kernel):
+    """
+    Constant covariance kernel for the probabilistic inference of constant coefficients.
+
+    ConstantKernel represents the prior variance `k(x1, x2) = var(c)` of a constant `c`.
+    The prior variance of the constant is optimized during the GP hyper-parameter
+    optimization stage. The actual value of the constant is computed (implicitly) using
+    the linear algebraic approaches for the computation of GP samples and posteriors.
+
+    The kernel (`k_constant`) is most useful as a modification of an arbitrary `k_base`:
+        1) Additive constants: The modification `k_base + k_constant` allows the GP to
+            infer a non-zero asymptotic value far from the training data, which
+            generally leads to more accurate extrapolation. Notably, the uncertainty in
+            this constant value affects the posterior covariances through the posterior
+            inference equations. This is not the case when a constant prior mean is
+            used, since the prior mean does not show up the posterior covariance.
+        2) Multiplicative constants: The modification `k_base * k_constant` allows the
+            GP to modulate the variance of the kernel `k_base`, and is mathematically
+            identical to `ScaleKernel(base_kernel)` with the same constant.
+    """
+
+    def __init__(
+        self,
+        batch_shape: Optional[torch.Size] = None,
+        constant_prior: Optional[Prior] = None,
+        constant_constraint: Optional[Interval] = None,
+    ):
+        """Constructor of ConstantKernel.
+
+        Args:
+            batch_shape: The batch shape of the kernel.
+            constant_prior: Prior over the constant parameter.
+            constant_constraint: Constraint to place on constant parameter.
+        """
+        super().__init__(batch_shape=batch_shape)
+
+        self.register_parameter(
+            name="raw_constant",
+            parameter=torch.nn.Parameter(torch.zeros(*self.batch_shape, 1)),
+        )
+
+        if constant_prior is not None:
+            if not isinstance(constant_prior, Prior):
+                raise TypeError(
+                    "Expected gpytorch.priors.Prior but got "
+                    + type(constant_prior).__name__
+                )
+            self.register_prior(
+                "constant_prior",
+                constant_prior,
+                lambda m: m.constant,
+                lambda m, v: m._set_constant(v),
+            )
+
+        if constant_constraint is None:
+            constant_constraint = Positive()
+        self.register_constraint("raw_constant", constant_constraint)
+
+    @property
+    def constant(self) -> torch.Tensor:
+        return self.raw_constant_constraint.transform(self.raw_constant)
+
+    @constant.setter
+    def constant(self, value: torch.Tensor) -> None:
+        self._set_constant(value)
+
+    def _set_constant(self, value: torch.Tensor) -> None:
+        value = value.view(*self.batch_shape, 1)
+        self.initialize(
+            raw_constant=self.raw_constant_constraint.inverse_transform(value)
+        )
+
+    def forward(
+        self,
+        x1: torch.Tensor,
+        x2: torch.Tensor,
+        diag: Optional[bool] = False,
+        last_dim_is_batch: Optional[bool] = False,
+    ) -> torch.Tensor:
+        """Evaluates the constant kernel.
+
+        Args:
+            x1: First input tensor of shape (batch_shape x n1 x d).
+            x2: Second input tensor of shape (batch_shape x n2 x d).
+            diag: If True, returns the diagonal of the covariance matrix.
+            last_dim_is_batch: If True, the last dimension of size `d` of the input
+                tensors are treated as a batch dimension.
+
+        Returns:
+            A (batch_shape x n1 x n2)-dim, resp. (batch_shape x n1)-dim, tensor of
+            constant covariance values if diag is False, resp. True.
+        """
+        if last_dim_is_batch:
+            x1 = x1.transpose(-1, -2).unsqueeze(-1)
+            x2 = x2.transpose(-1, -2).unsqueeze(-1)
+
+        dtype = torch.promote_types(x1.dtype, x2.dtype)
+        batch_shape = torch.broadcast_shapes(x1.shape[:-2], x2.shape[:-2])
+        shape = batch_shape + (x1.shape[-2],) + (() if diag else (x2.shape[-2],))
+        constant = self.constant.to(dtype=dtype, device=x1.device)
+        if not diag:
+            constant = constant.unsqueeze(-1)
+        if last_dim_is_batch:
+            constant = constant.unsqueeze(-1)
+
+        return torch.ones(shape, dtype=dtype, device=x1.device) * constant

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -126,6 +126,9 @@ Kernels
 .. automodule:: botorch.models.kernels.orthogonal_additive_kernel
 .. autoclass:: OrthogonalAdditiveKernel
 
+.. automodule:: botorch.models.kernels.constant
+.. autoclass:: ConstantKernel
+
 Likelihoods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.models.likelihoods.pairwise

--- a/test/models/kernels/test_constant.py
+++ b/test/models/kernels/test_constant.py
@@ -1,0 +1,108 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+
+import torch
+from botorch.models.kernels.constant import ConstantKernel
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.kernels import AdditiveKernel, MaternKernel, ProductKernel, ScaleKernel
+from gpytorch.lazy import LazyEvaluatedKernelTensor
+from gpytorch.priors.torch_priors import GammaPrior
+from torch import Tensor
+
+
+class TestConstantKernel(BotorchTestCase):
+    def test_kernel(self):
+        n, d = 3, 5
+        dtypes = [torch.float, torch.double]
+        batch_shapes = [(), (2,), (7, 2)]
+        for dtype, batch_shape in itertools.product(dtypes, batch_shapes):
+            tkwargs = {"dtype": dtype, "device": self.device}
+            places = 6 if dtype == torch.float else 12
+            X = torch.rand(*batch_shape, n, d, **tkwargs)
+
+            constant_kernel = ConstantKernel(batch_shape=batch_shape)
+            KL = constant_kernel(X)
+            self.assertIsInstance(KL, LazyEvaluatedKernelTensor)
+            KM = KL.to_dense()
+            self.assertIsInstance(KM, Tensor)
+            self.assertEqual(KM.shape, (*batch_shape, n, n))
+            self.assertEqual(KM.dtype, dtype)
+            self.assertEqual(KM.device.type, self.device.type)
+            # standard deviation is zero iff KM is constant
+            self.assertAlmostEqual(KM.std().item(), 0, places=places)
+
+            # testing last_dim_is_batch
+            with self.subTest(last_dim_is_batch=True):
+                KD = constant_kernel(X, last_dim_is_batch=True).to(device=self.device)
+                self.assertIsInstance(KD, LazyEvaluatedKernelTensor)
+                KM = KD.to_dense()
+                self.assertIsInstance(KM, Tensor)
+                self.assertEqual(KM.shape, (*batch_shape, d, n, n))
+                self.assertAlmostEqual(KM.std().item(), 0, places=places)
+                self.assertEqual(KM.dtype, dtype)
+                self.assertEqual(KM.device.type, self.device.type)
+
+            # testing diag
+            with self.subTest(diag=True):
+                KD = constant_kernel(X, diag=True)
+                self.assertIsInstance(KD, Tensor)
+                self.assertEqual(KD.shape, (*batch_shape, n))
+                self.assertAlmostEqual(KD.std().item(), 0, places=places)
+                self.assertEqual(KD.dtype, dtype)
+                self.assertEqual(KD.device.type, self.device.type)
+
+            # testing diag and last_dim_is_batch
+            with self.subTest(diag=True, last_dim_is_batch=True):
+                KD = constant_kernel(X, diag=True, last_dim_is_batch=True)
+                self.assertIsInstance(KD, Tensor)
+                self.assertEqual(KD.shape, (*batch_shape, d, n))
+                self.assertAlmostEqual(KD.std().item(), 0, places=places)
+                self.assertEqual(KD.dtype, dtype)
+                self.assertEqual(KD.device.type, self.device.type)
+
+            # testing AD
+            with self.subTest(requires_grad=True):
+                X.requires_grad = True
+                constant_kernel(X).to_dense().sum().backward()
+                self.assertIsNone(X.grad)  # constant kernel is not dependent on X
+
+            # testing algebraic combinations with another kernel
+            base_kernel = MaternKernel().to(device=self.device)
+
+            with self.subTest(additive=True):
+                sum_kernel = base_kernel + constant_kernel
+                self.assertIsInstance(sum_kernel, AdditiveKernel)
+                self.assertAllClose(
+                    sum_kernel(X).to_dense(),
+                    base_kernel(X).to_dense() + constant_kernel.constant.unsqueeze(-1),
+                )
+
+            # product with constant is equivalent to scale kernel
+            with self.subTest(product=True):
+                product_kernel = base_kernel * constant_kernel
+                self.assertIsInstance(product_kernel, ProductKernel)
+
+                scale_kernel = ScaleKernel(base_kernel, batch_shape=batch_shape)
+                scale_kernel.to(device=self.device)
+                self.assertAllClose(
+                    scale_kernel(X).to_dense(), product_kernel(X).to_dense()
+                )
+
+            # setting constant
+            pies = torch.full_like(constant_kernel.constant, torch.pi)
+            constant_kernel.constant = pies
+            self.assertAllClose(constant_kernel.constant, pies)
+
+            # specifying prior
+            constant_kernel = ConstantKernel(
+                constant_prior=GammaPrior(concentration=2.4, rate=2.7)
+            )
+
+            with self.assertRaisesRegex(
+                TypeError, "Expected gpytorch.priors.Prior but got"
+            ):
+                ConstantKernel(constant_prior=1)


### PR DESCRIPTION
Summary:
# `ConstantKernel` vs `ConstantMean`

**Summary**: `ConstantKernel` promises to more stably infer the constant that the default GP converges to as it moves away from the training data, than the current `ConstantMean` approach.

**By default**, GPyTorch, and BoTorch by extension currently uses a `ConstantMean` whose constant value is optimized during the optimization of the marginal likelihood.

**This notebook** compares the default approach with the approach of using a `ConstantKernel` instead, which represents the prior variance of an unknown constant value. In this case, the prior variance of the constant is optimized during the hyper-parameter optimization stage, but the actual value of the constant is computed afterward using the standard linear algebraic approach for the computation of Gaussian process posteriors. Therefore, the inference of the constant value is likely more stable with the kernel approach, in addition to including the uncertainty quantification of the constant. 

**Pros and Cons**: While the number of free parameters is the same for the `ConstantMean` and `ConstantKernel` approaches, the latter infers more information, more stably, That is the `ConstantKernel` approach infers the prior variance in our belief of the constant and the inference of the posterior mean is done in closed form through the standard linear algebraic approach. `ConstantMean` by constrast infers the value of the constant using numerical optimization, which can be fickle, at times giving rise to seemingly non-sensical constants outside of the range of the observed `Y` values.
A current limitation of `ConstantKernel` is that it allocates another intermediate Tensor for the constant kernel matrix, which is wasteful. A more efficient implementation would use a low-rank, or best, a lazily evaluated constant linear operator.

It is also notable that the `LinearKernel` currently does not support a constant offset (though the `PolynomialKernel` of degree 1 does), so the `ConstantKernel` can also be used to introduce the offset to linear GP models.

Differential Revision: D53666027


