### PR TITLE
Fix Python version in workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install dependencies
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true

--- a/.github/workflows/reusable_website.yml
+++ b/.github/workflows/reusable_website.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - if: ${{ !inputs.publish_versioned_website }}


### PR DESCRIPTION
When 3.10 is not enclosed in quotes, the workflow fails after trying to install python 3.1. See: https://github.com/pytorch/botorch/actions/runs/8660750040/job/23749260305?fbclid=IwAR3w-htfo2N4O3FIvn59LTL-ha_kdzn06bEL5xVJYxY1iMty7XOrzydSlzQ

Test plan:
Nightly cron: https://github.com/pytorch/botorch/actions/runs/8665243516