### PR TITLE
Avoid division by zero in normalize & unnormalize when lower & upper bounds are equal

### DIFF
--- a/botorch/utils/multi_objective/scalarization.py
+++ b/botorch/utils/multi_objective/scalarization.py
@@ -95,14 +95,8 @@ def get_chebyshev_scalarization(
             return -chebyshev_obj(Y=-Y)
 
         return obj
-    if Y.shape[-2] == 1:
-        # If there is only one observation, set the bounds to be
-        # [min(Y_m), min(Y_m) + 1] for each objective m. This ensures we do not
-        # divide by zero
-        Y_bounds = torch.cat([Y, Y + 1], dim=0)
-    else:
-        # Set the bounds to be [min(Y_m), max(Y_m)], for each objective m
-        Y_bounds = torch.stack([Y.min(dim=-2).values, Y.max(dim=-2).values])
+    # Set the bounds to be [min(Y_m), max(Y_m)], for each objective m.
+    Y_bounds = torch.stack([Y.min(dim=-2).values, Y.max(dim=-2).values])
 
     def obj(Y: Tensor, X: Optional[Tensor] = None) -> Tensor:
         # scale to [0,1]

--- a/test/utils/multi_objective/test_scalarization.py
+++ b/test/utils/multi_objective/test_scalarization.py
@@ -120,3 +120,13 @@ class TestGetChebyshevScalarization(BotorchTestCase):
                     + 0.05 * (weights * normalized_neg_Y_test).sum(dim=-1)
                 )
                 self.assertAllClose(Y_transformed, expected_Y_transformed)
+
+                # Test that it works when Y is constant in each dimension.
+                objective_transform = get_chebyshev_scalarization(
+                    weights=weights, Y=torch.zeros(2, 2, **tkwargs), alpha=0.0
+                )
+                Y_transformed = objective_transform(Y_test)
+                self.assertFalse(Y_transformed.isnan().any())
+                self.assertFalse(Y_transformed.isinf().any())
+                expected_Y = -(-weights * Y_test).max(dim=-1).values
+                self.assertAllClose(Y_transformed, expected_Y)

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -59,7 +59,7 @@ class TestStandardize(BotorchTestCase):
 
 
 class TestNormalizeAndUnnormalize(BotorchTestCase):
-    def test_normalize_unnormalize(self):
+    def test_normalize_unnormalize(self) -> None:
         for dtype in (torch.float, torch.double):
             X = torch.tensor([0.0, 0.25, 0.5], device=self.device, dtype=dtype).view(
                 -1, 1
@@ -85,6 +85,17 @@ class TestNormalizeAndUnnormalize(BotorchTestCase):
             X2_normalized = normalize(X2, bounds=bounds2)
             self.assertTrue(torch.equal(X2_normalized, expected_X2_normalized))
             self.assertTrue(torch.equal(X2, unnormalize(X2_normalized, bounds=bounds2)))
+
+    def test_with_constant_bounds(self) -> None:
+        X = torch.rand(10, 2, dtype=torch.double)
+        # First dimension is constant, second has a range of 1.
+        # The transform should just add 1 to each dimension.
+        bounds = -torch.ones(2, 2, dtype=torch.double)
+        bounds[1, 1] = 0.0
+        X_normalized = normalize(X, bounds=bounds)
+        self.assertAllClose(X_normalized, X + 1)
+        X_unnormalized = unnormalize(X_normalized, bounds=bounds)
+        self.assertAllClose(X_unnormalized, X)
 
 
 class BMIMTestClass(BotorchTestCase):


### PR DESCRIPTION
Summary:
When lower and upper bounds are equal for a dimension, set `upper = lower + 1` to avoid division by zero in `normalize`. The behavior is mirrored in `unnormalize` to preserve `X = unnormalize(normalize(X, bounds), bounds)`.

This fixes some downstream issues observed in `get_chebyshev_objective`, and also lets us simplify `bounds` computation there.

Differential Revision: D58168827


