### PR TITLE
Remove correlation between the step size and the step direction (#2156)

### DIFF
--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -249,6 +249,7 @@ def sample_polytope(
     # pre-sample samples from hypersphere
     d = x0.size(0)
     # uniform samples from unit ball in d dims
+    # incrementing the seed by +1 to prevent correlation with the step size
     Rs = sample_hypersphere(
         d=d, n=n_tot, dtype=A.dtype, device=A.device, seed=seed + 1
     ).unsqueeze(-1)

--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -250,7 +250,7 @@ def sample_polytope(
     d = x0.size(0)
     # uniform samples from unit ball in d dims
     Rs = sample_hypersphere(
-        d=d, n=n_tot, dtype=A.dtype, device=A.device, seed=seed
+        d=d, n=n_tot, dtype=A.dtype, device=A.device, seed=seed + 1
     ).unsqueeze(-1)
 
     # compute matprods in batch

--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -249,7 +249,7 @@ def sample_polytope(
     # pre-sample samples from hypersphere
     d = x0.size(0)
     # uniform samples from unit ball in d dims
-    # incrementing the seed by +1 to prevent correlation with the step size
+    # increment seed by +1 to avoid correlation with step size, see #2156 for details
     Rs = sample_hypersphere(
         d=d, n=n_tot, dtype=A.dtype, device=A.device, seed=seed + 1
     ).unsqueeze(-1)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This is a quick fix of #2156. 

In the ```botorch.utils.sampling.sample_polytope()```, both the step size ```rands``` and direction ```Rs``` are currently sampled using the same seed value. This can lead to strong correlation and induce sampling bias, particularly with a small number of steps (e.g., ```n=1```), as illustrated in #2156. Adding ```+1``` to the seed value for ```Rs``` helps to avoid such behaviour.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Not sure if any unit tests needed for that change.