### PR TITLE
[GHA] Use 8-core-ubuntu for conda build

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -19,8 +19,6 @@ jobs:
     name: Package and deploy to pypi.org
     runs-on: ubuntu-latest
     needs: tests-and-coverage-pip
-    strategy:
-      fail-fast: true
     steps:
     - uses: actions/checkout@v4
     - name: Fetch all history for all tags and branches
@@ -48,10 +46,8 @@ jobs:
 
   package-deploy-conda:
     name: Package conda and deploy to anaconda.org
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     needs: tests-and-coverage-pip
-    strategy:
-      fail-fast: true
     steps:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -46,7 +46,7 @@ jobs:
 
   package-deploy-conda:
     name: Package conda and deploy to anaconda.org
-    runs-on: 4-core-ubuntu
+    runs-on: 8-core-ubuntu
     needs: tests-and-coverage-pip
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
 
   package-conda:
     name: Test conda build
-    runs-on: 4-core-ubuntu
+    runs-on: 8-core-ubuntu
     steps:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,8 +18,6 @@ jobs:
   package-test-deploy-pypi:
     name: Package and test deployment to test.pypi.org
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
     - uses: actions/checkout@v4
     - name: Fetch all history for all tags and branches
@@ -64,9 +62,7 @@ jobs:
 
   package-conda:
     name: Test conda build
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
+    runs-on: 4-core-ubuntu
     steps:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3


### PR DESCRIPTION
Conda build step has been hanging & getting cancelled without explanation recently. The best explanation I could get so far was:
```
The hosted runner: GitHub Actions 338 lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.
```
Assigning it a larger runner to see if it helps -- I believe the default is ~~2 core 7GB ram~~ 4 core & 16GB ram. The workflow is naturally slow, so worst case this would help with that. 

Update: I did not observe any noticeable improvement in the runtime after switching to 8 core workers, though I also did not observe the same error ~~(on 1 attempt so far)~~.

On 8 core -- success: https://github.com/pytorch/botorch/actions/runs/8916050507/job/24486781464
On 4 core (4-core-ubuntu) -- failed with a different error than usual: https://github.com/pytorch/botorch/actions/runs/8915839684/job/24486173601
On default (also 4 core) -- observed a mixture of failures (with `Error: The operation was canceled.`) and successes. This workflow fails at 1st attempt and passes on 2nd attempt:  https://github.com/pytorch/botorch/actions/runs/8908325162/job/24463737848

Two more attempts with 8 core -- both successful: 
- https://github.com/pytorch/botorch/actions/runs/8916396425/job/24487705712
- https://github.com/pytorch/botorch/actions/runs/8916397253/job/24487708888