### PR TITLE
Ignore "unused" import

### DIFF
--- a/botorch/__init__.py
+++ b/botorch/__init__.py
@@ -28,7 +28,7 @@ from botorch.utils import manual_seed
 try:
     # Marking this as a manual import to avoid autodeps complaints
     # due to imports from non-existent file.
-    from botorch.version import version as __version__  # @manual
+    from botorch.version import version as __version__  # @manual  # noqa: F401
 except Exception:  # pragma: no cover
     __version__ = "Unknown"
 


### PR DESCRIPTION
Summary: Some linters may falsely label this as an unused import (this is used in OSS for determining version numbers). Suppressing this false positive.

Reviewed By: esantorella

Differential Revision: D57209605


