### PR TITLE
Replace deprecated plt.cm.get_cmap in tutorials

### DIFF
--- a/tutorials/constrained_multi_objective_bo.ipynb
+++ b/tutorials/constrained_multi_objective_bo.ipynb
@@ -637,7 +637,7 @@
           "output_type": "stream",
           "text": [
             "/var/folders/_j/_hhj7k4913d4jlzgq92bw9b00000gn/T/ipykernel_16702/4269187899.py:7: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.\n",
-            "  cm = plt.cm.get_cmap(\"viridis\")\n"
+            "  cm = plt.get_cmap(\"viridis\")\n"
           ]
         },
         {
@@ -668,7 +668,7 @@
         "\n",
         "fig, axes = plt.subplots(1, 3, figsize=(17, 5))\n",
         "algos = [\"Sobol\", \"qParEGO\", \"qNEHVI\"]\n",
-        "cm = plt.cm.get_cmap(\"viridis\")\n",
+        "cm = plt.get_cmap(\"viridis\")\n",
         "\n",
         "batch_number = torch.cat(\n",
         "    [\n",

--- a/tutorials/multi_objective_bo.ipynb
+++ b/tutorials/multi_objective_bo.ipynb
@@ -710,7 +710,7 @@
         "\n",
         "fig, axes = plt.subplots(1, 4, figsize=(23, 7), sharex=True, sharey=True)\n",
         "algos = [\"Sobol\", \"qNParEGO\", \"qEHVI\", \"qNEHVI\"]\n",
-        "cm = plt.cm.get_cmap(\"viridis\")\n",
+        "cm = plt.get_cmap(\"viridis\")\n",
         "\n",
         "batch_number = torch.cat(\n",
         "    [\n",


### PR DESCRIPTION
`plt.cm.get_cmap` has been deprecated since v3.7 and got fully removed in v3.9: https://matplotlib.org/3.8.4/api/cm_api.html#matplotlib.cm.get_cmap
A recent failure caused by this: https://github.com/pytorch/botorch/actions/runs/9122432682
`plt.get_cmap` lives on with no deprecation notice according to v3.10 development docs: https://matplotlib.org/devdocs/api/_as_gen/matplotlib.pyplot.get_cmap.html

Test Plan: The tutorials CI job passes.