### PR TITLE
Clarify behavior on standard deviations with <1 degree of freedom and silence some unit test warnings

### DIFF
--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -286,7 +286,15 @@ class Standardize(OutcomeTransform):
                     f"Wrong output dimension. Y.size(-1) is {Y.size(-1)}; expected "
                     f"{self._m}."
                 )
-            stdvs = Y.std(dim=-2, keepdim=True)
+            if Y.shape[-2] < 1:
+                raise ValueError(f"Can't standardize with no observations. {Y.shape=}.")
+
+            elif Y.shape[-2] == 1:
+                stdvs = torch.ones(
+                    (*Y.shape[:-2], 1, Y.shape[-1]), dtype=Y.dtype, device=Y.device
+                )
+            else:
+                stdvs = Y.std(dim=-2, keepdim=True)
             stdvs = stdvs.where(stdvs >= self._min_stdv, torch.full_like(stdvs, 1.0))
             means = Y.mean(dim=-2, keepdim=True)
             if self._outputs is not None:

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -60,7 +60,7 @@ class BotorchTestCase(TestCase):
             )
             warnings.filterwarnings(
                 "ignore",
-                message="Input data is not standardized.",
+                message="Data is not standardized.",
                 category=InputDataWarning,
             )
             warnings.filterwarnings(


### PR DESCRIPTION
## Motivation

Unit tests were producing a lot of warnings about taking standard deviations across fewer than 2 observations, and it was not clear to me if these warnings were legitimate in context. 
* For checking the standardization of input data, no longer check the standard deviation if there is just one observation.
* For the standardize input transform, explicitly set standard deviations to 1 when there is only one observation. This actually matches the legacy behavior, but previously it wasn't clear because the standard deviation would become NaN before being corrected to 1.
* Error on attempting to standardize 0 observations. This never worked so now it is more clear.

## Test Plan

Added units

## Related PRs
