### PR TITLE
More removal of unused ** arguments

### DIFF
--- a/botorch/acquisition/multi_objective/predictive_entropy_search.py
+++ b/botorch/acquisition/multi_objective/predictive_entropy_search.py
@@ -891,7 +891,7 @@ def _safe_update_omega(
         check_no_nans(omega_f_nat_cov_new)
         return omega_f_nat_mean_new, omega_f_nat_cov_new
 
-    except RuntimeError or InputDataError:
+    except (RuntimeError, InputDataError):
         return omega_f_nat_mean, omega_f_nat_cov
 
 
@@ -1070,7 +1070,7 @@ def _update_damping_when_converged(
     damping_factor: Tensor,
     iteration: Tensor,
     threshold: float = 1e-3,
-) -> Tensor:
+) -> Tuple[Tensor, Tensor, Tensor]:
     r"""Set the damping factor to 0 once converged. Convergence is determined by the
     relative change in the entries of the mean and covariance matrix.
 
@@ -1087,8 +1087,10 @@ def _update_damping_when_converged(
         damping_factor: A `batch_shape`-dim Tensor containing the damping factor.
 
     Returns:
-        A `batch_shape x param_shape`-dim Tensor containing the updated damping
+        - A `batch_shape x param_shape`-dim Tensor containing the updated damping
         factor.
+        - Difference between `mean_new` and `mean_old`
+        - Difference between `cov_new` and `cov_old`
     """
     df = damping_factor.clone()
     delta_mean = mean_new - mean_old

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -133,7 +133,8 @@ class PyroModel:
 
     @abstractmethod
     def postprocess_mcmc_samples(
-        self, mcmc_samples: Dict[str, Tensor], **kwargs: Any
+        self,
+        mcmc_samples: Dict[str, Tensor],
     ) -> Dict[str, Tensor]:
         """Post-process the final MCMC samples."""
         pass  # pragma: no cover

--- a/botorch/models/kernels/categorical.py
+++ b/botorch/models/kernels/categorical.py
@@ -28,7 +28,6 @@ class CategoricalKernel(Kernel):
         x2: Tensor,
         diag: bool = False,
         last_dim_is_batch: bool = False,
-        **kwargs,
     ) -> Tensor:
         delta = x1.unsqueeze(-2) != x2.unsqueeze(-3)
         dists = delta / self.lengthscale.unsqueeze(-2)

--- a/botorch/models/likelihoods/pairwise.py
+++ b/botorch/models/likelihoods/pairwise.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
-from typing import Any, Tuple
+from typing import Tuple
 
 import torch
 from botorch.utils.probability.utils import (
@@ -41,7 +41,7 @@ class PairwiseLikelihood(Likelihood, ABC):
         """
         super().__init__(max_plate_nesting)
 
-    def forward(self, utility: Tensor, D: Tensor, **kwargs: Any) -> Bernoulli:
+    def forward(self, utility: Tensor, D: Tensor) -> Bernoulli:
         """Given the difference in (estimated) utility util_diff = f(v) - f(u),
         return a Bernoulli distribution object representing the likelihood of
         the user prefer v over u.

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -95,7 +95,6 @@ class Model(Module, ABC):
         output_indices: Optional[List[int]] = None,
         observation_noise: Union[bool, Tensor] = False,
         posterior_transform: Optional[PosteriorTransform] = None,
-        **kwargs: Any,
     ) -> Posterior:
         r"""Computes the posterior over model outputs at the provided points.
 
@@ -301,7 +300,9 @@ class FantasizeMixin(ABC):
 
     @abstractmethod
     def condition_on_observations(
-        self: TFantasizeMixin, X: Tensor, Y: Tensor, **kwargs: Any
+        self: TFantasizeMixin,
+        X: Tensor,
+        Y: Tensor,
     ) -> TFantasizeMixin:
         """
         Classes that inherit from `FantasizeMixin` must implement
@@ -314,7 +315,6 @@ class FantasizeMixin(ABC):
         X: Tensor,
         *args,
         observation_noise: bool = False,
-        **kwargs: Any,
     ) -> Posterior:
         """
         Classes that inherit from `FantasizeMixin` must implement
@@ -474,7 +474,6 @@ class ModelList(Model):
         output_indices: Optional[List[int]] = None,
         observation_noise: Union[bool, Tensor] = False,
         posterior_transform: Optional[Callable[[PosteriorList], Posterior]] = None,
-        **kwargs: Any,
     ) -> Posterior:
         r"""Computes the posterior over model outputs at the provided points.
 

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -572,7 +572,6 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
         output_indices: Optional[List[int]] = None,
         observation_noise: Union[bool, Tensor] = False,
         posterior_transform: Optional[PosteriorTransform] = None,
