### PR TITLE
Error out if scipy optimizer does not support bounds / constraints

### DIFF
--- a/botorch/generation/utils.py
+++ b/botorch/generation/utils.py
@@ -42,6 +42,7 @@ def _convert_nonlinear_inequality_constraints(
             "take a list of tuples. Passing a list of callables "
             "will result in an error in future versions.",
             DeprecationWarning,
+            stacklevel=3,
         )
 
     return nlcs

--- a/botorch/optim/utils/timeout.py
+++ b/botorch/optim/utils/timeout.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import time
+import warnings
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -77,6 +78,7 @@ def minimize_with_timeout(
         wrapped_callback = callback
 
     try:
+        warnings.filterwarnings("error", message="Method .* cannot handle")
         return optimize.minimize(
             fun=fun,
             x0=x0,

--- a/test/generation/test_gen.py
+++ b/test/generation/test_gen.py
@@ -350,6 +350,35 @@ class TestGenCandidates(TestBaseCandidateGeneration):
             options={"disp": False, "with_grad": False},
         )
 
+    def test_gen_candidates_scipy_invalid_method(self) -> None:
+        """Test with method that doesn't support constraint / bounds."""
+        self._setUp(double=True, expand=True)
+        acqf = qExpectedImprovement(self.model, best_f=self.f_best)
+        with self.assertRaisesRegex(
+            RuntimeWarning,
+            "Method L-BFGS-B cannot handle constraints",
+        ):
+            gen_candidates_scipy(
+                initial_conditions=self.initial_conditions,
+                acquisition_function=acqf,
+                options={"method": "L-BFGS-B"},
+                inequality_constraints=[
+                    (torch.tensor([0]), torch.tensor([1]), 0),
+                    (torch.tensor([1]), torch.tensor([-1]), -1),
+                ],
+            )
+        with self.assertRaisesRegex(
+            RuntimeWarning,
+            "Method Newton-CG cannot handle bounds",
+        ):
+            gen_candidates_scipy(
+                initial_conditions=self.initial_conditions,
+                acquisition_function=acqf,
+                options={"method": "Newton-CG"},
+                lower_bounds=0,
+                upper_bounds=1,
+            )
+
 
 class TestRandomRestartOptimization(TestBaseCandidateGeneration):
     def test_random_restart_optimization(self):


### PR DESCRIPTION
Summary:
Scipy ignores the bounds / constraints with a warning, if the given method does not support them. This can lead to significant bugs if the warning is filtered out somewhere.

Scipy behavior: https://github.com/scipy/scipy/blob/v1.13.0/scipy/optimize/_minimize.py#L577-L584

Differential Revision: D55724311


