### PR TITLE
Make cross-validation test less repetitive and add device and dtype checks

### DIFF
--- a/test/test_cross_validation.py
+++ b/test/test_cross_validation.py
@@ -16,10 +16,13 @@ from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikeliho
 
 
 class TestFitBatchCrossValidation(BotorchTestCase):
-    def test_single_task_batch_cv(self):
+    def test_single_task_batch_cv(self) -> None:
         n = 10
-        for batch_shape, m, dtype in itertools.product(
-            (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
+        for batch_shape, m, dtype, observe_noise in itertools.product(
+            (torch.Size(), torch.Size([2])),
+            (1, 2),
+            (torch.float, torch.double),
+            (False, True),
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
             train_X, train_Y = _get_random_data(
@@ -27,55 +30,69 @@ class TestFitBatchCrossValidation(BotorchTestCase):
             )
             if m == 1:
                 train_Y = train_Y.squeeze(-1)
-            train_Yvar = torch.full_like(train_Y, 0.01)
-            noiseless_cv_folds = gen_loo_cv_folds(train_X=train_X, train_Y=train_Y)
-            # check shapes
-            expected_shape_train_X = batch_shape + torch.Size(
-                [n, n - 1, train_X.shape[-1]]
-            )
-            expected_shape_test_X = batch_shape + torch.Size([n, 1, train_X.shape[-1]])
-            self.assertEqual(noiseless_cv_folds.train_X.shape, expected_shape_train_X)
-            self.assertEqual(noiseless_cv_folds.test_X.shape, expected_shape_test_X)
+            train_Yvar = torch.full_like(train_Y, 0.01) if observe_noise else None
 
-            expected_shape_train_Y = batch_shape + torch.Size([n, n - 1, m])
-            expected_shape_test_Y = batch_shape + torch.Size([n, 1, m])
-
-            self.assertEqual(noiseless_cv_folds.train_Y.shape, expected_shape_train_Y)
-            self.assertEqual(noiseless_cv_folds.test_Y.shape, expected_shape_test_Y)
-            self.assertIsNone(noiseless_cv_folds.train_Yvar)
-            self.assertIsNone(noiseless_cv_folds.test_Yvar)
-            # Test SingleTaskGP
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=OptimizationWarning)
-                cv_results = batch_cross_validation(
-                    model_cls=SingleTaskGP,
-                    mll_cls=ExactMarginalLogLikelihood,
-                    cv_folds=noiseless_cv_folds,
-                    fit_args={"optimizer_kwargs": {"options": {"maxiter": 1}}},
-                )
-            expected_shape = batch_shape + torch.Size([n, 1, m])
-            self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
-            self.assertEqual(cv_results.observed_Y.shape, expected_shape)
-
-            # Test with noise observations
-            noisy_cv_folds = gen_loo_cv_folds(
+            cv_folds = gen_loo_cv_folds(
                 train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar
             )
-            # check shapes
-            self.assertEqual(noisy_cv_folds.train_X.shape, expected_shape_train_X)
-            self.assertEqual(noisy_cv_folds.test_X.shape, expected_shape_test_X)
-            self.assertEqual(noisy_cv_folds.train_Y.shape, expected_shape_train_Y)
-            self.assertEqual(noisy_cv_folds.test_Y.shape, expected_shape_test_Y)
-            self.assertEqual(noisy_cv_folds.train_Yvar.shape, expected_shape_train_Y)
-            self.assertEqual(noisy_cv_folds.test_Yvar.shape, expected_shape_test_Y)
+            with self.subTest(
+                "gen_loo_cv_folds -- check shapes, device, and dtype",
+                batch_shape=batch_shape,
+                m=m,
+                dtype=dtype,
+                observe_noise=observe_noise,
+            ):
+                # check shapes
+                expected_shape_train_X = batch_shape + torch.Size(
+                    [n, n - 1, train_X.shape[-1]]
+                )
+                expected_shape_test_X = batch_shape + torch.Size(
+                    [n, 1, train_X.shape[-1]]
+                )
+                self.assertEqual(cv_folds.train_X.shape, expected_shape_train_X)
+                self.assertEqual(cv_folds.test_X.shape, expected_shape_test_X)
+
+                expected_shape_train_Y = batch_shape + torch.Size([n, n - 1, m])
+                expected_shape_test_Y = batch_shape + torch.Size([n, 1, m])
+
+                self.assertEqual(cv_folds.train_Y.shape, expected_shape_train_Y)
+                self.assertEqual(cv_folds.test_Y.shape, expected_shape_test_Y)
+                if observe_noise:
+                    self.assertEqual(cv_folds.train_Yvar.shape, expected_shape_train_Y)
+                    self.assertEqual(cv_folds.test_Yvar.shape, expected_shape_test_Y)
+                else:
+                    self.assertIsNone(cv_folds.train_Yvar)
+                    self.assertIsNone(cv_folds.test_Yvar)
+
+                # check device and dtype
+                self.assertEqual(cv_folds.train_X.device.type, self.device.type)
+                self.assertIs(cv_folds.train_X.dtype, dtype)
+
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=OptimizationWarning)
                 cv_results = batch_cross_validation(
                     model_cls=SingleTaskGP,
                     mll_cls=ExactMarginalLogLikelihood,
-                    cv_folds=noisy_cv_folds,
+                    cv_folds=cv_folds,
                     fit_args={"optimizer_kwargs": {"options": {"maxiter": 1}}},
                 )
-            self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
-            self.assertEqual(cv_results.observed_Y.shape, expected_shape)
-            self.assertEqual(cv_results.observed_Y.shape, expected_shape)
+            with self.subTest(
+                "batch_cross_validation",
+                batch_shape=batch_shape,
+                m=m,
+                dtype=dtype,
+                observe_noise=observe_noise,
+            ):
+                expected_shape = batch_shape + torch.Size([n, 1, m])
+                self.assertEqual(cv_results.posterior.mean.shape, expected_shape)
+                self.assertEqual(cv_results.observed_Y.shape, expected_shape)
+                if observe_noise:
+                    self.assertEqual(cv_results.observed_Yvar.shape, expected_shape)
+                else:
+                    self.assertIsNone(cv_results.observed_Yvar)
+
+                # check device and dtype
+                self.assertEqual(
+                    cv_results.posterior.mean.device.type, self.device.type
+                )
+                self.assertIs(cv_results.posterior.mean.dtype, dtype)


### PR DESCRIPTION
Summary:
- Deduplicated logic between the cases with and without noise observations
- Broke up into subtests
- Added checks for Yvar produced by cross-validation
- Added checks for device and dtype of results

Differential Revision: D55572962


