### PR TITLE
bump to minimum python version to 3.10 and test 3.12

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   host:
-    - python>=3.9
+    - python>=3.10
     - setuptools
     - setuptools_scm
   run:

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -15,10 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.9", "3.11"]
-        exclude:
-          - os: "macos-14"
-            python-version: "3.9"  # not available for macos-14
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -32,7 +29,7 @@ jobs:
       run: |
         pytest -ra --cov=. --cov-report term-missing
     - name: Upload coverage
-      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.9 }}
+      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.10 }}
       run: |
         bash <(curl -s https://codecov.io/bash)
 
@@ -79,7 +76,7 @@ jobs:
       with:
         miniconda-version: "latest"
         activate-environment: test
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - name: Install dependencies

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -46,7 +46,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         pip install .[test]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install dependencies
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         # pin dependencies to match Meta-internal versions
@@ -40,7 +40,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         pip install flake8 flake8-docstrings

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,10 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.9", "3.11"]
-        exclude:
-        - os: "macos-14"
-          python-version: "3.9"  # not available for macos-14
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -37,7 +34,7 @@ jobs:
       run: |
         pytest -ra --cov=. --cov-report term-missing
     - name: Upload coverage
-      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.9 }}
+      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.10 }}
       run: |
         bash <(curl -s https://codecov.io/bash)
 
@@ -53,7 +50,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install dependencies
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true
@@ -99,7 +96,7 @@ jobs:
       with:
         miniconda-version: "latest"
         activate-environment: test
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - name: Install dependencies

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -51,8 +51,7 @@ jobs:
       name: Install latest PyTorch & GPyTorch
       # Ax and cma are not compatible with numpy 2.0 yet
       run: |
-        pip install "numpy==2.0"
-        pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        pip install torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/linear_operator.git
         pip install git+https://github.com/cornellius-gp/gpytorch.git
     - if: ${{ inputs.use_stable_pytorch_gpytorch }}
@@ -63,7 +62,7 @@ jobs:
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
-        pip install "numpy<=2.0" "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}" torchvision
+        pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}" torchvision
     - name: Install BoTorch with tutorials dependencies
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -49,7 +49,9 @@ jobs:
       run: git fetch --prune --unshallow
     - if: ${{ !inputs.use_stable_pytorch_gpytorch }}
       name: Install latest PyTorch & GPyTorch
+      # Ax and cma are not compatible with numpy 2.0 yet
       run: |
+        pip install "numpy==1.26.4"
         pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/linear_operator.git
         pip install git+https://github.com/cornellius-gp/gpytorch.git
@@ -61,7 +63,7 @@ jobs:
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
-        pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}" torchvision
+        pip install "numpy<=1.26.4" "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}" torchvision
     - name: Install BoTorch with tutorials dependencies
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -49,7 +49,6 @@ jobs:
       run: git fetch --prune --unshallow
     - if: ${{ !inputs.use_stable_pytorch_gpytorch }}
       name: Install latest PyTorch & GPyTorch
-      # Ax and cma are not compatible with numpy 2.0 yet
       run: |
         pip install torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/linear_operator.git

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -51,7 +51,7 @@ jobs:
       name: Install latest PyTorch & GPyTorch
       # Ax and cma are not compatible with numpy 2.0 yet
       run: |
-        pip install "numpy==1.26.4"
+        pip install "numpy==2.0"
         pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         pip install git+https://github.com/cornellius-gp/linear_operator.git
         pip install git+https://github.com/cornellius-gp/gpytorch.git
@@ -63,7 +63,7 @@ jobs:
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
-        pip install "numpy<=1.26.4" "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}" torchvision
+        pip install "numpy<=2.0" "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}" torchvision
     - name: Install BoTorch with tutorials dependencies
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Fetch all history for all tags and branches
       # We need to do this so setuptools_scm knows how to set the BoTorch version.
       run: git fetch --prune --unshallow

