### PR TITLE
Swap out deprecated runner

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -46,7 +46,7 @@ jobs:
 
   package-deploy-conda:
     name: Package conda and deploy to anaconda.org
-    runs-on: 8-core
+    runs-on: 8-core-ubuntu
     needs: tests-and-coverage-pip
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
 
   package-conda:
     name: Test conda build
-    runs-on: 8-core
+    runs-on: 8-core-ubuntu
     steps:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3


### PR DESCRIPTION
Github is deprecating the N-core-ubuntu runner label, replacing it with N-core. We need to migrate PyTorch runners accordingly. Turns out github had originally asked for the change to be in the wrong direction

This only affects how github queues jobs, not where those jobs actually run

More details in pytorch/pytorch#125721

