### PR TITLE
Pull out mixin for setting `X_pending` in acquisition functions

### DIFF
--- a/botorch/acquisition/active_learning.py
+++ b/botorch/acquisition/active_learning.py
@@ -27,7 +27,7 @@ from typing import Optional
 
 import torch
 from botorch import settings
-from botorch.acquisition.analytic import AnalyticAcquisitionFunction
+from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.monte_carlo import MCAcquisitionFunction
 from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform
 from botorch.models.model import Model
@@ -37,7 +37,7 @@ from botorch.utils.transforms import concatenate_pending_points, t_batch_mode_tr
 from torch import Tensor
 
 
-class qNegIntegratedPosteriorVariance(AnalyticAcquisitionFunction):
+class qNegIntegratedPosteriorVariance(AcquisitionFunction):
     r"""Batch Integrated Negative Posterior Variance for Active Learning.
 
     This acquisition function quantifies the (negative) integrated posterior variance
@@ -75,7 +75,8 @@ class qNegIntegratedPosteriorVariance(AnalyticAcquisitionFunction):
                 points that have been submitted for function evaluation but
                 have not yet been evaluated.
         """
-        super().__init__(model=model, posterior_transform=posterior_transform)
+        super().__init__(model=model)
+        self.posterior_transform = posterior_transform
         if sampler is None:
             # If no sampler is provided, we use the following dummy sampler for the
             # fantasize() method in forward. IMPORTANT: This assumes that the posterior

--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -81,11 +81,6 @@ class AnalyticAcquisitionFunction(AcquisitionFunction, ABC):
                 )
         self.posterior_transform = posterior_transform
 
-    def set_X_pending(self, X_pending: Optional[Tensor] = None) -> None:
-        raise UnsupportedError(
-            "Analytic acquisition functions do not account for X_pending yet."
-        )
-
     def _mean_and_sigma(
         self, X: Tensor, compute_sigma: bool = True, min_var: float = 1e-12
     ) -> Tuple[Tensor, Optional[Tensor]]:

--- a/botorch/acquisition/fixed_feature.py
+++ b/botorch/acquisition/fixed_feature.py
@@ -15,7 +15,7 @@ from numbers import Number
 from typing import List, Optional, Sequence, Union
 
 import torch
-from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.acquisition import AcquisitionFunction, XPendingMixin
 from torch import Tensor
 from torch.nn import Module
 
@@ -49,7 +49,7 @@ def get_device_of_sequence(values: Sequence[Union[Tensor, float]]) -> torch.dtyp
     return torch.device("cuda") if any_cuda else torch.device("cpu")
 
 
-class FixedFeatureAcquisitionFunction(AcquisitionFunction):
+class FixedFeatureAcquisitionFunction(AcquisitionFunction, XPendingMixin):
     """A wrapper around AcquisitionFunctions to fix a subset of features.
 
     Example:

--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -37,7 +37,11 @@ from typing import Any, Callable, Optional
 
 import numpy as np
 import torch
-from botorch.acquisition.acquisition import AcquisitionFunction, MCSamplerMixin
+from botorch.acquisition.acquisition import (
+    AcquisitionFunction,
+    MCSamplerMixin,
+    XPendingMixin,
+)
 from botorch.acquisition.cost_aware import CostAwareUtility, InverseCostWeightedUtility
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.exceptions.errors import UnsupportedError
@@ -57,7 +61,7 @@ from torch import Tensor
 CLAMP_LB = 1.0e-8
 
 
-class MaxValueBase(AcquisitionFunction, ABC):
+class MaxValueBase(AcquisitionFunction, XPendingMixin, ABC):
     r"""Abstract base class for acquisition functions based on Max-value Entropy Search.
 
     This class provides the basic building blocks for constructing max-value

