### PR TITLE
Replace usage of deprecated FixedNoiseGP with SingleTaskGP

### DIFF
--- a/test/acquisition/test_logei.py
+++ b/test/acquisition/test_logei.py
@@ -44,7 +44,6 @@ from botorch.acquisition.utils import prune_inferior_points
 from botorch.exceptions import BotorchWarning, UnsupportedError
 from botorch.exceptions.errors import BotorchError
 from botorch.models import ModelListGP, SingleTaskGP
-from botorch.models.gp_regression import FixedNoiseGP
 from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.low_rank import sample_cached_cholesky
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
@@ -738,7 +737,7 @@ class TestIsLog(BotorchTestCase):
 
         # single objective case
         X, Y = torch.rand(3, 2), torch.randn(3, 1)
-        model = FixedNoiseGP(train_X=X, train_Y=Y, train_Yvar=torch.rand_like(Y))
+        model = SingleTaskGP(train_X=X, train_Y=Y, train_Yvar=torch.rand_like(Y))
 
         # (q)LogEI
         for acqf_class in [LogExpectedImprovement, qLogExpectedImprovement]:

--- a/test_community/models/test_gp_regression_multisource.py
+++ b/test_community/models/test_gp_regression_multisource.py
@@ -12,7 +12,7 @@ import torch
 
 from botorch import fit_gpytorch_mll
 from botorch.exceptions import InputDataError, OptimizationWarning
-from botorch.models import FixedNoiseGP, SingleTaskGP
+from botorch.models import SingleTaskGP
 from botorch.models.transforms import Normalize, Standardize
 from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling import SobolQMCNormalSampler
@@ -238,14 +238,14 @@ class TestAugmentedSingleTaskGP(BotorchTestCase):
             )
             c_kwargs = (
                 {"noise": torch.full_like(Y_fant, 0.01)}
-                if isinstance(model, FixedNoiseGP)
+                if isinstance(model.likelihood, FixedNoiseGaussianLikelihood)
                 else {}
             )
             cm = model.condition_on_observations(X_fant, Y_fant, **c_kwargs)
             # fantasize at same input points (check proper broadcasting)
             c_kwargs_same_inputs = (
                 {"noise": torch.full_like(Y_fant[0], 0.01)}
-                if isinstance(model, FixedNoiseGP)
+                if isinstance(model.likelihood, FixedNoiseGaussianLikelihood)
                 else {}
             )
             cm_same_inputs = model.condition_on_observations(


### PR DESCRIPTION
Summary: Cleans up usage of fixed noise models. The only remaining usage is in the Ax storage for backwards compatibility and in the corresponding test files for the deprecated classes.

Differential Revision: D56794557
