### PR TITLE
Use trusted publisher for PyPI uploads

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,8 +56,6 @@ jobs:
     - name: Deploy to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
         skip_existing: true
         verbose: true


### PR DESCRIPTION
[Upgrade to Trusted Publishing](https://github.com/pytorch/botorch/actions/runs/8914483363/job/24484640242#step:9:20)
Trusted Publishers allows publishing packages to PyPI from automated environments like GitHub Actions without needing to use username/password combinations or API tokens to authenticate with PyPI. Read more: https://docs.pypi.org/trusted-publishers

I set-up the trusted publishers for deploy & nightly workflows on pypi & test-pypi. These will generate temporary tokens for upload originating from these workflows and avoid the need for tokens.