--- a/botorch/acquisition/multi_objective/analytic.py
+++ b/botorch/acquisition/multi_objective/analytic.py
@@ -69,11 +69,6 @@ class MultiObjectiveAnalyticAcquisitionFunction(AcquisitionFunction):
         """
         pass  # pragma: no cover
 
-    def set_X_pending(self, X_pending: Optional[Tensor] = None) -> None:
-        raise UnsupportedError(
-            "Analytic acquisition functions do not account for X_pending yet."
-        )
-
 
 class ExpectedHypervolumeImprovement(MultiObjectiveAnalyticAcquisitionFunction):
     def __init__(

--- a/botorch/acquisition/multi_objective/predictive_entropy_search.py
+++ b/botorch/acquisition/multi_objective/predictive_entropy_search.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from typing import Any, Optional, Tuple
 
 import torch
-from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.acquisition import AcquisitionFunction, XPendingMixin
 from botorch.exceptions import InputDataError
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.model import Model
@@ -37,7 +37,7 @@ from torch import Tensor
 from torch.distributions import Normal
 
 
-class qMultiObjectivePredictiveEntropySearch(AcquisitionFunction):
+class qMultiObjectivePredictiveEntropySearch(AcquisitionFunction, XPendingMixin):
     r"""The acquisition function for Predictive Entropy Search. The code supports
     both single and multiple objectives as well as batching.
 

--- a/botorch/acquisition/penalized.py
+++ b/botorch/acquisition/penalized.py
@@ -14,8 +14,7 @@ import math
 from typing import Any, Callable, List, Optional
 
 import torch
-from botorch.acquisition.acquisition import AcquisitionFunction
-from botorch.acquisition.analytic import AnalyticAcquisitionFunction
+from botorch.acquisition.acquisition import AcquisitionFunction, XPendingMixin
 from botorch.acquisition.objective import GenericMCObjective
 from botorch.exceptions import UnsupportedError
 from torch import Tensor
@@ -237,7 +236,7 @@ class PenalizedAcquisitionFunction(AcquisitionFunction):
         return self.raw_acqf.X_pending
 
     def set_X_pending(self, X_pending: Optional[Tensor] = None) -> None:
