### PR TITLE
Remove _filter_kwargs

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -36,7 +36,6 @@ from botorch.optim.initializers import (
     TGenInitialConditions,
 )
 from botorch.optim.stopping import ExpMAStoppingCriterion
-from botorch.optim.utils import _filter_kwargs
 from torch import Tensor
 
 INIT_OPTION_KEYS = {
@@ -314,8 +313,6 @@ def _optimize_acqf_batch(opt_inputs: OptimizeAcqfInputs) -> Tuple[Tensor, Tensor
             "timeout_sec": timeout_sec,
         }
 
-        # only add parameter constraints to gen_kwargs if they are specified
-        # to avoid unnecessary warnings in _filter_kwargs
         for constraint_name in [
             "inequality_constraints",
             "equality_constraints",
@@ -323,8 +320,6 @@ def _optimize_acqf_batch(opt_inputs: OptimizeAcqfInputs) -> Tuple[Tensor, Tensor
         ]:
             if (constraint := getattr(opt_inputs, constraint_name)) is not None:
                 gen_kwargs[constraint_name] = constraint
-
-        filtered_gen_kwargs = _filter_kwargs(opt_inputs.gen_candidates, **gen_kwargs)
 
         for i, batched_ics_ in enumerate(batched_ics):
             # optimize using random restart optimization
@@ -334,7 +329,7 @@ def _optimize_acqf_batch(opt_inputs: OptimizeAcqfInputs) -> Tuple[Tensor, Tensor
                     batch_candidates_curr,
                     batch_acq_values_curr,
                 ) = opt_inputs.gen_candidates(
-                    batched_ics_, opt_inputs.acq_function, **filtered_gen_kwargs
+                    batched_ics_, opt_inputs.acq_function, **gen_kwargs
                 )
             opt_warnings += ws
             batch_candidates_list.append(batch_candidates_curr)

--- a/botorch/optim/utils/__init__.py
+++ b/botorch/optim/utils/__init__.py
@@ -10,7 +10,6 @@ from botorch.optim.utils.acquisition_utils import (
     get_X_baseline,
 )
 from botorch.optim.utils.common import (
-    _filter_kwargs,
     _handle_numerical_errors,
     _warning_handler_template,
 )
@@ -31,7 +30,6 @@ from botorch.optim.utils.numpy_utils import (
 from botorch.optim.utils.timeout import minimize_with_timeout
 
 __all__ = [
-    "_filter_kwargs",
     "_handle_numerical_errors",
     "_warning_handler_template",
     "as_ndarray",

--- a/botorch/optim/utils/common.py
+++ b/botorch/optim/utils/common.py
@@ -8,32 +8,12 @@ r"""General-purpose optimization utilities."""
 
 from __future__ import annotations
 
-from inspect import signature
 from logging import debug as logging_debug
-from typing import Any, Callable, Optional, Tuple
-from warnings import warn, warn_explicit, WarningMessage
+from typing import Callable, Optional, Tuple
+from warnings import warn_explicit, WarningMessage
 
 import numpy as np
 from linear_operator.utils.errors import NanError, NotPSDError
-
-
-def _filter_kwargs(function: Callable, **kwargs: Any) -> Any:
-    r"""Filter out kwargs that are not applicable for a given function.
-    Return a copy of given kwargs dict with only the required kwargs."""
-    allowed_params = signature(function).parameters
-    removed = {k for k in kwargs.keys() if k not in allowed_params}
-    if len(removed) > 0:
-        fn_descriptor = (
-            f" for function {function.__name__}"
-            if hasattr(function, "__name__")
-            else ""
-        )
-        warn(
-            f"Keyword arguments {list(removed)} will be ignored because they are"
-            f" not allowed parameters{fn_descriptor}. Allowed "
-            f"parameters are {list(allowed_params.keys())}."
-        )
-    return {k: v for k, v in kwargs.items() if k not in removed}
 
 
 def _handle_numerical_errors(

--- a/test/acquisition/test_knowledge_gradient.py
+++ b/test/acquisition/test_knowledge_gradient.py
@@ -24,10 +24,8 @@ from botorch.acquisition.objective import (
 )
 from botorch.acquisition.utils import project_to_sample_points
 from botorch.exceptions.errors import UnsupportedError
-from botorch.generation.gen import gen_candidates_scipy
 from botorch.models import SingleTaskGP
 from botorch.optim.optimize import optimize_acqf
-from botorch.optim.utils import _filter_kwargs
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.test_helpers import DummyNonScalarizingPosteriorTransform
@@ -587,11 +585,6 @@ class TestQMultiFidelityKnowledgeGradient(BotorchTestCase):
                     return_value=(
                         torch.zeros(2, n_f + 1, 2, **tkwargs),
                         torch.zeros(2, **tkwargs),
-                    ),
-                ), mock.patch(
-                    f"{optimize_acqf.__module__}._filter_kwargs",
-                    wraps=lambda f, **kwargs: _filter_kwargs(
-                        function=gen_candidates_scipy, **kwargs
                     ),
                 ):
 

--- a/test/optim/utils/test_common.py
+++ b/test/optim/utils/test_common.py
@@ -10,40 +10,12 @@ from functools import partial
 from warnings import catch_warnings, warn
 
 import numpy as np
-from botorch.optim.utils import (
-    _filter_kwargs,
-    _handle_numerical_errors,
-    _warning_handler_template,
-)
+from botorch.optim.utils import _handle_numerical_errors, _warning_handler_template
 from botorch.utils.testing import BotorchTestCase
 from linear_operator.utils.errors import NanError, NotPSDError
 
 
 class TestUtilsCommon(BotorchTestCase):
-    def test__filter_kwargs(self) -> None:
-        def mock_adam(params, lr: float = 0.001) -> None:
-            return  # pragma: nocover
-
-        kwargs = {"lr": 0.01, "maxiter": 3000}
-        expected_msg = (
-            r"Keyword arguments \['maxiter'\] will be ignored because they are "
-            r"not allowed parameters for function mock_adam. Allowed parameters "
-            r"are \['params', 'lr'\]."
-        )
-
-        with self.assertWarnsRegex(Warning, expected_msg):
-            valid_kwargs = _filter_kwargs(mock_adam, **kwargs)
-        self.assertEqual(set(valid_kwargs.keys()), {"lr"})
-
-        mock_partial = partial(mock_adam, lr=2.0)
-        expected_msg = (
-            r"Keyword arguments \['maxiter'\] will be ignored because they are "
-            r"not allowed parameters. Allowed parameters are \['params', 'lr'\]."
-        )
-        with self.assertWarnsRegex(Warning, expected_msg):
-            valid_kwargs = _filter_kwargs(mock_partial, **kwargs)
-        self.assertEqual(set(valid_kwargs.keys()), {"lr"})
-
     def test_handle_numerical_errors(self):
         x = np.zeros(1, dtype=np.float64)
 


### PR DESCRIPTION
Summary:
Now when incorrect arguments are passed to `optimize_acqf` in `gen_kwargs`, they will raise an exception (as incorrect arguments generally do) rather than being silently ignored.

There was only one usage of `_filter_kwargs`, and it would not be triggered by correct usage after a prior change that stopped creating unused arguments.

Differential Revision: D57250387


