### PR TITLE
Explicitly check timeout against None so that 0.0 isn't ignored

### DIFF
--- a/botorch/optim/utils/timeout.py
+++ b/botorch/optim/utils/timeout.py
@@ -16,7 +16,7 @@ from scipy import optimize
 
 
 def minimize_with_timeout(
-    fun: Callable[[np.ndarray, *Any], float],
+    fun: Callable[[np.ndarray, ...], float],
     x0: np.ndarray,
     args: Tuple[Any, ...] = (),
     method: Optional[str] = None,
@@ -40,7 +40,7 @@ def minimize_with_timeout(
     method that is injected to the scipy.optimize.minimize call and that keeps
     track of the runtime and the optimization variables at the current iteration.
     """
-    if timeout_sec:
+    if timeout_sec is not None:
 
         start_time = time.monotonic()
         callback_data = {"num_iterations": 0}  # update from withing callback below

--- a/test/optim/utils/test_timeout.py
+++ b/test/optim/utils/test_timeout.py
@@ -41,9 +41,13 @@ class TestMinimizeWithTimeout(BotorchTestCase):
             self.assertEqual(res.nit, 2)  # quadratic approx. is exact
 
         with self.subTest("test w/ binding timeout"):
-            res = minimize_with_timeout(**base_kwargs, args=(1e-2,), timeout_sec=1e-4)
-            self.assertFalse(res.success)
-            self.assertEqual(res.nit, 1)  # only one call to the callback is made
+            for timeout_sec in [0, 1e-4]:
+                res = minimize_with_timeout(
+                    **base_kwargs, args=(1e-2,), timeout_sec=timeout_sec
+                )
+                self.assertFalse(res.success)
+                self.assertEqual(res.nit, 1)  # only one call to the callback is made
+                self.assertIn("Optimization timed out", res.message)
 
         # set up callback with mutable object to verify callback execution
         check_set = set()


### PR DESCRIPTION
Summary: While testing some timeout-related code, I set a timeout to 0.0 to ensure that the timeout would bind. I was confused when nothing happened; it turned out that the presence of a timeout was tested for with "if timeout" rather than "if timeout is None," so that 0.0 was not considered a timeout.

Reviewed By: Balandat, SebastianAment

Differential Revision: D57542718


