### PR TITLE
Fix pathwise sampler bug

### DIFF
--- a/botorch/sampling/pathwise/posterior_samplers.py
+++ b/botorch/sampling/pathwise/posterior_samplers.py
@@ -139,7 +139,7 @@ def _draw_matheron_paths_ExactGP(
         update_paths = update_strategy(
             model=model,
             sample_values=sample_values,
-            train_targets=train_Y,
+            target_values=train_Y,
         )
 
     return MatheronPath(

--- a/botorch/sampling/pathwise/update_strategies.py
+++ b/botorch/sampling/pathwise/update_strategies.py
@@ -112,7 +112,6 @@ def _gaussian_update_ExactGP(
     points: Optional[Tensor] = None,
     noise_covariance: Optional[Union[Tensor, LinearOperator]] = None,
     scale_tril: Optional[Union[Tensor, LinearOperator]] = None,
-    **ignore: Any,
 ) -> GeneralizedLinearPath:
     if points is None:
         (points,) = get_train_inputs(model, transformed=True)


### PR DESCRIPTION
Summary: `_draw_matheron_paths_ExactGP` calls `_gaussian_update_ExactGP` (as the update_strategy argument). It was passing an incorrect argument `train_targets` in place of `target_values`. This led the `Y` values to being silently ignored.

Differential Revision: D57175013


