### PR TITLE
Use codecov github action for uploading coverage

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -30,8 +30,10 @@ jobs:
         pytest -ra --cov=. --cov-report term-missing
     - name: Upload coverage
       if: ${{ runner.os == 'Linux' && matrix.python-version == 3.10 }}
-      run: |
-        bash <(curl -s https://codecov.io/bash)
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   package-deploy-pypi:
     name: Package and deploy to pypi.org

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,8 +35,10 @@ jobs:
         pytest -ra --cov=. --cov-report term-missing
     - name: Upload coverage
       if: ${{ runner.os == 'Linux' && matrix.python-version == 3.10 }}
-      run: |
-        bash <(curl -s https://codecov.io/bash)
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   package-test-deploy-pypi:
     name: Package and test deployment to test.pypi.org

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,10 @@ jobs:
         pytest -ra --cov=. --cov-report term-missing
     - name: Upload coverage
       if: ${{ runner.os == 'Linux' && matrix.python-version == 3.10 }}
-      run: |
-        bash <(curl -s https://codecov.io/bash)
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   tests-conda:
     name: Tests (conda, ${{ matrix.os }})


### PR DESCRIPTION
Codecov bash uploader is marked for deprecation: https://docs.codecov.com/docs/about-the-codecov-bash-uploader
Switching the CI to use the codecov github action with the newly added upload token: https://github.com/marketplace/actions/codecov

Test Plan: 
Successfully uploaded https://app.codecov.io/github/pytorch/botorch/commit/6155e7425ad5327b2d9a13a156bb65ecc0c199f3
from https://github.com/pytorch/botorch/actions/runs/8882788744/job/24388210462