### PR TITLE
make qNIPV not an `AnalyticAcquisitionFunction`; optimize_acqf support clarity

### DIFF
--- a/botorch/acquisition/active_learning.py
+++ b/botorch/acquisition/active_learning.py
@@ -27,7 +27,7 @@ from typing import Optional
 
 import torch
 from botorch import settings
-from botorch.acquisition.analytic import AnalyticAcquisitionFunction
+from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.monte_carlo import MCAcquisitionFunction
 from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform
 from botorch.models.model import Model
@@ -37,7 +37,7 @@ from botorch.utils.transforms import concatenate_pending_points, t_batch_mode_tr
 from torch import Tensor
 
 
-class qNegIntegratedPosteriorVariance(AnalyticAcquisitionFunction):
+class qNegIntegratedPosteriorVariance(AcquisitionFunction):
     r"""Batch Integrated Negative Posterior Variance for Active Learning.
 
     This acquisition function quantifies the (negative) integrated posterior variance
@@ -75,7 +75,8 @@ class qNegIntegratedPosteriorVariance(AnalyticAcquisitionFunction):
                 points that have been submitted for function evaluation but
                 have not yet been evaluated.
         """
-        super().__init__(model=model, posterior_transform=posterior_transform)
+        super().__init__(model=model)
+        self.posterior_transform = posterior_transform
         if sampler is None:
             # If no sampler is provided, we use the following dummy sampler for the
             # fantasize() method in forward. IMPORTANT: This assumes that the posterior

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -153,6 +153,7 @@ def _raise_deprecation_warning_if_kwargs(fn_name: str, kwargs: Dict[str, Any]) -
             f"`{fn_name}` does not support arguments {list(kwargs.keys())}. In "
             "the future, this will become an error.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
 
@@ -366,7 +367,7 @@ def _optimize_acqf_batch(opt_inputs: OptimizeAcqfInputs) -> Tuple[Tensor, Tensor
             f"warning(s):\n{[w.message for w in ws]}\nTrying again with a new "
             "set of initial conditions."
         )
-        warnings.warn(first_warn_msg, RuntimeWarning)
+        warnings.warn(first_warn_msg, RuntimeWarning, stacklevel=2)
 
         if not initial_conditions_provided:
             batch_initial_conditions = opt_inputs.get_ic_generator()(
@@ -392,6 +393,7 @@ def _optimize_acqf_batch(opt_inputs: OptimizeAcqfInputs) -> Tuple[Tensor, Tensor
                     "Optimization failed on the second try, after generating a "
                     "new set of initial conditions.",
                     RuntimeWarning,
+                    stacklevel=2,
                 )
 
     if opt_inputs.post_processing_func is not None:

--- a/test/acquisition/test_fixed_feature.py
+++ b/test/acquisition/test_fixed_feature.py
@@ -12,6 +12,7 @@ from botorch.acquisition.fixed_feature import (
     get_dtype_of_sequence,
 )
 from botorch.acquisition.monte_carlo import qExpectedImprovement
+from botorch.exceptions import UnsupportedError
 from botorch.models import SingleTaskGP
 from botorch.utils.testing import BotorchTestCase, MockAcquisitionFunction
 


### PR DESCRIPTION
Summary:
I put a `LogExpectedImprovement` instance into `optimize_acqf`, and when I got an error about it not having an attribute `X_pending`, I was not sure if this was a bug or if I did something known to be unsupported.

- Make `qNegIntegratedPosteriorVariance` inherit from `AcquisitionFunction` rather than `AnalyticAcquisitionFunction`, because the functionality it was inheriting from `AnalyticAcquisitionFunction` was not relevant.
- `qNegIntegratedPosteriorVariance` loses an error message about not supporting multi-output with a `PosteriorTransform` that is not scalarized and gains a unit test showing that it does.

Differential Revision: D55843171


