### PR TITLE
Reduce runtime of BOPE tutorial in smoke test mode

### DIFF
--- a/tutorials/bope.ipynb
+++ b/tutorials/bope.ipynb
@@ -443,7 +443,7 @@
         "# Number of pairwise comparisons performed before checking posterior mean\n",
         "every_n_comps = 3\n",
         "# Total number of checking the maximum posterior mean\n",
-        "n_check_post_mean = 5\n",
+        "n_check_post_mean = 1 if SMOKE_TEST else 5\n",
         "n_outcome_model_initialization_points = 8\n",
         "within_session_results = []\n",
         "exp_candidate_results = []\n",


### PR DESCRIPTION
Summary: Reduces runtime of the only slow cell from 32s to 7s on my machine.

Reviewed By: saitcakmak

Differential Revision: D56253258


