### PR TITLE
Clarify is_non_dominated behavior with NaN

### DIFF
--- a/botorch/utils/multi_objective/pareto.py
+++ b/botorch/utils/multi_objective/pareto.py
@@ -30,6 +30,8 @@ def is_non_dominated(
 
     Args:
         Y: A `(batch_shape) x n x m`-dim tensor of outcomes.
+            If any element of `Y` is NaN, the corresponding point
+            will be treated as a dominated point (returning False).
         maximize: If True, assume maximization (default).
         deduplicate: A boolean indicating whether to only return
             unique points on the pareto frontier.

--- a/test/utils/multi_objective/test_pareto.py
+++ b/test/utils/multi_objective/test_pareto.py
@@ -158,6 +158,13 @@ class TestPareto(BotorchTestCase):
                 cargs = mock_is_non_dominated_loop.call_args[0]
                 self.assertTrue(torch.equal(cargs[0], y))
 
+    def test_is_non_dominated_with_nan(self) -> None:
+        # NaN should always evaluate to False.
+        Y = torch.rand(10, 2)
+        Y[3, 1] = float("nan")
+        Y[7, 0] = float("nan")
+        self.assertFalse(is_non_dominated(Y)[[3, 7]].any())
+
     def test_is_non_dominated_loop(self):
         n = 20
         tkwargs = {"device": self.device}


### PR DESCRIPTION
Summary: Since `<=` & `>=` always evaluate to False with NaN elements of tensors, this counts NaNs as dominated point, which is the desired behavior.

Differential Revision: D56945207


