### PR TITLE
User InputDataWarning for dtype warnings

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -29,6 +29,7 @@ from botorch.exceptions.errors import (
 from botorch.exceptions.warnings import (
     _get_single_precision_warning,
     BotorchTensorDimensionWarning,
+    InputDataWarning,
 )
 from botorch.models.model import Model, ModelList
 from botorch.models.utils import (
@@ -126,9 +127,10 @@ class GPyTorchModel(Model, ABC):
                 f"{Yvar.dtype if Yvar is not None else None} for Yvar."
             )
         if X.dtype != torch.float64:
-            # NOTE: Not using a BotorchWarning since those get ignored.
             warnings.warn(
-                _get_single_precision_warning(str(X.dtype)), UserWarning, stacklevel=2
+                _get_single_precision_warning(str(X.dtype)),
+                InputDataWarning,
+                stacklevel=3,  # Warn at model constructor call.
             )
 
     @property

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -16,6 +16,7 @@ from botorch.exceptions import (
     BotorchTensorDimensionWarning,
 )
 from botorch.exceptions.errors import DeprecationError, InputDataError
+from botorch.exceptions.warnings import InputDataWarning
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.gpytorch import (
     BatchedMultiOutputGPyTorchModel,
@@ -306,7 +307,7 @@ class TestGPyTorchModel(BotorchTestCase):
         self.assertTrue(torch.equal(post.mean, torch.zeros(3, 1, **tkwargs)))
 
     def test_float_warning_and_dtype_error(self):
-        with self.assertWarnsRegex(UserWarning, "double precision"):
+        with self.assertWarnsRegex(InputDataWarning, "double precision"):
             SimpleGPyTorchModel(torch.rand(5, 1), torch.randn(5, 1))
         with self.assertRaisesRegex(InputDataError, "same dtype"):
             SimpleGPyTorchModel(torch.rand(5, 1), torch.randn(5, 1, dtype=torch.double))


### PR DESCRIPTION
Summary:
This was previously using `UserWarning` since `BoTorchWarning` were being ignored when `settings.debug` was off. This has since been updated and `BoTorchWarning`s are not ignored by default. All other use cases for this warning already use `InputDataWarning`.

Related to https://github.com/facebook/Ax/pull/2389

Differential Revision: D56443417


