### PR TITLE
Support custom all_tasks for MTGPs

### DIFF
--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -45,6 +45,7 @@ class LCEMGP(MultiTaskGP):
         context_emb_feature: Optional[Tensor] = None,
         embs_dim_list: Optional[List[int]] = None,
         output_tasks: Optional[List[int]] = None,
+        all_tasks: Optional[List[int]] = None,
         input_transform: Optional[InputTransform] = None,
         outcome_transform: Optional[OutcomeTransform] = None,
     ) -> None:
@@ -67,7 +68,9 @@ class LCEMGP(MultiTaskGP):
                 for each categorical variable.
             output_tasks: A list of task indices for which to compute model
                 outputs for. If omitted, return outputs for all task indices.
-
+            all_tasks: By default, MTGPs infer the list of all tasks from the task
+                features in `train_X`. This is an experimental feature that enables
+                creation of MTGPs with tasks that don't appear in the training data.
         """
         super().__init__(
             train_X=train_X,
@@ -75,13 +78,18 @@ class LCEMGP(MultiTaskGP):
             task_feature=task_feature,
             train_Yvar=train_Yvar,
             output_tasks=output_tasks,
+            all_tasks=all_tasks,
             input_transform=input_transform,
             outcome_transform=outcome_transform,
         )
         self.device = train_X.device
         #  context indices
-        all_tasks = train_X[:, task_feature].unique()
-        self.all_tasks = all_tasks.to(dtype=torch.long).tolist()
+        if all_tasks is None:
+            all_tasks = train_X[:, task_feature].unique()
+            self.all_tasks = all_tasks.to(dtype=torch.long).tolist()
+        else:
+            self.all_tasks = all_tasks
+            all_tasks = torch.tensor(all_tasks, dtype=torch.long)
         self.all_tasks.sort()  # unique in python does automatic sort; add for safety
 
         if context_cat_feature is None:

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -149,6 +149,7 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
         task_covar_prior: Optional[Prior] = None,
         output_tasks: Optional[List[int]] = None,
         rank: Optional[int] = None,
+        all_tasks: Optional[List[int]] = None,
         input_transform: Optional[InputTransform] = None,
         outcome_transform: Optional[OutcomeTransform] = None,
     ) -> None:
@@ -176,6 +177,9 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
                 full rank (i.e. number of tasks) kernel.
             task_covar_prior : A Prior on the task covariance matrix. Must operate
                 on p.s.d. matrices. A common prior for this is the `LKJ` prior.
+            all_tasks: By default, MTGPs infer the list of all tasks from the task
+                features in `train_X`. This is an experimental feature that enables
+                creation of MTGPs with tasks that don't appear in the training data.
             input_transform: An input transform that is applied in the model's
                 forward pass.
             outcome_transform: An outcome transform that is applied to the
@@ -197,9 +201,12 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
                 X=train_X, input_transform=input_transform
             )
         self._validate_tensor_args(X=transformed_X, Y=train_Y, Yvar=train_Yvar)
-        all_tasks, task_feature, self.num_non_task_features = self.get_all_tasks(
-            transformed_X, task_feature, output_tasks
-        )
+        (
+            all_tasks_inferred,
+            task_feature,
+            self.num_non_task_features,
+        ) = self.get_all_tasks(transformed_X, task_feature, output_tasks)
+        all_tasks = all_tasks or all_tasks_inferred
         self.num_tasks = len(all_tasks)
         if outcome_transform is not None:
             train_Y, train_Yvar = outcome_transform(Y=train_Y, Yvar=train_Yvar)
@@ -360,13 +367,16 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
         base_inputs = super().construct_inputs(
             training_data=training_data, task_feature=task_feature, **kwargs
         )
-        return {
-            **base_inputs,
-            "task_feature": task_feature,
-            "output_tasks": output_tasks,
-            "task_covar_prior": task_covar_prior,
-            "rank": rank,
-        }
+        if isinstance(training_data, MultiTaskDataset):
+            all_tasks = list(range(len(training_data.datasets)))
+            base_inputs["all_tasks"] = all_tasks
+        if task_covar_prior is not None:
+            base_inputs["task_covar_prior"] = task_covar_prior
+        if rank is not None:
+            base_inputs["rank"] = rank
+        base_inputs["task_feature"] = task_feature
+        base_inputs["output_tasks"] = output_tasks
+        return base_inputs
 
 
 class FixedNoiseMultiTaskGP(MultiTaskGP):
@@ -428,6 +438,7 @@ class FixedNoiseMultiTaskGP(MultiTaskGP):
             "When `train_Yvar` is specified, `MultiTaskGP` behaves the same "
             "as the `FixedNoiseMultiTaskGP`.",
             DeprecationWarning,
+            stacklevel=2,
         )
         super().__init__(
             train_X=train_X,

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -583,7 +583,10 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
             )
             self.assertTrue(torch.equal(data_dict["train_X"], train_X))
             self.assertTrue(torch.equal(data_dict["train_Y"], train_Y))
-            self.assertAllClose(data_dict["train_Yvar"], train_Yvar)
+            if train_Yvar is not None:
+                self.assertAllClose(data_dict["train_Yvar"], train_Yvar)
+            else:
+                self.assertFalse("train_Yvar" in data_dict)
             self.assertEqual(data_dict["task_feature"], task_feature)
             self.assertEqual(data_dict["rank"], 1)
             self.assertTrue("task_covar_prior" not in data_dict)


### PR DESCRIPTION
Summary: This allows creation of MTGPs that support inference from tasks that don't appear in the training data. See https://github.com/pytorch/botorch/issues/2265 for some discussion on how the task covariance behaves in the absence of task specific data.

Differential Revision: D53029681


