### PR TITLE
Properly ingore unused import lint

### DIFF
--- a/botorch/__init__.py
+++ b/botorch/__init__.py
@@ -28,7 +28,8 @@ from botorch.utils import manual_seed
 try:
     # Marking this as a manual import to avoid autodeps complaints
     # due to imports from non-existent file.
-    from botorch.version import version as __version__  # @manual  # noqa: F401
+    # lint-ignore: UnusedImportsRule
+    from botorch.version import version as __version__  # @manual
 except Exception:  # pragma: no cover
     __version__ = "Unknown"
 


### PR DESCRIPTION
Summary: #2339 attempted to ignore an unused import lint, but did so incorrectly. This fixed that.

Reviewed By: saitcakmak

Differential Revision: D57280457


