### PR TITLE
Speed up multi-objective BO tutorial in smoke test mode by reducing number of iterations

### DIFF
--- a/tutorials/multi_objective_bo.ipynb
+++ b/tutorials/multi_objective_bo.ipynb
@@ -431,7 +431,7 @@
         "warnings.filterwarnings(\"ignore\", category=BadInitialCandidatesWarning)\n",
         "warnings.filterwarnings(\"ignore\", category=RuntimeWarning)\n",
         "\n",
-        "N_BATCH = 20 if not SMOKE_TEST else 10\n",
+        "N_BATCH = 20 if not SMOKE_TEST else 5\n",
         "MC_SAMPLES = 128 if not SMOKE_TEST else 16\n",
         "\n",
         "verbose = True\n",


### PR DESCRIPTION
Summary: This reduces the runtime of the slowest cell from 23s to 10s on my machine.

Differential Revision: D56262442


