### PR TITLE
Update polytope sampling code and add thinning capability

### DIFF
--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -494,8 +494,8 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                     n=n,
                     q=q,
                     bounds=bounds,
-                    n_burnin=10000,
-                    thinning=32,
+                    n_burnin=20,
+                    n_thinning=4,
                     seed=42,
                     inequality_constraints=inequalities,
                     equality_constraints=equalities,
@@ -571,8 +571,8 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                             "alpha": 0.1,
                             "seed": seed,
                             "init_batch_limit": init_batch_limit,
-                            "thinning": 2,
                             "n_burnin": 3,
+                            "n_thinning": 2,
                         },
                         inequality_constraints=inequality_constraints,
                         equality_constraints=equality_constraints,
@@ -669,8 +669,8 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                             "alpha": 0.1,
                             "seed": seed,
                             "init_batch_limit": None,
-                            "thinning": 2,
                             "n_burnin": 3,
+                            "n_thinning": 2,
                         },
                         inequality_constraints=inequality_constraints,
                         equality_constraints=equality_constraints,
@@ -714,7 +714,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                 [True, False], [None, 1234], [None, 1], [None, {0: 0.5}]
             ):
 
-                def generator(n: int, q: int, seed: int):
+                def generator(n: int, q: int, seed: Optional[int]):
                     with manual_seed(seed):
                         X_rnd_nlzd = torch.rand(
                             n,
@@ -770,7 +770,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
     def test_error_generator_with_sample_around_best(self):
         tkwargs = {"device": self.device, "dtype": torch.double}
 
-        def generator(n: int, q: int, seed: int):
+        def generator(n: int, q: int, seed: Optional[int]):
             return torch.rand(n, q, 3).to(**tkwargs)
 
         with self.assertRaisesRegex(


### PR DESCRIPTION
This set of changes does the following:
* adds an `n_thinning` argument to `sample_polytope` and `HitAndRunPolytopeSampler`; changes the defaults for `HitAndRunPolytopeSampler` args to `n_burnin=200` and `n_thinning=20`
* Changes `HitAndRunPolytopeSampler` to take the `seed` arg in its constructor, and removes the arg from the `draw()` method (the method on the base class is adjusted accordingly). The resulting behavior is that if a `HitAndRunPolytopeSampler` is instantiated with the same args and seed, then the sequence of `draw()`s will be deterministic. `DelaunayPolytopeSampler` is stateless, and so retains its existing behavior.
* normalizes the (inequality and equality) constraints in `HitAndRunPolytopeSampler` to avoid the same issue as https://github.com/pytorch/botorch/issues/1225. If `bounds` are note provided, emits a warning that this cannot be performed (doing this would require vertex enumeration of the constraint polytope, which is NP-hard and too costly).
* introduces `normalize_dense_linear_constraints` to normalize constraint given in dense format to the unit cube
* removes `normalize_linear_constraint`; `normalize_sparse_linear_constraints` is to be used instead
* simplifies some of the testing code

Note: This change is in preparation for fixing https://github.com/facebook/Ax/issues/2373