--- a/.github/workflows/reusable_website.yml
+++ b/.github/workflows/reusable_website.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - if: ${{ !inputs.publish_versioned_website }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.9", "3.11"]
-        exclude:
-          - os: "macos-14"
-            python-version: "3.9"  # not available for macos-14
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -38,7 +35,7 @@ jobs:
       run: |
         pytest -ra --cov=. --cov-report term-missing
     - name: Upload coverage
-      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.9 }}
+      if: ${{ runner.os == 'Linux' && matrix.python-version == 3.10 }}
       run: |
         bash <(curl -s https://codecov.io/bash)
 
@@ -49,10 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.9", "3.11"]
-        exclude:
-        - os: "macos-14"
-          python-version: "3.9"  # not available for macos-14
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -12,10 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.9", "3.11"]
-        exclude:
-          - os: "macos-14"
-            python-version: "3.9"  # not available for macos-14
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -37,10 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.9", "3.11"]
-        exclude:
-          - os: "macos-14"
-            python-version: "3.9"  # not available for macos-14
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3
@@ -70,10 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14"]
-        python-version: ["3.9", "3.11"]
-        exclude:
-        - os: "macos-14"
-          python-version: "3.9"  # not available for macos-14
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ every `__init__` function contains an `Args:` block. We use the
 
 #### Type Hints
 
-BoTorch is fully typed using python 3.9+
+BoTorch is fully typed using python 3.10+
 [type hints](https://www.python.org/dev/peps/pep-0484/). We expect any
 contributions to also use proper type annotations. While we currently do not
 enforce full consistency of these in our continuous integration test, you should

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Optimization simply use Ax.
 ## Installation
 
 **Installation Requirements**
-- Python >= 3.9
+- Python >= 3.10
 - PyTorch >= 1.13.1
 - gpytorch == 1.11
 - linear_operator == 0.5.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 # Minimum required python version
 REQUIRED_MAJOR = 3
-REQUIRED_MINOR = 9
+REQUIRED_MINOR = 10
 
 # Requirements for testing, formatting, and tutorials
 TEST_REQUIRES = ["pytest", "pytest-cov"]
@@ -98,7 +98,7 @@ setup(
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     packages=find_packages(exclude=["test", "test.*"]),
     install_requires=install_requires,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.10",
+    python_requires=f">={REQUIRED_MAJOR}.{REQUIRED_MINOR}",
     packages=find_packages(exclude=["test", "test.*"]),
     install_requires=install_requires,
     extras_require={

--- a/test/acquisition/test_decoupled.py
+++ b/test/acquisition/test_decoupled.py
@@ -22,9 +22,7 @@ class DummyDecoupledAcquisitionFunction(DecoupledAcquisitionFunction):
 
 class TestDecoupledAcquisitionFunction(BotorchTestCase):
     def test_decoupled_acquisition_function(self):
-        msg = (
-            "Can't instantiate abstract class DecoupledAcquisitionFunction"
-        )
+        msg = "Can't instantiate abstract class DecoupledAcquisitionFunction"
         with self.assertRaisesRegex(TypeError, msg):
             DecoupledAcquisitionFunction()
         # test raises error if model is not ModelList

--- a/test/acquisition/test_decoupled.py
+++ b/test/acquisition/test_decoupled.py
@@ -24,7 +24,6 @@ class TestDecoupledAcquisitionFunction(BotorchTestCase):
     def test_decoupled_acquisition_function(self):
         msg = (
             "Can't instantiate abstract class DecoupledAcquisitionFunction"
-            " with abstract method forward"
         )
         with self.assertRaisesRegex(TypeError, msg):
             DecoupledAcquisitionFunction()


### PR DESCRIPTION
## Motivation
Bump minimum version of python from 3.9 -> 3.10 and start testing 3.12, since scientific python is no longer supporting py3.9: https://scientific-python.org/specs/spec-0000/

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

Circle CI, running manual nightly job: https://github.com/sdaulton/botorch/actions/runs/8638469226