-        **kwargs: Any,
     ) -> MultitaskGPPosterior:
         self.eval()
 

--- a/botorch/models/pairwise_gp.py
+++ b/botorch/models/pairwise_gp.py
@@ -1070,7 +1070,6 @@ class PairwiseGP(Model, GP, FantasizeMixin):
         output_indices: Optional[List[int]] = None,
         observation_noise: bool = False,
         posterior_transform: Optional[PosteriorTransform] = None,
-        **kwargs: Any,
     ) -> Posterior:
         r"""Computes the posterior over model outputs at the provided points.
 
@@ -1100,11 +1099,11 @@ class PairwiseGP(Model, GP, FantasizeMixin):
             return posterior_transform(posterior)
         return posterior
 
-    def condition_on_observations(self, X: Tensor, Y: Tensor, **kwargs: Any) -> Model:
+    def condition_on_observations(self, X: Tensor, Y: Tensor) -> Model:
         r"""Condition the model on new observations.
 
         Note that unlike other BoTorch models, PairwiseGP requires Y to be
-        pairwise comparisons
+        pairwise comparisons.
 
         Args:
             X: A `batch_shape x n x d` dimension tensor X

--- a/botorch/optim/closures/model_closures.py
+++ b/botorch/optim/closures/model_closures.py
@@ -104,8 +104,8 @@ def get_loss_closure_with_grads(
 @GetLossClosureWithGrads.register(object, object, object, object)
 def _get_loss_closure_with_grads_fallback(
     mll: MarginalLogLikelihood,
-    _: object,
-    __: object,
+    _likelihood_type: object,
+    _model_type: object,
     data_loader: Optional[DataLoader],
     parameters: Dict[str, Tensor],
     reducer: Callable[[Tensor], Tensor] = Tensor.sum,
@@ -127,8 +127,8 @@ def _get_loss_closure_with_grads_fallback(
 @GetLossClosure.register(MarginalLogLikelihood, object, object, DataLoader)
 def _get_loss_closure_fallback_external(
     mll: MarginalLogLikelihood,
-    _: object,
-    __: object,
+    _likelihood_type: object,
+    _model_type: object,
     data_loader: DataLoader,
     **ignore: Any,
 ) -> Callable[[], Tensor]:
@@ -153,7 +153,7 @@ def _get_loss_closure_fallback_external(
 
 @GetLossClosure.register(MarginalLogLikelihood, object, object, NoneType)
 def _get_loss_closure_fallback_internal(
-    mll: MarginalLogLikelihood, _: object, __: object, ___: NoneType, **ignore: Any
+    mll: MarginalLogLikelihood, _: object, __: object, ___: None, **ignore: Any
 ) -> Callable[[], Tensor]:
     r"""Fallback loss closure with internally managed data."""
 
@@ -167,7 +167,7 @@ def _get_loss_closure_fallback_internal(
 
 @GetLossClosure.register(ExactMarginalLogLikelihood, object, object, NoneType)
 def _get_loss_closure_exact_internal(
-    mll: ExactMarginalLogLikelihood, _: object, __: object, ___: NoneType, **ignore: Any
+    mll: ExactMarginalLogLikelihood, _: object, __: object, ___: None, **ignore: Any
 ) -> Callable[[], Tensor]:
     r"""ExactMarginalLogLikelihood loss closure with internally managed data."""
 
@@ -183,7 +183,7 @@ def _get_loss_closure_exact_internal(
 
 @GetLossClosure.register(SumMarginalLogLikelihood, object, object, NoneType)
 def _get_loss_closure_sum_internal(
-    mll: SumMarginalLogLikelihood, _: object, __: object, ___: NoneType, **ignore: Any
+    mll: SumMarginalLogLikelihood, _: object, __: object, ___: None, **ignore: Any
 ) -> Callable[[], Tensor]:
     r"""SumMarginalLogLikelihood loss closure with internally managed data."""
 

--- a/botorch/sampling/pathwise/posterior_samplers.py
+++ b/botorch/sampling/pathwise/posterior_samplers.py
@@ -17,7 +17,7 @@ r"""
 
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 from botorch.models.approximate_gp import ApproximateGPyTorchModel
 from botorch.models.model_list_gp_regression import ModelListGP
@@ -88,7 +88,6 @@ def draw_matheron_paths(
     sample_shape: Size,
     prior_sampler: TPathwisePriorSampler = draw_kernel_feature_paths,
     update_strategy: TPathwiseUpdate = gaussian_update,
-    **kwargs: Any,
 ) -> MatheronPath:
     r"""Generates function draws from (an approximate) Gaussian process prior.
 
@@ -111,13 +110,28 @@ def draw_matheron_paths(
         sample_shape=sample_shape,
         prior_sampler=prior_sampler,
         update_strategy=update_strategy,
-        **kwargs,
     )
 
 
 @DrawMatheronPaths.register(ModelListGP)
-def _draw_matheron_paths_ModelListGP(model: ModelListGP, **kwargs: Any):
-    return PathList([draw_matheron_paths(m, **kwargs) for m in model.models])
+def _draw_matheron_paths_ModelListGP(
+    model: ModelListGP,
+    sample_shape: Size,
+    *,
+    prior_sampler: TPathwisePriorSampler = draw_kernel_feature_paths,
+    update_strategy: TPathwiseUpdate = gaussian_update,
+):
+    return PathList(
+        [
+            draw_matheron_paths(
+                model=m,
+                sample_shape=sample_shape,
+                prior_sampler=prior_sampler,
+                update_strategy=update_strategy,
+            )
+            for m in model.models
+        ]
+    )
 
 
 @DrawMatheronPaths.register(ExactGP)
@@ -139,7 +153,7 @@ def _draw_matheron_paths_ExactGP(
         update_paths = update_strategy(
             model=model,
             sample_values=sample_values,
-            train_targets=train_Y,
+            target_values=train_Y,
         )
 
     return MatheronPath(
@@ -156,7 +170,6 @@ def _draw_matheron_paths_ApproximateGP(
     sample_shape: Size,
     prior_sampler: TPathwisePriorSampler,
     update_strategy: TPathwiseUpdate,
-    **kwargs: Any,
 ) -> MatheronPath:
     # Note: Inducing points are assumed to be pre-transformed
     Z = (

--- a/botorch/sampling/pathwise/update_strategies.py
+++ b/botorch/sampling/pathwise/update_strategies.py
@@ -112,7 +112,6 @@ def _gaussian_update_ExactGP(
     points: Optional[Tensor] = None,
     noise_covariance: Optional[Union[Tensor, LinearOperator]] = None,
     scale_tril: Optional[Union[Tensor, LinearOperator]] = None,
-    **ignore: Any,
 ) -> GeneralizedLinearPath:
     if points is None:
         (points,) = get_train_inputs(model, transformed=True)
@@ -137,7 +136,7 @@ def _gaussian_update_ExactGP(
 @GaussianUpdate.register(ApproximateGPyTorchModel, (Likelihood, NoneType))
 def _gaussian_update_ApproximateGPyTorchModel(
     model: ApproximateGPyTorchModel,
-    likelihood: Union[Likelihood, NoneType],
+    likelihood: Optional[Likelihood],
     **kwargs: Any,
 ) -> GeneralizedLinearPath:
     return GaussianUpdate(
@@ -147,7 +146,7 @@ def _gaussian_update_ApproximateGPyTorchModel(
 
 @GaussianUpdate.register(ApproximateGP, (Likelihood, NoneType))
 def _gaussian_update_ApproximateGP(
-    model: ApproximateGP, likelihood: Union[Likelihood, NoneType], **kwargs: Any
+    model: ApproximateGP, likelihood: Optional[Likelihood], **kwargs: Any
 ) -> GeneralizedLinearPath:
     return GaussianUpdate(model, model.variational_strategy, **kwargs)
 

--- a/test/sampling/pathwise/test_posterior_samplers.py
+++ b/test/sampling/pathwise/test_posterior_samplers.py
@@ -22,8 +22,8 @@ from torch.nn.functional import pad
 
 
 class TestPosteriorSamplers(BotorchTestCase):
-    def setUp(self) -> None:
-        super().setUp()
+    def setUp(self, suppress_input_warnings: bool = True) -> None:
+        super().setUp(suppress_input_warnings=suppress_input_warnings)
         tkwargs = {"device": self.device, "dtype": torch.float64}
         torch.manual_seed(0)
 


### PR DESCRIPTION
Summary:
I am auditing cases in which BoTorch functions admit ** arguments and then don't use them. In many cases, it was easier to fix the issue than write it up. These are the easy cases.

Note on inheritance: Type-checkers say that if a method accepts an argument, so must methods that override it.
* I removed `**kwargs` from abstract methods to remove the implication that their subclasses must also support `**kwargs` even if they don't use them.
* In cases where the base method admits `**kwargs` and is GPyTorch, I chose to "inconsistent override" GPyTorch rather than also having ignored `**kwargs` in BoTorch. This was the case for overriding `Module.forward` (in an ExactGP), `Kernel.forward`, and `Likelihood.forward`.

Changes:
* Small correctness fix in error-catching
* Some small typing fixes
* Removed `**kwargs` in many cases.

Differential Revision: D56849296