-        if not isinstance(self.raw_acqf, AnalyticAcquisitionFunction):
+        if isinstance(self.raw_acqf, XPendingMixin):
             self.raw_acqf.set_X_pending(X_pending=X_pending)
         else:
             raise UnsupportedError(

--- a/botorch/acquisition/prior_guided.py
+++ b/botorch/acquisition/prior_guided.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.acquisition import AcquisitionFunction, XPendingMixin
 from botorch.acquisition.monte_carlo import SampleReducingMCAcquisitionFunction
 from botorch.utils.transforms import concatenate_pending_points, t_batch_mode_transform
 from torch import Tensor
@@ -27,7 +27,7 @@ from torch import Tensor
 from torch.nn import Module
 
 
-class PriorGuidedAcquisitionFunction(AcquisitionFunction):
+class PriorGuidedAcquisitionFunction(AcquisitionFunction, XPendingMixin):
     r"""Class for weighting acquisition functions by a prior distribution.
 
     Supports MC and batch acquisition functions via

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -153,6 +153,7 @@ def _raise_deprecation_warning_if_kwargs(fn_name: str, kwargs: Dict[str, Any]) -
             f"`{fn_name}` does not support arguments {list(kwargs.keys())}. In "
             "the future, this will become an error.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
 
@@ -366,7 +367,7 @@ def _optimize_acqf_batch(opt_inputs: OptimizeAcqfInputs) -> Tuple[Tensor, Tensor
             f"warning(s):\n{[w.message for w in ws]}\nTrying again with a new "
             "set of initial conditions."
         )
-        warnings.warn(first_warn_msg, RuntimeWarning)
+        warnings.warn(first_warn_msg, RuntimeWarning, stacklevel=2)
 
         if not initial_conditions_provided:
             batch_initial_conditions = opt_inputs.get_ic_generator()(
@@ -392,6 +393,7 @@ def _optimize_acqf_batch(opt_inputs: OptimizeAcqfInputs) -> Tuple[Tensor, Tensor
                     "Optimization failed on the second try, after generating a "
                     "new set of initial conditions.",
                     RuntimeWarning,
+                    stacklevel=2,
                 )
 
     if opt_inputs.post_processing_func is not None:

--- a/botorch_community/acquisition/bayesian_active_learning.py
+++ b/botorch_community/acquisition/bayesian_active_learning.py
@@ -36,7 +36,11 @@ from __future__ import annotations
 from typing import Optional
 
 import torch
-from botorch.acquisition.acquisition import AcquisitionFunction, MCSamplerMixin
+from botorch.acquisition.acquisition import (
+    AcquisitionFunction,
+    MCSamplerMixin,
+    XPendingMixin,
+)
 from botorch.models.fully_bayesian import MCMC_DIM, SaasFullyBayesianSingleTaskGP
 from botorch.models.model import Model
 from botorch.utils.transforms import concatenate_pending_points, t_batch_mode_transform
@@ -70,7 +74,7 @@ class FullyBayesianAcquisitionFunction(AcquisitionFunction):
             )
 
 
-class qBayesianVarianceReduction(FullyBayesianAcquisitionFunction):
+class qBayesianVarianceReduction(FullyBayesianAcquisitionFunction, XPendingMixin):
     def __init__(
         self,
         model: SaasFullyBayesianSingleTaskGP,
@@ -98,7 +102,7 @@ class qBayesianVarianceReduction(FullyBayesianAcquisitionFunction):
         return res.unsqueeze(-1)
 
 
-class qBayesianQueryByComittee(FullyBayesianAcquisitionFunction):
+class qBayesianQueryByComittee(FullyBayesianAcquisitionFunction, XPendingMixin):
     def __init__(
         self,
         model: SaasFullyBayesianSingleTaskGP,

--- a/test/acquisition/multi_objective/test_analytic.py
+++ b/test/acquisition/multi_objective/test_analytic.py
@@ -58,9 +58,6 @@ class TestMultiObjectiveAnalyticAcquisitionFunction(BotorchTestCase):
                 model=mm, posterior_transform=IdentityMCMultiOutputObjective()
             )
         acqf = DummyMultiObjectiveAnalyticAcquisitionFunction(model=mm)
-        # test set_X_pending
-        with self.assertRaises(UnsupportedError):
-            acqf.set_X_pending()
 
 
 class TestExpectedHypervolumeImprovement(BotorchTestCase):

--- a/test/acquisition/test_analytic.py
+++ b/test/acquisition/test_analytic.py
@@ -93,10 +93,6 @@ class TestExpectedImprovement(BotorchTestCase):
             ei_expected = torch.tensor(0.6978, device=self.device, dtype=dtype)
             self.assertAllClose(ei, ei_expected, atol=1e-4)
             self.assertAllClose(log_ei, ei_expected.log(), atol=1e-4)
-            with self.assertRaises(UnsupportedError):
-                module.set_X_pending(None)
-            with self.assertRaises(UnsupportedError):
-                log_module.set_X_pending(None)
             # test posterior transform (single-output)
             mean = torch.tensor([0.5], device=self.device, dtype=dtype)
             covar = torch.tensor([[0.16]], device=self.device, dtype=dtype)

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -8,7 +8,7 @@ from typing import List
 
 import torch
 from botorch.acquisition import LinearMCObjective, ScalarizedPosteriorTransform
-from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.acquisition import AcquisitionFunction, XPendingMixin
 from botorch.acquisition.analytic import ExpectedImprovement
 from botorch.acquisition.monte_carlo import qExpectedImprovement
 from botorch.acquisition.proximal import ProximalAcquisitionFunction
@@ -31,7 +31,7 @@ class DummyModel(GPyTorchModel):
         pass
 
 
-class DummyAcquisitionFunction(AcquisitionFunction):
+class DummyAcquisitionFunction(AcquisitionFunction, XPendingMixin):
     def forward(self, X):
         pass
 


### PR DESCRIPTION
Summary:
Formerly, all subclasses of `Acquisition` had a method `set_X_pending`, even if they did not support pending points. This confused me while writing tests for optimizing acquisition functions.
- Pulled out a mixin `XPendingMixin` so that classes only have the method `set_X_pending` where it is functional and appropriate
- Removed "UnsupportedError" overrides from classes that no longer have a `set_X_pending` method
- Clarified which classes are supported in `optimize_acqf` and similar functions; added more precise type hints.

Differential Revision: D55843962


