### PR TITLE
Remove deprecated Posterior.event_shape

### DIFF
--- a/botorch/posteriors/posterior.py
+++ b/botorch/posteriors/posterior.py
@@ -10,8 +10,6 @@ Abstract base module for all botorch posteriors.
 
 from __future__ import annotations
 
-import warnings
-
 from abc import ABC, abstractmethod, abstractproperty
 from typing import Optional, Tuple
 
@@ -83,17 +81,6 @@ class Posterior(ABC):
         """
         with torch.no_grad():
             return self.rsample(sample_shape=sample_shape)
-
-    @property
-    def event_shape(self) -> torch.Size:
-        r"""The event shape (i.e. the shape of a single sample)."""
-        warnings.warn(
-            "The `event_shape` attribute of `Posterior` is deprecated. It will default "
-            "to the `event_shape` of the underlying distribution in a future version. "
-            "Use `_extended_shape` instead.",
-            DeprecationWarning,
-        )
-        return self._extended_shape()
 
     @abstractproperty
     def device(self) -> torch.device:

--- a/test/posteriors/test_posterior.py
+++ b/test/posteriors/test_posterior.py
@@ -72,10 +72,6 @@ class TestPosteriorList(BotorchTestCase):
             p_1 = make_posterior(shape, dtype)
             p_2 = make_posterior(shape, dtype)
             p = PosteriorList(p_1, p_2)
-            with self.assertWarnsRegex(
-                DeprecationWarning, "The `event_shape` attribute"
-            ):
-                self.assertEqual(p.event_shape, p._extended_shape())
             with self.assertRaisesRegex(NotImplementedError, "base_sample_shape"):
                 p.base_sample_shape
             self.assertEqual(p._extended_shape(), shape + torch.Size([2]))


### PR DESCRIPTION
Summary: Deprecated since https://github.com/pytorch/botorch/pull/1486

Differential Revision: D56799082
