### PR TITLE
Improve error messages around max_points

### DIFF
--- a/botorch/acquisition/multi_objective/utils.py
+++ b/botorch/acquisition/multi_objective/utils.py
@@ -120,9 +120,11 @@ def prune_inferior_points_multi_objective(
             "Batched inputs `X` are currently unsupported by "
             "prune_inferior_points_multi_objective"
         )
-    max_points = math.ceil(max_frac * X.size(-2))
-    if max_points < 1 or max_points > X.size(-2):
+    if X.size(-2) == 0:
+        raise ValueError("X must have at least one point.")
+    if max_frac <= 0 or max_frac > 1.0:
         raise ValueError(f"max_frac must take values in (0, 1], is {max_frac}")
+    max_points = math.ceil(max_frac * X.size(-2))
     with torch.no_grad():
         posterior = model.posterior(X=X)
     sampler = get_sampler(posterior, sample_shape=torch.Size([num_samples]))

--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -299,9 +299,11 @@ def prune_inferior_points(
         raise UnsupportedError(
             "Batched inputs `X` are currently unsupported by prune_inferior_points"
         )
-    max_points = math.ceil(max_frac * X.size(-2))
-    if max_points < 1 or max_points > X.size(-2):
+    if X.size(-2) == 0:
+        raise ValueError("X must have at least one point.")
+    if max_frac <= 0 or max_frac > 1.0:
         raise ValueError(f"max_frac must take values in (0, 1], is {max_frac}")
+    max_points = math.ceil(max_frac * X.size(-2))
     with torch.no_grad():
         posterior = model.posterior(X=X, posterior_transform=posterior_transform)
     if sampler is None:

--- a/test/acquisition/multi_objective/test_utils.py
+++ b/test/acquisition/multi_objective/test_utils.py
@@ -88,6 +88,11 @@ class TestMultiObjectiveUtils(BotorchTestCase):
                 prune_inferior_points_multi_objective(
                     model=mm, X=X, max_frac=1.1, ref_point=ref_point
                 )
+            # test that invalid X is checked properly
+            with self.assertRaises(ValueError):
+                prune_inferior_points_multi_objective(
+                    model=mm, X=torch.empty(0, 0), ref_point=ref_point
+                )
             # test basic behaviour
             X_pruned = prune_inferior_points_multi_objective(
                 model=mm, X=X, ref_point=ref_point

--- a/test/acquisition/test_utils.py
+++ b/test/acquisition/test_utils.py
@@ -246,6 +246,9 @@ class TestPruneInferiorPoints(BotorchTestCase):
             # test that invalid max_frac is checked properly
             with self.assertRaises(ValueError):
                 prune_inferior_points(model=mm, X=X, max_frac=1.1)
+            # test that invalid X is checked properly
+            with self.assertRaises(ValueError):
+                prune_inferior_points(model=mm, X=torch.empty(0, 0))
             # test basic behaviour
             X_pruned = prune_inferior_points(model=mm, X=X)
             self.assertTrue(torch.equal(X_pruned, X[[-1]]))


### PR DESCRIPTION
Summary: Previously, a check was made on max_points, but an error was raised on max_frac. This rectifies this by making the check on max_frac instead.

Differential Revision: D56531830


