### PR TITLE
add initial objective values to initial state for sample efficiency

### DIFF
--- a/tutorials/turbo_1.ipynb
+++ b/tutorials/turbo_1.ipynb
@@ -31,14 +31,27 @@
     "originalKey": "c11881c9-13f5-4e35-bdc8-b8f817089713",
     "requestMsgId": "b21eda64-89d8-461f-a9d1-57117892e0c9"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[KeOps] Warning : omp.h header is not in the path, disabling OpenMP. To fix this, you can set the environment\n",
+      "                  variable OMP_PATH to the location of the header before importing keopscore or pykeops,\n",
+      "                  e.g. using os.environ: import os; os.environ['OMP_PATH'] = '/path/to/omp/header'\n",
+      "[KeOps] Warning : Cuda libraries were not detected on the system or could not be loaded ; using cpu only mode\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import math\n",
+    "import warnings\n",
     "from dataclasses import dataclass\n",
     "\n",
     "import torch\n",
     "from botorch.acquisition import qExpectedImprovement, qLogExpectedImprovement\n",
+    "from botorch.exceptions import BadInitialCandidatesWarning\n",
     "from botorch.fit import fit_gpytorch_mll\n",
     "from botorch.generation import MaxPosteriorSampling\n",
     "from botorch.models import SingleTaskGP\n",
@@ -52,8 +65,10 @@
     "from gpytorch.kernels import MaternKernel, ScaleKernel\n",
     "from gpytorch.likelihoods import GaussianLikelihood\n",
     "from gpytorch.mlls import ExactMarginalLogLikelihood\n",
-    "from gpytorch.priors import HorseshoePrior\n",
     "\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\", category=BadInitialCandidatesWarning)\n",
+    "warnings.filterwarnings(\"ignore\", category=RuntimeWarning)\n",
     "\n",
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "dtype = torch.double\n",
@@ -372,647 +387,130 @@
      "text": [
       "44) Best value: -1.17e+01, TR length: 8.00e-01\n",
       "48) Best value: -1.17e+01, TR length: 8.00e-01\n",
-      "52) Best value: -1.11e+01, TR length: 8.00e-01\n",
-      "56) Best value: -1.03e+01, TR length: 8.00e-01\n",
-      "60) Best value: -1.03e+01, TR length: 8.00e-01\n",
-      "64) Best value: -1.03e+01, TR length: 8.00e-01\n",
-      "68) Best value: -1.03e+01, TR length: 8.00e-01\n",
-      "72) Best value: -9.51e+00, TR length: 8.00e-01\n",
-      "76) Best value: -9.51e+00, TR length: 8.00e-01\n",
-      "80) Best value: -7.32e+00, TR length: 8.00e-01\n",
-      "84) Best value: -7.32e+00, TR length: 8.00e-01\n",
-      "88) Best value: -7.32e+00, TR length: 8.00e-01\n",
-      "92) Best value: -7.32e+00, TR length: 8.00e-01\n",
-      "96) Best value: -7.32e+00, TR length: 8.00e-01\n",
-      "100) Best value: -7.32e+00, TR length: 4.00e-01\n",
-      "104) Best value: -7.12e+00, TR length: 4.00e-01\n",
-      "108) Best value: -7.12e+00, TR length: 4.00e-01\n",
-      "112) Best value: -6.53e+00, TR length: 4.00e-01\n",
-      "116) Best value: -5.61e+00, TR length: 4.00e-01\n",
-      "120) Best value: -5.61e+00, TR length: 4.00e-01\n",
-      "124) Best value: -5.61e+00, TR length: 4.00e-01\n",
-      "128) Best value: -5.58e+00, TR length: 4.00e-01\n",
-      "132) Best value: -5.58e+00, TR length: 4.00e-01\n",
-      "136) Best value: -5.58e+00, TR length: 4.00e-01\n",
-      "140) Best value: -5.58e+00, TR length: 4.00e-01\n",
-      "144) Best value: -5.57e+00, TR length: 4.00e-01\n",
-      "148) Best value: -5.53e+00, TR length: 4.00e-01\n",
-      "152) Best value: -5.53e+00, TR length: 4.00e-01\n",
-      "156) Best value: -5.53e+00, TR length: 4.00e-01\n",
-      "160) Best value: -5.53e+00, TR length: 4.00e-01\n",
-      "164) Best value: -4.98e+00, TR length: 4.00e-01\n",
-      "168) Best value: -4.98e+00, TR length: 4.00e-01\n",
-      "172) Best value: -4.98e+00, TR length: 4.00e-01\n",
-      "176) Best value: -4.98e+00, TR length: 4.00e-01\n",
-      "180) Best value: -4.98e+00, TR length: 4.00e-01\n",
-      "184) Best value: -4.98e+00, TR length: 2.00e-01\n",
-      "188) Best value: -4.54e+00, TR length: 2.00e-01\n",
-      "192) Best value: -4.27e+00, TR length: 2.00e-01\n",
-      "196) Best value: -4.09e+00, TR length: 2.00e-01\n",
-      "200) Best value: -3.90e+00, TR length: 2.00e-01\n",
-      "204) Best value: -3.90e+00, TR length: 2.00e-01\n",
-      "208) Best value: -3.90e+00, TR length: 2.00e-01\n",
-      "212) Best value: -3.90e+00, TR length: 2.00e-01\n",
-      "216) Best value: -3.72e+00, TR length: 2.00e-01\n",
-      "220) Best value: -3.72e+00, TR length: 2.00e-01\n",
-      "224) Best value: -3.72e+00, TR length: 2.00e-01\n",
-      "228) Best value: -3.72e+00, TR length: 2.00e-01\n",
-      "232) Best value: -3.72e+00, TR length: 2.00e-01\n",
-      "236) Best value: -3.72e+00, TR length: 1.00e-01\n",
-      "240) Best value: -3.72e+00, TR length: 1.00e-01\n",
-      "244) Best value: -3.62e+00, TR length: 1.00e-01\n",
-      "248) Best value: -3.18e+00, TR length: 1.00e-01\n",
-      "252) Best value: -2.71e+00, TR length: 1.00e-01\n",
-      "256) Best value: -2.71e+00, TR length: 1.00e-01\n",
-      "260) Best value: -2.71e+00, TR length: 1.00e-01\n",
-      "264) Best value: -2.71e+00, TR length: 1.00e-01\n",
-      "268) Best value: -2.71e+00, TR length: 1.00e-01\n",
-      "272) Best value: -2.71e+00, TR length: 5.00e-02\n",
-      "276) Best value: -2.30e+00, TR length: 5.00e-02\n",
-      "280) Best value: -1.89e+00, TR length: 5.00e-02\n",
-      "284) Best value: -1.89e+00, TR length: 5.00e-02\n",
-      "288) Best value: -1.89e+00, TR length: 5.00e-02\n",
-      "292) Best value: -1.89e+00, TR length: 5.00e-02\n",
-      "296) Best value: -1.89e+00, TR length: 5.00e-02\n",
-      "300) Best value: -1.89e+00, TR length: 2.50e-02\n",
-      "304) Best value: -1.81e+00, TR length: 2.50e-02\n",
-      "308) Best value: -1.80e+00, TR length: 2.50e-02\n",
-      "312) Best value: -1.80e+00, TR length: 2.50e-02\n",
-      "316) Best value: -1.80e+00, TR length: 2.50e-02\n",
-      "320) Best value: -1.80e+00, TR length: 2.50e-02\n",
-      "324) Best value: -1.80e+00, TR length: 2.50e-02\n",
-      "328) Best value: -1.80e+00, TR length: 1.25e-02\n",
-      "332) Best value: -1.64e+00, TR length: 1.25e-02\n",
-      "336) Best value: -1.56e+00, TR length: 1.25e-02\n",
-      "340) Best value: -1.52e+00, TR length: 1.25e-02\n",
-      "344) Best value: -1.52e+00, TR length: 1.25e-02\n",
-      "348) Best value: -1.46e+00, TR length: 1.25e-02\n",
-      "352) Best value: -1.46e+00, TR length: 1.25e-02\n",
-      "356) Best value: -1.37e+00, TR length: 1.25e-02\n",
-      "360) Best value: -1.37e+00, TR length: 1.25e-02\n",
-      "364) Best value: -1.37e+00, TR length: 1.25e-02\n",
-      "368) Best value: -1.34e+00, TR length: 1.25e-02\n",
-      "372) Best value: -1.34e+00, TR length: 1.25e-02\n",
-      "376) Best value: -1.34e+00, TR length: 1.25e-02\n",
-      "380) Best value: -1.34e+00, TR length: 1.25e-02\n",
-      "384) Best value: -1.34e+00, TR length: 1.25e-02\n",
-      "388) Best value: -1.34e+00, TR length: 1.25e-02\n",
-      "392) Best value: -1.34e+00, TR length: 1.25e-02\n",
-      "396) Best value: -1.34e+00, TR length: 1.25e-02\n",
-      "400) Best value: -1.34e+00, TR length: 6.25e-03\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "72) Best value: -9.41e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "76) Best value: -9.41e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "80) Best value: -9.41e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "84) Best value: -8.82e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "88) Best value: -8.82e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "92) Best value: -8.82e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "96) Best value: -8.36e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100) Best value: -7.93e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "104) Best value: -7.93e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "108) Best value: -7.93e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "112) Best value: -7.93e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "116) Best value: -7.93e+00, TR length: 8.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "120) Best value: -7.93e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "124) Best value: -6.72e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "128) Best value: -6.34e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "132) Best value: -6.01e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "136) Best value: -5.51e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "140) Best value: -5.51e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "144) Best value: -5.51e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "148) Best value: -5.45e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "152) Best value: -5.27e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "156) Best value: -5.27e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "160) Best value: -5.27e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "164) Best value: -5.27e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "168) Best value: -5.06e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "172) Best value: -5.06e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "176) Best value: -5.06e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "180) Best value: -5.06e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "184) Best value: -5.06e+00, TR length: 4.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "188) Best value: -5.06e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "192) Best value: -4.32e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "196) Best value: -3.86e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "200) Best value: -3.69e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "204) Best value: -3.69e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "208) Best value: -3.69e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "212) Best value: -3.69e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "216) Best value: -3.41e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "220) Best value: -3.41e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "224) Best value: -3.41e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "228) Best value: -3.41e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "232) Best value: -3.41e+00, TR length: 2.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "236) Best value: -3.41e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "240) Best value: -2.95e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "244) Best value: -2.65e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "248) Best value: -2.65e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "252) Best value: -2.65e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "256) Best value: -2.54e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "260) Best value: -2.54e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "264) Best value: -2.54e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "268) Best value: -2.38e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "272) Best value: -2.38e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "276) Best value: -2.38e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "280) Best value: -2.38e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "284) Best value: -2.38e+00, TR length: 1.00e-01\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "288) Best value: -2.38e+00, TR length: 5.00e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "292) Best value: -1.91e+00, TR length: 5.00e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "296) Best value: -1.91e+00, TR length: 5.00e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "300) Best value: -1.91e+00, TR length: 5.00e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "304) Best value: -1.31e+00, TR length: 5.00e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "308) Best value: -1.31e+00, TR length: 5.00e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "312) Best value: -1.31e+00, TR length: 5.00e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "316) Best value: -1.31e+00, TR length: 5.00e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "320) Best value: -1.31e+00, TR length: 5.00e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "324) Best value: -1.31e+00, TR length: 2.50e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "328) Best value: -1.31e+00, TR length: 2.50e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "332) Best value: -1.31e+00, TR length: 2.50e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "336) Best value: -1.31e+00, TR length: 2.50e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "340) Best value: -1.31e+00, TR length: 2.50e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "344) Best value: -1.31e+00, TR length: 1.25e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "348) Best value: -1.14e+00, TR length: 1.25e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "352) Best value: -1.14e+00, TR length: 1.25e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "356) Best value: -1.14e+00, TR length: 1.25e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "360) Best value: -1.14e+00, TR length: 1.25e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "364) Best value: -1.12e+00, TR length: 1.25e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "368) Best value: -1.12e+00, TR length: 1.25e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "372) Best value: -1.12e+00, TR length: 1.25e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "376) Best value: -1.12e+00, TR length: 1.25e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "380) Best value: -1.12e+00, TR length: 1.25e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "384) Best value: -1.12e+00, TR length: 6.25e-03\n"
+      "52) Best value: -1.12e+01, TR length: 8.00e-01\n",
+      "56) Best value: -1.04e+01, TR length: 8.00e-01\n",
+      "60) Best value: -1.04e+01, TR length: 8.00e-01\n",
+      "64) Best value: -9.42e+00, TR length: 8.00e-01\n",
+      "68) Best value: -9.42e+00, TR length: 8.00e-01\n",
+      "72) Best value: -9.42e+00, TR length: 8.00e-01\n",
+      "76) Best value: -9.42e+00, TR length: 8.00e-01\n",
+      "80) Best value: -8.75e+00, TR length: 8.00e-01\n",
+      "84) Best value: -8.75e+00, TR length: 8.00e-01\n",
+      "88) Best value: -8.75e+00, TR length: 8.00e-01\n",
+      "92) Best value: -8.75e+00, TR length: 8.00e-01\n",
+      "96) Best value: -8.27e+00, TR length: 8.00e-01\n",
+      "100) Best value: -8.27e+00, TR length: 8.00e-01\n",
+      "104) Best value: -8.27e+00, TR length: 8.00e-01\n",
+      "108) Best value: -8.27e+00, TR length: 8.00e-01\n",
+      "112) Best value: -8.27e+00, TR length: 8.00e-01\n",
+      "116) Best value: -8.27e+00, TR length: 4.00e-01\n",
+      "120) Best value: -6.45e+00, TR length: 4.00e-01\n",
+      "124) Best value: -6.45e+00, TR length: 4.00e-01\n",
+      "128) Best value: -6.45e+00, TR length: 4.00e-01\n",
+      "132) Best value: -6.45e+00, TR length: 4.00e-01\n",
+      "136) Best value: -5.85e+00, TR length: 4.00e-01\n",
+      "140) Best value: -5.85e+00, TR length: 4.00e-01\n",
+      "144) Best value: -5.85e+00, TR length: 4.00e-01\n",
+      "148) Best value: -5.70e+00, TR length: 4.00e-01\n",
+      "152) Best value: -5.70e+00, TR length: 4.00e-01\n",
+      "156) Best value: -5.70e+00, TR length: 4.00e-01\n",
+      "160) Best value: -5.70e+00, TR length: 4.00e-01\n",
+      "164) Best value: -5.70e+00, TR length: 4.00e-01\n",
+      "168) Best value: -5.70e+00, TR length: 2.00e-01\n",
+      "172) Best value: -4.70e+00, TR length: 2.00e-01\n",
+      "176) Best value: -4.45e+00, TR length: 2.00e-01\n",
+      "180) Best value: -4.03e+00, TR length: 2.00e-01\n",
+      "184) Best value: -4.03e+00, TR length: 2.00e-01\n",
+      "188) Best value: -4.03e+00, TR length: 2.00e-01\n",
+      "192) Best value: -4.03e+00, TR length: 2.00e-01\n",
+      "196) Best value: -4.03e+00, TR length: 2.00e-01\n",
+      "200) Best value: -3.97e+00, TR length: 2.00e-01\n",
+      "204) Best value: -3.97e+00, TR length: 2.00e-01\n",
+      "208) Best value: -3.97e+00, TR length: 2.00e-01\n",
+      "212) Best value: -3.97e+00, TR length: 2.00e-01\n",
+      "216) Best value: -3.77e+00, TR length: 2.00e-01\n",
+      "220) Best value: -3.77e+00, TR length: 2.00e-01\n",
+      "224) Best value: -3.71e+00, TR length: 2.00e-01\n",
+      "228) Best value: -3.67e+00, TR length: 2.00e-01\n",
+      "232) Best value: -3.67e+00, TR length: 2.00e-01\n",
+      "236) Best value: -3.67e+00, TR length: 2.00e-01\n",
+      "240) Best value: -3.67e+00, TR length: 2.00e-01\n",
+      "244) Best value: -3.67e+00, TR length: 2.00e-01\n",
+      "248) Best value: -3.67e+00, TR length: 1.00e-01\n",
+      "252) Best value: -3.23e+00, TR length: 1.00e-01\n",
+      "256) Best value: -3.23e+00, TR length: 1.00e-01\n",
+      "260) Best value: -3.23e+00, TR length: 1.00e-01\n",
+      "264) Best value: -2.73e+00, TR length: 1.00e-01\n",
+      "268) Best value: -2.73e+00, TR length: 1.00e-01\n",
+      "272) Best value: -2.39e+00, TR length: 1.00e-01\n",
+      "276) Best value: -2.39e+00, TR length: 1.00e-01\n",
+      "280) Best value: -2.39e+00, TR length: 1.00e-01\n",
+      "284) Best value: -2.39e+00, TR length: 1.00e-01\n",
+      "288) Best value: -2.39e+00, TR length: 1.00e-01\n",
+      "292) Best value: -2.39e+00, TR length: 5.00e-02\n",
+      "296) Best value: -2.15e+00, TR length: 5.00e-02\n",
+      "300) Best value: -2.15e+00, TR length: 5.00e-02\n",
+      "304) Best value: -1.83e+00, TR length: 5.00e-02\n",
+      "308) Best value: -1.83e+00, TR length: 5.00e-02\n",
+      "312) Best value: -1.83e+00, TR length: 5.00e-02\n",
+      "316) Best value: -1.83e+00, TR length: 5.00e-02\n",
+      "320) Best value: -1.83e+00, TR length: 5.00e-02\n",
+      "324) Best value: -1.73e+00, TR length: 5.00e-02\n",
+      "328) Best value: -1.73e+00, TR length: 5.00e-02\n",
+      "332) Best value: -1.73e+00, TR length: 5.00e-02\n",
+      "336) Best value: -1.73e+00, TR length: 5.00e-02\n",
+      "340) Best value: -1.66e+00, TR length: 5.00e-02\n",
+      "344) Best value: -1.66e+00, TR length: 5.00e-02\n",
+      "348) Best value: -1.66e+00, TR length: 5.00e-02\n",
+      "352) Best value: -1.66e+00, TR length: 5.00e-02\n",
+      "356) Best value: -1.62e+00, TR length: 5.00e-02\n",
+      "360) Best value: -1.28e+00, TR length: 5.00e-02\n",
+      "364) Best value: -1.28e+00, TR length: 5.00e-02\n",
+      "368) Best value: -1.28e+00, TR length: 5.00e-02\n",
+      "372) Best value: -1.28e+00, TR length: 5.00e-02\n",
+      "376) Best value: -1.28e+00, TR length: 5.00e-02\n",
+      "380) Best value: -1.28e+00, TR length: 2.50e-02\n",
+      "384) Best value: -1.05e+00, TR length: 2.50e-02\n",
+      "388) Best value: -1.05e+00, TR length: 2.50e-02\n",
+      "392) Best value: -1.05e+00, TR length: 2.50e-02\n",
+      "396) Best value: -1.05e+00, TR length: 2.50e-02\n",
+      "400) Best value: -1.04e+00, TR length: 2.50e-02\n",
+      "404) Best value: -1.04e+00, TR length: 2.50e-02\n",
+      "408) Best value: -1.04e+00, TR length: 2.50e-02\n",
+      "412) Best value: -1.04e+00, TR length: 2.50e-02\n",
+      "416) Best value: -9.62e-01, TR length: 2.50e-02\n",
+      "420) Best value: -9.62e-01, TR length: 2.50e-02\n",
+      "424) Best value: -9.62e-01, TR length: 2.50e-02\n",
+      "428) Best value: -9.62e-01, TR length: 2.50e-02\n",
+      "432) Best value: -9.62e-01, TR length: 2.50e-02\n",
+      "436) Best value: -8.91e-01, TR length: 2.50e-02\n",
+      "440) Best value: -8.91e-01, TR length: 2.50e-02\n",
+      "444) Best value: -7.98e-01, TR length: 2.50e-02\n",
+      "448) Best value: -7.98e-01, TR length: 2.50e-02\n",
+      "452) Best value: -7.98e-01, TR length: 2.50e-02\n",
+      "456) Best value: -7.98e-01, TR length: 2.50e-02\n",
+      "460) Best value: -7.98e-01, TR length: 2.50e-02\n",
+      "464) Best value: -6.43e-01, TR length: 2.50e-02\n",
+      "468) Best value: -6.43e-01, TR length: 2.50e-02\n",
+      "472) Best value: -6.43e-01, TR length: 2.50e-02\n",
+      "476) Best value: -6.43e-01, TR length: 2.50e-02\n",
+      "480) Best value: -6.43e-01, TR length: 2.50e-02\n",
+      "484) Best value: -6.43e-01, TR length: 1.25e-02\n",
+      "488) Best value: -6.43e-01, TR length: 1.25e-02\n",
+      "492) Best value: -6.06e-01, TR length: 1.25e-02\n",
+      "496) Best value: -5.59e-01, TR length: 1.25e-02\n",
+      "500) Best value: -3.93e-01, TR length: 1.25e-02\n",
+      "504) Best value: -3.53e-01, TR length: 1.25e-02\n",
+      "508) Best value: -3.53e-01, TR length: 1.25e-02\n",
+      "512) Best value: -3.02e-01, TR length: 1.25e-02\n",
+      "516) Best value: -2.70e-01, TR length: 1.25e-02\n",
+      "520) Best value: -2.27e-01, TR length: 1.25e-02\n",
+      "524) Best value: -1.81e-01, TR length: 1.25e-02\n",
+      "528) Best value: -1.81e-01, TR length: 1.25e-02\n",
+      "532) Best value: -1.81e-01, TR length: 1.25e-02\n",
+      "536) Best value: -1.81e-01, TR length: 1.25e-02\n",
+      "540) Best value: -1.81e-01, TR length: 1.25e-02\n",
+      "544) Best value: -1.81e-01, TR length: 6.25e-03\n"
      ]
     }
    ],
@@ -1022,7 +520,7 @@
     "    [eval_objective(x) for x in X_turbo], dtype=dtype, device=device\n",
     ").unsqueeze(-1)\n",
     "\n",
-    "state = TurboState(dim, batch_size=batch_size)\n",
+    "state = TurboState(dim, batch_size=batch_size, best_value=max(Y_turbo).item())\n",
     "\n",
     "NUM_RESTARTS = 10 if not SMOKE_TEST else 2\n",
     "RAW_SAMPLES = 512 if not SMOKE_TEST else 4\n",
@@ -1112,95 +610,131 @@
      "output_type": "stream",
      "text": [
       "44) Best value: -1.15e+01\n",
-      "48) Best value: -1.06e+01\n",
+      "48) Best value: -1.04e+01\n",
       "52) Best value: -1.02e+01\n",
-      "56) Best value: -9.65e+00\n",
-      "60) Best value: -9.28e+00\n",
-      "64) Best value: -7.83e+00\n",
-      "68) Best value: -7.57e+00\n",
-      "72) Best value: -6.93e+00\n",
-      "76) Best value: -6.42e+00\n",
-      "80) Best value: -6.08e+00\n",
-      "84) Best value: -6.08e+00\n",
-      "88) Best value: -5.93e+00\n",
-      "92) Best value: -5.44e+00\n",
-      "96) Best value: -5.44e+00\n",
-      "100) Best value: -5.25e+00\n",
-      "104) Best value: -5.17e+00\n",
-      "108) Best value: -4.56e+00\n",
-      "112) Best value: -4.56e+00\n",
-      "116) Best value: -4.56e+00\n",
-      "120) Best value: -4.38e+00\n",
-      "124) Best value: -4.35e+00\n",
-      "128) Best value: -4.26e+00\n",
-      "132) Best value: -3.83e+00\n",
-      "136) Best value: -3.83e+00\n",
-      "140) Best value: -3.83e+00\n",
-      "144) Best value: -3.83e+00\n",
-      "148) Best value: -3.83e+00\n",
-      "152) Best value: -3.53e+00\n",
-      "156) Best value: -3.53e+00\n",
-      "160) Best value: -3.53e+00\n",
-      "164) Best value: -3.53e+00\n",
-      "168) Best value: -3.53e+00\n",
-      "172) Best value: -3.27e+00\n",
-      "176) Best value: -3.27e+00\n",
-      "180) Best value: -3.27e+00\n",
-      "184) Best value: -3.27e+00\n",
-      "188) Best value: -3.27e+00\n",
-      "192) Best value: -3.27e+00\n",
-      "196) Best value: -3.27e+00\n",
-      "200) Best value: -2.99e+00\n",
-      "204) Best value: -2.79e+00\n",
-      "208) Best value: -2.79e+00\n",
-      "212) Best value: -2.79e+00\n",
-      "216) Best value: -2.79e+00\n",
-      "220) Best value: -2.79e+00\n",
-      "224) Best value: -2.79e+00\n",
-      "228) Best value: -2.73e+00\n",
-      "232) Best value: -2.57e+00\n",
-      "236) Best value: -2.57e+00\n",
-      "240) Best value: -2.57e+00\n",
-      "244) Best value: -2.57e+00\n",
-      "248) Best value: -2.22e+00\n",
-      "252) Best value: -2.22e+00\n",
-      "256) Best value: -2.22e+00\n",
-      "260) Best value: -2.22e+00\n",
-      "264) Best value: -2.22e+00\n",
-      "268) Best value: -2.22e+00\n",
-      "272) Best value: -2.22e+00\n",
-      "276) Best value: -2.22e+00\n",
-      "280) Best value: -2.22e+00\n",
-      "284) Best value: -2.22e+00\n",
-      "288) Best value: -2.22e+00\n",
-      "292) Best value: -2.22e+00\n",
-      "296) Best value: -2.22e+00\n",
-      "300) Best value: -2.22e+00\n",
-      "304) Best value: -2.22e+00\n",
-      "308) Best value: -2.22e+00\n",
-      "312) Best value: -2.22e+00\n",
-      "316) Best value: -2.22e+00\n",
-      "320) Best value: -2.22e+00\n",
-      "324) Best value: -2.22e+00\n",
-      "328) Best value: -2.22e+00\n",
-      "332) Best value: -2.22e+00\n",
-      "336) Best value: -2.22e+00\n",
-      "340) Best value: -2.22e+00\n",
-      "344) Best value: -2.22e+00\n",
-      "348) Best value: -2.22e+00\n",
-      "352) Best value: -2.22e+00\n",
-      "356) Best value: -2.22e+00\n",
-      "360) Best value: -2.22e+00\n",
-      "364) Best value: -2.22e+00\n",
-      "368) Best value: -2.22e+00\n",
-      "372) Best value: -2.22e+00\n",
-      "376) Best value: -2.22e+00\n",
-      "380) Best value: -2.22e+00\n",
-      "384) Best value: -2.22e+00\n",
-      "388) Best value: -2.22e+00\n",
-      "392) Best value: -2.22e+00\n",
-      "396) Best value: -2.22e+00\n",
-      "400) Best value: -2.22e+00\n"
+      "56) Best value: -9.98e+00\n",
+      "60) Best value: -9.62e+00\n",
+      "64) Best value: -9.10e+00\n",
+      "68) Best value: -9.10e+00\n",
+      "72) Best value: -8.87e+00\n",
+      "76) Best value: -8.87e+00\n",
+      "80) Best value: -8.75e+00\n",
+      "84) Best value: -8.18e+00\n",
+      "88) Best value: -7.58e+00\n",
+      "92) Best value: -7.24e+00\n",
+      "96) Best value: -6.86e+00\n",
+      "100) Best value: -6.75e+00\n",
+      "104) Best value: -6.35e+00\n",
+      "108) Best value: -5.74e+00\n",
+      "112) Best value: -5.43e+00\n",
+      "116) Best value: -5.25e+00\n",
+      "120) Best value: -4.66e+00\n",
+      "124) Best value: -4.66e+00\n",
+      "128) Best value: -4.66e+00\n",
+      "132) Best value: -4.66e+00\n",
+      "136) Best value: -4.55e+00\n",
+      "140) Best value: -4.36e+00\n",
+      "144) Best value: -4.24e+00\n",
+      "148) Best value: -4.22e+00\n",
+      "152) Best value: -4.22e+00\n",
+      "156) Best value: -3.97e+00\n",
+      "160) Best value: -3.86e+00\n",
+      "164) Best value: -3.63e+00\n",
+      "168) Best value: -3.63e+00\n",
+      "172) Best value: -3.59e+00\n",
+      "176) Best value: -3.59e+00\n",
+      "180) Best value: -3.59e+00\n",
+      "184) Best value: -3.59e+00\n",
+      "188) Best value: -3.20e+00\n",
+      "192) Best value: -3.20e+00\n",
+      "196) Best value: -3.20e+00\n",
+      "200) Best value: -3.20e+00\n",
+      "204) Best value: -3.20e+00\n",
+      "208) Best value: -3.20e+00\n",
+      "212) Best value: -2.64e+00\n",
+      "216) Best value: -2.64e+00\n",
+      "220) Best value: -2.64e+00\n",
+      "224) Best value: -2.62e+00\n",
+      "228) Best value: -2.62e+00\n",
+      "232) Best value: -2.62e+00\n",
+      "236) Best value: -2.62e+00\n",
+      "240) Best value: -2.49e+00\n",
+      "244) Best value: -2.49e+00\n",
+      "248) Best value: -2.49e+00\n",
+      "252) Best value: -2.49e+00\n",
+      "256) Best value: -2.49e+00\n",
+      "260) Best value: -2.49e+00\n",
+      "264) Best value: -2.49e+00\n",
+      "268) Best value: -2.49e+00\n",
+      "272) Best value: -2.12e+00\n",
+      "276) Best value: -2.12e+00\n",
+      "280) Best value: -2.11e+00\n",
+      "284) Best value: -2.11e+00\n",
+      "288) Best value: -2.11e+00\n",
+      "292) Best value: -2.11e+00\n",
+      "296) Best value: -2.11e+00\n",
+      "300) Best value: -2.11e+00\n",
+      "304) Best value: -2.11e+00\n",
+      "308) Best value: -2.11e+00\n",
+      "312) Best value: -2.11e+00\n",
+      "316) Best value: -2.11e+00\n",
+      "320) Best value: -2.11e+00\n",
+      "324) Best value: -2.11e+00\n",
+      "328) Best value: -2.11e+00\n",
+      "332) Best value: -2.11e+00\n",
+      "336) Best value: -2.11e+00\n",
+      "340) Best value: -2.11e+00\n",
+      "344) Best value: -2.11e+00\n",
+      "348) Best value: -2.11e+00\n",
+      "352) Best value: -2.11e+00\n",
+      "356) Best value: -2.11e+00\n",
+      "360) Best value: -2.11e+00\n",
+      "364) Best value: -2.11e+00\n",
+      "368) Best value: -2.11e+00\n",
+      "372) Best value: -2.11e+00\n",
+      "376) Best value: -2.11e+00\n",
+      "380) Best value: -2.11e+00\n",
+      "384) Best value: -2.11e+00\n",
+      "388) Best value: -2.11e+00\n",
+      "392) Best value: -2.11e+00\n",
+      "396) Best value: -2.11e+00\n",
+      "400) Best value: -2.11e+00\n",
+      "404) Best value: -2.11e+00\n",
+      "408) Best value: -2.11e+00\n",
+      "412) Best value: -2.11e+00\n",
+      "416) Best value: -2.11e+00\n",
+      "420) Best value: -2.11e+00\n",
+      "424) Best value: -2.11e+00\n",
+      "428) Best value: -2.11e+00\n",
+      "432) Best value: -2.11e+00\n",
+      "436) Best value: -2.11e+00\n",
+      "440) Best value: -2.11e+00\n",
+      "444) Best value: -2.11e+00\n",
+      "448) Best value: -2.11e+00\n",
+      "452) Best value: -2.11e+00\n",
+      "456) Best value: -2.11e+00\n",
+      "460) Best value: -2.11e+00\n",
+      "464) Best value: -2.11e+00\n",
+      "468) Best value: -2.11e+00\n",
+      "472) Best value: -2.11e+00\n",
+      "476) Best value: -2.11e+00\n",
+      "480) Best value: -2.11e+00\n",
+      "484) Best value: -2.11e+00\n",
+      "488) Best value: -2.11e+00\n",
+      "492) Best value: -2.11e+00\n",
+      "496) Best value: -2.11e+00\n",
+      "500) Best value: -2.11e+00\n",
+      "504) Best value: -2.11e+00\n",
+      "508) Best value: -2.11e+00\n",
+      "512) Best value: -2.11e+00\n",
+      "516) Best value: -2.11e+00\n",
+      "520) Best value: -2.11e+00\n",
+      "524) Best value: -2.11e+00\n",
+      "528) Best value: -2.11e+00\n",
+      "532) Best value: -2.11e+00\n",
+      "536) Best value: -2.11e+00\n",
+      "540) Best value: -2.11e+00\n",
+      "544) Best value: -2.11e+00\n"
      ]
     }
    ],
@@ -1266,1249 +800,129 @@
       "44) Best value: -1.13e+01\n",
       "48) Best value: -1.04e+01\n",
       "52) Best value: -9.96e+00\n",
-      "56) Best value: -9.40e+00\n",
-      "60) Best value: -9.27e+00\n",
-      "64) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "68) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "72) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "76) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "80) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "84) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "88) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "92) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "96) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "104) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "108) Best value: -8.76e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "112) Best value: -8.76e+00\n",
-      "116) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "120) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "124) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "128) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "132) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "136) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "140) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "144) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "148) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "152) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "156) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "160) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "164) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "168) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "172) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "176) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "180) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "184) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "188) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "192) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "196) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "200) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "204) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "208) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "212) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "216) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "220) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "224) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "228) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "232) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "236) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "240) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "244) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "248) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "252) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "256) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "260) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "264) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "268) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "272) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "276) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "280) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "284) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "288) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "292) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "296) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "300) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "304) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "308) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "312) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "316) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "320) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "324) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "328) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "332) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "336) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "340) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "344) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "348) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "352) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "356) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "360) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "364) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "368) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "372) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "376) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "380) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "384) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "388) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "392) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "396) Best value: -8.13e+00\n",
-      "400) Best value: -8.13e+00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/deriksson/Documents/GitHub/botorch/botorch/optim/initializers.py:432: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
-      "  warnings.warn(\n"
+      "56) Best value: -8.97e+00\n",
+      "60) Best value: -8.73e+00\n",
+      "64) Best value: -8.73e+00\n",
+      "68) Best value: -8.73e+00\n",
+      "72) Best value: -8.68e+00\n",
+      "76) Best value: -8.68e+00\n",
+      "80) Best value: -8.68e+00\n",
+      "84) Best value: -8.68e+00\n",
+      "88) Best value: -8.68e+00\n",
+      "92) Best value: -8.68e+00\n",
+      "96) Best value: -8.68e+00\n",
+      "100) Best value: -8.68e+00\n",
+      "104) Best value: -8.68e+00\n",
+      "108) Best value: -8.68e+00\n",
+      "112) Best value: -8.68e+00\n",
+      "116) Best value: -8.68e+00\n",
+      "120) Best value: -8.68e+00\n",
+      "124) Best value: -8.68e+00\n",
+      "128) Best value: -8.68e+00\n",
+      "132) Best value: -8.68e+00\n",
+      "136) Best value: -8.68e+00\n",
+      "140) Best value: -8.68e+00\n",
+      "144) Best value: -8.68e+00\n",
+      "148) Best value: -8.68e+00\n",
+      "152) Best value: -8.68e+00\n",
+      "156) Best value: -8.68e+00\n",
+      "160) Best value: -8.68e+00\n",
+      "164) Best value: -8.68e+00\n",
+      "168) Best value: -8.68e+00\n",
+      "172) Best value: -8.68e+00\n",
+      "176) Best value: -8.68e+00\n",
+      "180) Best value: -8.68e+00\n",
+      "184) Best value: -8.68e+00\n",
+      "188) Best value: -8.68e+00\n",
+      "192) Best value: -8.68e+00\n",
+      "196) Best value: -8.68e+00\n",
+      "200) Best value: -8.68e+00\n",
+      "204) Best value: -8.68e+00\n",
+      "208) Best value: -8.68e+00\n",
+      "212) Best value: -8.68e+00\n",
+      "216) Best value: -8.68e+00\n",
+      "220) Best value: -8.68e+00\n",
+      "224) Best value: -8.68e+00\n",
+      "228) Best value: -8.68e+00\n",
+      "232) Best value: -8.68e+00\n",
+      "236) Best value: -8.68e+00\n",
+      "240) Best value: -8.68e+00\n",
+      "244) Best value: -8.68e+00\n",
+      "248) Best value: -8.68e+00\n",
+      "252) Best value: -8.68e+00\n",
+      "256) Best value: -8.68e+00\n",
+      "260) Best value: -8.68e+00\n",
+      "264) Best value: -8.68e+00\n",
+      "268) Best value: -8.68e+00\n",
+      "272) Best value: -8.68e+00\n",
+      "276) Best value: -8.68e+00\n",
+      "280) Best value: -8.68e+00\n",
+      "284) Best value: -8.68e+00\n",
+      "288) Best value: -8.68e+00\n",
+      "292) Best value: -8.68e+00\n",
+      "296) Best value: -8.68e+00\n",
+      "300) Best value: -8.68e+00\n",
+      "304) Best value: -8.68e+00\n",
+      "308) Best value: -8.68e+00\n",
+      "312) Best value: -8.68e+00\n",
+      "316) Best value: -8.68e+00\n",
+      "320) Best value: -8.68e+00\n",
+      "324) Best value: -8.68e+00\n",
+      "328) Best value: -8.68e+00\n",
+      "332) Best value: -8.68e+00\n",
+      "336) Best value: -8.68e+00\n",
+      "340) Best value: -8.68e+00\n",
+      "344) Best value: -8.68e+00\n",
+      "348) Best value: -8.68e+00\n",
+      "352) Best value: -8.68e+00\n",
+      "356) Best value: -8.68e+00\n",
+      "360) Best value: -8.68e+00\n",
+      "364) Best value: -8.68e+00\n",
+      "368) Best value: -8.68e+00\n",
+      "372) Best value: -8.68e+00\n",
+      "376) Best value: -8.68e+00\n",
+      "380) Best value: -8.68e+00\n",
+      "384) Best value: -8.68e+00\n",
+      "388) Best value: -8.68e+00\n",
+      "392) Best value: -8.68e+00\n",
+      "396) Best value: -8.68e+00\n",
+      "400) Best value: -8.68e+00\n",
+      "404) Best value: -8.68e+00\n",
+      "408) Best value: -8.68e+00\n",
+      "412) Best value: -8.68e+00\n",
+      "416) Best value: -8.68e+00\n",
+      "420) Best value: -8.68e+00\n",
+      "424) Best value: -8.68e+00\n",
+      "428) Best value: -8.68e+00\n",
+      "432) Best value: -8.68e+00\n",
+      "436) Best value: -8.68e+00\n",
+      "440) Best value: -8.68e+00\n",
+      "444) Best value: -8.68e+00\n",
+      "448) Best value: -8.68e+00\n",
+      "452) Best value: -8.68e+00\n",
+      "456) Best value: -8.68e+00\n",
+      "460) Best value: -8.68e+00\n",
+      "464) Best value: -8.68e+00\n",
+      "468) Best value: -8.68e+00\n",
+      "472) Best value: -8.68e+00\n",
+      "476) Best value: -8.68e+00\n",
+      "480) Best value: -8.68e+00\n",
+      "484) Best value: -8.68e+00\n",
+      "488) Best value: -8.68e+00\n",
+      "492) Best value: -8.68e+00\n",
+      "496) Best value: -8.68e+00\n",
+      "500) Best value: -8.68e+00\n",
+      "504) Best value: -8.68e+00\n",
+      "508) Best value: -8.68e+00\n",
+      "512) Best value: -8.68e+00\n",
+      "516) Best value: -8.68e+00\n",
+      "520) Best value: -8.68e+00\n",
+      "524) Best value: -8.68e+00\n",
+      "528) Best value: -8.68e+00\n",
+      "532) Best value: -8.68e+00\n",
+      "536) Best value: -8.68e+00\n",
+      "540) Best value: -8.68e+00\n",
+      "544) Best value: -8.68e+00\n"
      ]
     }
    ],
@@ -2614,7 +1028,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+IAAAKBCAYAAADTDRELAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAClI0lEQVR4nOzdd3xUVf7/8fckmUx6DyFAqArSRIoFG6Biwd77igVXXdvqrl87sLb9Lq4/21rWdZVdde2uu4oKCKiIKCIgoiBICQihpJOQZDJzf3/kmzHT0mbm3mTm9Xw88nDOveee+8nJZZzPnHPPtRmGYQgAAAAAAJgizuoAAAAAAACIJSTiAAAAAACYiEQcAAAAAAATkYgDAAAAAGAiEnEAAAAAAExEIg4AAAAAgIlIxAEAAAAAMBGJOAAAAAAAJiIRBwAAAADARCTiAAAgYqZOnSqbzSabzaYXX3wxpLYWLVrkaWvixIlhiQ8AACuQiAMAuoTNmzfrueee0yWXXKJRo0YpOztbdrtdOTk5OvDAA/XrX/9an3zySafb//jjj/WrX/1KgwcPVmpqqqfd3//+91q7dm272miZCPr+xMXFKTMzU3379tXIkSN19tln68EHH9S8efPU2NjY6bg767DDDvOK7+233zY9BgAAEFiC1QEAAGLbihUrdM011+irr74KuL+8vFzl5eVavXq1/vrXv2rixImaPXu2+vbt2672q6qqdPXVV+u1117z2l5bW+tp97HHHtPMmTN1xx13dPr3MAxDVVVVqqqq0tatW/Xdd995kt/CwkJdccUV+u1vf6vc3NxOn6O9fvzxR3355Zde22bPnq2zzjor4ucGAABtIxEHAFhq3bp1fkn44MGDNWLECOXl5amiokJLlizRtm3bJDWNSo8fP16fffaZBg4c2GrbTqdTZ511lj7++GPPthEjRmjs2LHat2+fPv30U5WUlMjpdOrOO++U0+nUvffe2+7Yf/Ob33iV6+rqVF5erh07dmjlypXat2+fJGnHjh164IEH9Pzzz+v555/XlClT2n2Ozpg9e7bftjlz5mj37t3Kz8+P6LkBAEDbSMQBAF3Cfvvtp6uuukqXXHKJevfu7bXP7XbrhRde0I033qja2lpt375dF198sZYsWSKbzRa0zfvuu8+ThCclJemFF17QBRdc4Nnf0NCgu+++W7NmzZIkTZ8+XRMmTNCECRPaFfOTTz4ZdJ/T6dTnn3+uxx57TO+++64Mw1BJSYlOPvlk/etf//KKI5zcbrf++c9/espJSUmqq6tTY2OjXnnlFd10000ROS8AAGg/7hEHAFiqsLBQL7zwgtauXav/+Z//8UvCJSkuLk5XXnmlXnrpJc+2pUuXau7cuUHb3bVrlx555BFP+dFHH/VLfhMTE/WnP/1J559/vmdbKNPTW7Lb7Zo4caLeeecdvf/++8rJyfHsu/zyy/X111+H5Ty+Fi5cqK1bt0qSMjIydM8993j2BRopBwAA5iMRBwBYasKECZo6dari4+PbrHvmmWfqkEMO8ZTff//9oHVnz56tmpoaSU1T3a+++uqgdf/0pz8pLq7pf4lffPGFVqxY0d7w2+Wkk07Sf//7XyUkNE1Eq6ur0+9+97uwnqNZy2T7nHPO0RVXXOHp2xUrVmj16tUROS8AAGg/EnEAQLdyxBFHeF5v3rw5aL1///vfntfNj9AKpm/fvjr22GM95XfeeSekGAM5/PDDddttt3nKn3zyiT7//POwnmPv3r1eq6Nfeuml6tmzpyZPnuzZ1plR8aqqKj3xxBM69dRT1b9/f6WlpcnhcKhXr1469thjNXPmTK1Zsybk+D/66COlpaV5Vnq/7rrr5Ha7Q2pz69atuu+++3TUUUepV69ecjgcysnJ0ejRo/W73/1OP/74Y9BjH3nkEU8sJ554YrvPOXfuXM9xRUVFIf8OAIDoQyIOAOhWWibULpcrYJ26ujotXbrUU27PM6db1lmwYEGn42vNDTfcoMTERE/59ddfD2v7b775pmcWQN++fT33ul966aWeOi+//HLQfgvkmWeeUf/+/XXjjTfqvffe05YtW1RTU6OGhgbt2LFDCxYs0IwZMzRixAh9+OGHnY791Vdf1amnnuqJ/5577tFTTz3lmanQUW63W/fee68GDx6se++9V4sXL9aOHTvU0NCg8vJyrVy5Un/+8581fPhw3XXXXTIMw6+Nyy67TA6HQ5I0b948FRcXt+vcf//73z2vL7/88k7/DgCA6MX/GQAA3UrLqdVFRUUB66xbt84zCmmz2TR69Og22x0zZozn9Q8//BBilIH17NlTRx55pKf86aefhrX9lqPdF198sedLizPPPFPp6emSpJKSEn300Uftau/GG2/Utddeq/LycklSfHy8DjvsMF166aWaNm2azjjjDPXv399Tv66urlNxP/nkk7rooovkdDpls9n0+OOP6w9/+EOn2pKavqA577zzdN9993liKiws1BlnnKGrr75aF110kQYNGiRJamxs1IMPPqhf//rXfu3k5uZ6Hvnmdrv14osvtnnusrIyz2wMm82myy+/vNO/BwAgepGIAwC6ja1bt3qNVh933HEB661bt87zukePHkpKSmqz7ZbPJS8rK9Pu3btDiDS4Qw891PP622+/9TziLFRbtmzRJ5984ilfcsklntfJyck6++yzPeV//OMfbbb3zDPP6IknnvCUzzvvPG3evFlffPGF/vGPf+ivf/2r3nnnHW3atEmrV6/WjTfeqJSUlA7HPX36dN1www0yDEN2u10vvfSSbrjhhg6309LMmTP11ltvSWr6+7/22mvatm2b3nnnHT377LN6+eWXtWHDBr3xxhvKzMyUJD333HMBZyi0XFvghRdeCDhy3tLLL7+s+vp6SdKxxx6rAQMGhPS7AACiE4k4AKDb+O1vf+uZVt23b1+deuqpAeuVlpZ6XhcUFLSr7Z49e3qVy8rKOhll64YMGeJ57Xa7tWfPnrC0+89//tOTJI4ZM0bDhg3z2t9yevq7776rioqKoG2Vl5d73c9+zTXX6LXXXlOfPn0C1h8xYoQee+wxHX/88e2O1+1269prr/WMfKekpOjdd9/VRRdd1O42Atm8ebMefPBBSVJ6ero++eQTnXfeeQGnh59zzjle99TPmDHDL9GeOHGiBg8e7Gm75TPpA2k5Lf3KK6/s9O8BAIhuJOIAgG5h9uzZnlFOSXrooYc89+/62rt3r+d1cnJyu9r3rdeyjXBqHoFt1jztO1QtR7lbJt3NJk2a5JnKX1dX1+r96X/9619VXV0tSerXr58effTRsMTYrKGhQRdccIGeeeYZSVJ2drbmzZunk046KeS2H3vsMc+XNbfddpsOOOCAVusfc8wxOuGEEyQ13ZIQaMX8q666yvP6+eefD9rW8uXLtXLlSklSTk6OzjzzzI6GDwCIESTiAIAu7+uvv9Y111zjKZ9//vmtjpy2vFe55eJorfFN6sM1ZdxXWlqaV7k54Q3FkiVLtH79eklN93FfeOGFfnVsNpsuvvhiT7m11dNbLro2bdq0oF94dMbevXt18skn64033pAk9erVS59++qkOP/zwsLQ/Z84cz2vf58YHc8wxx3heL1682G//1KlTPdfRO++8E3S2RMvR8EsuuSSs/QYAiC4JVgcAAEBrNm3apFNPPdWTXI8cOVLPPvtsq8e0vCe8oaGhXedpvq+3WXtH0jvKN/HOyMgIuc2WSfXkyZODTse/9NJL9cc//lHSL8n7/vvv71fvyy+/9LyeNGlSyPE127NnjyZNmqSvv/5akrT//vtr7ty5Xgu+haK0tNTrcWT/7//9v1YfW9fs+++/97zeunWr3/78/HydfvrpeuONN1RfX6+XX37Z7z72uro6vfLKK55yy1F0AAB8kYgDALqsHTt2aPLkySopKZEkDRw4UB999JHf9G5fLUed2zuy7VvPd+Q6XCorK73KOTk5IbXnO8080LT0ZsOGDdPYsWO1fPlySU3T2e+77z6vOlVVVV59MXDgwJDia+mOO+5QY2OjJOnAAw/UvHnz1KNHj7C1v2PHDq/yU0891eE2gt0qcPXVV3tG8Z9//nm/RPztt9/23Hd/8MEHa+TIkR0+NwAgdjA1HQDQJZWWlmry5Mn66aefJDU9fmr+/PkqLCxs89jc3FzP6507d7brfM3JfrNQE+Rg1q5d63kdHx+vvLy8kNprufBaWlqazjjjjFbrt0zUWy7w1sx3xD6cX0jY7XbP6507d4Ztobpmvl9ydEbzFwW+jj32WM8jz1atWqVvvvnGa3/Le8cZDQcAtIVEHADQ5VRVVenEE0/UmjVrJDUl1vPmzWv3o6Barky+a9eudj3furi42PM6JydH+fn5HYy6fVpO+x49enTI9xG3nJa+d+9epaamymazBf25+eabPfW3bNmiRYsWebXX/Lzxlm2Gy0MPPaRDDjlEUlMifswxx4T1me2pqame11lZWTIMo8M/wZ4VbrPZgi7atmnTJi1cuFBS0+rv7b03HQAQu0jEAQBdSk1NjaZMmeK5jzgjI0MfffSRhg8f3u42hgwZ4nlclWEYnpWsW9NyhHPo0KEdC7qdtm/frs8//9xTPuqoo0Jqr6SkRHPnzg2pDd9nimdkZHjdH79p06aQ2m8pMzNTc+fO9UrGJ02aFLZkvOW98RUVFWF/Fvzll1/uGdV/5ZVXPFP4Wz5f/Nxzzw3Lff8AgOhGIg4A6DLq6up02mmneZLVlJQUzZkzR2PHju1QO0lJSTrssMM8Zd9R30A++eQTz+uWq2iH0xNPPCGn0+kphzpy+vLLL3se1ZWWlqZDDz20XT8jRozwtPHmm2+qpqbGq91DDz3U83rBggUhxeirORk/+OCDJf0yMt5yyn5nFRYWqm/fvp5yqF9S+CooKPA8u76iokJvv/223G631yg609IBAO1BIg4A6BKcTqfOPvtsT+LncDj07rvv6ogjjuhUey3vlQ423bjZtm3b9PHHHwc8NlyWLFmihx9+2FM+7rjjPCPDndVyWvq0adO0dOnSdv189dVXnlHbvXv36u233/Zqt+XzvJ977jm/FeVDlZmZqXnz5nmS8ZKSEk2aNCksyfjJJ5/sef3oo4/63QMfqquvvtrz+vnnn9e8efM8K60PGTJERx55ZFjPBwCITiTiAADLuVwuXXTRRZ5nQCckJOj111/Xcccd1+k2L7vsMs89w+vWrdPf/va3oHVvu+02z8jy+PHjNWbMmE6fN5APP/xQp556qmchsJSUFK+kvDNWrFih1atXe8otnxHeluTkZJ111lmesu8zxadNm+ZZpG3Lli1e95WHS7BkfN26dSG1e+uttyo+Pl5S0/PnZ86c2e5jfRfsC2Ty5Mmex60tWrRIM2bM8Oy78sorOxQrACB2kYgDACxlGIauuuoqvfnmm5KkuLg4/fOf/9Rpp50WUrs9evTQLbfc4infeOONXo/5kpqeMX777bfrX//6l2fbQw89FNJ5mzU2NuqTTz7R2WefrZNPPlllZWWSmhb9+uc//6lRo0aF1H7L5Hnw4MEdnr7fMnFfuHCh1/Ozs7Oz9b//+7+e8jPPPKPzzz9f27ZtC9jWmjVrdNNNN3V4KrjvNPVwJOODBg3S3Xff7SnPnDlTU6dODRq7y+XS/Pnz9atf/apdX8DExcV5Em7DMLR06VJJTV8e/epXv+p03ACA2MJzxAEAlnr66ae9po4PGjRIixcv1uLFi9s8Njc3t9URz3vuuUeff/65FixYoH379un888/X/fffrzFjxqiurk6ffvqp17OnZ86cqQkTJrQ79uuvv96rXFdXp4qKCpWUlOibb77xezZ579699cILL2jy5MntPkcgjY2NeuWVVzzljoyGNzvmmGPUq1cvbd++XW63W//85z915513evZfd911+u677/T0009Lkl5//XW99dZbOvjggzV48GAlJSVp9+7dWrFihTZv3ixJmjRpUofjyMrK0ty5czV58mR9/fXX2rFjhyZNmqSFCxd6rX7fEdOnT9fmzZs9X1bMnj1bL730kkaPHq0DDjhAaWlpqqqq0pYtW7Rq1SrPyvAtH3vXmiuuuEIzZ870etTZqaee6rVYHAAArTIAALDQ9OnTDUmd+unXr1+b7VdUVBjnnXdeq+3Y7XbjgQceaLOthQsXdirO3r17G/fcc49RVlYWhh4zjHfffder/fXr13eqnVtuucXTxuDBgwPWefTRR42MjIw2f0ebzWZ89NFHfsdfdtllnjovvPBC0FjKy8uNcePGeeoWFhYa69at86rTsv8nTJjQ5u/3xBNPGNnZ2e36G9lsNuO0005rs81mp59+utfx7733XruPBQCAqekAgKiWmZmp1157TfPmzdMll1yiQYMGKSUlRZmZmRoxYoRuvfVWrVq1yms0uDNsNpvS09PVu3dvDR8+XGeeeaYeeOABzZ8/X1u2bNEf/vAHZWdnh+V3ajkt/ZBDDtF+++3XqXZajqT/+OOPnmnWLd10003auHGjHn74YU2ePFm9e/eWw+GQw+FQ7969ddxxx+m+++7TunXrdPzxx3cqDqlpZHzevHkaN26cJHlGxn/88cdOt3n99ddry5Yt+stf/qIzzjhDAwYMUFpamhISEpSdna2RI0fqggsu0DPPPKMtW7bo3XffbXfbZ599tud17969deKJJ3Y6TgBA7LEZRpiXEwUAAIhyU6dO9Xwhctddd+n++++3OCIAQHdCIg4AANABVVVVKiwsVG1trWw2mzZs2KCBAwdaHRYAoBthajoAAEAH/O1vf1Ntba0k6fjjjycJBwB0GCPiAAAA7bR582aNHTvW8zi6jz76KKR74wEAsYlEHAAAoBW/+93vJEnbt2/Xf//7X8/jziZNmqQFCxZYGRoAoJsiEQcAAGiFzWbz29ajRw8tXbpUAwYMsCAiAEB3l2B1AIhObrdb27dvV3p6esAPMAAAdDfx8fEqKCjQMccco9tvv125ubmqqqqyOiwA3ZxhGKqurlavXr0UF8cSXrGCEXFExLZt21RUVGR1GAAAAEC3sHXrVvXp08fqMGASRsQREenp6ZKkTZs2KScnx+JoopfT6dTcuXN1/PHHy263Wx1O1KKfI48+Ngf9bA76OfLoY3PQz+YoKyvTgAEDPJ+fERtIxBERzdPR09PTlZGRYXE00cvpdColJUUZGRn8DzKC6OfIo4/NQT+bg36OPPrYHPSzOZxOp6TA61EgenETAgAAAAAAJiIRBwAAAADARCTiAAAAAACYiEQcAAAAAAATkYgDAAAAAGAiEnEAAAAAAExEIg4AAAAAgIlIxAEAAAAAMBGJOAAAAAAAJiIRBwAAAADARCTiAAAAAACYiEQcAAAAAAATkYgDAAAAAGAiEnEAAAAAAExEIg4AAAAAgIlIxAEAAAAAMBGJOAAAAAAAJiIRBwAAAADARCTiAAAAAACYiEQcAAAAAAATkYgDAAAAAGAiEnEAAAAAAExEIg4AAAAAgIlIxAEAAAAAMBGJOIJ66qmnNGDAACUlJWns2LH67LPPrA4JAAAAALq9BKsDQNf02muv6eabb9ZTTz2lI444Qs8++6xOOukkff/99+rbt2+729mzZ4/cbneHz5+Wlqbk5OSgbRqG0eE2JSklJUWpqakB95WVlcnlcnWq3aSkJKWnpwfcV1FRIafT2al2ExMTlZmZGXBfZWWlampqVFlZqd27d8tut7e7XbvdrqysrID7qqurVVdX15lwFR8fr5ycnID7ampqVFtb26l2bTab8vLyAu7bt2+f9u7d26l2JSk/Pz/g9vr6elVVVUmSnE5nh/s5NzdXcXH+33U2NDSosrKy0/FmZ2crIcH/rbuxsVHl5eWdbjczM1OJiYl+291ut0pLSzvdbkZGhhwOR8B9u3fv9rzuaB/zHtGkrfeIhoYGr23t7WfeI37RnvcIX+3pZ94jmrT3PcJXW33Me0STjr5H+ArWz7xH/KIz7xG+ysrKOn1+dGMGEMAhhxxiXHPNNV7bDjjgAOP2229v1/GVlZWGpE7/PPnkk0HbzsvL63S706dPD9rusGHDOt3uddddF7TdCRMmdLrdc845J2i755xzTqfbnTBhQtB2r7vuuk63O2zYsKDtTp8+vdPt5uXlBW33ySefDOlaC+b1118Pqd1du3YFbHfhwoUhtfvdd98FbPe7774Lqd2FCxcGbHfXrl0htfv6668H7eNQ2uU9oumH94imH94jfvnhPaLph/eIph/eI5p+ust7RGVlZdD2EH0YEYefhoYGLV++XLfffrvX9uOPP15LliwJeEx9fb3q6+s95fZ+AxiMy+Xq9Le/nW3X6OS341LTiIDZ7XZmpkEzwzBMb7ezowTNzG63sbEx5HYDtR2pdkP999LY2Ghqu6HiPaLtdnmPiGy7vEdEtt1Q8R7Rdru8R0S23VD/LSP6kYjDz549e+RyuVRQUOC1vaCgQCUlJQGPeeihhzRz5sywxbBmzRrNmTMn4L62plG1Zv369UHbDWVa0pYtW4K2G8qUvZKSkqDtBvtbtEdpaWnQdrds2dLpdvfu3Ru03fXr13e63YaGhqDtrlmzptPtSgra7ooVK0Jqd/78+QGnA65evTqkdj/77LOAf6Pi4uKQ2l26dKlqamr8tocyRVZq6seUlJSQ2giE94gmvEc04T3iF7xHNOE9ognvEU2643sEoh+JOIKy2WxeZcMw/LY1u+OOO3TLLbd4ylVVVSoqKur0uYcPH64pU6YE3BfoHrX22n///YO2e8cdd3S63X79+gVt95FHHul0uz179gza7j/+8Y9Ot5ubmxu03Q8//LDT7aalpQVt9+uvv+50u4mJiUHbDeV/+JKCttvZ+9CaHXfccQHvGwt2b2F7HXXUURo+fLjf9lA/SBx22GGaMGGC3/bW7tFsj9GjRwft41DwHtGE94gmvEf8gveIJrxHNOE9okl3fI9A9LMZocx3QVRqaGhQSkqK3njjDZ155pme7TfddJNWrlypTz75pM02qqqqlJmZqbVr1wZddKM1LLLSpD2Ltc2fP1/HHXcci7V1UnsXa+toP7MQU5OOLNbWkT7mPaJJZxZra08/8x7xi84u1tZWP/Me0SSUxdpa62PeI5qEY7G2QP3Me8QvwrVY2wEHHKDKykplZGR0OhZ0L4yIw09iYqLGjh2refPmeSXi8+bN0+mnn96htvLy8pSbmxvW+IK9kYaqM18YtEew/1GFKjMzUykpKcrMzFR+fn6HEvHWpKenB/0wEIrU1NSQR3oCSU5ODvphKxQOh8PzP1en0xm2fk5MTAz6P+1QJCQkRKTduLi4iLQreX94CWcf8x7RJNCH73D0M+8RTVq+R/gKpZ95j/hFa+2G0se8RzQJlqC31Jl+5j2iSWvvEb4CfSmH6EcijoBuueUWXXrppRo3bpzGjx+vv/71ryouLtY111xjdWgAAAAA0K2RiCOg888/X6WlpfrDH/6gHTt2aMSIEZozZ4769etndWgAAAAA0K2RiCOo6667Ttddd53VYQAAAABAVOGGBAAAAAAATEQiDgAAAACAiUjEAQAAAAAwEYk4AAAAAAAmIhEHAAAAAMBEJOIAAAAAAJiIRBwAAAAAABORiAMAAAAAYCIScQAAAAAATEQiDgAAAACAiUjEAQAAAAAwEYk4AAAAAAAmIhEHAAAAAMBEJOIAAAAAAJiIRBwAAAAAABORiAMAAAAAYCIScQAAAAAATEQiDgAAAACAiUjEAQAAAAAwEYk4AAAAAAAmIhEHAAAAAMBEJOIAAAAAAJiIRBwAAAAAABORiAMAAAAAYCIScQAAAAAATEQiDgAAAACAiUjEAQAAAAAwEYk4AAAAAAAmIhEHAAAAAMBEJOIAAAAAAJgoweoAAAAAACBcauobtaNyn5wuw+pQ2qWivNrqEGABEnEAAAAArdrX4NLyLeXaW98YkfZr6hv1+U97tHj9HtWEcA5DUm2DK3yBmcBdX2t1CLAAiTgAAACAoEprGnTx88v00+4aq0MBogb3iAMAAAAIauZ/fyAJB8KMEXEAAAAghtQ2NGr2ki3aUtp6cu12u7V+c5xWlO40KbLwirNZHUE7dZc4EVYk4gAAAECM2Nfg0kXPfamVWyvaeYT3BNoke5x6ZSaHPS5Jyk93aPKwAo3snSl7Qucn7mYkJah3VoqSE+PDGF3klJaWKu//WR0FzEYiDgAAAHRzTpdb7327XSuKK+RyB18t/IcdVR1Iwv3979kH6vSDenf6eABNSMQBAACALu7D73Zo6caygEl2ndOlxRv2aEdlXURjOOXAQp02qldEzwHEChJxAAAAoAt79pOf9NAHa8PebmayXWeN6S1bkJuU3W6XNm3erAH9+2tIYabOGdtHNhs3NAPhQCIOAAAAdFHf/VypWR+tC3u7joQ4/e2ycTq4f07QOk6nU3PmbNSUKQfIbreHPQYglpGIAwAAAF3EW8u36X8/XKtd1fWdOn5gfqoOHZCrxPjgI9epjgSdflBvDemZ3tkwAYSIRBwAAACwiMttyOU2VF7boMc/Xq+Xvyxutf7Rg/PVN8d/1fLE+HgdNjBHxw0tUFy3eW4XELtIxAEAAACTNTS6dec7q/WfVdvV0Ohu1zEjemfob78ap8QQHu0FoGsgEQcAAABM9uSC9Xpz+bZ21y/KSdaTF44hCQeiBIk4AAAAokad06Vt5fvkNoI/S9tqu6vr9fQnPwXdH2eT7j55mI7aP0+SlBAfp345KUw5B6IIiTgAAAC6rW+3VejPc39USWWdnG63iktr1RjgWdvdQZojQWP6ZevaCYM0flCu1eEAiCAScQAAAHRLW8trdfFzX6q6vtHqUEJy4vCeuuvkoeqVlax4Rr2BmEAiDgAAAEmSYRj6prhcP+2usTqUVrlcLn27y6bnX/u22yfhRTnJ+n/nH6TkxHirQwFgIhJxAAAASJIe+3i9Hp2/3uow2ileUpXVQXSazSYN7ZlBEg7EKBJxeNm8ebPuu+8+LViwQCUlJerVq5cuueQS3XXXXUpMTLQ6PAAAECFut6HnP9tkdRgh+eNZIzWoR5qGFmYozcHHXABdF+9Q8LJ27Vq53W49++yz2m+//fTdd99p2rRpqqmp0cMPP2x1eAAAIEJKquq67TTvxPg4vX3d4RrRO9PqUACgXUjE4eXEE0/UiSee6CkPHDhQ69at09NPP00iDgBAFNu8x/u+8IQ4m4Z30cTWMNyqrKhUZlam8tKSNO2ogSThALoVEnG0qbKyUjk5Oa3Wqa+vV319vadcVdV0z5bT6ZTT6YxofLGsuW/p48iinyOPPjYH/WyO7trP63d632+9f480vXn1IRZF0zqn06l58+Zp8uSxstvtnm0Ir+56LXc39G9sshmG0T0ftAhT/PTTTxozZoz+/Oc/66qrrgpab8aMGZo5c6bf9ldeeUUpKSmRDBEAAITBO5vjtGhHnKd8UK5blw92WxgREBtqa2t10UUXqbKyUhkZGVaHA5OQiMeIYIlyS8uWLdO4ceM85e3bt2vChAmaMGGC/va3v7V6bKAR8aKiIu3YsUO5ubmhBY+gfhkRmOwZEUD40c+RRx+bg342R3ft51+/tEIL1u32lK+dMEC3HLe/hREF1137uLuhn81RWlqqwsJCEvEYw9T0GHH99dfrggsuaLVO//79Pa+3b9+uSZMmafz48frrX//aZvsOh0MOh8Nvu91u543bBPSzOejnyKOPzUE/m6O79fPmslqv8qAeGV0+/u7Wx90V/RxZ9G1sIhGPEXl5ecrLy2tX3Z9//lmTJk3S2LFj9cILLyguLq7tgwAAQLfV6HJrq08iPiCPW8sAIFJIxOFl+/btmjhxovr27auHH35Yu3f/MkWtZ8+eFkYGAEAXsfZ9ad0Hkqsh4O54t1tjfv5Z8e/+V+omX2bX1Tfqf+N2Si3CHfHlO9Lyrhl/d+zj7oh+Nkf83jqrQ4AFSMThZe7cudqwYYM2bNigPn36eO1jOQEAQMz7ca706kWtVomTVCRJ5WYEFB5pks6K99n4vRWRtE937OPuiH42R1w9n7FjEV9twcvUqVNlGEbAHwAAYt6ad6yOAAAQBUjEAQAA2mv3D1ZHAACIAkxNBwAAaA+3W9q9znvbgedL6YVem1xutzb+9JMGDhqk+C50X+2ry7aqvDbwfe2+xvXP1sH9ciIcUed11T6ONvSzOVzV+yTNsjoMmIxEHAAAoD0qiyWn98rimvwHKd17MVO306nv6+ao/zFTFN9FHktUU9+o2z/+qN31XzjqYGlIjwhGFJqu2MfRiH42h7u0VCTisYdEHAAAoD12rfUuJ2VJaQWWhNJRm0tr2lUvziadMbq3jt4/P8IRAUBsIxEHAABoD9/7w3sMlWw2a2LpoM17vEfyCzOT9N4NR/rVS06MV0oiHw8BINJ4pwUAAGgP3xHx/AOsiaMTNu3Z61UemJ+q3DSHRdEAAFh1AQAAoD0CjYh3E5t8RsQH5KVaFAkAQCIRBwAAaJvbLe3+0XtbNx4R759LIg4AVmJqOgAA6D4qtkr/uUH6+RtJhnnnNQypcZ/3tm41Iu69WNvAfBJxALASiTgAAOg+3rlG2rLY6iik5BwptXusLF5R26DyWqfXtgF5aRZFAwCQmJoOAAC6i10/dI0kXJJ6HdRtVkz3HQ2Pj7OpT3ayRdEAACQScQAA0F1880+rI2iSmCYd/Xuro2g332eI981JkT2ej4AAYCWmpgMAgK6tvlra9Jm09C/e28dcJh10sbmx2OKkHgdIjnSvzZ/+uFtPLFiv3dX1MgyppjZej6xb3CUGzSv3eU9L75+bYlEkAIBmJOIAAKDrKtsozT5dqiz233fETVLuIPNj8lFd59Sv/7lc+5yuFltt2lNXG/QYK3F/OABYj0QcAIBY1lArbVsmuZ1t1zWb2y19eHvgJLzfkV0iCZek1dsqfZLwrm1ITxJxALAaiTgAALFq5xrp+eOlhr1t1+1qDrvG6gg8tpZ3zZHvQAbmp+qkkYVWhwEAMY9EHACAWDX3nu6XhPcc2XRf+NBTrY7EY1u59/PFRxdlakxKmcaOGav4hHiLovKX5kjQ6L5ZSknk4x8AWI13YgAAYlFdpbTpU6ujaL+M3tJV86WMXlZH4mdrmfeI+IF9MnWgSjV5WA/Z7XaLogIAdGUk4gAAxKIN873vC7fFSWk9rYunNT2GSlNmdckkXPIfEe+dlSxVWBMLAKB7IBEHACAWrfvAuzzoWOmSN62JpZvzvUe8KDtZDRXWxAIA6B5IxAEAiHZbvpB2rVGcy6X+u9cobnmJtH6ud50hJ1kTWzdX53RpZ1W917Y+2cnauMmigAAA3QKJOAAA0ezzx6V590iS4iWNkqRtAeqRiHfK9op9ftt6ZyVrowWxAAC6jzirAwAAABFiGNKSJ9qu12t0l73/uqvb6nN/eFaKXelJjHMAAFpHIg4AQLSqKJZqdrVdb9wVkY8lSm3zuT+8T3ayRZEAALoTvrIFACBa/bzcq2gkJKnU0U85OdmKs8VJCQ5p8InS6EstCrD721rmPSJelJ1iUSQAgO6ERBwAgGjlm4j3O1KfZ/xKU6ZMURzPtw4LRsQBAJ1BIg4AQLT6+RuvotFrtLTXoliihGEYemnpFs37YZfqnS79sKPKa39RDiPiAIC2kYgDABCNXI3SjpVem4xeY6QfndbEEyWeX7xJ97//Q9D9jIgDANqDxdoAAIhGu3+QnN7Tpo3C0RYFEx1+2r1Xsz5a12qdAXlpJkUDAOjOGBEHACCQjZ9IC+6X9vxodSSd4/IZ+c7qJ6XmWRNLFNizt163vLZS9Y3uoHWO2j9PA/JS5XQy6wAA0DoScQAAfDXUSG9Pk/butDqS8OkzzuoIuq3F6/foxldXqKymwWv7ySMLdejAHElSj/QkTRySb0V4AIBuiEQcAABfW7+KriRckooOszqCbqmmvlHXvLRce+sbvbb3z03Rw+eOUnJivEWRAQC6M+4RBwDA19YvrY4gvHoMl0adb3UU3dKqrRV+SXhOaqL+cvEYknAAQKcxIg4AgC/fRHzkedK4y62JJVT2FKlguBRvl7h3ucO+93k8mSTN/e3RyktzWBANACBakIgDANCS2yVt+9p729BTpH6HWxMPLPX9du9E/IKDi0jCAQAhY2o6AAAt7V4r1fuMgvY5xJpYYDnfEfFhvTIsigQAEE0YEQcAdB2GITXWWxvDliXe5ay+UkahNbHAUnVOlzbs2uu1bVghiTgAIHQk4gCALiG/arUSnvgfqXqH1aF4KzrU6ghgkQ279qrRbXhtO4BEHAAQBiTiAADrGW6NLn5eNmeZ1ZH4IxGPWb73h/fPTVGag49OAIDQcY84AMB65ZuU3BWTcNmkAROsDgIWKKtp0N8/3+S1jfvDAQDhwte6AADL2Uq+tToEf/EO6ahbpPzBVkcCE23YtVdPLdyg/6za7jctnfvDAQDhQiIOALCcbccq7w0DjpZOedSSWDzSekiOdGtjgKneXfmzfv/Gt2pwuQPuZ0QcABAuJOIAAMvZSnwS8aJDpdxB1gSDkFXXOTX/h53aVrbP6lDaxWUYWr6lXJ+t3xO0TpI9TmP6ZpsYFQAgmpGIAwCsZRj+U9MLD7IkFITO5TZ05Ytf66vNXfGe/47LTU1UfrpDNx+3v7JSEq0OBwAQJUjEAQDWKt8sW12l97bCUdbEgpAt+WlPVCThFxxcpNtOPEA5qSTfAIDwIxEHAFhrx0rvckqulNnHklAQuo/WlFgdQkgS4my67cQhmnbUQNlsNqvDAQBEKRJxAIhVu3+U/n2ttOt7yTDarh8pbqd3ufAgiQSoW3K7Dc1ds9Nr24jeGeqVmWxRRO2Xk5qoEb0zNWFwvopyUqwOBwAQ5UjEASBWzblV+vlrq6Pwx7T0bmvltgrtqq732vbYBaM1KD/NoogAAOiaSMQBIBa53dLWr6yOIrCiQ62OoNt7bVmx3v7mZ+2tb/TabhiGqqri9ezmLyIy7bqspsGrvF+PNJJwAAACIBEHgFi0t0RqrLM6Cj/uARMVt99xVofRrX22frf+563VrdSwSTXVpsRywvACU84DAEB3QyKOoOrr63XooYdq1apVWrFihQ466CCrQwIQLmUbvcsJydLU9yWLbs1ubGzUoqUrNOHMKxQXz/+aQvHqV1utDsHj+GE9rQ4BAIAuiU87COq2225Tr169tGrVKqtDARBuvol4zkCpz1hrYpFkOJ2qSSphkbYQ1TldWrhul9VhSJJOG9VLB/bJtDoMAAC6JBJxBPTBBx9o7ty5euutt/TBBx+0Wb++vl719b8s0FNVVSVJcjqdcjqdwQ5DiJr7lj6OrGjs57g9GxTfouzO7i+Xhb9fNPaxFRb9sEu1DS5POc4m3X/6cCXGN33B0ehy6bvvvtOIESOUEB8frJmQ9c1J0ag+mWpsbGy7chTieo48+tgc9LM56N/YZDMMK59Zg65o586dGjt2rP79738rLy9PAwYMaHNq+owZMzRz5ky/7a+88opSUngMDNDVjNv0pHpX/LJY2/oeJ+n73hdaGBFCVeeSnlgTr201v8wqGJRu6MYRrlaOAgBYrba2VhdddJEqKyuVkZFhdTgwCYk4vBiGoSlTpuiII47Q3Xffrc2bN7crEQ80Il5UVKQdO3YoNzfXhMhjk9Pp1Lx58zR58mTZ7Xarw4la0djPCX+bJNvOXxb0cp30sNxjploWTzT2sZn+tWyrZr63Vi639//S75oyRFPH9/OU6Wdz0M+RRx+bg342R2lpqQoLC0nEYwxT02NEsBHrlpYtW6YlS5aoqqpKd9xxR4fadzgccjgcftvtdjtv3Cagn80RNf1sGFL5Zq9N8fn7K74L/G5R08cmKq9p0P1z1vkl4ZI05cDeAfuTfjYH/Rx59LE56OfIom9jE4l4jLj++ut1wQUXtFqnf//+uv/++7V06VK/pHrcuHG6+OKLNXv27EiGCcAMNXukBp/HV+UMtCYWhGzu9yVqaHT7bT9kQI56ZyVbEBEAAGgLiXiMyMvLU15eXpv1Hn/8cd1///2e8vbt23XCCSfotdde06GHHhrJEAGYxXfF9PhEKaO3NbEgZHNWl/htO6R/jv509oEWRAMAANqDRBxe+vbt61VOS0uTJA0aNEh9+vSxIiQAHbF3t9Swt/U6P3/tXc7qJ8VFbgVtRE5lrVOfb9jjte3xC0frtFG9LIoIAAC0B4k4AESDhhrp9V9JG+Z3/FimpXdpP1fs02Pzf9S28n1++yr3OdXY4t5wR0Kcjjmgh5nhAQCATiARR6v69+8vFtYHuoF50zuXhEsk4l2YYRiaNvtrfb+jql31JwzOV5qD/7UDANDVxVkdAAAgRBvmS8ue6/zxvceGLxaE1dayfe1OwiVpysjCCEYDAADCha/NAaArctZJa9+Tdn7Xer3KbdLqNzp3jji7NOIsadjpnTseEfdNcXm7647snamTRvaMYDQAACBcSMQBoCv64PfSN//o3LEnPCiNu6LtenEJUjzPLu3KfBPxkb0zdfYY/xXuCzKSdPTgfDkSWHQPAIDugEQcALqaqu2dT8L7HyUdeq0Ux51H0cA3ET9pZE9NPWKARdEAAIBw4ZMaAHQ1a9/v+DG2OOmgi6ULXyUJjxK1DY36YUe117YxfbMtigYAAIQTI+IA0NWsfc+7nDdEKhwVvH5mb2nUhVL+kMjGBVN9u61SrhaPJouPs+nAPpkWRgQAAMKFRBwAupLaMmnzYu9tk+6Uhp9hSTiIrJLKOr22bKs27N7rt6+4tMarfEDPdKUk8r9tAACiAf9HB4DOWvGy9OXT0r6K8LXZWC+5G38pJyRJ+x0XvvbRJRiGoZeWbtH/frhOe+sb2z5ATEsHACCakIgDQGeU/iS9e13kzzPoGMmRFvnzwFTPL96k+9//oUPHjO6bFZlgAACA6VjRBwA6Y+uX5pxn6GnmnAemenP5tg7Vz0936PjhPCMcAIBowYg4AHRG9Y7In6Pv4dLIcyN/HpjK7Ta0cY/3/d/pjgRdOr6f4mw2v/qZyXadMqpQaQ7+lw0AQLTg/+oA0BnVO73Lg45pen53uKTmSoWjeRRZFNpeuU8NjW6vbQt+N1H56Q6LIgIAAGYjEQeAzthb4l3uNVoafLw1saBb2RRgNDwvLdGiaAAAgBUYagGAzqj2ScTTuH8X7eObiA/IT5UtwJR0AAAQvUjEAaAzfBPx9AJr4kC3s3G3TyKel2pRJAAAwCok4gDQUYYh7fW5Rzy90JpY0O34joj3zyURBwAg1pCIA0BH1VVIjXXe29IYEUf7+CbiA/NJxAEAiDUk4gDQUb4rpksk4miXhka3tpXXem1jajoAALGHRBwAOsp3xfSkLMmeZEko6F6Ky2rlNry39ScRBwAg5vD4MgDoKN8Rce4P79L27K3Xkp9Kta+h0epQtK5kr1c5L82hjCS7RdEAAACrkIgDQEdV7/Aus2J6l7Wjcp9OfeJz7dlbb3UoAQ1kNBwAgJjE1HQA6CjfFdN5hniX9d6qHV02CZek/nkpVocAAAAsQCIOAB3l9wxxEvGuaktZTduVLHT04HyrQwAAABZgajoAdBSJeLdRUuk9Gt4rM0k9MqxfWM+REKcThvfUySNZXwAAgFhEIg4AHeW7ajqPLuuySqr2eZVvOHZ/XXhIX4uiAQAAaEIiDgBtcTk1uORdxb/yvGS4pYpi7/2MiHdZviPiPbvAaDgAAACJOAC0If7D2zR0x1vBK5CId0kNjW6V1vgk4pkk4gAAwHok4gBQVyVtWSK5Gvz3la5X3Mp/Bj82zs5zxLuoXdV1MgzvbYyIAwCAroBEHEBs27VWem6S5Kzt3PGjL5HsyeGNCWGxs6rOq+xIiFNWit2iaAAAAH5BIg4gtn08s2NJ+OE3Sln/t9hX9gBp0DGRiQsh87s/PDNJNpvNomgAAAB+QSIOIHY11Eo/LWh3dfeBFyju+PsiGBDCaUel94rpTEsHAABdBYk4gNi1cZHU2GL6si1OyhnoV82IS9BG9VPfkx5WnHnRIUS+U9NZqA0AAHQVJOIAYte6Od7lfkdIU9/zq9bodOq7OXPUN4FErjvZUUkiDgAAuiYScQDRqWqHtGG+1FATvM66D7zLQ06KbEwwld+IOFPTAQBAF0EiDiD6VJdIzxwp1e7p2HEk4lGlhEQcAAB0UdzuCCD6fP9ux5Pw/AMC3h+O7skwDO0MsGo6AABAV8CIOIDoU7ax48ccfFX444BHeU2D3vpmm9aWVAfc73a7tW1bnD55+zvFxYX+HXGjy60Gl9trG4k4AADoKkjEAUSfimLvcvaAX5797Ss+Udp/sjTuysjHZYLymgbVOl2Wnd/tNlRcVqv1O6s9ifC28n36z6rtqqh1tnF0nL7avT0iccXZpPw0R0TaBgAA6CgScQDRp2Krd/moW6Qxv7Imlg6oc7r03c+Vamh0t125BUPSpj01em3ZVq3+uTIywXVzPTOSlBDP3VgAAKBrIBEHEH18R8SDjYZ3IVvLanXuM1/4LTCG8Dh9dG+rQwAAAPAgEQcQXfZVSPU+o8KZRZaE0hGvLiuOiSR8WGGGDhuYK9/BabfbrY0bN2ngwAFhuUe8mc1m09DCdJ0+ikQcAAB0HSTiAKJL5Vb/bZl9zI+jg7aV77M6hLBxJMRpSM90ZackerZlpdh1yoG9dNzQHrLZbH7HOJ1OzZnzk6acOER2u93McAEAAExHIg4guvjeH55eKCV0/UW6Kvd5L2SWkhivlMT4DrUxKD9NFx3aVxOH9FB8nH+ya5Zke7yl5wcAAOjqSMQBRBff+8O7wbR0yT8Rv+vkobr40H4WRQMAAIBIYglZANHFd2p6N1ioTZKqfBLxzGSmZwMAAEQrEnEA0aVii3c5q7uMiDd6lTOSSMQBAACiFYk4gOjie494NxgRNwyDEXEAAIAYQiIOILr43SPe9RPx+ka3Glxur20k4gAAANGLxdoAdE9ut/TJH6V1H0iN9b9s31fmXa8bTE33XahNkjJIxAEAAKIWI+II6P3339ehhx6q5ORk5eXl6ayzzrI6JMDbV89Kn/yvVPKttGfdLz++usGq6QET8SS+JwUAAIhWfNKDn7feekvTpk3Tgw8+qGOOOUaGYWj16tVWhwX8wu2Wvnym7XoZfaTElMjHEyLf+8PTHAlKiOd7UgAAgGhFIg4vjY2NuummmzRr1ixdeeWVnu1Dhgxp9bj6+nrV1/8yPbiqqkqS5HQ65XT6j/YhPJr7Ntb62LZlsRLKN7dZzzX+BrnD0DeR7ufSvXVe5fSkhJj7m8bqtWw2+tkc9HPk0cfmoJ/NQf/GJpthGIbVQaDr+Oqrr3TooYfq73//ux5//HGVlJTooIMO0sMPP6zhw4cHPW7GjBmaOXOm3/ZXXnlFKSldf0QS1opzNyi5oaztiv9n6I431bviK0+52lGotYVne9WpTuqt6uTeYYsxkpbttumlDfGecq8UQ/8zymVhRAAAwCy1tbW66KKLVFlZqYyMDKvDgUlIxOHl1Vdf1YUXXqi+ffvqkUceUf/+/fXnP/9Zc+fO1Y8//qicnJyAxwUaES8qKtKOHTuUm5trVvgxx+l0at68eZo8ebLs9u65uJfth/8o/j+/ka1xX6fbcB33B7kPvS6MUXmLdD//Y2mx7nt/rad8SP9svXzlwWE/T1cWDddyd0A/m4N+jjz62Bz0szlKS0tVWFhIIh5jmJoeI4KNWLe0bNkyud1Nj1C66667dPbZTSOML7zwgvr06aM33nhDv/71rwMe63A45HA4/Lbb7XbeuE3QbfvZMKT590ghJOGKS1D8QRcp3oTfP1L9vLfe59FlKYnd8+8ZBt32Wu5m6Gdz0M+RRx+bg36OLPo2NpGIx4jrr79eF1xwQat1+vfvr+rqaknSsGHDPNsdDocGDhyo4uLiYIcCnVO9Q6r6ObQ2DjhFSssPTzwW8V01nWeIAwAARDcS8RiRl5envLy8NuuNHTtWDodD69at05FHHimpaVrS5s2b1a9fv0iHiViz8/sQDrZJ/Q6XpjwctnCsUlVHIg4AABBLSMThJSMjQ9dcc42mT5+uoqIi9evXT7NmzZIknXvuuRZHh6izyycR7z1WuvzD9h1rs0nx0ZGw+o6IZyRFx+8FAACAwEjE4WfWrFlKSEjQpZdeqn379unQQw/VggULlJ2dbXVoiDa+iXjBcCkh0ZpYLOQ/NZ23ZgAAgGjGpz34sdvtevjhh/Xww91/yi+6uJ1rvMs9gj8iL5pV+SbiKYyIAwAARLM4qwMAEKPcLmn3Ou9tBcMC141yvok4U9MBAACiG4k4AGuUbZRc9d7bYnREnFXTAQAAYguJOABr+E5LTyuQUnOticVCjS63ahpcXttIxAEAAKIb94gDiJyyTdIHt0m71/rvq6/2LvcYak5MXUxVXaPftgwScQAAgKhGIg4gct79jbTl8/bVZVq6ByPiAAAA0Y2p6QAiw9UoFS9tf/1eB0UslK7Md6G2xIQ4JdnjLYoGAAAAZmBEHEBk7C2RDFfb9SSpYIR0wCmRjcciX28u02vLtqqqzn/kW5LKahq8yqyYDgAAEP1IxAFERuU273JCknTubP96jnSp91jJnmROXCbaXrFPFz33pRpc7nYfk5nM2zIAAEC04xMfgMjwTcQz+0hDTrQmFot8vmFPh5JwScpLc0QoGgAAAHQV3CMOIDIqir3LmX2sicNCO6vqOnzMOWNjr58AAABiDSPiACIj0Ih4jNlZVe9VHlWUpeMO6BGwblycTWP7ZeuwgbH3LHUAAIBYQyIOIDL8EvG+1sRhId8R8QmD83XDsftbFA0AAAC6CqamA4gMRsS1s9p7RLxHOvd/AwAAgEQcQKSQiGu3z4h4QUb0rQwPAACAjiMRBxB+dZVSfaX3tqwia2KxiNttaJfPiHhBBiPiAAAAIBEHEAm+o+GSlNHb/DgsVFbboEa34bWNEXEAAABIJOIAIsE3EU8rkBJiazTYd6E2m03KTU20KBoAAAB0JSTiAMKvcqt3OTO2pqVL0i6fR5flpTmUEM9bLgAAAHh8GYBw2fqV9PXfpX3lUukG730xuFDbrmrfhdpia0YAAAAAgiMRBxC6vbuk2adKjXWB98dgIr7TZ0S8IJ37wwEAANCEeZIAQrf5s+BJuCRl9zctlK7C9x7xHizUBgAAgP9DIg4gdNU7g+9LzpGGnmpeLF2E74h4j3SmpgMAAKAJU9MBhG6vTyLec6Q0/CzJkS4NPlFK72lNXBba7XePOCPiAAAAaEIiDiB0e3d5l/sdKR11izWxdBF+94izWBsAAAD+D4k4gNDV+CTiafnWxBEBz326UW99s027y+P18NrPZLPZ2nVcSRUj4gAAAAiMRBxA6HynpqcVWBNHmM1dU6IH5vzwfyWbSuv3dbqtHoyIAwAA4P+wWBuA0O3d7V1O7WFNHGH25vJtYWkn3ZGg3FQScQAAADQhEQcQGrdbqvFJxNO6fyJe53Rp8YY9YWnrmomDFB/XvintAAAAiH5MTQcQmn1lkuHy3hYFU9OXbixVbcMvv5dNhh47f5RSHIkdaqd/Xqr265EW7vAAAADQjZGIAwiN7/3hkpSaZ34cYbZgrfcCdP3TpZNG9JTdbrcoIgAAAEQLEnEAofF9dFlKrhQfPFl1uw09+vF6zV1TojqnK2g9q+2o9F71fHi226JIAAAAEG1IxAGExjcRb2OhtndX/azHP14fwYAiY3iWYXUIAAAAiBIs1gYgNH7PEG89EV+1tTKCwURGn6wkFaZYHQUAAACiBYk4gNB08Bni9Y3da4p3nE26a8oBsrHoOQAAAMKEqekAQuP7DPE2RsQbfBLxycMKdM7YPuGOKizibDYdVJSlrKQ4zdlkdTQAAACIFiTiAELjNyLeRiLu8k7EBxek6YThPcMdVVg5nU6rQwAAAEAUYWo6gNB0cLG2hkbvldIT4+PDHREAAADQpTEiDqB1tWVS6U/B91fv8C53cGp6YgLfBwIAACC2kIgDCG7p09LcuyV3Y/uPaWOxNt+p6STiAAAAiDV8AgYQ2L5yaf6MjiXhEiPiAAAAQBv4BAwgsK1fSY11HTsms0hKyWu1im8i7ojnbQgAAACxhanpAAIrXupdtsVL9uTg9bP7S1NmSXGtJ9a+zxFnRBwAAACxhkQcQGBbv/QuH3GTdNz0kJvlHnEAAADEOj4BA/DX2CD9vNx7W9/DwtK03z3iTE0HAABAjOETMAB/O1b53x/e5+CwNM1ibQAAAIh1TE0HYl1dpbTuQ6lm9y/btn3lXSf/ACklJyynY2o6AAAAYh2JOBDLXI3S30+Sdq1pvV7RoWE7JSPiAAAAiHV8AgZi2fZv2k7CpbDdHy5xjzgAAADAJ2AgltXsabtOSp40+MSwnM7tNtToNry2ORgRBwAAQIzhEzD8/Pjjjzr99NOVl5enjIwMHXHEEVq4cKHVYSESnLXe5cQ0adAxv/yMvkS65M2I3R8uMTUdAAAAsYd7xOHn5JNP1uDBg7VgwQIlJyfr0Ucf1SmnnKKffvpJPXv2tDo8hJNvIp43WLr0nYidjkQcAAAAYEQcPvbs2aMNGzbo9ttv14EHHqj9999ff/zjH1VbW6s1a9pxLzG6F+c+73JiakRP53t/uMQ94gAAAIg9jIjDS25uroYOHap//OMfGjNmjBwOh5599lkVFBRo7NixQY+rr69XfX29p1xVVSVJcjqdcjqdEY87VjX3bWf7OK6uWvEtyu54h1wR/HvV1jX4bbMZri5/jYTaz2gbfWwO+tkc9HPk0cfmoJ/NQf/GJpthGEbb1RBLfv75Z51++un65ptvFBcXp4KCAr3//vs66KCDgh4zY8YMzZw502/7K6+8opSUlAhGi1AcsOMtDSl511P+OesQfT3g+oidb/c+6f6V3t//PXxoo+wMigMAgBhVW1uriy66SJWVlcrIyLA6HJiERDxGBEuUW1q2bJnGjh2rM844Q06nU3fddZeSk5P1t7/9Tf/5z3+0bNkyFRYWBjw20Ih4UVGRduzYodzc3LD+LviF0+nUvHnzNHnyZNnt9g4fHzf/HsV/+bSn7D7wArlOfTKcIXpZv3Ovpjy5xGvbupmTFRdni9g5wyHUfm6vnbU79c2ub9Tg8p85EO1cLpfWrFmj4cOHKz4+vu0D0Cn0szno58ijj81BP5ujurJaVxx2BYl4jGFqeoy4/vrrdcEFF7Rap3///lqwYIHee+89lZeXe94InnrqKc2bN0+zZ8/W7bffHvBYh8Mhh8Pht91ut0c0cUGTTvezq96rGOdIU1wE/15um/fQtz3eJocjMWLnC7dIXs8/lv+oX33wK9U4ayLSfnfxzteRWywQv6CfzUE/Rx59bA76ObJc+1xWhwALkIjHiLy8POXl5bVZr7a2aRXtuDjvhCkuLk5ut/9CW+jmGnxWTbcnR/R09T6LtbFQ2y/+veHfMZ+EAwAAxAo+BcPL+PHjlZ2drcsuu0yrVq3Sjz/+qN///vfatGmTTj75ZKvDQ7j5Pr7Mbu6q6Ty67Bc/V/9sdQgAAAAwCSPi8JKXl6cPP/xQd911l4455hg5nU4NHz5c7777rkaNGmV1eAg338eXRXhE3Pc54iTiv9hTt8er3Dutt3KSciyKxnyGYaiiokJZWVmy2br2mgHdGf1sDvo58uhjc9DP5mioadAP+sHqMGAyEnH4GTdunD766COrw4AZfEfETX6OOIn4L0r3lXqVf3/w73Vs32MtisZ8TqdTc+bM0ZQTprCuRATRz+agnyOPPjYH/WyO0tJSvaW3rA4DJuNTMBDL/KamR3hEnHvEAzIMQ3v2eY+I5yW3vaYDAAAAuic+BQOxzG+xtsg+873B5b0qaGICj0KRpL3Ovar3WcGeRBwAACB6kYgDsczvHvEIJ+JMTQ9o977dfttyk3ItiAQAAABm4FMwEMt8H5eVaG4i7mBquiT/+8PT7elKSkiyKBoAAABEGp+CgVhm8oi433PEGRGXJL/7w3OTGQ0HAACIZnwKBmKV2x1gsbZI3yNOIh6IbyKen5JvUSQAAAAwA5+CgVjVWOe/zeSp6aya3sRvxfQkFmoDAACIZnwKBmKV72i4xGJtFmFqOgAAQGzhUzAQq0jEuwyeIQ4AABBb+BQMxCrfZ4hLkj05oqd0co94QCTiAAAAsYVPwUCs8h0RT0iS4uIjekq/xdq4R1wSiTgAAECs4VMwEKv8VkyP7Gi45P/4Mgcj4mp0N6q8rtxrG4k4AABAdONTMBCr/J4hnhrxU/reI25nRFxldWUyZHhtY7E2AACA6JZgdQAALNJQ413+vxHxrdVbtWLXCjW6G8N+yq3OzbJnVnnKG+uL9fb6NWE/T7i5XC59W/+tGn5qUHx8eKfv76zZ6VWOt8Ur25Ed1nMAAACgayERB2KV74h4YoqW71yuq+derQZ3Q8ROm9Trl9eflUufLYnYqcLu31/+O+LnyEnKUXyE79UHAACAtZgXCsQqp++IeIpeX/d6RJNwtI37wwEAAKIfiTgQq/zuEU9RcVWxNbHA45Ceh1gdAgAAACKMqelArPJ9jrg9WTtqfvbaNDBzoNLsaWE75bqdVaptcHnKfXNSlJvqCFv7keI23KqoqFBWVpbibJH5/jLOFqdR+aN0/ejrI9I+AAAAug4ScSBW+Ty+rN6erNK9pV7bZk2YpcHZg8N2yhMf/VRrS6o95WsPO0inH9Q7bO1HitPp1Jw5czTlhCmy2+1WhwMAAIBujqnpQKzyScR3xtv8qhSmFob1lL6PL0vk8WUAAACIQXwKBmKVTyK+I847EU+zpyk9MT2sp6z3TcQTeAsCAABA7OFTMBCrfO4R3yHv54b3TO0Z/lO6SMQBAAAAPgUDscpn1fQdcnqVwz0tXWJqOgAAACCRiAOxy+c54iXueq+yKYk4I+IAAACIQXwKBmKV74h4o/dU9cK0CCTiTE0HAAAASMSBmOV7j3jjXq9yuO8Rd7kNudyG1zYHiTgAAABiEJ+CgVjVYtV0Q1KJs8prd6QfXSZJifHxYT0HAAAA0B2QiAOxqkUiXhEXpzp3ZBdrC5iIMyIOAACAGJRgdQAAzFHXWKd6V4sF2RrrpP97dviGRLtX3ThbnPJT8sN6/nqXy28biTgAAABiEYk4EOVcbpemL5mu9ze9r0Z3i2eFF2ZKygx4TH5yvuxx9oD7OosRcQAAAKAJiTgQ5d788U29+9O7HTomEo8uc7oMv208RxwAAACxiE/BQBRzuV2a/f3sDh83JGdI2GMJNCJuj7eF/TwAAABAV8eIOBCl6hrr9NIPL2lr9dYOHbdf1n66YsQVYY/HNxFPTIiTzUYiDgAAgNhDIg5Eof/+9F9NXzJdTp+V0IdlDtKTqz/xrjzuSunI30rxiYqPi1dOUk5EYmrwWayNaekAAACIVSTiQJRxuV2atWyWXxIuSZfnjlG+a+EvG1J7SCc9bEpc9QFGxAEAAIBYxCdhIMqU1pWqvL7cb3vvtN46rt5nwbSeI0yKKsDUdEbEAQAAEKMYEQeizK7aXX7b+mf01/8e/b9K+Gim946C0BPx736u1CPzftT2in2t1ttb3+hVZkQcAAAAsYpEHIgyvol4blKu/nvmf5sKJd95Vw4xEXe5DV05e5l2VtV3+FgScQAAAMQqPgkDUcY3Ee+d3rvpRW2ZVLXNu3KIU9OLy2o7lYRLUm5qYkjnBgAAALorEnEgyvgm4gUpBU0vdq7xrhifKOUNDulcZTUNnTouziZNPbx/SOcGAAAAuiumpgPRYscq6aeF2lmy0Gtzj7Kt0qL/lRY96F0/f4gUbw/plBW13ol4Tmqipp86rNVjbDabDuydqf55qSGdGwAAAOiuSMSBKGAr/kJ6+UzJ3ahdPfOl5GTPvh5bvpC+net/UMHIkM/rOyJemJmk0w/qHXK7AAAAQDRjajoQBeJWvy65m1Yl3xXv/f1aj0ZX4IMGHB3yect9RsSzU7jvGwAAAGgLI+JANGixCNuuhHivXQUun0TcFieN+ZU04uyQT1te6/QqZ7MAGwAAANAmEnEgCtiqSyRJtTab9sZ5T3TJ73u0FOeQ4uKlniOlURdKmX3Cct7yGt8R8dDuOQcAAABiAYk4EA32NiXiu+Lj/Xb1OPcfkj0lIqdlajoAAADQcdwjDnRzce4G2faVS/Kflp5uT1dKhJJwSSqv8Z6ansPUdAAAAKBNJOJAN5fkrPS83ukzIt4jpUdEz+07Ip7F1HQAAACgTSTiQDeX5CzzvPYdETc7EWdEHAAAAGgbiXgMeuCBB3T44YcrJSVFWVlZAesUFxfr1FNPVWpqqvLy8nTjjTeqoaEhYF2Yq9ZZq70Ne5t+nHtlOHdrr82mvTabtif4PLosgom4YRj+q6ZzjzgAAADQJhZri0ENDQ0699xzNX78eD3//PN++10ul04++WTl5+dr8eLFKi0t1WWXXSbDMPTEE09YEDEkaVPlJt2y6BZtqNjgvcMmqX9RwGMimYhX1TXK5Ta8tvH4MgAAAKBtJOIxaObMmZKkF198MeD+uXPn6vvvv9fWrVvVq1cvSdKf//xnTZ06VQ888IAyMjLMChUtPLHiCf8kvA0FKQURisb/0WUSjy8DAAAA2oNEHH6++OILjRgxwpOES9IJJ5yg+vp6LV++XJMmTfI7pr6+XvX19Z5yVVWVJMnpdMrpdPrVR8et3r26w8cMzBgYsf7fXVXrVXYkxClB7qj8ezf/TtH4u3UV9LE56Gdz0M+RRx+bg342B/0bm0jE4aekpEQFBd4jqdnZ2UpMTFRJSUnAYx566CHPSHtLCxcuVEpK5B6fFSuchlM7a3e2u75NNo1OHK1tX23Tdtv2iMS0ptwm6ZfF4ZLiXPrggw8icq6uYt68eVaHEPXoY3PQz+agnyOPPjYH/RxZtbW1bVdC1CERjxIzZswImAi3tGzZMo0bN65d7dlsNr9thmEE3C5Jd9xxh2655RZPuaqqSkVFRZo0aZJyc3PbdU4Et7Fyo4z3ve/Hfuvkt2SXXe7nT1Rqw27P9sYT/qiU4ecoPTE9ojHVr9gurf3OUy7MydCUKeMjek6rOJ1OzZs3T5MnT5bdzvT7SKCPzUE/m4N+jjz62Bz0szlKS0utDgEWIBGPEtdff70uuOCCVuv079+/XW317NlTX375pde28vJyOZ1Ov5HyZg6HQw6Hw2+73W7njTsMSvZ5z0TIScrR4LzBcjqdstVXKMHt+mVnwQgpNSfiMVXVu7zKuWmJUf+35nqOPPrYHPSzOejnyKOPzUE/RxZ9G5tIxKNEXl6e8vLywtLW+PHj9cADD2jHjh0qLCyU1LSAm8Ph0NixY8NyDnRMcXWxV7ko/f9WSa+vVoK7zrtyek9TYvJ9hngWjy4DAAAA2oVEPAYVFxerrKxMxcXFcrlcWrlypSRpv/32U1pamo4//ngNGzZMl156qWbNmqWysjL97ne/07Rp01gx3SJbq7d6lfum9216sTfAPftp5iTiZTXeC4vkkIgDAAAA7UIiHoPuvfdezZ4921MePXq0pKaF1SZOnKj4+Hi9//77uu6663TEEUcoOTlZF110kR5++GGrQo55fiPiK1+TPpvtPSVdkpIypURzFsfzfXwZjy4DAAAA2odEPAa9+OKLQZ8h3qxv37567733zAkIbdpWvc2rXFRXKzXUym/pvPTCsJ2zuLRWX28pk2EE3v/T7r1e5exURsQBAACA9iARB7q4Rnejfq7+2WtbUWNj4Mp5+4d8vjqnS9PfXaPXvt7aduUWspmaDgAAALQLiTjQxZXUlKjR8E68+zoDJOKOTG0fcY2u/cvnWr2tQkEGstsUbAS8LYyIAwAAAO1DIg50UbXOWpXWlWrlrpVe29PcbmW53dJl/1Wjza4lS5bo8COOVELhSE1/9Xut2rrT9FgTE+J0UJ8s088LAAAAdEck4kAX9OyqZ/X0qqflMlx++4qcjbKl5EkDjpbhdKo8dZeMXmPkjk/Q0p9KwxpHsj1e+/VIa7VOblqirj5qoDJZrA0AAABoFxJxoIspryvXU6uekttwB9xf5HRKufv5bS8uq1V1fZB7xzvhoKIsPXzugdqvR3rY2gQAAABAIg50OcXVxUGTcEkaWd8g9Rrkt/277ZVe5dzURL0y7bBOxZCWlKDeWcmdOhYAAABA60jEgS6mqr4q4PZ4w9BRtft0TvVeKWeg3/7vfvY+bkTvTA3pyWg2AAAA0NWQiANdTFWDd0I9MHOgXtu8UfEVW+W5Czs3UCLuPSI+ondGhCIEAAAAEAoScaCL8U3EsxIzlFS5zbtSjvfUdMMw/Kamj+yd2ekYXJWV2vXwn1W3dm3nn2cWRQzDUN/KSm39xz9ls9msDicq0cfmoJ/NQT9HHn1sDvrZHFUNDVaHAAuQiANdTGW9d0KdYUuQfO8Z95mavr2yThW1Tq9tw3t1PhEvmTlTVXM+6PTx0ShJUv22bW3WQ+fRx+agn81BP0cefWwO+jnyGlz+T8lB9IuzOgAA3nxHxDP2/ORdITVfSvKedu57f3hmsl19sju/2FrtNys6fSwAAACA1pGIA12M72JtGeVbvCvk+K+YvmaH70JtGSFNITP27ev0sQAAAABax9R0oIvxGxF3+0xLz/VPxDfvqfUqDysMbaE2d329Vznvumtl71MUUpvdmcvl0rffrtKBB45SfHy81eFEJfrYHPSzOejnyKOPzUE/m6OiulqaepnVYcBkJOJAF9NmIr7/ZL9jtlfWeZX75qR0+vyGYcjwScTTTzhBSUOGdLrN7s7pdKoq0a6MKVNkt9vbPgAdRh+bg342B/0cefSxOehnc7hKS60OARZgajrQxfgt1uZqkYif+pg07Ay/Y3b4JOKFmZ2/P1xOp99K6bbExM63BwAAAMALI+JAF+M7Ip7ZPCJ+9O+lsVP96je6pV3V3iPYvbI6n4j7TkuXpDiHo9PtAQAAAPDGiDjQxVQ3VHuVPVPT03sGrF8R4NGTvUNIxH2npUuSLSmp0+0BAAAA8EYiDnQhTpdT+xq9Vyz/JREvDHhMeb336uipifHKSO78ZJeAiXgiI+IAAABAuJCIA11IZUOl3zbPPeLtHBHvlZUc0qPL3PX+Q+xxDu4RBwAAAMKFRBzoQnyfIS61uEc8LXAiXu4zgB3K/eGSZNR7L/ym+HjZWCkVAAAACBsScaAL8V2oLdntVlMKbJPSegQ8xndqeuiJuHdmb2OhNgAAACCsSMSBLiToM8RT86X4wKPS5T4zyXtnhbawmu/U9DgeXQYAAACEFYk40IX4PUO8jRXTpUiMiHtPTWfFdAAAACC8SMSBLsRvRLyNhdoMw/C7R7wwM7RE3Pc54jYWagMAAADCikQc6EJ8F2tra0S8qq5R9W7vEfFQniEuSYbf1HTuEQcAAADCiUQc6EKC3iMe5Bni2yt8ppHbpILM0BJnpqYDAAAAkUUiDnQhwRPxwCPi2yv3eZXz0xxyJMSHFANT0wEAAIDIIhEHuhDfqeltPUO8pNJ79DrUhdokpqYDAAAAkUYiDnQhHV2sbbtPIh7q/eESU9MBAACASCMRB7qQ3ft2e5U7eo94rxCfIS4xNR0AAACItASrAwBimWEYenHNi5pfPF/7Gvdpa/VWr/0Zbrdki5NS8wMev4Op6QAAAEC3QyIOWOijzR/pkeWPBN2f6XZL+UOl+MD/VH2npocnEfcZEWdqOgAAABBWTE0HLPRVyVdB92W7XBpa3yD1Gx9wf6PLrZ1VPol4ZuiJuNv3HnGmpgMAAABhRSIOWGhn7U6/bTbD0Lh9dXquZJfsktQ3cCK+s7pebsN7WzjuEfebmu5gajoAAAAQTkxNByxUUlPiVZ6QP0Yzlv9Hec2rpUtBE/HtFd7PEHckxCknNfTRa7+p6Q6mpgMAAADhxIg4YCHfEfGLk/t5J+FZfaXM3gGP9U3Ee2cly2azhRwTU9MBAACAyCIRByyyr3GfKusrvbYVLPmLd6Ugo+GS9LNPIh6OhdokpqYDAAAAkUYiDlhkV+0uv20FjS7vDa0k4jsi8AxxianpAAAAQKSRiAMW2VnjPS093eVWqtFi9TVbnDTg6KDH+05ND9eIOFPTAQAAgMgiEQcs4nt/eIGr0bvC0bdJuYOCHs/UdAAAAKB7YtV0wGxul7Tta+3c+LHX5uZp6Q15w7XnnDdlJGVLPsl2S76JeO+wJeJMTQcAAAAiiUQcMNu/r5O+fVUludlSRrpnc4GrKRG/5Oez9NWjKzrcbGFmeBJmpqYDAAAAkcXUdMBM1Tulb1+VJO2Mj/fa1bOxURvdPfWVcUCnmmZqOgAAANA9kIgDZqrc5nm5M8F7QkpBo0svuk6Q1PFngQ/KT1WSPb7tiu3A1HQAAAAgspiaDpipttTzcmeCd+K8uH683nYd3+EmsxINzTx1aMihSZJhGAEScaamAwAAAOFEIg6Y6f8S8XqbVOYzNf3yaQ/qvszgq6QH4nQ6tWj+XB06ICcs4RkNDX7bmJoOAAAAhBeJOGCm2j2qtdn0fGaG367+Wb2Umtixf5LOOEO2js9kD8p3NFySbElMTQcAAADCiUQcMFNtqa4vyNeyZO/kNik+RWn2NIuC+kXARDyRqekAAABAOLFYG2CibdXb/JJwSSpM7SlbOIe2O8kdIBFnajoAAAAQXiTigIm279sdcPvEvhNMjiSwgCPiJOIAAABAWJGIx6AHHnhAhx9+uFJSUpSVleW3f9WqVbrwwgtVVFSk5ORkDR06VI899pj5gUahnfXlftt6u8/RDaNvsCAaf36JuN0uW3x4HosGAAAAoAn3iMeghoYGnXvuuRo/fryef/55v/3Lly9Xfn6+XnrpJRUVFWnJkiW6+uqrFR8fr+uvv96CiKPHzoYqqcXM9KyafB1edK7scXbrgmrBXeediMdxfzgAAAAQdiTiMWjmzJmSpBdffDHg/iuuuMKrPHDgQH3xxRd6++23gybi9fX1qm8xmlpVVSWp6fFaTqczDFFHh12ufZJaJLeNGeqXk9TpPmo+Llx97Kyt8SrbHA7+fgp/P8MffWwO+tkc9HPk0cfmoJ/NQf/GJhJxtEtlZaVycoI/q/qhhx7yJPgtLVy4UCkpKZEMrfsw3NqlRrVMxF3OLO366TvN2bM6pKbnzZsXYnBNUteuVe8W5Tq3W3PmzAlL29EgXP2M4Ohjc9DP5qCfI48+Ngf9HFm1tbVWhwALkIijTV988YVef/11vf/++0Hr3HHHHbrllls85aqqKhUVFWnSpEnKzc01I8yur7ZUr73qfb91nTNX50+ZpMLMzj2r2+l0at68eZo8ebLs9tCnt++121XSopySlakpU6aE3G53F+5+hj/62Bz0szno58ijj81BP5ujtLTU6hBgARLxKDFjxoyAI9ItLVu2TOPGjetQu2vWrNHpp5+ue++9V5MnTw5az+FwyBFgdW273c4bd7OGKu1M8E7EXSpQUW5ayI8uC1c/x7lc3mVHEn+/FrieI48+Ngf9bA76OfLoY3PQz5FF38YmEvEocf311+uCCy5otU7//v071Ob333+vY445RtOmTdPdd98dQnSQJFfNLpX6rEBemFnUJZ4f3sx31XRbEo8uAwAAAMKNRDxK5OXlKS8vL2ztrVmzRsccc4wuu+wyPfDAA2FrN5aVVm6RyyfpHpLXO0hta/ivmk4iDgAAAIQbiXgMKi4uVllZmYqLi+VyubRy5UpJ0n777ae0tDStWbNGkyZN0vHHH69bbrlFJSVNdw3Hx8crPz/fwsi7t11VW73K8YY0oqCXRdEE5jciHuB2AwAAAAChIRGPQffee69mz57tKY8ePVpS0wrnEydO1BtvvKHdu3fr5Zdf1ssvv+yp169fP23evNnscKPGzr3bvcoZjXEa3DPTomgCMxqYmg4AAABEWpzVAcB8L774ogzD8PuZOHGipKaF3wLtJwkPTXH1Tq9yaqNdQwrSLYomMHc9U9MBAACASCMRB0yyvdb70RQp7iQVZHStRNeoY2o6AAAAEGkk4oBJdjmrvcrptvQutWK6xNR0AAAAwAzcIw6E6J2Hpsn53UrJZbRab6itRv3imhJvmyEVGTUq2X1fB87k377b5VaP4i3a/c0KxcV7f69mGK3HE0jtV8u8ykxNBwAAAMKPRBwIwet3nK2R73zfgSNaJse7Vb7ilZBjyJJU+cXSkNsJhKnpAAAAQPgxNR0IQdqyH6wOIaLi0tOsDgEAAACIOiTiQCftq6lSr50dn/7dXdjsdqUdPcHqMAAAAICow9R0oJO+nDNbBU7vbWtGJMmIa30BNrvNrv0KRys3s2fThs6s1/Z/i7y53W4VbylW3359FRcX/Hu1ji4KF5eSovTjj1fSkMGdCA4AAABAa0jEgU7aufQjFbQo78mUznlzhakxOJ1OfT1njsZNmSK73W7quQEAAAB0DlPTgU6K37zNq7y7J4kwAAAAgLaRiAOdlLvD+5nbDX17WhQJAAAAgO6EqenoUqrKd+mzf/1ZzppKq0NplauhQQeUeW/LGXu0NcEAAAAA6FZIxNFlrF/1uXZfeZUG7rU6ko5zxkuHnX611WEAAAAA6AaYmo4uY8VDNym7GybhkrQj36aM7B5WhwEAAACgGyARR5ewr6ZK/X6ssTqMTivfL9fqEAAAAAB0E0xNR5cw77l7tH+t97bSDGti6QhXvLSrb7KOu+8fVocCAAAAoJsgEYdpXI2NWvPlB9pbscd/34KFXuVtBTZN/uR7s0IDAAAAANOQiMMUW3/6Tt9fdZ767jCUHWC/77bSkb3NCAsAAAAATMc94jDF50/epr47jHbVdUsaddn/RDYgAAAAALAIiThMEbdrd7vrbuoXp6EHHxfBaAAAAADAOkxNhyni6pxt1nFL2trLpr73/jHyAQEAAACARUjEYYqEepdXedX4HJ351Dy/esOTU8wKCQAAAAAsQSIOU9gb3F5lIzVZDpJuAAAAADGIe8RhCnu990JtcSlpFkUCAAAAANYiEYcpHA3eiXh8WoZFkQAAAACAtUjEYQpHg3c5MSPQ08QBAAAAIPqRiMMUSfU+5ax8awIBAAAAAIuRiCPiaqor5Wj03paW39uaYAAAAADAYiTiiLjd29b7bcvuUWRBJAAAAABgPRJxRFzp9k1+2/L7DLIgEgAAAACwHok4Iq5q91avsssmZeczIg4AAAAgNpGII+Jqy3Z6lescUnxCgkXRAAAAAIC1SMQRcQ1V5V7lukSLAgEAAACALoBEHBHnrPZOxOsdFgUCAAAAAF0AiTgizl1T7VVuSLRZFAkAAAAAWI9EHBFn1O7zKjsTuewAAAAAxC4yIkRcXF2dV7nREW9RJAAAAABgPRJxRFxcndOr7HKwYjoAAACA2EUijohLqG/0KruSWDYdAAAAQOwiEUfEJTS4vcpGMsumAwAAAIhdJOKIOHu9dyJuS0m1KBIAAAAAsB6JOCIuscHwKsenpFkUCQAAAABYj0QcEedo8C4nZGRbEwgAAAAAdAEk4oi4pHqfclauNYEAAAAAQBdAIo6IcjbU+yXiydk9rQkGAAAAALoAEnFEVGnJVr+LLLNHH0tiAQAAAICugEQcEVW+e4vfttxeAy2IBAAAAAC6BhJxRNTeXdv8thX02d+CSAAAAACgayARR0TVlO3yKtfZJUdyikXRAAAAAID1SMQRUfXVpV7lOodFgQAAAABAF0EiHoMeeOABHX744UpJSVFWVlardUtLS9WnTx/ZbDZVVFR0+FwNZbu9yiTiAAAAAGIdiXgMamho0Lnnnqtrr722zbpXXnmlDjzwwE6fy1VR5lWuTeWSAwAAABDbyIpi0MyZM/Xb3/5WI0eObLXe008/rYqKCv3ud7/r9Lniqvd6letTEzrdFgAAAABEA7IiBPT999/rD3/4g7788ktt3Lixzfr19fWqr6/3lKuqqiRJ9r31XvWcaUlyOp3hDTaGNfclfRpZ9HPk0cfmoJ/NQT9HHn1sDvrZHPRvbCIRh5/6+npdeOGFmjVrlvr27duuRPyhhx7SzJkz/bYn1Taq5cSLfY5EzZkzJ5zhQtK8efOsDiEm0M+RRx+bg342B/0cefSxOejnyKqtrbU6BFiARDxKzJgxI2Ai3NKyZcs0bty4Ntu64447NHToUF1yySXtPv8dd9yhW265xVOuqqpSUVGRkmsNr3ophb01ZcqUdreL1jmdTs2bN0+TJ0+W3W63OpyoRT9HHn1sDvrZHPRz5NHH5qCfzVFaWtp2JUQdEvEocf311+uCCy5otU7//v3b1daCBQu0evVqvfnmm5Ikw2hKpvPy8nTXXXcFTPgdDoccDv8l0dN8vuBLLezHG3kE2O12+tUE9HPk0cfmoJ/NQT9HHn1sDvo5sujb2EQiHiXy8vKUl5cXlrbeeust7du3z1NetmyZrrjiCn322WcaNGhQh9pKqZcU/0s5u98BYYkRAAAAALorEvEYVFxcrLKyMhUXF8vlcmnlypWSpP32209paWl+yfaePXskSUOHDm3zueNt6Tfs0JCOBwAAAIDujkQ8Bt17772aPXu2pzx69GhJ0sKFCzVx4sSInbc+QepZNDhi7QMAAABAd8BzxGPQiy++KMMw/H6CJeETJ06UYRghj4ZXp0rxCXz3AwAAACC2kYjDNDWpNqtDAAAAAADLkYjDNHUp8W1XAgAAAIAoRyIO0zSk+T/eDAAAAABiDYk4TOPKSLE6BAAAAACwHIk4TBOfnWt1CAAAAABgORJxmMbRo5fVIQAAAACA5UjEYZqM3oOsDgEAAAAALEciDtP0GjLG6hAAAAAAwHIk4jBNYf9hVocAAAAAAJYjEYcpXDYpNT3H6jAAAAAAwHIk4jBFfaIUn5BgdRgAAAAAYDkScZiiwW51BAAAAADQNZCIwxQk4gAAAADQhEQcpnCSiAMAAACAJBJxmMRpt1kdAgAAAAB0CSTiMEUjiTgAAAAASCIRh0lcdi41AAAAAJBIxGESlz3e6hAAAAAAoEsgEYcpXIkk4gAAAAAgkYjDJEZigtUhAAAAAECXQCIOUxiJiVaHAAAAAABdAok4TGEkOawOAQAAAAC6BOYLIyIMw5Ak7XW7JEl1ildVVZWVIUUlp9Op2tpaVVVVyW63Wx1O1KKfI48+Ngf9bA76OfLoY3PQz+aorq6W9MvnZ8QGm8FfHBGwceNGDRo0yOowAAAAgG7hp59+0sCBA60OAyZhRBwRkZOTI0kqLi5WZmamxdFEr6qqKhUVFWnr1q3KyMiwOpyoRT9HHn1sDvrZHPRz5NHH5qCfzVFZWam+fft6Pj8jNpCIIyLi4pqWH8jMzOSN2wQZGRn0swno58ijj81BP5uDfo48+tgc9LM5mj8/Izbw1wYAAAAAwEQk4gAAAAAAmIhEHBHhcDg0ffp0ORw8tiyS6Gdz0M+RRx+bg342B/0cefSxOehnc9DPsYlV0wEAAAAAMBEj4gAAAAAAmIhEHAAAAAAAE5GIAwAAAABgIhJxAAAAAABMRCKOiHjqqac0YMAAJSUlaezYsfrss8+sDqnbmjFjhmw2m9dPz549PfsNw9CMGTPUq1cvJScna+LEiVqzZo2FEXcPn376qU499VT16tVLNptN//73v732t6df6+vrdcMNNygvL0+pqak67bTTtG3bNhN/i66vrX6eOnWq3/V92GGHedWhn1v30EMP6eCDD1Z6erp69OihM844Q+vWrfOqw/Ucmvb0Mddy6J5++mkdeOCBysjIUEZGhsaPH68PPvjAs5/rODza6meu5fB76KGHZLPZdPPNN3u2cT2DRBxh99prr+nmm2/WXXfdpRUrVuioo47SSSedpOLiYqtD67aGDx+uHTt2eH5Wr17t2fenP/1JjzzyiJ588kktW7ZMPXv21OTJk1VdXW1hxF1fTU2NRo0apSeffDLg/vb0680336x33nlHr776qhYvXqy9e/fqlFNOkcvlMuvX6PLa6mdJOvHEE72u7zlz5njtp59b98knn+g3v/mNli5dqnnz5qmxsVHHH3+8ampqPHW4nkPTnj6WuJZD1adPH/3xj3/U119/ra+//lrHHHOMTj/9dE9ywnUcHm31s8S1HE7Lli3TX//6Vx144IFe27meIQMIs0MOOcS45pprvLYdcMABxu23325RRN3b9OnTjVGjRgXc53a7jZ49exp//OMfPdvq6uqMzMxM45lnnjEpwu5PkvHOO+94yu3p14qKCsNutxuvvvqqp87PP/9sxMXFGR9++KFpsXcnvv1sGIZx2WWXGaeffnrQY+jnjtu1a5chyfjkk08Mw+B6jgTfPjYMruVIyc7ONv72t79xHUdYcz8bBtdyOFVXVxv777+/MW/ePGPChAnGTTfdZBgG78towog4wqqhoUHLly/X8ccf77X9+OOP15IlSyyKqvtbv369evXqpQEDBuiCCy7Qxo0bJUmbNm1SSUmJV387HA5NmDCB/g5Be/p1+fLlcjqdXnV69eqlESNG0PcdtGjRIvXo0UODBw/WtGnTtGvXLs8++rnjKisrJUk5OTmSuJ4jwbePm3Eth4/L5dKrr76qmpoajR8/nus4Qnz7uRnXcnj85je/0cknn6zjjjvOazvXMyQpweoAEF327Nkjl8ulgoICr+0FBQUqKSmxKKru7dBDD9U//vEPDR48WDt37tT999+vww8/XGvWrPH0aaD+3rJlixXhRoX29GtJSYkSExOVnZ3tV4drvf1OOukknXvuuerXr582bdqke+65R8ccc4yWL18uh8NBP3eQYRi65ZZbdOSRR2rEiBGSuJ7DLVAfS1zL4bJ69WqNHz9edXV1SktL0zvvvKNhw4Z5Eg+u4/AI1s8S13K4vPrqq/rmm2+0bNkyv328L0MiEUeE2Gw2r7JhGH7b0D4nnXSS5/XIkSM1fvx4DRo0SLNnz/YsnkJ/R0Zn+pW+75jzzz/f83rEiBEaN26c+vXrp/fff19nnXVW0OPo58Cuv/56ffvtt1q8eLHfPq7n8AjWx1zL4TFkyBCtXLlSFRUVeuutt3TZZZfpk08+8eznOg6PYP08bNgwruUw2Lp1q2666SbNnTtXSUlJQetxPcc2pqYjrPLy8hQfH+/3Td2uXbv8vvVD56SmpmrkyJFav369Z/V0+ju82tOvPXv2VENDg8rLy4PWQccVFhaqX79+Wr9+vST6uSNuuOEG/ec//9HChQvVp08fz3au5/AJ1seBcC13TmJiovbbbz+NGzdODz30kEaNGqXHHnuM6zjMgvVzIFzLHbd8+XLt2rVLY8eOVUJCghISEvTJJ5/o8ccfV0JCgqefuJ5jG4k4wioxMVFjx47VvHnzvLbPmzdPhx9+uEVRRZf6+nr98MMPKiws1IABA9SzZ0+v/m5oaNAnn3xCf4egPf06duxY2e12rzo7duzQd999R9+HoLS0VFu3blVhYaEk+rk9DMPQ9ddfr7ffflsLFizQgAEDvPZzPYeurT4OhGs5PAzDUH19PddxhDX3cyBcyx137LHHavXq1Vq5cqXnZ9y4cbr44ou1cuVKDRw4kOsZrJqO8Hv11VcNu91uPP/888b3339v3HzzzUZqaqqxefNmq0Prlm699VZj0aJFxsaNG42lS5cap5xyipGenu7pzz/+8Y9GZmam8fbbbxurV682LrzwQqOwsNCoqqqyOPKurbq62lixYoWxYsUKQ5LxyCOPGCtWrDC2bNliGEb7+vWaa64x+vTpY8yfP9/45ptvjGOOOcYYNWqU0djYaNWv1eW01s/V1dXGrbfeaixZssTYtGmTsXDhQmP8+PFG79696ecOuPbaa43MzExj0aJFxo4dOzw/tbW1njpcz6Fpq4+5lsPjjjvuMD799FNj06ZNxrfffmvceeedRlxcnDF37lzDMLiOw6W1fuZajpyWq6YbBtczDINEHBHxl7/8xejXr5+RmJhojBkzxusRL+iY888/3ygsLDTsdrvRq1cv46yzzjLWrFnj2e92u43p06cbPXv2NBwOh3H00Ucbq1evtjDi7mHhwoWGJL+fyy67zDCM9vXrvn37jOuvv97IyckxkpOTjVNOOcUoLi624Lfpulrr59raWuP444838vPzDbvdbvTt29e47LLL/PqQfm5doP6VZLzwwgueOlzPoWmrj7mWw+OKK67wfHbIz883jj32WE8Sbhhcx+HSWj9zLUeObyLO9QybYRiGeePvAAAAAADENu4RBwAAAADARCTiAAAAAACYiEQcAAAAAAATkYgDAAAAAGAiEnEAAAAAAExEIg4AAAAAgIlIxAEAAAAAMBGJOAAAAAAAJiIRBwB0CxMnTpTNZtOMGTOsDsVSLpdLjzzyiEaPHq3U1FTZbDbZbDb9+9//tjq0iFm0aJHn9+yOXnzxRdlsNvXv39/qUAAAXQSJOAB0YzNmzPAkKKmpqdq+fXvQups3b/bUXbRokXlBIqxuvvlm3XrrrVq5cqUaGxtVUFCggoICJSUlWR1azNm8ebNmzJgR818OAQA6jkQcAKJEbW2tZs6caXUYiKDq6mo9++yzkqQ//elPqqurU0lJiUpKSnTiiSdaHF3s2bx5s2bOnNnmv7vMzEwNGTJEgwYNMikyAEBXRyIOAFHk73//u3788Uerw0CErF27Vk6nU5J07bXXdtup2rHmzDPP1Nq1a/Xxxx9bHQoAoIsgEQeAKFBUVKQDDzxQjY2NuvPOO60OBxFSW1vreZ2WlmZhJAAAIBQk4gAQBeLi4vTQQw9Jkt566y199dVXHTq+5f3jmzdvDlqvf//+stlsevHFF1s9fsuWLZo2bZr69u2rpKQkDRo0SHfffbdqamo8x3z33Xe65JJLVFRUpKSkJO2///66//77PSO+rWloaNAf//hHHXjggUpNTVV2drYmT56sDz74oM1jf/rpJ91www0aOnSo0tLSlJKSoqFDh+rmm29WcXFxwGN8F9tauHChzjjjDBUWFio+Pl5Tp05t87wtuVwu/f3vf9cxxxyjvLw8ORwO9e7dW+eee27A+/ebzz9x4kTPtub+9t3eXh3th9NOO002m01nnXVWm+02x7V48WLP9n379uk///mPpk2bpoMOOkj5+flyOBzq1auXzjjjjHb97QJpXiehtT5obbE3p9OpefPm6cYbb9S4ceNUWFioxMRE9ejRQyeccIL+9a9/yTAMv+P69++vSZMmecot/x42m83rmmjPYm0//fSTrr32Wu2///5KTk5WRkaGxowZoz/84Q+qqqpq1++1YcMGXXHFFSoqKpLD4VCfPn00bdo0/fzzz0HPu3btWl199dUaPHiwUlJSlJycrKKiIh122GG68847tXbt2qDHAgBCYAAAuq3p06cbkox+/foZhmEYEyZMMCQZkyZN8qu7adMmQ5IhyVi4cGHQfZs2bQp6vn79+hmSjBdeeCHo8W+99ZaRlZVlSDIyMjKM+Ph4z76jjjrKaGhoMN577z0jJSXFkGRkZmYaNpvNU+f8888PeO7m3+2OO+4wjjrqKEOSkZCQ4DlX88/06dODxv/Xv/7VsNvtnroOh8NITk72lDMyMoy5c+f6HffCCy94+vmxxx7zxJuZmWnY7XbjsssuC3pOXxUVFcbEiRM954yPjzeysrK8+uB3v/ud1zGvvvqqUVBQYGRnZ3vqFBQUeH7OPPPMdp+/s/3wxhtvGJKMxMREo7S0NGjbM2bMMCQZAwYMMNxut2d7cx82/yQnJ3uugeafW2+9NWCbCxcu9NTx1fxvYMKECUFjau34lvua+yItLc1r27nnnmu4XC6v48aNGxf071FQUGDceOONfr97879TX6+99prhcDg8baWnp3uVi4qKjO+//77V2BcsWOCJOz093UhISPDs69Wrl7Ft2za/4+fOnet1Hrvd3qF/TwCAziMRB4BuzDcRX7p0qecD9AcffOBV16xEPCsryzj22GONNWvWGIZhGLW1tcbjjz/uScjvvvtuIzMz0zj//PONzZs3G4ZhGNXV1cZdd93laWPevHl+525OxDMzMw2Hw2E888wzxr59+wzDMIzi4mLjnHPO8Rz/7rvv+h3/zjvveJKN22+/3di8ebPhdrsNt9ttrF271jj33HM9SeiWLVu8jm1OpJKSkoz4+Hhj6tSpRnFxsWEYhtHY2Ghs2LAhaJ/5Ovvssz0J7eOPP27U1NQYhmEYO3bsMK644grP7/D000/7HdtaQtlene2Huro6T+IZKLZm++23nyHJuPfee/3Oe/XVVxsLFy409uzZ49m+fft2Y+bMmZ4vBgL97SKZiC9dutS46KKLjPfff98oKSnxfHlQWlpqPPbYY0ZGRoYhyXjsscc61G5LrSXiy5cv9/zuRxxxhLFq1SrDMAzD5XIZ//nPf4zCwkJDkjFo0CCjuro66Pmzs7ON0047zfjhhx8MwzCM+vp647XXXjPS09MNScall17qd+7mv9Xxxx9vrF692rN93759xurVq40ZM2YYf//731v93QAAnUMiDgDdmG8ibhiGceaZZxqSjIMOOshrRNKsRHz48OFGXV2d37GXXnqpp87kyZO9YmvWPNJ95ZVX+u1rTsQlGc8//7zffpfLZRx99NGGJGPYsGFe++rr643evXsHPbbZaaedZkgybrrpJq/tLUdzzzrrrKDHt+XLL7/0tPPss88GrNOcqOfl5Xm+aGgWaiIeaj/8+te/NiQZ48ePD3jckiVLPPGtX7++Q7HNmjXLkGQce+yxfvsimYi3pXkmwKBBgzrdbmuJ+IknnmhIMvbbbz/PlzItffPNN57R7VmzZgU9/6RJk/xG7Q3DMB5//HHPDASn0+nZvnPnTs+x27dvbzV+AED4cY84AESZBx98UPHx8Vq5cqX+9a9/mX7+3/72t3I4HH7bTzjhBM/r22+/PeD9us11vv3226DtFxUV6fLLL/fbHhcXp7vvvluS9P3332v16tWefR988IF+/vlnFRQUBDy22a9+9StJ0kcffRS0zh133BF0X1teffVVSVKfPn101VVXBaxz3333SZL27NmjefPmdfpcgYTaD5deeqkk6YsvvtCGDRv8jvvnP/8pSRo/frz222+/DsV28skne9p2uVwdOjaSmuP66aeftGPHjrC2XVFR4enj3//+90pJSfGrM3r0aM99+a39e77zzjsVF+f/se7000+X1HSP/vr16z3b09PTPfXD/XsBANpGIg4AUeaAAw7wJFn33HNPuxY/C6dDDjkk4PaCggLP64MPPrjVOuXl5UHbnzhxYtDHdh199NFKSEiQJH399dee7c2LhpWXl6uwsFA9e/YM+DNt2jRJ0pYtWwK2n5ycrDFjxgSNrS3NMU2aNClg0iRJQ4cOVe/evf1+h3AItR+OOOIIz7OwX3rpJa99DQ0Neu211yT9ksj72rlzp6ZPn67x48crNzdXCQkJnsXGhg0bJqlpZfjW/v6RUF1drVmzZmnChAnq0aOHEhMTPXG1TI5bW/SsM7755hvPQnDHHXdc0HqTJ0+W1PQFVbB/z4ceemjA7b169fK8Lisr87xOTk7WscceK0k68cQTde+99+rLL79UQ0NDx34JAECnkIgDQBSaMWOGkpOTtXHjRj3zzDOmnjs9PT3g9uYEuT11WvvyoDlJDcThcCg3N1eStGvXLs/27du3S2pKFnfu3Bn0pzkB3LdvX8D2c3NzgybQ7dEcU2u/g9Q0Yu77O4RDOPqheVS8efS72Zw5c1RWViaHw6Hzzz/f77gvvvhCBxxwgP7whz9o6dKlKisrU3Jysnr06KGCggLl5eV56rZcXT/SfvzxRw0bNky33XabPv30U+3evVt2u135+fkqKCjw+gIp3HG1/Pu2dk00Xw+NjY1eyXRL7fl35/vv6m9/+5tGjRql3bt367777tNhhx2m9PR0HXnkkZo1a1bQcwEAQkciDgBRqHfv3rrhhhskSffff7/27t1rcUThE2w0vDXNU51PPPFEGU3ro7T5E0h8fHxIsTdr7+/Qmd+1NeHoh+ZEfOPGjfr8888925sT81NOOUXZ2dlexzQ2NurCCy9URUWFDjroIM2ZM0dVVVWqrq7Wzp07VVJSoqVLl3rqB+v/SLj88su1bds29e/fX2+88YZKS0tVU1OjXbt2qaSkxGsU3My4ggnnNdG3b1998803+vDDD3XjjTdq7Nixcrvd+vzzz3Xbbbdpv/3204IFC8J2PgDAL0jEASBK3XHHHcrOztauXbv05z//udW6LUfN6urqgtarrKwMW3ydtW3btqD76uvrVVpaKknq0aOHZ3vPnj0lyeu+cSs0x7R169ZW6zX/jvn5+WE9fzj6YeDAgTriiCMk/ZJ8l5eX6/3335f0S6Le0hdffKEtW7YoPj5e7733nk466SS/EdySkpJOxdN87Xbmut26dauWLFkiqen+63POOUc5OTlhias9Wl6jrV3XzfsSEhL8vuQIVVxcnE444QQ99thj+vrrr1VWVqaXX35Zffv2VXl5uS666CKmqwNABJCIA0CUysrK0u233y5J+vOf/9zqNOeWH+6DJYk//vijKioqwhpjZ3zyySdBRyY/++wzNTY2SpLGjRvn2d6cOP7888+e+6St0BzTwoUL5Xa7A9ZZu3atZxQ22L30nRWufmi+B/z1119XfX295795eXmaMmWKX/3mayo/Pz/oFOz58+d3Kpbma7e1Lze+/PLLgNtbHjN69OgOx9XyNoXOjJaPGTPG08bHH38ctF5zDKNGjZLdbu/weToiPT1dF110kZ5//nlJTff1W/0FFgBEIxJxAIhiN954o/r06aPq6mrdf//9QeulpqZ6FuF66623AtZ54IEHIhJjRxUXF2v27Nl+291utx588EFJTQuejRw50rPv1FNPVWFhoSTppptuUm1tbavniNS9sRdccIGkpkT4b3/7W8A69957ryQpLy+v1QW8OiNc/XDeeefJ4XCovLxc7733nmdk/IILLgiYKGZmZkqS5x50X9u2bdPjjz/eod+l2ahRoyQ13f/ecnp7s127dum5554LeGxzXJK0atUqv/1t/bvJyMjwvO7Ml1RZWVmeJwXMmjUr4N9j1apVnn+TF154YYfPEUxbo9zJycme1+G6JQMA8AsScQCIYklJSZoxY4Yk6b///W+rdZs/5P/973/XU0895Vmoa+vWrbrqqqv02muvBXy8ktkyMzN17bXX6rnnnvNMR966dasuvPBCLVy4UJL/lwZJSUl66qmnZLPZ9M033+iII47QRx995JWMbNq0Sc8++6wOOeQQPfXUUxGJ/ZBDDtHZZ58tSbrhhhv05JNPepKvkpISTZs2TW+88YakpseYJSUlhfX84eqHrKwsnXrqqZKkhx56yHOveKBp6ZJ05JFHKjU1VYZh6LzzztOPP/4oqeme9Y8++qjVlfDbcvjhh6tfv36SpKlTp+rrr7+WYRhyu91atGiRJk6cGHT2wbBhw9S3b19J0hVXXKHly5d79n3xxReaOHFiqyu4Dx48WImJiZKaFj7rzKj4Aw88ILvdrg0bNuiEE07wjD673W7NmTNHU6ZMUWNjowYNGqRf//rXHW4/mCVLlujAAw/U//t//08//PCDp48Mw9CSJUt07bXXSmpaKK7ll1oAgDAx5WnlAICImD59uiHJ6NevX9A6jY2NxgEHHGBI8vwsXLjQr151dbUxbNgwT524uDgjKyvLkGTY7XbjX//6l9GvXz9DkvHCCy94Hbtp0ybPcZs2bQoYx8KFCz11gnnhhReC/j4TJkwwJBl33HGHceSRR3riys7O9vrd7r777qDtv/TSS0ZKSoqnbkJCgpGbm2s4HA6vNu6///52x9VRFRUVnt+lOYbs7GzDZrN5tv3ud78LeGx7+rA9OtsPLf3nP//xqjtkyJBWz/n000971U9LSzOSkpIMSUZeXp5Xe77XUFu/94cffmjY7XZPnZSUFE/b+++/v/Gvf/0r6PH//e9/jYSEBK9jm/smJSXFmD9/fqv/bq688kqvY/v27Wv069fPuPXWWz112rp+Xn31VSMxMdHTTkZGhid+SUZRUZHx/fff+x3X3ushUPwtj23+t5Sbm+vVFxkZGcann37aatsAgM5hRBwAolx8fLxnynZr0tLStHjxYt1yyy0aMGCAEhISZLfbdfbZZ+uLL77wTKu2WmJioj7++GM9+OCDGjJkiOrr65WZmaljjz1W77//vu67776gx1588cXasGGD7r77bo0bN05paWmqqKhQUlKSDjroIF1//fWaP3++/ud//idi8WdmZurjjz/W888/r4kTJyo9PV179+5Vz549dfbZZ2vhwoWaNWtWxM4vhacfTjrpJK/F5II9O7zZNddco/fff18TJ05UWlqaGhsbPav7r1q1KqRR1xNOOEGfffaZZ8V2l8uloqIi3X777Vq+fLlnkbpATjnlFH366ac6+eSTlZWVpcbGRuXl5enyyy/XN99843nWdjB/+ctfNGPGDI0YMUJS060TW7Zs0Z49e9od//nnn681a9bo17/+tQYNGqT6+nolJCTooIMO0syZM/Xdd99p6NCh7W6vPQ4++GC9/vrruvbaazV27Fjl5eWpsrLScw3cdttt+uGHH3TUUUeF9bwAgCY2w+gCz+IAAAAAACBGMCIOAAAAAICJSMQBAAAAADARiTgAAAAAACYiEQcAAAAAwEQk4gAAAAAAmIhEHAAAAAAAE5GIAwAAAABgIhJxAAAAAABMRCIOAAAAAICJSMQBAAAAADARiTgAAAAAACYiEQcAAAAAwEQk4gAAAAAAmCihMwc1NjaqsbEx3LEAAAAAANCtJCQkKCGhY6l1h2rX1tZqz549qqmp6dBJAAAAAACIVqmpqcrLy1NKSkq76tsMwzDaU7GhoUGbNm2S3W5XTk6OHA6HbDZbSMECAAAAANBdGYah+vp6lZWVyel0asCAAUpMTGzzuHYn4tu2bVNdXZ0GDBig+Pj4kAMGAAAAACAauFwubdq0SUlJSerTp0+b9du1WJthGKqtrVVmZiZJOAAAAAAALcTHxyszM1O1tbVqz1h3uxJxp9Mpl8ul5OTkkAMEAAAAACDaJCcny+Vyyel0tlm3XYm42+2WJEbDAQAAAAAIoDlfbs6fW9Oh54izOBsAAAAAAP46ki93KBEHAAAAAAChIREHAAAAAMBEJOIAAAAAAJiIRBwAAMAEixYtks1m08SJE00534svviibzaapU6eacj50XVOnTpXNZtOLL74Ylvb69+8vm82mzZs3h6W9tthstm6/VtXmzZtls9nUv39/q0NpVbivlXCbMWOGbDabZsyYYXUoISMRD4PmN4eO/HTmf8LNF17Ln/j4eOXl5WnSpEl67rnngq7Q1/w/f9+fhIQE5efna/LkyXr55ZfbfObdrl27dO+992rcuHHKyclRUlKSioqKdO655+rdd9/t8O/ka9myZXrkkUd0wQUXaMCAAZ44Fy9eHHLb6Bqa/+fd1d7gg/0bCfQT7Dh0b83XZls/La/drno9o+OKi4t1yy23aMSIEUpNTVVycrL69u2rww8/XL///e/10UcfWR0ioK+++kq/+c1vNGLECGVnZ8tutysvL0+HH364brvtNi1fvtzqEGPWo48+qhkzZqiiosLqUNBNJFgdQDQ44ogj/LZVVlbqu+++C7p/5MiRnT5fRkaG53in06lNmzZp0aJFWrRokf7973/r3XffVUJC8D9ty3j27dunTZs2af78+Zo/f77mzJmjl19+OeBxr7/+uq666ipVV1crPj5egwcPVkpKijZu3Kg333xTb775piZPnqw33nhDmZmZnfrdpk2bplWrVnXqWCBcAv2bRezYf//91aNHj6D7CwoKTIwGZliwYIHOOOMMz//fioqK1KNHD5WVlWnp0qX64osv9MILL2jPnj1Wh4oYVVtbq6uuukr/+te/JEl2u12DBg1SRkaGysrK9NVXX+mLL77QrFmzdNJJJ2nOnDkWRxx7Hn30UW3ZskVTp05VVlaW33673a4hQ4aod+/e5geHLolEPAwCjdYuWrRIkyZNCro/FKNHj9aiRYu8tv3jH//Q5Zdfrjlz5uiFF17QtGnT2h1vY2OjHn/8cd1666165ZVXdPHFF2vKlCledd58801deOGFcrvd+s1vfqPp06crPz/fc/zbb7+tG264QfPmzdPkyZO1ePFiJSYmdvh3GzhwoIYNG6ZDDjlEhxxyiM4//3xt27atw+0AoWAGRmy78847mcobQ6qqqnT++eerurpaJ598sv7yl7+oX79+nv0VFRV699139frrr1sYJWKZ0+nUCSecoMWLF6uwsFAPPPCAzjvvPKWmpnrqNF+nf/rTn7RgwQILo0UwvXv31tq1a60OA10IU9OjxK9+9StddNFFkqS33367Q8cmJCTolltu0cEHHyxJmj9/vtf+kpISTZs2TW63W/fcc4+efPJJTxLefPx5552nBQsWKC0tTcuWLev0fRtvv/22XnnlFd188806/PDDFR8f36l2AABojzlz5mjPnj3KyMjQ66+/7pWES1JWVpYuu+wyvf/++xZFiFg3Y8YMLV68WL169dKXX36pyy+/3CsJl365TletWqV77rnHokgBdASJuAUmTpwom83mN6rdrLOLJDQn0p1dOKP5w0dDQ4PX9ieffFIVFRUaOnSo7r333qDHDx8+XHfeeack6YknnlBlZWWn4gBaKi4u1rXXXqsBAwbI4XAoLy9PJ510kj744IOgxxiGoWeeeUajRo1ScnKyCgoKdNFFF2njxo0sXgTAy8aNGyXJc7tVR9TU1Oj+++/XgQceqNT/3959R0Vx7XEA/+4CuywsTbCCIgoEUMQCGpWIxBI1mhiNiLGgxmNPYo2FGDXGp8ZwLCiaaOwdn+VZHpZgsKAilhe74LF3VFCks7/3x56Z7LqVIgr+PufsOZyZuTN3lpm793fnzr22trC3t0ezZs2wePFiFBQUGE2bn5+P6dOnw9vbG9bW1nB1dcWIESPw7Nkzg2mKUx6y8i09PR0LFy4EACxcuBA1a9Y0ur2lpSUiIyOLfJw9e/agQ4cOcHFxgVwuh4eHB4YPH447d+6YTLtv3z60bt0aDg4OsLe3R7t27XDkyBG92z58+BDR0dH45JNPULt2bVhbW8PJyQkhISFYu3ZtkfNtSn5+PqKjo9G0aVPY29vD1tYWAQEBmDlzJrKysnS21xxQjYgQHR0Nf39/2NjYoEqVKujbty9u376tlUaoV9y6dQsAtMY40qzvGxusTXOsme3bt6NFixZQKpWoWrUqIiIi8PDhQ3HblStXokmTJrC1tUWVKlUwdOhQvXXuwsJC7Ny5EwMHDkS9evXg4OAAGxsb+Pr64vvvvy+1V23GjRsHiUSCkSNHGtzmwoULkEgkqFKlilbZeODAAYwcORIBAQHi2FN169bFsGHDdL5nU0wN4maq/nf37l18++238Pb2hkKhgKOjI0JDQ7F169Yi5aMoStw1XaUiPM/KM73hO8zJRgaptPwPtCQUKEWtSADq7uXnzp0DAPj4+GitE7rjDR482Oi754D6He8ff/wRmZmZ2Lt3L3r16lXkvFQ4KhWQbbhiVW4oKgHSsm27O3nyJDp06ID09HTY2trC398fjx49QlxcHOLi4jBlyhT89NNPOukGDRqEFStWAFD/IFaqVAnbt29HXFwcRowYUabn8C5TkQrpuelvOxsl5ih3hFTC7cpFQSoVCivAgEIWjo6QlLBcsre3BwCkpKQgPT1d77ud+jx58gRt2rTB+fPnIZVKUb9+feTn5yMpKQlJSUnYuXMn/vOf/8Da2lonLRHhiy++wJ49e+Dl5QVfX19cuHABMTEx2L9/P44dO6YzTkFxy8OK4MmTJ8VOq1QqoVAo9K5LS0szOUitITY2NjpPpd+EvXv3IjMzE9WqVUPXrl3fyDEmTZqE2bNnAwDc3NxQu3ZtXL58GUuWLMGmTZuwf/9+BAYG6k27adMmTJ48GU5OTvD29hbHHYqPj8emTZvQo0cPre2XL1+OKVOmQKFQoEaNGvD398fjx49x+PBhHD58GImJiViyZEmpnFd2djY6d+4sdtX39fWFlZUVLly4gL///htbt27FwYMH4ezsrDf9iBEjsGTJEtSqVQt+fn64ePEi1q1bh3379uHIkSP44IMPAKjHDWnZsiWSk5ORm5uLwMBAyOVycT9FGTcpOjoa3377Ldzc3ODp6YkrV65gzZo1SE5OxunTpzFhwgQsXLgQderUgYeHB65evYrffvsNV65cwaFDh7QGjn3w4AG6du0KqVSKqlWrwtPTE1lZWbh58ybmzp2L2NhYnDhxosTjnnz11VeIiopCbGwsFixYoLc364YNGwAAPXr00IolOnbsCJVKhcqVK8Pd3R0FBQW4ceMGli5ditjYWBw+fBh+fn4lyp85EhIS8PnnnyMjIwMKhQJeXl5IT08Xx+AaO3Ysfv3111I/bokD8edZeWjy80HTG77DTv/QFs5KuekN33FxcXEAgIYNG5qdJicnB6mpqZg5cyZSU1Ph5uaGfv36ievT0tKQkpICAAgJCTG5PxcXF/j6+uL8+fM4fvw4B+KAOgifW/dt56Lkxl8HbF3K7HBZWVkICwtDeno6wsLCsHz5ctjZ2QEAVq9eja+//hozZsxA8+bN0bFjRzHd1q1bsWLFCsjlcmzevBmff/45AODZs2fo1asX5syZU2bn8K5Lz01HyGbT9/W7LqFnAipZV3rb2ShXCtPTkdKi/A9K6JV4DJaVSva/b9++PaRSKTIyMtC2bVtMmjQJbdu2NVl5HjZsGM6fP4969eph586dqFtXXc4nJyejc+fOOHDgAKZOnaq3zElMTISNjQ3i4+PF8WRu376Nzz77DP/73/8wYsQIxMbGitsXtzysKIwNnmjKokWLDDbA+vr6Fvup4NSpU8tk+qTExEQAQPPmzd/I63q7d+/G7NmzYWlpiVWrVqF3794A1GMn9O/fH9u3b0ePHj1w6dIlvQ0aU6ZMwejRozF79mxYWVmhoKAAkZGR+OWXXzBo0CAEBwejevXq4vatW7dGfHw8WrVqpXU+f//9N8LDw7F06VKEh4ebVec0ZcqUKYiPj0eNGjWwa9cuNG7cGACQmpqKLl264Ny5cxg+fDg2b96sk/bevXtYvnw5Nm7ciPDwcADA06dPER4ejoMHD6Jfv344ceIEJBIJOnbsiI4dO6J27dq4desWYmNjiz1F2aRJk7Bhwwax/nz37l2Ehobi0qVL6NWrFw4dOoSDBw+iTZs2AIDz58+jdevWSEhIQFxcnNb9b2dnh1WrVqFLly6opFFOpqeni6+aTpw4EStXrixWXgWNGzeGj48Prly5gj///BPt27fX2WbTpk0AIL5GK4iJiUHnzp1Ro0YNcVl2djbmzZuHyMhIjBgxAocOHSpR/ky5f/8+unXrhhcvXuBf//oXxowZIzakJCYmIiwsDFFRUWjdujU6d+5cqsfmRwjlXH5+Pq5evYpBgwYhISEB1tbWGDVqlNE0mt1lFAoF/P39sWXLFgwZMgQnT54Unw4A6oJIIFQyTBG240HWWEls2LABt2/fRtWqVbF69Wqx0gkAERERGDJkCABg1qxZWumioqIAqH+AhSAcACpVqoRNmzaZ9QTD2NRVb+qJBHt3DBgwwOg1wFPTVCze3t6YMWMGAOD06dP48ssv4eTkBB8fHwwYMACbN29Gbm6uVpqUlBRxPJa1a9dq/T4GBgYiOjoaALB48WK8fPlS55gFBQWYNm2aGIQDQK1atbBmzRoAwL///W+xyzxQ/PKQlX9CPexNzT0tPAkfMWKEGIQD6p4i69atg4uLC27evCmO1v66evXqISoqClZWVgDUXePnzJmDxo0b48WLF1i6dKnW9sHBwQgNDdVpVGjQoIF43xiavacoXrx4IT5ZX7x4sRiEA4Cnp6d4r8XGxuL69es66QsKCjBs2DAxCAcAZ2dnrF+/HtbW1khKSjL4imlJDBo0SOshlpubG8aPHw8A2LFjB6ZNmyYG4YB6FqbBgwcD+OeBnMDBwQERERFaQTigHk8gOjoaNWvWxJYtW0y+RmMOIc/6rpMTJ07gxo0bcHd3R4sWLbTWDR48WCsIBwCFQoHJkycjODgYf/31l1Ys8iZERUXh2bNnGDVqFCZNmqTVm6FFixbiNTxv3rxSPzYH4uVQQkKCWCGUyWTw8fHBH3/8AT8/P+zZs8fk1GgtW7YUPx9++CFcXV1BRNiyZYvOqLCaFQhzu2AJ2+mrfDBmrv379wNQv+6gr2vnd999B0DdWvnq1SsA6mvu5MmTANTB1OucnJzMCqQ175HXP2XRRYq9XV5eXkavAVOv6LDyZ/LkyYiPj0enTp0gk8lARLh69SpWrVqF8PBweHt7a1W6Dxw4ACJCcHAwGjVqpLO/7t27w83NDa9evcKxY8d01stkMgwaNEhneYMGDRAcHAwiEstAoHjlIasYhLqUoTrYpk2b9DYYmjPOUGZmJo4fPw4A+Oabb3TW29jYiLPwaF6PmoYPH250+b59+3TWvXz5EsuWLUNERATat2+Pjz76CMHBwZg4cSIAlMo0tkePHkVWVhZq1aql1SgvCAoKQvPmzUFEOHDggN596OtJUaVKFXz55ZcA9J9bSX399dc6yzR7ug4cOFBnvVAGaTbeaYqPj8fo0aPx6aefolWrVggODkZwcDAyMjKQlZUl9nwtCeFJ9/bt23UaLoXgPDw8XKvrvCA5ORkTJ07EZ599hpCQEDF/165dA6DuLfEmCY2q+spkAOjQoQNkMhkSExNLpdFCE9cmyiHNecRfvnyJa9euIScnB66urlotfobom5opOTkZPXv2xOjRo2FhYSEWyJqt7q9evdJ6Wm6IUAnQTMtYUQkFsKHA18vLCzKZDHl5ebh+/ToaNGiA1NRUEBGcnZ11WlgFDRo0MHlsnr7s/cbTl72fQkNDERoaiuzsbCQnJ+PkyZPYu3cv/vrrL9y+fRudOnXCmTNn4OPjY7J8kkql8PHxwd27d3Ht2jV06NBBa72bm5vB30hfX18cPXpUPAZQvPKQVQzCdWKogaVy5cpo2fKf10wuXLhg9mC5qampUKlUkMvlqFOnjt5t6tWrBwBa16MmX19fo8tfT3f27Fl07twZ9+/fN5gvYwMWmks4ro+Pj97gD1Cf2/Hjx/Wem5WVFTw9PfWmM3RupUFf71NhpqLKlSvrrYcL6zMzM7WW5+XloWfPntixY4fRY5bG9+3p6YmgoCCcOnUKe/fuxRdffAEAUKlU4kO+119XJSKMHDkSMTExbzx/hmRmZoqDXAs9CwzJycnB06dPS/xOvaYSB+JONjKc/qFtaeTlrXGyKfp812/T6/OIp6WlYcCAAdi9ezd69OiB/fv3Gyx0DAkMDMSCBQvQpUsX/PTTTxg6dCisrKzg6uoqbnP9+nW9Lf+vE7r4aKY9e/as3tbWTp06iSOtV1iKSur3q8s7Rdm+gyv8oBh6N1AikaBy5cq4d++e+MTAnEYgbiD6h6PcEQk9E952NkrMUe74trNQ7lg4OsIrUfdJbXljYebAakWhUCjw0Ucf4aOPPsK4ceNw9OhRdOjQAa9evUJUVBSWLVtmsnwCIFbW9PUOK2q64pSHFcnjx4+LnVapVBpcd/ny5RIN1lYWhLqUoRlx2rRpo9VVuW3btvjzzz/N2rdwXVWuXNlgvdHYdQwYvib1pSssLERYWBju37+PTp06YcKECahXrx4cHR1hYWGB1NRUeHl5IT8/36z8G1PSe9TZ2RlSAwNBmvpOSkLfdSX8bwxdc8L616/l2bNnY8eOHahWrRp++eUXtGrVCtWqVRO7XgcHB+PYsWOl8n0D6qfip06dwsaNG8VA/NChQ3j48CH8/PwQEBCgtf3atWsRExMDW1tbzJ07F+3atYOrq6s4FkGfPn2wfv36UsufPpqNVvp6L70uOzu7VI9f4kBcKpVUiIHOypKhG0ZQ1G5lLi4u2LhxI3x8fHDw4EGsX78effr0KXK+hPc20tLScOPGDXh7e8PFxQVeXl5ISUlBQkKCyUA8LS0Nly9fBqAeWESQkZGh9wI31NpYoUilZTrIWUUhVJ4MVcCISBxJVwiuha57r7cKa6qIldTikkqkPMjZe0oilZZ4kLP3RXBwMIYPH465c+ciKSkJgOnyCQAePXoEQH/jn7FRwIV9aqYrTnlYkQhP/Eqbi8u7/9vcvHlzLF68GImJiSgsLCzVAduE6+rJkycgIr3BuLHrWEgrjB6uSd91nJSUhNTUVLi7u2Pbtm1a7+ICMGuqNHOV9B59+vQpVCqV3mBc37m9i4R37VetWoVPPvlEZ31pft8A0LNnT4wdOxa7d+/Gy5cvYWdnJ3ZL1zd4s5C/qKgocZyLkuSvOPGVZkNdXl6eONZBWeF3xN8CIVgw9EOcmppa5H0qlUpMmTIFgHoevcLCwiLvQ6VSiX9rdgMRpp5YtmyZyXcjli9fjoKCAiiVSnTq1Elc3rp1axCRzqeoc6Wz94e3tzcA4NKlS3rXp6SkIC8vDxYWFmJXLk9PT0ilUqSlpeHBgwd6050/f/7NZJgxVmEJ3Xbz8tTTtZoqn1QqFa5cuaK1raY7d+4YbDAUGrM10xWnPGQVQ6dOnaBUKvHo0SNs3769VPct/Gbm5uYafL/44sWLAPRfx8A/16uh5ZrphKf6TZo00QnCgdJ5N1wgHNdYrwdj55afn693EDdhn/rSFbU36psmfN+vD5AGqBsaSnsQtOrVq6N169bIzs7Gjh07kJeXJ75/rS8QN5a//Px8g9eWIcWJrxwcHMRXGYXroSxxIP4WCD/op06d0lmXnJxc7IKof//+qFatGq5fvy5OE1AUwhQZEokEHh4e4vKRI0fCwcEBly5dMjpH6cWLFzFz5kwA6gEuzJ2LlTF9hNbbZcuWIScnR2f9woULAagHVhMKXzs7OzRr1gwA9DbyZGRkmHxXijH2fjFnLmnh99HLywuAesoziUSCo0eP4uzZszrbb9u2DXfv3oWtra3W+7uCvLw8/PHHHzrLL1y4gCNHjkAikaBdu3bi8uKUh6xicHJywsiRIwGoB+W7fft2qe1bqVSKQZAwYrmm7OxsLF++HAD0PlEFYPD9XmG55lRWQpdj4Um0pvz8fMyfP9/8zJsQHBwMGxsb3LlzBzt37tRZn5ycjOPHj+vca5r0nduTJ0/EqQVfn6ZLOL/S7r5cXMa+76ioqGI9tDNFGLRt48aN+O9//4vnz5+jadOmehsIjeVv5cqVRnsO6WMsvnr16pXB2Khbt24AUKrXn7k4EH8LhDn+li1bJnZzA9Qt2hEREcUekVcul4sjp86aNatI7z0lJSWJadu1a6c1EEH16tXx+++/QyKRYMaMGRg5cqTWzVFQUIDY2Fh8/PHHyMzMROPGjTF9+vRinQNjgl69eqFWrVp49OgR+vfvr/X0aN26dfjtt98AQBxlVTBmzBgAwIwZM7Br1y5x+fPnzxEeHm602zpj7P2zbt06NGzYEMuWLcPTp0+11qWnp+PHH3/EunXrAPwzG4Onp6dYeevXr5/W08QzZ87g22+/BaBuyNbXfdXS0hJTp05FQsI/YzTcvXsX/fr1A6CuGGpWXItbHrKKYfr06WjevDnu37+PZs2aYcWKFTq/Zfn5+di6dSuuXr1apH1PmDABgDro3LBhg7j85cuX6NevH548eYLatWtrTeOl6cKFC/j+++/F93gLCgowefJknD59GnZ2dhg6dKi47YcffghLS0scO3ZMnD4MUDeS9+7dW29AVlz29vYYNmwYAPV9qNlgdv36dURERAAAwsLC9AaJlpaWiImJEYNuQN1btE+fPsjJyUFgYKDW9IPAP4Gg5n39NgUHBwMAxo4dK14vRIQ1a9bg119/1TsDQ0l1794dcrkcBw4cwKJFiwDozh3+ev5++OEHrbgiLi4O48ePL3L+QkNDYW1tjeTkZPz+++/i8vT0dPTv31+nfBdMmDABlSpVwurVqzFmzBidKUqfPXuGFStW4Oeffy5SfsxCZsjOzqZLly5Rdna2OZszIjp06BABIH1fsUqlorZt2xIAkkql9MEHH1D9+vVJKpVSq1at6KuvviIAtHLlSq10U6dOJQAUEhJi8Ljp6elkZ2dHAGj79u1689OyZUvx8+GHH5Kbm5u4rk6dOnTr1i29+96wYQMplUoCQBYWFuTn50dNmjQhJycnMX2bNm3o+fPnxfjG1ObMmUPOzs7iRyqVEgBycHAQlzVq1KjY+2dvn7u7OwEgpVKp9b9+/XP+/Hk6ceIEOTg4EACytbWlwMBAqlmzpni9/fDDD3qPMXDgQK1rOjAwkBQKBTk5OVFkZCQBoIEDB2qlMXSP6PukpKToTcfKN+Ha9PLyMvr/X7BggU6a18trVn7Mnz9fvIcBkIeHBzVt2pS8vLxIJpOJy8eNG6eV7vHjx+Tv7y/+JgYEBJCfn5+4fdu2bXXqTUJ50apVK/r0008JAHl7e1OjRo3I0tJSLLMePHigk8/ilIcrV64kABQREVGq3xkre5mZmRQWFib+v62srMjHx4eaNm1KdevWJRsbG3Fd+/bt6ebNm1rpIyIiDJZVEydOFNPWrFmTAgMDydbWlgCQk5MTJSUl6aQRyr5Zs2aRRCIhZ2dnCgoKIhcXF7F+u3HjRp1048aNE49Vq1YtatKkCSkUCrKysqIlS5YQAHJ3d9dJV5zf2aysLAoNDRXT+vn5UUBAAFlYWBAACggIoLS0NK00N27cEPMwbNgw8W+hHgGAnJ2d6dKlSzrHW7NmjXis+vXrU0hICIWEhNDZs2d19l2U8zOWjuifcuX1+CA5OZnkcjkBIHt7e2rSpAnVqFGDAFDfvn0pJCSEANChQ4e00hm7VszRtWtX8XykUindv39f73a3bt2iSpUqEQBSKBTUsGFDql27NgGg0NBQ6t27t9F4aOrUqTr7nDFjhnhsV1dX8fqqWrUqTZs2zWB5ePToUfHatbKyIn9/f2rWrBnVqVOHJBIJAaCePXuadf5FiZs5EH9DTFXOX758SWPGjCE3NzeSyWTk4eFBkZGRlJOTY/AGMCcQJ/qnkAsKCtKbH82PRCIhe3t7CgoKopkzZ9KLFy+M7vvhw4cUGRlJjRo1IkdHR5LJZOTq6krdunWjbdu2mfXdGCOco7GPoYKIlQ/Cj7epj/DDdfPmTRoyZAi5u7uTTCYjJycnat++Pe3Zs8fgMQoLCykmJob8/f1JLpdT5cqVKSwsjFJSUmjRokUEgL777jutNIbuEWN5ez0dK9/MvTY1rx0OxMu/vLw8io+Pp/Hjx1OLFi2oVq1aJJPJyMbGhry8vKhfv3505MgRvWkzMzPpp59+ovr165NCoSBbW1sKCgqi6OhoysvL09les8Kcl5dH06ZNI09PT5LL5VS9enUaNmwYPXnyxGBei1oeciBe8Zw4cYKGDh1Kfn5+5ODgQJaWluTs7EzNmjWjsWPH0unTp/WmMxVc7dq1i9q1a0dOTk4kk8nI3d2dhg4dSrdv39a7vVD23bhxg+Li4qhVq1ZkZ2dHSqWSPv74Y0pISNCbTqVS0fz588nHx4dkMhm5uLhQly5d6MSJE8UOVI3Jy8ujBQsWiI0LCoWC/P396eeff6ZXr17pbK+ZB5VKRQsWLKD69euTtbU1ubi4UO/evXUaOTQtWLCAGjRoIAbtmoFuWQfiREQnT56kdu3akVKpJFtbW2rYsCEtXLiQVCrVGwvEt2zZIp5PmzZtjG579epV6tatGzk4OJC1tTX5+PjQ9OnTKTc312Q8pC8QJyJavHgx+fn5kUwmoypVqlDfvn3pzp07JsvDx48fU2RkJAUEBJBSqSSFQkGenp7UsWNHiomJoYcPH5p1/kWJmyVEpvsv5+Tk4MaNG/Dw8Hgj3RgYY6ysfPPNN1i0aBHmzZuHUaNGve3sMMYYY+wdcfPmTXh4eMDd3d3glHGMGVOUuJnfEWeMvTcyMzOxdetWANA7gBJjjDHGGGNlgQNxxliFM3/+fJw7d05r2b1799C9e3c8fPgQjRs3RlBQ0NvJHGOMMcYYe+8Vb3huxhh7h+3YsQOjR4+Gg4MD6tSpg9zcXFy5cgUqlQouLi5YvXr1284iY4wxxhh7j3EgzhircL777js4OTnhzJkzuHLlCogIdevWRceOHfH999/D1dX1bWeRMcYYY4y9x3iwNsYYY4wxxhhjrIR4sDbGGGOMMcYYY+wdxYE4Y4wxxhhjjDFWhjgQZ4wxxhhjjDHGylCRAnEzXidnjDHGGGOMMcbeO0WJl80KxC0sLAAA+fn5xcsRY4wxxhhjjDFWgQnxshA/G2NWIG5lZQW5XI6MjAx+Ks4YY4wxxhhjjGkgImRkZEAul8PKysrk9mZNXwYAL168wL1796BUKuHg4AArKytIJJISZ5gxxhhjjDHGGCuPiAj5+fnIyMhAZmYmXF1dYW9vbzKd2YE4oA7G09LSkJubW6LMMsYYY4wxxhhjFYVcLoeLi4tZQThQxEBckJ+fj8LCwiJnjjHGGGOMMcYYq0gsLCzM6o6uqViBOGOMMcYYY4wxxoqH5xFnjDHGGGOMMcbKEAfijDHGGGOMMcZYGeJAnDHGGGOMMcYYK0MciDPGGGOMMcYYY2WIA3HGGGOMMcYYY6wMcSDOGGOMMcYYY4yVIQ7EGWOMMcYYY4yxMvR/r8X1qyK0fPYAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+IAAAKBCAYAAADTDRELAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy80BEi2AAAACXBIWXMAAA9hAAAPYQGoP6dpAACk+UlEQVR4nOzdd5hU1f3H8c/M7mxn+7K0pQlSBZEmEgNIsUeNBREFrFE00aBG/GlEEhWNJcZuEgU7tphEbCDFiihN6Yj0snS2lyn398dmx71Tts5O2Xm/nmcf55577rnfGc5e57vn3HMthmEYAgAAAAAAQWENdQAAAAAAAEQTEnEAAAAAAIKIRBwAAAAAgCAiEQcAAAAAIIhIxAEAAAAACCIScQAAAAAAgohEHAAAAACAICIRBwAAAAAgiEjEAQAAAAAIIhJxAAAQEnPmzJHFYpHFYtGUKVOa3F51WxaLpenBAQDQjEjEAQBhb/v27frHP/6hyy+/XP3791dGRoZsNpsyMzPVr18//eY3v9Fnn33W6Pa/++47TZ06Vb1791ZqaqpSU1PVu3dvTZ06Vd999129Y6yZCNb8sVqtatWqlTp06KA+ffro3HPP1b333qt58+apvLy80XE31uWXX26K76GHHgp6DAAARDOLYRhGqIMAAMCXVatW6frrr9e3335br/ojR47USy+9pI4dO9arfmVlpW6//XY9+eST8ve/Q4vFoptvvll/+ctfZLPZ/La1fft2denSpV7nrSkzM1OTJk3StGnTlJeX1+DjG6qoqEht2rRRaWmpu6xXr15av359s5/b05w5c3TllVdKkiZPnqw5c+Y0qb2aI+F8vQEAhLPYUAcAAIA/mzZt8krCjz/+ePXt21fZ2dk6duyYvv76a+3evVuStGTJEg0bNkxffPGFunbtWmf71157rV5++WX3dteuXXXyySdLkr755htt3bpVhmHo8ccfV2FhoV544YV6xz5p0iS1atXKvV1ZWamjR4/qwIEDWrVqlYqKiiRJR44c0eOPP67Zs2fr6aef1sSJE+t9jsZ4++23TUm4JG3YsEHfffedBg8e3KznBgAAVUjEAQBhr1u3brrmmmt0+eWXq3379qZ9LpdLc+bM0W9/+1uVlpZq7969mjhxor7++uta7xV+8cUX3Um41WrVo48+qt/97neyWq3udp944gndeuutcrlcevHFFzVixAhNmjSpXjHPnDlTnTt39rnP5XJp5cqVeuqpp/T666/LbreroKBAl19+ufbt26fbbrutXudojJdeesn9OjExUWVlZe5yEnEAAIKDe8QBAGGrbdu2mj17tjZu3Kg77rjDKwmXqpLoq666Sq+++qq77JtvvtH8+fP9tltRUaF7773Xvf2HP/xBt9xyizsJr273lltu0e233+4uu+eee1RZWdnEd1XV9qBBgzRnzhx99dVXpqn0d9xxhz744IMmn8OXbdu26YsvvpBUNY37kUcece974403AvLeAABA3UjEAQBha8SIEZoyZYpiYmLqrHvBBRdoyJAh7u3aktn//ve/2rVrlyQpLS1Nf/zjH/3Wveeee5SamipJ2rFjR8CT5MGDB2vRokXuc7hcLt1yyy1yOp0BPY8kvfzyy+57p0eMGKHrrrtOOTk5kqqmyM+bNy/g5wQAAN5IxAEALcbw4cPdr7dv3+633r///W/36/HjxyspKclv3aSkJF1yySXu7ffee69JMfpy3HHHmUant2zZorfeeiug5zAMw3Q//BVXXKHY2Fhdeuml7rKa09bry+l06q233tKkSZPUo0cP94r2WVlZGjp0qG6++WYtXLiwyYun7dy5Uz179nSv9D506FAdPny4SW2WlJTo2Wef1bnnnqtOnTopKSlJrVq1Uvfu3XXVVVdp0aJFfo9dtWqVO5aMjIx6r35fVFSklJQU97E//PBDk94DACAykYgDAFqMmveE1zaivHjxYvfrkSNH1tnuqFGj3K9rS86aYtKkSe7RaUmaO3duQNv/8ssvtXXrVklSQkKCLrroIklVCXm1jz76SAcPHqx3m1988YV69+6t8ePH65VXXtHmzZt17NgxORwOHTlyRN9++62eeOIJjRkzRnfeeWejY1+3bp1OOeUUbdq0SZI0duxYLVq0SFlZWY1u8+2331a3bt00depUzZs3Tzt37lRZWZmKi4u1ZcsWzZ49W6NHj9a5556rgoICr+MHDBiggQMHSpKOHTumd999t17nffPNN1VSUiKpajZEv379Gv0eAACRi0QcANBirFmzxv3a36PACgoKtG/fPvf2SSedVGe7Nevs2bNHhYWFTYjSt/j4eJ177rnu7S+//DKgj+CqOdp93nnnuafCDx48WD179pQk2e12vf766/Vqb+7cuRo9erQ2b97sLjv++OM1fvx4XXfddbr00kt1wgknuO+7b+zz0pcuXapTTz1Ve/bskVQ1g2HevHlKTk5uVHuS9Ne//lXjx49Xfn6+JCk1NVWnn366rr76ak2ZMkWDBw92/1Fn3rx5GjlypNdK85J03XXXuV/Xd0X9mvWuueaaRr8HAEBkIxEHALQIO3fuNI1Wjxkzxme96lHVavV55rhnHc82AmXo0KHu10eOHNGPP/4YkHbLysr09ttvu7drjoJ7btdnevqqVat05ZVXym63S6oaHf7mm2+0adMmzZ07V88//7zeeOMN/fDDD9qzZ48efvhhtWvXrsFxf/jhhxozZoyOHj0qSZo6dapef/11xcXFNbitagsXLtRtt90mwzAUFxenBx98UPv27dPHH3+sf/7zn5o9e7a+/fZbrVy5Ur1795YkrV692udK9pdddplSUlIkVT06r3rGgT/r16/XN998I0lKTk7WhAkTGv0+AACRjUQcANAiTJs2zT0dvWPHjqbR5Zpq3lecmpqqxMTEOtuuvne42pEjR5oYrW89evQwbe/fvz8g7b733nvuUfycnBydfvrppv0TJ050jwCvWrXKNLPAl9/+9rfuEe5Bgwbp888/N/0RoaY2bdrotttu0x/+8IcGxfzqq6/qvPPOc49E33PPPXr66adNK9s3lMvl0g033CCXyyWpalT/jjvu8LlGwIknnqiFCxcqNzdXkvTPf/7T/bz6aikpKe5k2jAMvfjii7Wev+Zo+CWXXGLqUwCA6EIiDgCIeC+99JLpHt1Zs2YpPj7eZ93i4mL36/ok4b7q1mwjkNLS0kzb1SPBTVVzlHvChAmKjY017e/UqZN++ctf+qzvadmyZfrqq68kVd2T/9JLL7lHhQPlr3/9qyZNmiSHwyGr1aqnnnpKM2fObHK777//vnuWwfnnn68LLrig1vpt2rTRLbfcIqlq2r6vBfSuvfZa9+s5c+b4XZvAbrfrlVdecW8zLR0AohuJOAAgoi1fvlzXX3+9e3vChAm67LLL/Navea9yQ6Y410zsy8rKGhhl/XgmtEVFRU1uc8+ePfr000/d257T0qtNmjTJ/fq1117zm1B+/PHH7tejR492T98OlDvvvFPTpk2TYRiy2Wx67bXXdOONNwak7Q8//ND9urY+UtNpp53mfv3ll1967R88eLBOPPFESVWf9SeffOKznf/+97/uhfB69+6tU045pb5hAwBaoNi6qwAAEJ62bdumc889151c9+vXT88991ytxyQkJLhfV1ZW1vtcFRUV7tcNGUlvCM/Eu3pBtaZ49dVX3VOxe/bsqUGDBvmsd9FFF+nGG29UeXm58vPz9cknn+iss87yqld9j7NkXk2+qZxOp6655hr39O3k5GS9++67XtPom2Lp0qXu1++++64+++yzOo+puWJ69bPnPV133XWaOnWqpKrp574+t5rT0q+++up6xwwAaJlIxAEAEWnfvn0aO3ase+Xrrl276uOPP64zea056tyQke2adQM9Fbua52OyMjMzm9xmzWnm/kbDpaqk/7zzztObb77pPs5XQlnzvvWuXbs2Ob5qc+fOlcPhkFQ1Rf+TTz7xe995Y+3du9f9uvp9NoS/WwUmTpyo22+/XSUlJXr//fd18OBB06Podu/e7R4pj4uLM80+AABEJ6amAwAizuHDhzV27Fj99NNPkqS2bdvq008/Vdu2bes8tuazpwsLC+v1WK3S0lLTaHUgEmRfNm7caNpu06ZNk9r77rvvtGHDBklV93NPnDix1vo1E/X//ve/OnbsmFedmp9DIP8gYbPZ3K+Li4u1Y8eOgLVdzdfzwBui+g8FnlJTUzV+/HhJVfeCv/zyy6b9c+bMcc9KOO+885Sdnd2kOAAAkY9EHAAQUQoLC3X66adr3bp1kqTs7Gx9+umn6tKlS72O91yZvD4J386dO2ttI1CWLVvmfp2Tk6PjjjuuSe3VHA03DEOdO3eWxWLx+3POOee465eXl/scNa650ncgF627+OKL3ff6O51OXXbZZT4XR2uKms8eX7lypQzDaNDP9u3b/bZdc9G2mtPQDcPQ7Nmz3dss0gYAkEjEAQARpKSkRGeddZZWrFghqWoK88cff9ygBcPS0tJMI+erVq2q85iVK1e6X7dv3z4g9257Ki8v17x589zbp556apPaq6ys1BtvvNGkNnytnl79OC+p6h79QLFYLHrmmWdMyfjEiRMDmozXjL36loZAOfnkk9WvXz9J0oYNG9z3oy9evNj9fPFOnTr5fb49ACC6kIgDACJCeXm5fvWrX7kfnZWUlKQPPvhAAwcObHBbNRcZW7JkSZ31ay7qVXMV7UB6+eWXdejQIff2pZde2qT25s2b537eeWxsrIYOHVqvn8GDB7vbWLp0qTZv3mxq9+STT3a/XrRoUZNi9FSdjP/mN7+RVDUVPJDJeM17zqv7USD5GhWvOTp+5ZVXNuk56ACAFsQAACDMVVZWGmeddZYhyZBkxMfHGwsWLGh0e2+99Za7rfT0dKO0tNRv3dLSUiM9Pd1d/9133/VZb9u2be46koxt27bVO54tW7YYqamp7mN79eplOJ3Ohr4tk1/96lfu9s4999wGHdu3b1/3sXfddZdp37Jly9z7LBaLsX79+kbHOHv2bHdbkydPdpe7XC7jN7/5jXtfbGys8dZbb9XZXs3P35c333zTvb9t27ZGWVlZo2P35ejRo0ZiYqIhyUhJSTF27dplJCQkGJIMq9Vq7Ny5M6DnAwBELv4sCwAIa9X3C1c/Azo2NlZvvfVWk6b4/upXv1KHDh0kSceOHdP999/vt+6f//xn96JlnTp1Mt1HHQjLly/XaaedpsLCQklSTEyMHn/88SaNnB48eFAfffSRe/vyyy9v0PE167/yyisyDMO9PWTIEA0fPlxS1f3PkyZNCui94lLVyPizzz6r6667TlLVyPhll12mt99+u0ntXnjhherWrZukqlX3p06danpvtSkuLlZJSUmtddLT03XJJZe461900UXuxQDHjRunvLy8JkQPAGhJSMQBAGHLMAxdffXVeueddyRJVqtVr7zyin71q181qd34+HjNnDnTvT1r1iw98cQT7pWtJcnlcumJJ57QQw895C7705/+pLi4uCadu7rt5cuX68orr9Tw4cNNi8H99a9/1bhx45rU/uuvvy673S6panG1c889t0HHT5gwQRaLRVLVQnWLFy827X/iiScUHx8vqeoPCb/85S9NC83VlJ+fr0ceeUQPP/xwg2KwWCx67rnnApqMx8TE6Nlnn1VMTIwkafbs2Tr77LPdK8v7snr1at1xxx3Ky8ur1z3xNaen1/xMWKQNAFCTxajvn4IBAAiyZ555RjfeeKN7u3v37g1KUp966qla90+aNEmvvPKKe/u4445z3wP9zTffuB+PJlXd3/viiy/6bWv79u2mldsnTZpkWmG8srJSx44d08GDB7Vy5Ur3CHi1jIwMPfvss+7HYDXFSSed5F6EbvLkyZozZ06D2xgxYoQ+//xzSVXvxXPhttdee01TpkwxPdKrR48eGjBggNLS0lRQUKD169dr7dq1crlcuvnmm/X444+b2pgzZ46uvPLKWuM0DEO/+c1v9I9//ENS1YyIN954QxdddJFX3eo/HlQf588//vEP3XDDDXI6ne7jevfurX79+ik1NVWlpaXat2+fvv/+ex08eNB93Jo1a9S3b1+/7Vbr27eve1V/SWrdurV2795tekQbACDKhW5WPAAAtZsxY4bpvt+G/tSloqLCuOmmmwyLxeK3DYvFYvzud78zKisra23L8x7x+v5kZWUZ06ZNM3bv3h2Qz+yHH34wtd/Ye+n//ve/u9tITk42ioqKvOosXLjQ6NKlS73ep+e95obh/x5xTy6Xy7j22mtN94y//fbbXvUa8m+/aNEio3v37vX+d+rTp4+xZ8+eOts1DMN4/PHHTcfedttt9ToOABA9YpuWxgMAELni4uL05JNP6oorrtCLL76oJUuWaM+ePZKqHlM2cuRIXX311aaVxBsrOTlZaWlpSktLU9euXTVo0CANGTJEo0ePdk/zDoSaI9dt27Zt9CrvF110kX7729+qoqJCJSUleueddzRlyhRTndNOO02bNm3S3LlzNW/ePC1fvlwHDhxQRUWF0tLS1K1bNw0bNkwXXHBBkx7HZrFY9Pzzz0uqGs12OByaMGGCO87GGDVqlDZs2KB///vf+uCDD/TNN98oPz9fhYWFSkpKUm5urnr27KlTTjlFZ555pk488cR6t/3rX/9at9xyi3ubaekAAE9MTQcAAAigl156yf1Hi1/84hf64osvQhsQACDssFgbAABAANV8dnjNxdsAAKjGiDgAAECArFq1SieddJIkKTMzU3v27FFCQkKIowIAhBtGxAEAAAKgvLxcv/3tb93b119/PUk4AMAnRsQBAAAa6amnntKWLVt07NgxLVy4ULt375YkZWdna9OmTcrMzAxxhACAcMSq6QAAAI30zjvv6LPPPjOVxcTE6IUXXiAJBwD4RSKOZuFyubR37161atVKFosl1OEAANAsnE6n+3V6erqGDh2qadOm6eSTT1ZhYWEIIwPQkhmGoaKiIrVr105WK3cbRyKmpqNZ7N69W3l5eaEOAwAAAGixdu3apQ4dOoQ6DDQCI+JoFq1atZIkbdu2jal5MLHb7Zo/f77GjRsnm80W6nAQJugX8IV+AX/oG/AlmvpFYWGh8vLy3N+5EXlIxNEsqqejt2rVSqmpqSGOBuHEbrcrKSlJqampLf5/kqg/+gV8oV/AH/oGfInGfsEtoJGLGwoAAAAAAAgiEnEAAAAAAIKIRBwAAAAAgCAiEQcAAAAAIIhIxAEAAAAACCIScQAAAAAAgohEHAAAAACAICIRBwAAAAAgiEjEAQAAAAAIIhJxAAAAAACCiEQcAAAAAIAgIhEHAAAAACCISMQBAAAAAAgiEnEAAAAAAIKIRBwAAAAAgCAiEQcAAAAAIIhIxAEAAAAACCIScQAAAAAAgohEHAAAAACAICIRBwAAAAAgiEjEAQAAAAAIIhJxAAAAAACCiEQcAAAAAIAgIhEHAAAAACCISMRRq6efflqdO3dWQkKChg4dqm+//TbUIQEAAABARIsNdQAIX2+++aamTZum5557TkOHDtXjjz+u008/XZs2bVLr1q3r1cahQ4fkcrkafO6UlBQlJib6bdMwjAa3KUlJSUlKTk72ue/IkSNyOp2NajchIUGtWrXyue/YsWOy2+2NajcuLk5paWk+9xUUFKiysrJR7dpsNqWnp/vcV1RUpPLy8ka1GxMTo8zMTJ/7SkpKVFpaKrvdroKCAh08eFA2m61e7VosFmVnZ/vcV1ZWpuLi4kbFK0k5OTk+yysqKlRYWNjodrOysmS1ev+ts7KyUgUFBY1uNyMjQ7Gx3pduh8Oho0ePNrrdtLQ0xcXFeZW7XC4dPny40e2mpqYqPj7e576DBw+6Xze0X3CNqNISrxE11bdfcI34WUu9Rniqq29wjajS0q8Rnvz1i5Z4jSgqKmp02wgTBuDHkCFDjBtvvNG97XQ6jXbt2hmzZs2q89iCggJDUqN/nnrqKb9tZ2dnN7rdGTNm+G23d+/ejW536tSpftsdMWJEo9u96KKL/LZ70UUXNbrdESNG+G136tSpjW63d+/eftudMWNGo9vNzs722+5TTz3VpL7mz1tvvdWkdg8cOOCz3cWLFzep3bVr1/psd+3atU1qd/HixT7bPXDgQJPafeutt/x+xk1pl2tE1Q/XiKofrhE//3CNqPrhGlH1wzWi6qclXyMKCgr8xoDwxog4fKqsrNSKFSt05513ususVqvGjBmjpUuXetWvqKhQRUWFe7spfwGUJKfT2ei//ja2XaORfx2XqkYEgt1uY2YaVDMMI+jtNnaUoFqw23U4HE1u11fbzdVuU39fHA5HUNttKq4RdbfLNaJ52+Ua0bztNhXXiLrb5RrRvO2G6zUC4YNEHD4dOnRITqdTubm5pvLc3Fxt3LjRq/6sWbM0c+bMgJ1/3bp1+vDDD33ua+w0Kkn68ccf/bbblGlJO3bs8NtuU6bs5efn+203Pz+/0e0ePnzYb7s7duxodLvFxcV+2/3xxx8b3W5lZaXfdtetW9fodiX5bXfVqlVNavfTTz/1OR1wzZo1TWr3iy++8PlvtHPnzia1+80336ikpMSrvClTZKWqzzEpKalJbfjCNaIK14gqXCN+xjWiCteIKlwjqnCNQDgiEUdA3HnnnZo2bZp7u7CwUHl5eY1ur0+fPjrrrLN87vN1j1p9de/e3W+7NUf/G6pTp05+233sscca3W6bNm38tvvyyy83ut2srCy/7X788ceNbjclJcVvu8uXL290u3FxcX7bbcr/8CX5bbeu+9DqMmbMGJ/3jfm7t7C+Tj31VPXp08ervKlfJE4++WSNGDHCq7y2ezTrY8CAAX4/46bgGlGFa0QVrhE/4xpRhWtEFa4RVbhGIBxZjKbMd0GLVVlZqaSkJL3zzjs6//zz3eWTJ0/WsWPH9J///KfW4wsLC5WWlqaNGzf6XXSjNiyyUqUlLrJit9v16aefasyYMSzW1ggtdSGmhvYLrhFVWuI1oqb69guuET9rqdcIT3X1Da4RVVr6NcKTv34RjGuEYRiqdP48LT8Yi7X17nG8CgoKlJqa2ujzIHQYEYdPcXFxGjhwoBYuXOhOxF0ulxYuXKibbrqp3u1kZ2crKysroLH5u5A2VWP+YFAf/v5H1VT+/sfaVK1atfL7ZaApkpOTlZycLLvdrrS0NOXk5NQ7Ea9NYmKi3y9bTREfH+/3C3hTxMXFNUu7sbGxzdKu1WptlnYlc4ITyH7BNaJKpF4jagpEv+AaUSXSrxGemtI3uEZUaQnXCE+N6ReBuEYs2XRA//evNdpb0Lg/QDSGq6JpI+4IPRJx+DVt2jRNnjxZgwYN0pAhQ/T444+rpKREV155ZahDAwAAAILiUHGFXvxym/YeK/Pa9+OBYq3b27RFihGdSMTh1/jx43Xw4EHdc889ys/P14knnqiPP/7YawE3AAAAoKXZdaRUH6zZp398vlWHSxq/yB/gC4k4anXTTTc1aCo6AAAAEAk27CvUD7uPyeEy5HIZchmSyzDkdBlavv2o5q/Pl4vVtNBMSMQBAAAARJVXlm7XPf9dp0AuW33KcVn68/l9FWOxBK5RP4qKCtXv8WY/DZoRiTgAAACAiFdc4dCuYunFr7ZrwYaDOlhc4bPeriOljRrpzmkVr3P7tVO8zbyauUVSr7apOvuEtrJamz8Jl6TCuMat0I/wQSIOAAAAICIt3LBfn6zL155jZfp22xHZnbHSms0Ba99qkUb1aK0z+rbRBQPaKzbG+5FiQGOQiAMAAACIOIs3HdDVLy0PSFtDumTKapGsFousFossFqlLdrImDu2kHm0C/zg2gEQcAAAAQEQxDEOPzt/U5HamnNJZM87tLUsQ7usGaiIRBwAAABAx9hwr07Q3V2vtHt/P746PtWpIl0yd0beNWrdK8NtOh4xE9Wqb2lxhArUiEQcAAAAQEQ4WVejXz3yl/YXeC7Hdf15vWff+oIt+dZZsNlsIogPqj0QcAAAAQFha+tNhffHjQZXZnap0uPT97mM+k/A/nddHlwxqrw8//CEEUQINRyIOAAAAIOQOFJUrv6Dcvf3y0h16Z8XuOo87PjdFFw/Mk+RqxuiAwCIRBwAAAKKUYRg6VFwZ8hieWfKTXl66vcHP975lTHdNHtZZiXExsttJxBE5SMQBAACAKPTd9iO6Ze5q7TlWFupQGizWatE/Jg/SqB6tQx0K0Cgk4gAAAECUMQxDf3jnh4hJwrtmJ2t4t2zFxVqVHB+r03q21ol56aEOC2g0EnEAAAAgymzaX6Rth0pCHYZfCTarJCkzKU63jDlelwzOC3FEQGCRiAMAAABRZvHGg6EOwUu7tAQ9cnF/ndItO9ShAM2ORBwAAAAIsb3HyvT55oMqqXQG5XzvrTKvRj5+UJ7uOLNnUM7ti0VSepJNFoslZDEAwUQiDgAAAITQtkMlOv/pr1RQZg9ZDOP65CozOS5k5weijTXUAQAAAADR7JFPNoU0CY+LtWrYcVkhOz8QjRgRBwAAAJrB9kMleuPbnbU+p9swDH24dl8Qo/J24UntlRRHWgAEE79xAAAAQIAdKCzXRc99XWsS7ktSXIwGdspopqi8DeqUqatP7RK08wGoQiIOAACAqFVud+rjtfnafbQ0oO1+ueVQg5NwSbpyeGfdfnroFk0DEBwk4gAAAIhKLpeh615Zoc83h8ejvNqlJejqX3QNdRgAgoBEHAAAAGHLMAztOVamcvvPj/Wy2x3KL5W2HCiWzdb4r7Nf/HgoKEl4epJNlwzKq7VOZnKczu3fjpXLgShBIg4AAICA+GH3Mb2zYrdW7DiqSocrIG0eLa30M8U7VrO+/zog52hufzy7ty4c2CHUYQAIIyTiAAAAaLL/fr9XN89dJcMIdSSN98vjcxQfG7in+ybYYjSud67O7d8uYG0CaBlIxAEAANBkzyzeEtFJ+Ijjc/TSVUNCHQaAKEEiDgAAgCY5UFSujflFoQ6jUawW6eSuWXr0kv6hDgVAFCERBwAAQJN8veWwV9lfx/eXLabp07xjrRb1apuqDhlJsvyvzG6368OPPtJZZ54pm83W5HNYrZa6KwFAAJGIAwAAoEm++PGQaXtMr1xdMKD5FiezWi2yWv73X5JoABEocKtRAAAAIOpUOJyavz7fVHZq9+wQRQMAkYERcQAAgBaiwuHUY/M3a+nWw3I4g7Ny2vp9hV5lvyARB4BakYgDAAC0EH//bKue/3xrSGPo3TZVXbOTQxoDAIQ7pqYDAAC0EF9uOVR3pWaUFBejhy/uJ4uF+7YBoDYk4gAAAC3EriOlITt3fKxVT1w6QH3apYUsBgCIFExNBwAAaAEqHE7tKyw3lf3hjB5qm5bQ7OeOsVo1IC9deZlJzX4uAGgJSMQBAABagD1Hy2R4rM92+cmdlJrQ9OdsAwACi6npAAAALcBOj2np6Uk2knAACFMk4gAAAC2A5/3hnZgmDgBhi0QcAACgBfAcEed+bQAIXyTiAAAALYBnIt6RRBwAwhaLtQEAAESYj9fm618rd6vM7nSXrd51zFSHRBwAwheJOAAAQBCUVDi0aOMBHSquaFI7H/ywT8t3HK2zHok4AIQvEnEAAIBmVlbp1KV//0Zr9hQE7Zyds5ODdi4AQMOQiAMAgKi3bm+Bvtt2RE6j7rqNsWLHkaAm4WN6tVa79MSgnQ8A0DAk4gAAIKp9uGafpr62MtRhNMqAjuk6+4S2prK2aYka07t1iCICANQHiTgAAIhaDqdL981bH9RzxsVaNahTRpPaSIqL0YUnddCZHkk4ACAykIgDAICwVe6QPliTr6JKV7O0v+1gifYWlDdL2/784fQeuubUrkE9JwAgvJCIAwCAsGR3uvTXtTHK/+6HoJ2zdat4HZ/bqlnajou1anSv1rpsSMdmaR8AEDlIxAEAQFj6ZusR5ZdZgnrOGef20dn9mO4NAGhe1lAHAAAA4MuPB4qDer7jc1N0ep/coJ4TABCdGBGHl+3bt+vPf/6zFi1apPz8fLVr106XX3657rrrLsXFxYU6PABAlNh6qNS0nZsar05ZzfNs7ONyUjR15HGKjWGMAgDQ/EjE4WXjxo1yuVx6/vnn1a1bN61du1bXXnutSkpK9Mgjj4Q6PABAlNh2qMS0PfmUzpo6sluIogEAIHBIxOHljDPO0BlnnOHe7tq1qzZt2qRnn32WRBwAEDTbD5tHxLtmp4QoEgAAAotEHPVSUFCgzMxMv/srKipUUVHh3i4sLJQk2e122e32Zo8PkaO6P9AvUBP9Ap6Kyh06UFRhKuuYEU8fgSSuGfAtmvpFNLzHls5iGIYR6iAQ3rZs2aKBAwfqkUce0bXXXuuzzr333quZM2d6lb/++utKSkpq7hABAC3MzmLp0TU/jxdYZOiRoU7Fcgs3AKi0tFSXXXaZCgoKlJqaGupw0Agk4lFk+vTpeuihh2qts2HDBvXs2dO9vWfPHo0YMUIjR47UP//5T7/H+RoRz8vL0759+5SVldX04NFi2O12LViwQGPHjpXNZgt1OAgT9IvgsWz+WJati2VxVjbsQJddlr2rpIJdzROYB6fLUKXD5d62WKQEW0xQzo1IYMjpdComJkZScB9xh3AWPf2isNyl9PsOkIhHMKamR5Fbb71VU6ZMqbVO165d3a/37t2rUaNG6ZRTTtHf//73Wo+Lj49XfHy8V7nNZuNLNXyib8AX+kUzW/9f6e0rQh1FvcRKivX8Hs1MTNQQK0muumoh2kRLv7A4GEuNdCTiUSQnJ0c5OTn1qrtnzx6NGjVKAwcO1OzZs2W1MhcQACLe+n+HOgIAACAScfiwZ88ejRw5Up06ddIjjzyigwcPuve1adMmhJEBAJrk6I5QRwAAAEQiDh8WLFigLVu2aMuWLerQoYNpH0sKAEAE87y/u+c5UloH33V9adVG6jBYik1sdAjfbjus+z/cUO/6qXHS1NOO17DjWjf6nGh5HA6Hvvr6Kw0/ZbhiY/k6iypR1S+KiqUHR4Y6CjRBC++haIwpU6bUeS85ACDC2Mul4v3mslH/J+X2CWoYyzb9qO+Nn2/27pHbStec2sVn3azkWB3d+K0GnTJGYu0A1GDY7TqWnC+j/Un0DbhFVb/436OCEblIxAEAiAYFu73L0vKCHsbG/CLT9rDjsnTxIN9x2O12fbg5GFEBABBcrMAFAEA0KNhp3k5IkxKC/8ibDfnmUZyebVoFPQYAAEKNEXEAAKLBMY/7w9M6SpJ2HSnVsm1HZHc2//N+XIah7YdKTGU92/L8WwBA9CERBwAgGngu1Jaep7V7CnTJ80tVWukMSUgWS9U94gAARBumpgMAEA28RsTz9OZ3u0KWhEtSl6xkJcbFhOz8AACECiPiAAAEiqNS2vSBtHd1qCPxtvNr83Z6nrauLw5NLP8zqiePJAMARCcScQAAAuXTGdI3z4Q6ivpJ76idR0pNRcflJCstsfkf+WO1WHRSpwxNG3t8s58LAIBwRCIOAEAglB6Rvv17qKOoN3tqnvYeyzeV/XX8ierXIT00AQEAEEW4RxwAgEDY8L7kcoQ6ivpJ76R98d3ldBmm4o6ZSSEKCACA6MKIOAAgepUckta+Kx3d0fS2tiwwb2d1l9qf1PR2Ay0lVxpyrXYerDAVt0qIDcq0dAAAQCIOAIhku1dIS5+sSqgbyl4m7V0pGc30/OzT7pL6XNA8bQfAzk07TdsdM5NksVhCFA0AANGFRBwAEJkqiqWXz5Mqi0IdiTdbktR9XKijqJXnQm1MSwcAIHhIxAEAkWnvyvBMwiVpyHVSXHLITu9yGfrxQLEKyux+66zZc8y0TSIOAEDwkIgDACJTycHAtdXuJKl1b6nJM7MtUt5Qqf+lgYiqUSodLk1+8Vst3Xq4Qcd1IBEHACBoSMQBAJGp9Ih5O7OrdPLUhrVhjZU6niy17hW4uELs658ONTgJlxgRBwAgmEjEAQCRyXOBtpxe0pBrQxNLGNl2qKTBx9hiLOrXPq0ZogEAAL6QiAMAIlOpx6hvclZo4ggzB4vMjyWzxViUFOf/f/fZKXG6eczxykiOa+7QAADA/5CIAwAik2cinkQiLnkn4hOHdtK9v+oTomgAAIAv1lAHAABAo5R6TE1Pyg5NHGHmYLE5Ec9pFR+iSAAAgD8k4gCAyOS5WBsj4pK8R8RJxAEACD8k4gCAyOS5WBuJuCQScQAAIgGJOAAg8hgGi7X54HQZOlxSaSrLSSERBwAg3JCIAwAiT0WR5LKbyxgR19HSSjldhqmsNSPiAACEHRJxAEDk8VyoTWKxNnlPS7dYpEweSwYAQNghEQcARB7Phdpi4qW45NDEEkY8E/Gs5DjFxvC/egAAwg3/dwYARB5fzxC3WEITSxjxTMSzuT8cAICwRCIOAIg8niums1CbJJ4hDgBApIgNdQAAgAjz02Jp8QNScX7Amow1pDFlpYrderdUn4HtiiLzdgtcqM3hdMlpGHVX/J9P1x/Qgx9tNJWRiAMAEJ5IxAEA9VdZIr15uVRZHNBmLZKSJamyjor+RHgibhiGdh8tU5ndqX0F5Xp92Q4t2XRQFQ5Xk9olEQcAIDyRiAMA6m//uoAn4QGR3inUETRaQaldk15cpu93FwS87c5ZLGAHAEA44h5xAED9FewKdQTeUnKlk64IdRSN9u/Ve5olCe+R20pn9W0b8HYBAEDTMSIOAKi/gj3m7TYnSKf9scnNOhwOLV++XIMGDVJsbAP+1xQTJ7UfKCWkNjmGUNm0v6juSvXUJjVBlw7J06gerdW7XapsPLoMAICwRCIOAKi/gt3m7dwTpONPb3Kzht2u/T86ZHQfJ9lsTW4vkuQXlHuVZSbH6cy+bTRhSEe1Sqjf/6qtFos6ZCTKwmPcAAAIeyTiAID6K/QYEU9rH5o4WhDPRPwvF/bTJYPzQhQNAAAIBuasAQDqz/Me8bQOoYmjBckvNCfiuWkJIYoEAAAEC4k4AKD+PO8RTyURb4pyu1NHSszPbGtLIg4AQItHIg4AqB97mVR6yFzGiHiTHCis8CrLTSURBwCgpSMRBwDUT+Fe7zLuEW8Sz2npSXExSq3n4mwAACBy8X97AGjpDEM6slWqaOJjsvauMm8npEnxrZrWZpTbV1Bm2m6TlsCq5wAARAEScQCIVIZRd52yo9I7V0pblwT+/Nwf3mT7PUbE2zAtHQCAqEAiDgCRaOMH0oe3ez9OLJi4P7zJ9nk8uqwNC7UBABAVSMQBINI4KqT/3Fg12h1K7QeG9vwB9tnmg/r3qj06WlpZd+UA2bCv0LTNiDgAANGBRBwAIs3+tY1Pwq2xkqWJ63TGxEnHnSadfH3T2gkRp8vQa8t2aPWuY+7Z/St3HtWOw6WhDUw8ugwAgGhBIg4AkWbf9w0/pu2J0qWvMZ1c0t3/XqM3vt0V6jB86pCZFOoQAABAEJCIA0Ck8UzEjz9DGjPTf/3YeCm9k2RtuU+sNAxDL3y5Tf/9fq9KKhx+6/10sCSIUTVM56wkDeuaFeowAABAEJCIA0Ck8UzEO50ite4ZmljCxPz1+3XfBxua3I7VIp3Zt636dUgLQFT1l5EUp7G9c5VgiwnqeQEAQGiQiANAODOMqpXRDVfVtssp7V9nrtO2f/DjCjP//X5vo47rkp2sM/q2kSRlJsXprH5t1T49MZChAQAAeCERB4BwdXCT9OpFUsHO2uu16ReceMLYyh0NX7zu2lO76K6zezdDNAAAALUjEQeAcPWfm+pOwtM7SkmZwYknTO09Vub1PO4/n9dHWSnxfo/pmJmkvu2DO/0cAACgGok4AISj/DXS7m/rrtfpF80fS5hbudM8Gp6aEKuJQzvJarWEKCIAAIDakYijVhUVFRo6dKi+//57rVq1SieeeGKoQwJapj0rpM8fkYr3V20XH6j7mLYnSiOnN2tYze2Nb3fq5aU7VFRWqdKyGD284XPJ0rAEurDMbto+qVMGSTgAAAhrJOKo1R/+8Ae1a9dO33/fiOcWA6gfe1nVveBlR/zXOfXWqp9qFqtki+xFxT74YZ/u/NeaGiUWHako91u/vgZ2zGhyGwAAAM2JRBx+ffTRR5o/f77effddffTRR7XWraioUEVFhXu7sLBQkmS322W32/0dhihU3R/oFz+z7Fim2FqScMNilaP/FZIlzrwjgJ/hur2Fmv7eOm05UBywNmvjcBnN1vbAjmn0rxaC6wX8oW/Al2jqF9HwHls6i2EYzfdtCBFr//79GjhwoP79738rOztbXbp0qXVq+r333quZM2d6lb/++utKSkpq5miByNbl4Hz12/2q3/2bc8/RhnaXNGsMj62J0Y7iyJ/O3S/TpauOdzV0djsAABGltLRUl112mQoKCpSamhrqcNAIJOLwYhiGzjrrLA0fPlx33323tm/fXmci7mtEPC8vT/v27VNWVlaQIkcksNvtWrBggcaOHSubzRbqcMJCzAe/l3X1K+5tV97JcvWbULWR00tGuxOrpqI3kwqHS/3+9KmacZC6TmmJsbqkY4UGDDhRMbGNm6zVNjVBPdukyEIW3mJwvYA/9A34Ek39orCwUNnZ2STiEYyp6VFk+vTpeuihh2qts2HDBs2fP19FRUW688476912fHy84uO9HxVks9la/IUQjUPfqOHQRtOmtedZsg6eErTT7zhaFNIk/KSO6frH5QP05eIFGtunLf0CXrhewB/6BnyJhn7R0t9fNCARjyK33nqrpkyZUmudrl27atGiRVq6dKlXYj1o0CBNnDhRL730UjNGCUQZl0s6sMFc1rpPUEPYerDEtJ2VHKdXrh4alHMnx8eoY2aSHA5HUM4HAAAQDkjEo0hOTo5ycnLqrPfEE0/ovvvuc2/v3btXp59+ut58800NHRqcL+dAi1F2TCrY7X9/8X6p0mOBtNzgJuLbDpkT8eNap6h3O6a5AQAANBcScXjp2LGjaTslJUWSdNxxx6lDhw6hCAmILOv+LW36SDq2U9q1TDKc9T82MUNq1abZQvPFMxHvmp0c1PMDAABEGxJxAAik9f+R3p7c+ONb91Gwl/ze6pGIdyERBwAAaFYk4qhT586dxeL6QD198VjTju90SmDiaADPEXEScQAAgOZFIg4ATeGolI5uq3p9dIe0b7XvenU9fsxqk7qNlobdGNDw6lJUbtfBogpTWdccEnEAAIDmRCIOAI218QPp31Ol8mP+65z/nNTrHCm+VdDCaogfD5gXirNapLzMpBBFAwAAEB1IxAGgMVxOad602pPwU2+TTpwQtJAa45N1+abtzlnJio+NCVE0AAAA0aGOuZIAAJ8ObpSK8/3vt9qkARODF08jHCqu0POfbTWVje2TG6JoAAAAogeJOAA0xq5l/ve1aif96gkps2vw4mmgf63crUH3fepVfsGA9iGIBgAAILowNR0AGmPXt+btvhdJv/5H1WuLJeiPIGsIwzD00Mcbvcp7tmmlnm1SQxARAABAdCERB4D6MAzp0I9S6eGq7R1fmfd3PFmyRsYko/2FFdpfWOFVPmFIxxBEAwAAEH1IxAGgLk679Pol0k+L/NfJGxK8eJpoQ36hV9nkYZ10xcmdQhANAABA9CERB4C6rH699iTcliy17hO8eJpoU36RaXtAx3TNPK9viKIBAACIPpExjxIAQmn5i7Xv73mWFBM5f9fcuM88Is594QAAAMEVOd8cAcAfp0P6dIa04b+SvTzAjRtSyUFzUXzq/xZks0pdfimNuy/A52xeGz1GxHu2aRWiSAAAAKITiTiAyPfDm9LSp4JzrtQO0i0/SNaY4JyvCQzD0L9X79EXPx6Sw2m4y7ccKDbVIxEHAAAILhJxAJFvz4rgneukSRGRhEvSOyt26/Z3fqizHlPTAQAAgot7xAFEvrIjwTlP7gnSsBuDc64AWLTxQJ112qYlKC3JFoRoAAAAUI0RcQCRr/rZ3tUGXyP1+lVgz5GQKrXpHzHPCpekgjJ7nXXGD84LQiQAAACoiUQcQOQrPWrebj9I6joiNLGEkZIKh2l7dM/W6tm26n5wiyzq0y5VZ/RtE4rQAAAAohqJOIDI5zk1PSkzNHGEmWKPRPyCk9rrnH7tQhQNAAAAqkXOHEsA8MdzanpSVmjiCDOeiXhKPH97BQAACAck4gAiW2Wp5PB4dnhiRmhiCTMlFU7TNok4AABAeCARBxDZfK2YztR0uVyG94h4Aok4AABAOCARBxDZPKelW6xSfFpoYgkjpXanV1lyHIk4AABAOCARBxDZSj1GxBMzI+oRY82luNzhVdaKEXEAAICwwLdVAJGNFdN98pyWLknJ3CMOAAAQFkjEAUQ2XyPi8ErE42OtssVwyQcAAAgHfCsDENk8E3FGxCVJJTy6DAAAIGyRiAOIbExN98lzRJxp6QAAAOGDRBxAZGNquk+ei7UxIg4AABA+SMQBRLaifeZtRsQlSSWVJOIAAADhikQcQOT68nFp+xfmMkbEJUlFniPiPLoMAAAgbJCIA4hMh36UFs70Lk/KCn4sYchzsTbuEQcAAAgfJOIAItOWTyXD5V3eulfwYwlDnou1MTUdAAAgfJCIA4hM27/0Ljv1NinruODHEoa8E/GYEEUCAAAATwyRAIg8Lpe04ytz2a+elE6aFJp4wpD3qum2EEUCAAAATyTiAMLXnpXSdy9IZUfN5Y5y77Kuo4IXVwTwXDU9mRFxAACAsEEiDiA8lR6R5pwt2UvrrpveSUrPa/6YIkhxhdO03YpV0wEAAMIG94gDCE9bF9cvCZekzqc2bywRqLjcbtpm1XQAAIDwQSIOIDwd/ql+9WLipOG/a95YIlCJx4g4iTgAAED44JsZgPDkmYjnnSx1H2MusyVLPc6QMrsGL64I4blqeisScQAAgLDBNzMA4enwFvN2n/Olk28ISSiRxu50+Visjcs9AABAuGBqOoDwdMRjRDyT54PX1/LtR2UY5rLWreJDEwwAAAC8kIgDCD+lR7wfT5ZFIl5fCzfsN233aZeqrBQScQAAgHDBXEUA4cfz/nBrbNUjyiLIvoIy/XvVXu0vLA/6uT9Ys8+0PaZXbtBjAAAAgH8k4gDCQ/4aaftXkssu5a8170vvJMVEzuWqtNKhy/6xTNsOlYQ6FEkk4gAAAOEmcr7ZAmi5flokvXqRZDh978/qFtx4muiTdflhk4Tnpsarb/vUUIcBAACAGrhHHEDorX7dfxIuRdz94Z+uPxDqENyuPbWrLBZLqMMAAABADYyIAwi9wn217z/+9ODEUYdjpZUqKnfUWsfpMvTZ5oOmshHH56h9RmJzhuYlxmLR0K6ZOqtv26CeFwAAAHUjEQcQemVHzNu5J0gprSVbotTnAqnryJCEVc3pMjTtrdX6z+q9jTr+4Yv7qXWrhABHBQAAgEhFIg4g9Eo9EvEx90rdx4QkFF+WbT3c6CS8f146STgAAABMuEccQGgZhvczw5MyQhOLHz8dLG70sef2Y2o4AAAAzEjE4dcHH3ygoUOHKjExURkZGTr//PNDHRJaInup5KwwlyWGVyJ+tNTe4GPiYqw6t387TT6lc+ADAgAAQERjajp8evfdd3XttdfqgQce0GmnnSaHw6G1a9fWfSDQUJ7T0iUpMTP4cdTiaGmlafvXJ7XXAxecUOsxMVaLbDH8rRMAAADeSMThxeFw6Oabb9bDDz+sq6++2l3eu3dvv8dUVFSoouLnUc3CwkJJkt1ul93e8NFEtFzV/cHdL4oOyFZjv2GJkSMmSQqjfnOk2Dxin5EYqxi5aj/IJdldtTySDSZe/QIQ/QL+0TfgSzT1i2h4jy0diTi8rFy5Unv27JHVatWAAQOUn5+vE088UQ8//LD69u3r85hZs2Zp5syZXuWLFy9WUlJSc4eMCLRgwQJJUk7hWp1So7wyJkkff/RRaILyY/MOq2reybN/11Z9+OFPoQuoBavuF0BN9Av4Q9+AL9HQL0pLS0MdAprIYhiGEeogEF7mzp2rCRMmqGPHjnrsscfUuXNnPfroo5o/f742b96szEzvacO+RsTz8vK0b98+ZWVlBTN8hDm73a4FCxZo7Nixstlssqx/T7HvXeveb2R1l+P6pSGM0NuFz3+jH3YXurfvO6+3xg/qEMKIWh7PfgFI9Av4R9+AL9HULwoLC5Wdna2CggKlpqaGOhw0AiPiUWT69Ol66KGHaq2zYcMGuVxVU27vuusuXXjhhZKk2bNnq0OHDnr77bf1m9/8xuu4+Ph4xcfHe5XbbLYWfyFE47j7RmWhqdySlBV2faagzGHazm6VEHYxthRcM+AL/QL+0DfgSzT0i5b+/qIBiXgUufXWWzVlypRa63Tt2lX79u2TZL4nPD4+Xl27dtXOnTubM0REo1KPR5eF2YrpknS0xLxYW3pSXIgiAQAAQEtAIh5FcnJylJOTU2e9gQMHKj4+Xps2bdIvfvELSVVTfbZv365OnTo1d5iINmUeq6YnhdeK6Q6nS4Xl5hHxDBJxAAAANAGJOLykpqbq+uuv14wZM5SXl6dOnTrp4YcfliRdfPHFIY4OLY7n48vCbES8oMx7VdKMJKaDAQAAoPFIxOHTww8/rNjYWF1xxRUqKyvT0KFDtWjRImVkhFeShBYgzEfEj5Z6J+JMTQcAAEBTkIjDJ5vNpkceeUSPPPJIqENBS+c1Ih5eifixUvP94clxMYqLtfqpDQAAANSNRBxA0MU4y6XDP0qxNqnkgHlnmE1N9xwRZzQcAAAATUUiDiCoLKte1lk/3C7rD07fFcJuarp5RDwjmfvDAQAA0DQk4gCCx1GpmIX3yiI/SbgU9lPTWTEdAAAATUUiDiB4CvfIUlHof39sopTZpdHNO5wuuYxGH+7TYZ4hDgAAgAAjEQcQPIV7/e9LyZXG/lmKS25ws2WVTt329veavz5fdmeAM3EP6YlMTQcAAEDTkIgDCB7PRDyrmzR1WdVra4xksTSq2XdW7tYHa/Y1Mbj64RniAAAAaCoScQDBU7jHvJ3aXopp+mVoc35Rk9uor+NapwTtXAAAAGiZeBgugODxHBFPbR+QZksqHQFppy6nds/WuN5tgnIuAAAAtFyMiAMIHq8R8XYBabakwpyITzmlsyaf0jkgbVdLjotR69SEgLYJAACA6EQiDiB4PEfE0wIzIl5aaX4cWvv0RHXJbviibwAAAEAwMDUdQPA009T0Yo8R8eR4/sYIAACA8EUiDiA4nHapeL+5LEBT00srzCPiyfExAWkXAAAAaA4k4gCCoyhfksczvptrRDyOEXEAAACEL76tAgi88gLp/VuknUsl1/9Gq112UxUjNkGWxIyAnK60kqnpAAAAiBx8WwUQeB/eLq37V+11WrWVLJaAnK6EqekAAACIIExNBxBYRfnS2nfrrGZkdQvI6SodLlU6XaYyRsQBAAAQzvi2CqDpXE5p+YvSnpXSka2Sy1FrdYc1Xhr2u4D8JdBzWrrEPeIAAAAIb3xbBdB0Sx6UPv+L7329fiUNvsa96XAZmv/9Xo3tOCwgp/ZcqE1iajoAAADCG4k4gKarbSr6qdOkdgPcm4bdLvu6DwN26tJKp1dZEiPiAAAACGPcIw6gaSpLqqaj+9LrV6YkvDl4jogn2mIUYw3MInAAAABAc2DYCEDTHNwor+eDD/lNVQLe+7xmP32p14rpXNYAAAAQ3vjGCqBp9q8zb2d1l87yc794M/AcEef+cAAAAIQ7pqYDaBrPRDy3d1BP77lqOiumAwAAINyRiANoGq9EvG9QT1/CiDgAAAAiDIk4gMYzDGn/WnNZbp+ghlBSyT3iAAAAiCwk4gAa79gOqeyouSzYibjniDhT0wEAABDmSMQBNN6G983biRlSWseghsBibQAAAIg0JOIAGscwpGXPm8t6ni1Zg3tZ8Xx8WRIj4gAAAAhzfGMF0HB7Vkr/GOVd3ueCoIdS7LFqegr3iAMAACDMMSIOoOEW/sm7LDFD6jIi6KGUek1NJxEHAABAeCMRB9Bw+773LutzgRRjC3ooJRWeq6ZzjzgAAADCG4k4gIYpL5DKjpjLUtpIo2eEJJySSlZNBwAAQGThGyuAhjm63bvsljVSbFzQQ5F8PL6MEXEAAACEOUbEATSMZyKelheyJFySSio9p6bz90UAAACENxJxAA3jmYhndA5FFG6eI+I8vgwAAADhjkQcQMN4JeKdQhKGJLlchko9RsR5fBkAAADCHYk4gIYJoxHxUrvTq4x7xAEAABDuSMQBNIxXIt4lJGFI3tPSJVZNBwAAQPjjGyuA2q1+XVr8gFS8v2rbWWneH8IRcZ+JOFPTAQAAEOb4xgrAv9Ij0n9ukgzvKeBu6aG7R7ykwhyXLcaiuFgm+gAAACC88Y0VgH/719WehKfkSsnZwYvHQ0ml5zPE+dsiAAAAwh+JOAD/yo7432eJkcbMlCyW4MXjwXNqOveHAwAAIBLwrRWAf6UeiXjr3tL5z1a9zuwiJaQFP6YaSjweXcaK6QAAAIgEJOIA/PMcEU9tL7U7MSSh+OI1Is7UdAAAAEQApqYD8M9zRDwpMzRx+MHUdAAAAEQiEnEA/pUdNW8nhlsiztR0AAAARB4ScQD+hfuIuOeq6YyIAwAAIAKQiAPwz/Me8cSM0MThB/eIAwAAIBKRiAPwL9xHxD0S8SSmpgMAACACkIjDp82bN+u8885Tdna2UlNT9Ytf/EKLFy8OdVgINq8R8TBLxD0eX5bC1HQAAABEABJx+HTOOefI4XBo0aJFWrFihfr3769zzjlH+fn5oQ4NweJyeS/WFuYj4kxNBwAAQCQgEYeXQ4cO6ccff9T06dPVr18/de/eXQ8++KBKS0u1du3aUIeHYKkolAyXuSzMR8RZNR0AAACRgOEjeMnKylKPHj308ssv66STTlJ8fLyef/55tW7dWgMHDvR5TEVFhSoqKtzbhYWFkiS73S673R6UuBFgRQdk8yiy21pJTfz3rO4PgegXxeXmNhJiLPS3CBXIfoGWg34Bf+gb8CWa+kU0vMeWzmIYhhHqIBB+du/erfPPP18rV66U1WpV69at9cEHH2jAgAE+6997772aOXOmV/nrr7+upKSk5g4XzSC95CeN2Pzzv6nTYtO8/v+ULJYQRmU2Y0WMjlX+HM91PZ3qk8ElDQAAtGylpaW67LLLVFBQoNTU1FCHg0YgEY8i06dP10MPPVRrnQ0bNqhHjx46//zzZbfbdddddykxMVH//Oc/9d///lffffed2rZt63WcrxHxvLw87du3T1lZWQF/L2h+li2fKvbNS93bRkobOW5u+q0JdrtdCxYs0NixY2WzeY65N8zA+xepsPzn+8Rfv3qwBncOr0esoX4C2S/QctAv4A99A75EU78oLCxUdnY2iXgEY2p6FLn11ls1ZcqUWut07dpVixYt0rx583T06FH3L/YzzzyjBQsW6KWXXtL06dO9jouPj1d8fLxXuc1ma/EXwharstC0aUnKCui/ZVP7hmEYKvW4Rzw1KZ7+FuG4ZsAX+gX8oW/Al2joFy39/UUDEvEokpOTo5ycnDrrlZaWSpKsVvNaflarVS6Xy9chiHSF+6T5d0kHNvxcFubPEK9wuORwmSf0pLBqOgAAACIA31rhZdiwYcrIyNDkyZN1zz33KDExUf/4xz+0bds2nX322aEOD83hPzdKPy2svU5ieE359nx0mcTjywAAABAZ+NYKL9nZ2fr4449111136bTTTpPdblefPn30n//8R/379w91eGgOO5fWXSctr9bdpZUObTlQLFcdq044HA7tKJK+312g2NjGX4IOFJZ7lfH4MgAAAEQCEnH4NGjQIH3yySehDgPBUFkq2Utrr5OQJg243O/ub7cd0ZWzv/V6rrd/sXps7bL6x1gPFouUaCMRBwAAQPgjEQeiXdkR77LznpZiE6pex8ZLeUOllNZ+m3hy0Y8NSMKbR3JcrCxh9Gg1AAAAwB8ScSDalR42b1tipBMnNuh54VsPlgQ4qIbr3ZZHdwAAACAykIgD0c4zEU/KalASbhiGDhVXmMriY62Ksfpvw+FwNOn+cE892rTS/Rf0DVh7AAAAQHMiEQeinddjyrIadHhRhUMVDvNj7T6dNkJ5mUk+69vtdn344Yc666zTeQYmAAAAopK17ioAWrSSQ+btBibih4oqvMqyU+KbEhEAAADQopGIA9HOa2p6ZoMOP+iRiKfExyoxjtXLAQAAAH9IxIFo5+se8QY4VFxp2s5OiWtqRAAAAECLRiIORLsmJ+LmEfGcVkxLBwAAAGpDIg5EuyYm4p5T07k/HAAAAKgdiTgQ7TxXTU/ObtDhjIgDAAAADUMiDkS7AC/Wxog4AAAAUDuLYRhGqINAy1NYWKi0tDQdOnRIWVkNm+qMximxl+gv3/1Fy/OXy2k463/g0R3m7dS2Ukz9F1zbX1iuSsfPl5HMZJuS42P9H2BIpWWlSkpMkiz1DxMtHP0CvtAv4A99A75EUb9wlDq0cNJCFRQUKDU1NdThoBFq+bYMIBQMw9Du4t0qd5TX+xiX4dLvl/xeu4p2NfyENo/LQNnBhh1vlaw18vZj9qqfuhwtOdqw8yAq0C/gC/0C/tA34Es09AtnWQMGXRCWSMSBMFJcWazrFlynNYfWhDoUAAAAAM2Ee8SBMPL+1vdJwgEAAIAWjhFxIIx8f/D7gLRzZZ8rdVLuSaayF77Yqq+3HlY7y2H9OXaOz+P2G+n6P8fVjT6vxSI9c9lAxcX6/xufw+HQihUrNHDgQMXGcglCFfoFfKFfwB/6BnyJpn5RUlSic3ROqMNAE7TsHgpEmE1HNnmVWRqw2khuUq5u7zFR43IHe+37pCBf3UoqNDnma42MLfN5/H32X8vp7F3/gD2M7tla47p4n7smu92ukh9KNKLDCNlstkafCy0L/QK+0C/gD30DvkRTvygsLAx1CGgiEnEgTFQ4K7StYJup7JUzX9GJrU+sXwMHNkovnyetu9nn7lmS5OPJYmtb/UI/Jg/UvoRuKkjur4sbFPXPOmcna/IpnRt5NAAAABA9SMSBMLHl2BbTY8cssqh7Rvf6N/DFo1JxfoPP23fSY+qb06PBxwEAAABoHBZrA8LE5iObTdsdUzsq2ZZc/wZ2f9vwk3Y8RSIJBwAAAIKKEXEgBD7a9pGeWf2MDpUdcpdVOCtMdY7POL7+DZYXSEe3+9hRdX+5Ickwfi51yaKKNicp+fxn6n8OAAAAAAFBIg4EWUFFgf7vi/+Tw3DUWq9nZs/6N7p/nXnbapP+b68UGydJKiq3q9+9801Vvrx0lJIzkup/DgAAAAABwdR0IMi2HNtSZxIuSX2z+9a/0XyPZ4/n9HQn4ZJUUGr3OiQtsWWvJgoAAACEK0bEgSArsZfUWWd4u+E6OXeIZC+vX6N7V5u325xg2iwoMyfiMVaLUuL59QcAAABCgW/iQJB5JuLtU9rrwVMfdG+nxqWq89avZX30eKn0cONO4pGIF3ok4qkJsbJY6v98cgAAAACBQyIOBFmxvdi0nZWYZX5WeEWR9OGtkqOeo+G+1DEizrR0AAAAIHS4RxwIspJK84h4cqzHI8oOb2laEh4TL7XtZyo65pmIJ8UJAAAAQGiQiANBVuIwJ+IpcSkeFQ6p0Swx0tg/SQlppmJGxAEAAIDwwdR0IMiKK81T05NtHiPiJQfN2zk9pQlv1K/x5NZSfIpXMYk4AAAAED5IxIEgK3WUmrbrTMRT20mZXZt0Tu9EnF99AAAAIFSYmg4EWZ0j4sUHzNvJOU0+JyPiAAAAQPggEQeCzPPxZSm2Ou4RD0Ai7vn4MhJxAAAAIHRIxIEg80zE65yanpzd5HMeKzUn4umJrJoOAAAAhAo3igJB5vkc8boS8QU7Da3/9McmnXP3UfN96amMiAMAAAAhQyIOBFmp3ZwUe09NNyfir60t1RLX5oDGwNR0AAAAIHSYmg4EmeeIeJIt6ecNw/BKxA8b5meCB0JGMok4AAAAECok4kAQGYZR+2Jt5cckl8O0/7CRGtAY2qcnqnvrVgFtEwAAAED9MTUdCKIKZ4WchtNUZkrEPVdMl3RYVYn44M4ZykqOb9L526Ql6MrhnRVjtTSpHQAAAACNRyIOBJHntHTJY2q6xzPEC41EVahqhfPpZ/bSwE4ZzRofAAAAgOZHIg4EkedCbZKUcmCz9ON8yVEuHdlm2ldzWnpKPL+uAAAAQEvAN3sgiDxHxGMtMYp76Ryv+8KrHdLPC7UlxcU0a2wAAAAAgoPF2oAg8lyoLVkxsvhJwiXpoJH+c11GxAEAAIAWgUQcCCKvFdPrqP+xc7D7NSPiAAAAQMvAEBsQRF7PEHeaV1BXx1OkrON0pNzQnd9n6xPXEElSrNWi+Fj+bgYAAAC0BCTiQBCVVHqMiDvs5gq/uEU6/nRt2XZEn6xa6i5OiouRxcIjxwAAAICWgCE2IIhKHB73iDsqzBXSO1bVqzTfN8794QAAAEDLQSIOBNGag2tM28kul7lCWp4kqbTCPGWd+8MBAACAloNEHAiS1QdWa+HOhaayLGeNRDwxU4qvWr6NEXEAAACg5SIRB4LA6XJqxtczZMgwlZ9ZUmOq+v+mpUtSSYVHIh5HIg4AAAC0FCTiUej+++/XKaecoqSkJKWnp/uss3PnTp199tlKSkpS69atdfvtt8vh8P+8a5gZhqGtx7Zqxf4VWrF/hV7d8Kq2Fmw11bk6pYdOrKj8uSA9z/2ytNI8NT05nqnpAAAAQEvBMFsUqqys1MUXX6xhw4bphRde8NrvdDp19tlnq02bNvr666+1b98+TZo0STabTQ888EAIIo4shmHolsW3aNGuRX7rHJ/aWb/9foG5ML2T+6XniHgSI+IAAABAi8GIeBSaOXOmfv/73+uEE07wuX/+/Plav369Xn31VZ144ok688wz9ec//1lPP/20KisrfR6Dn60/vL7WJFySfpO/W15j3DWmpjMiDgAAALRcDLPBy9KlS3XCCScoNzfXXXb66afrhhtu0Lp16zRgwACvYyoqKlRR8fOjuAoLCyVJdrtddrvdq35Ltvnw5lr3d09sozHbvvUqd7TqION/n1VRufkPHomx1hbzOVa/j5byfhAY9Av4Qr+AP/QN+BJN/SIa3mNLRyIOL/n5+aYkXJJ7Oz8/3+cxs2bN0syZM73KFy9erKSkpMAHGcY+L//ctB2jGMVZ4iRJbWPa6veHY72mopTZMrVwU4mcP34oSfppu1U1J6zs2blNH374U3OGHXQLFiyouxKiDv0CvtAv4A99A75EQ78oLS0NdQhoIhLxFmL69Ol66KGHaq2zYcMG9ezZs1nOf+edd2ratGnu7cLCQuXl5WnUqFHKyspqlnOGq1XfrpK2/Lz9q+N+pT8O/aN7O2bOmab6hi1JsTd8ptNbtXWXvXtohXTksHu7f58eOusXXZov6CCy2+1asGCBxo4dK5vNFupwECboF/CFfgF/6BvwJZr6RfXsU0QuEvEW4tZbb9WUKVNqrdO1a9d6tdWmTRt9+6156vT+/fvd+3yJj49XfHy8V7nNZmvxF0JPB8oOmLbbJWTIZi+q2nBUSPtWm/Zbxr8qW2ZHU1mZ3WXabpUY3+I+x2jsG6gb/QK+0C/gD30DvkRDv2jp7y8akIi3EDk5OcrJyQlIW8OGDdP999+vAwcOqHXr1pKqpvikpqaqd+/eATlHS5Zfap6+32bJw9K8e31XtsRIeUO8iksqPBZri2OxNgAAAKClIBGPQjt37tSRI0e0c+dOOZ1OrV69WpLUrVs3paSkaNy4cerdu7euuOIK/eUvf1F+fr7uvvtu3XjjjT5HvWGWX7TXtN2mtuevt+0vxbfyKi6pNB+THM+vKgAAANBS8O0+Ct1zzz166aWX3NvVq6AvXrxYI0eOVExMjObNm6cbbrhBw4YNU3JysiZPnqw//elPoQo5YpTaS1XkKDGV5TqdfmpL6j7OZ7H3iDi/qgAAAEBLwbf7KDRnzhzNmTOn1jqdOnXShx9+GJyAWhDPaemS1MbhKxG3SF1+KQ3/nc92Sj1GxJN4jjgAAADQYpCIAwGUX2JOxNOcTiWOmC4NuspcMSZOSkz32YbLZai0khFxAAAAoKXi2z3QRPuK92nlgZWyu+xavX+laV8bh1PqeLKU0tpdtudYmb7eeEgVjgKf7dmdLq+yZEbEAQAAgBaDRBxogjUH1+iqT65SubPc5/42TqfUpp97e8uBIl3w9NcqqqhlATcfGBEHAAAAWg5rqAMAItm/tvzLbxIuSW2sCVJSpnv77RW7G5yES9wjDgAAALQkJOJAExwqO1Tr/qEpHU3bPx0o8VPTv4GdMhQfSyIOAAAAtBTMdwWaoMxeZtpuK5uyKooV7zI0prRMY/pdbNq/60ipafu4nGRlJft/NnuX7GT9fuzxgQsYAAAAQMiRiANNUOowJ9bX2+P06737fy5Iz3O/NAxDOz0S8fsvOEEnd81q1hgBAAAAhBempgNNUGo3J9ZJpUfNFdI6uF8eLK5Qmd38WLKOmUnNFhsAAACA8MSIONAEniPiSWXHzBVS27lf7jxsrhsXY1Wb1IR6nad802Ydevpp2ffubVSc4cQwDHUsKNCul1+RxWIJdTgIE/QL+EK/gD/0DfgSTf2iyG4PdQhoIhJxoAk8E/FEwzBXSG3vfuk5Lb1DZqKs1rr/J2G4XNp1/fVy7NvX+EDDTIKkit27Qx0Gwgz9Ar7QL+APfQO+REu/qHA6666EsMbUdKAJSuzmVdCTXK6fN2zJUkKae3OHx4h4p3pOS3fk57eoJBwAAACIdiTiQCPZnXY5XOZngifVHBFPay/VmBbluWJ6fe8Pd1VUND5IAAAAAGGHqelAI3lOS5ekJFeNRLzG/eGStMMzEc9Krtd5jErve4DaPvBAvY4NR06nUz/88L369euvmBiej44q9Av4Qr+AP/QN+BJN/aKwtFS64vJQh4EmIBEHGslzxXTJY2p6agfTvt1HGzcibngsxmGx2ZT+6wvqGWX4sdvtKoyzKfWss2Sz2UIdDsIE/QK+0C/gD30DvkRTv7AWFoY6BDQRU9OBRvI1Ip7oOTX9f1wuQ4eKK01126bVb8V0w24+zhIX14AoAQAAAIQbEnGgkTxHxOMNjykmNaamHy2tlNNlXlE9OyW+XufxNSIOAAAAIHKRiAON5PUMca9Hl/08Nd1zNFySslLqN7LteY84iTgAAAAQ2UjEgUbyHBFP8nyeY9rPifjBIvPK5xlJNtli6vfr5zU1nUQcAAAAiGgk4kAjeY+I11iozWKVMru4Nw8VmxPxnFb1m5Yu+Ziazj3iAAAAQEQjEQcaySsRr3kPeHonKfbnZNtzRLy+94dL3CMOAAAAtDQk4kAjeU1Nrzkint3dtC+gI+Ik4gAAAEBEIxEHGqnWEfEscyLepBHxSu4RBwAAAFoSEnGgkcrsZaZtUyLuMSJ+kHvEAQAAAPwPiTjQSLUu1uaZiHOPOAAAAID/IREHGsnrHvFapqZ7Pkece8QBAACA6EUiDjSS54h4YvWIeHyqlNLaXe50GTpS4jkiXv/p5V73iMeRiAMAAACRjEQcaCS/I+IZnSWLxV1+pKRSNQfLJSmnSVPTuUccAAAAiGQk4kAj+b1HPK2Dqdzz/nCLRcpMbsCIOFPTAQAAgBaFRBxoJL+PL0ttbyr3fIZ4ZlKcYmPq/6vnvWo6iTgAAAAQyUjEgUbymppuVCfi7UzlniPiDVmoTWJEHAAAAGhpSMSBRvh0x6faU7zHVJbk8j013XNEvCGPLpN8LNbGPeIAAABARCMRBxpoV9EuTVsyzav856npzTwiztR0AAAAIKKRiAMNtOrAKhkyvMpznM6qF3XcI96QR5dJTE0HAAAAWhoScaCBjpYf9SobW1KqNu5E3DwifqjYPLWce8QBAACA6EYiDjTQkfIjpu3WDof+cuBQ1UZyjhRrTrQ9p6Y3+R7xOO4RBwAAACIZiTjQQJ4j4mNKyhRbveExLV3ynprOiDgAAAAQ3UjEgQbyTMQzXM6fNzwScYfTpSOl5hHtBo+Ik4gDAAAALQqJONBARyrMU9Mzna6fN9LMifiRkkoZHuu6MSIOAAAARDcScaCBvEbEnTVGxNsNMO074HF/uNUiZSQ1cNX0ShJxAAAAoCUhEQcayHtq+v9GxPtfJvW90LTP8/7wzOR4xVgtDTqfYWexNgAAAKAlia27CoBqlc5KFduLTWWZTqdKu/9KR0c9JhW7JJW59205YK7b0GnpElPTAQAAgJaGRBxogPX793qVZThdenR9ql5Ys6jO47NTGj6aTSIOAAAAtCxMTQfqa9sXKn/tHFOR1TCU5nJplatbvZpgRBwAAAAAiThQH4Yh/XuqXM6DpuJ0l0sOI0brjM71aqZXm9SGn9pzsTbuEQcAAAAiGok4UB8VhVLBTh2NMf/KZDidWm10U4VqT46tFmlUjxxdOiSvwadmRBwAAABoWbhHHKiP8gJJ0tGYGFNxumHRCZMe1bq8YbUeHmO1KMEWU2sdf0jEAQAAgJaFRByoj/ICuST9NyXZVJzceawSu53abKc1DEMiEQcAAABaFKamA/VRXqAHsjK0Id48BT23VetmPa3naLjEPeIAAABApCMRB+rBXnpY76WkeJVnJ2Y163k9F2qTGBEHAAAAIh2JOFAPR0vyVWm1eJWf3PbkZj2vYa/0KiMRBwAAACIbiXgUuv/++3XKKacoKSlJ6enpXvu///57TZgwQXl5eUpMTFSvXr30t7/9LfiBhpGjJQe8ynrFXK+Tck9q1vP6nJpOIg4AAABENBZri0KVlZW6+OKLNWzYML3wwgte+1esWKHWrVvr1VdfVV5enr7++mtdd911iomJ0U033RSCiEPvaNlh03ay06IBOac1/4m5RxwAAABocUjEo9DMmTMlSXPmzPG5/6qrrjJtd+3aVUuXLtW//vUvv4l4RUWFKioq3NuFhYWSJLvdLruPZDLSHC47ZNpOcMaqdau4Zn9vlaWlXmUOSZYI/kyrP7OW0C8QOPQL+EK/gD/0DfgSTf0iGt5jS0cijnopKChQZmam3/2zZs1yJ/g1LV68WElJSc0ZWlDsPrBTSvx5O95p094t6/ThkbXNet64/Hx19ij7aP58yeJ9v3qkWbBgQahDQBiiX8AX+gX8oW/Al2joF6U+BmsQWUjEUaevv/5ab775pj744AO/de68805NmzbNvV1YWKi8vDyNGjVKWVnNu7J4MDw/92+S6+ftWEe8zjljuPq2T23W85avX6/dNQtsNp119tnNes7mZrfbtWDBAo0dO1Y27nfH/9Av4Av9Av7QN+BLNPWL6tmniFwk4i3E9OnT9dBDD9VaZ8OGDerZs2eD2l27dq3OO+88zZgxQ+PGjfNbLz4+XvHx8V7lNputRVwIj9hLpZift63OROVlpzT7e3MYhmnbGhfXIj5PqeX0DQQW/QK+0C/gD30DvkRDv2jp7y8akIi3ELfeequmTJlSa52uXbs2qM3169dr9OjRuu6663T33Xc3IbrId8RZYUrEY4wkZSU3/6Jprkrz48tYMR0AAACIfCTiLUROTo5ycnIC1t66det02mmnafLkybr//vsD1m6kOmbYJf18X3ZSbLosQbhP2/PxZSTiAAAAQOQjEY9CO3fu1JEjR7Rz5045nU6tXr1aktStWzelpKRo7dq1Ou2003T66adr2rRpys/PlyTFxMQENNmPJAUWp2r+uqTEZwflvCTiAAAAQMtDIh6F7rnnHr300kvu7QEDBkiqWuF85MiReuedd3Tw4EG9+uqrevXVV931OnXqpO3btwc73NBzuVRgNY9+ZyS3DsqpvRJxniEOAAAARDxrqANA8M2ZM0eGYXj9jBw5UpJ07733+twflUm4JKO8QEdjzL8qrdM6BOfkjIgDAAAALQ6JOFCH4uJ9cnjcD94hu2NQzs1ibQAAAEDLQyIO1OFAwS6vsuPaNGwF+sbiHnEAAACg5eEecUDSkrefVP4Hr8tabvfa55BdV8Y43dsxhtR66z+UH9OYVdONuqvUULH5R9M294gDAAAAkY9EHFFvxcK3lTHzGeU66n9Myco3VNJ8IfnFiDgAAAAQ+Ziajqj347vPKq4BSXgoWZOTQh0CAAAAgCYiEUfUs+UfCXUI9dZqzJhQhwAAAACgiZiajqjX6oh5ZfLt7S0qykrwqmexSKlxmTqh63BZPFZRl+d2PXi1UZuYWCWfPFStRo9u8HkAAAAAhBcScUQ1p8Oh7CPmBdTs547VJbf8LUQRAQAAAGjpmJqOqLZh+QIlmgfE1XnIuNAEAwAAACAqkIgjqm395mPTdlmc1GfI6SGKBgAAAEA0YGo6Qu6Hrz/Q1q/eD8m57cu/M20fyrAoJpZfCwAAAADNh4wDIfXGTWN04qd71CPUgfxPUVZcqEMAAAAA0MIxNR0hc2DPT+q9ZE+owzCpbJ0R6hAAAAAAtHAk4giZpXMfU5wj1FGY5Qzn/nAAAAAAzYup6QiZ8lXm+7MrbFJxYmhiqYiXDg7srEuvmB6aAAAAAABEDRJxBEVFWam+/+Jfctjt7rKc7UWmOhuHZOnSF74MdmgAAAAAEFQk4mh2X7z3rGLvf0LpxbXXSxs6IjgBAQAAAEAIcY84mt3Bl56rMwmvsEmnjr81OAEBAAAAQAiRiKPZJRfY66yzratNKWmZQYgGAAAAAEKLqelodja74XefS9KOPKt63v1Y8AICAAAAgBAiEUezs3kMiK+/YqjOmfaMe7tPYlKQIwIAAACA0CERR7PzTMTjUtIVT/INAAAAIEpxjziaXZzDYzslPSRxAAAAAEA4IBFHs3I6HIqvNJfFp2aFJhgAAAAACAMk4mhWxQUHvTpZclp2SGIBAAAAgHBAIo5mdezQXq+yVlm5IYgEAAAAAMIDiTiaVdGRA15ladntQhAJAAAAAIQHEnE0q9LCQ15lma07hiASAAAAAAgPJOJoVuVFR0zblTHi0WUAAAAAohqJOJqVvajAtF1pC1EgAAAAABAmSMTRrCpLC83bJOIAAAAAohyJOJqVs7TEtG0nEQcAAAAQ5UjE0axc5aWmbbvNEqJIAAAAACA8kIijWbnKy03bjtgQBQIAAAAAYYJEHM2rssK06WBEHAAAAECUIxFHs7JUVJq2nTa6HAAAAIDoRlaEZmWx203bTltMiCIBAAAAgPBAIo5mZbU7TdsuEnEAAAAAUY5EHM0qxjMRj2O1NgAAAADRjUQczcpqd5m2jbi4EEUCAAAAAOGBRBzNKtZhTsQVTyIOAAAAILqRiKNZxdgNc0FCQmgCAQAAAIAwQSKOZhXrkYhbExJDFAkAAAAAhAcScTQrm8O8HZOYHJpAAAAAACBMkIijWcV5JOKxSamhCQQAAAAAwgSJOJqVzW7ejmtFIg4AAAAgupGIo1nFeSTi8a0yQxMIAAAAAIQJEnE0q1iPp5clpWeHJhAAAAAACBMk4giqlIzWoQ4BAAAAAEKKRDwK3X///TrllFOUlJSk9PT0WusePnxYHTp0kMVi0bFjx5p87ozcTk1uAwAAAAAiGYl4FKqsrNTFF1+sG264oc66V199tfr16xeQ8zotUpu84wPSFgAAAABEKhLxKDRz5kz9/ve/1wknnFBrvWeffVbHjh3TbbfdFpDzliRKMbGxAWkLAAAAACIVWRF8Wr9+vf70pz9p2bJl2rp1a531KyoqVFFR4d4uLCz0qlOWINntdq9yRJfqPkBfQE30C/hCv4A/9A34Ek39IhreY0tHIg4vFRUVmjBhgh5++GF17NixXon4rFmzNHPmzFrrlMdb9OGHHwYqTES4BQsWhDoEhCH6BXyhX8Af+gZ8iYZ+UVpaGuoQ0EQk4i3E9OnT9dBDD9VaZ8OGDerZs2edbd15553q1auXLr/88nqf/84779S0adPc24WFhcrLyzPVqUy06qyzzqp3m2iZ7Ha7FixYoLFjx8pms4U6HIQJ+gV8oV/AH/oGfImmfuFr9ikiC4l4C3HrrbdqypQptdbp2rVrvdpatGiR1qxZo3feeUeSZBiGJCk7O1t33XWXz5Hv+Ph4xcfH19quPSG2xV8UUX82m43+AC/0C/hCv4A/9A34Eg39oqW/v2hAIt5C5OTkKCcnJyBtvfvuuyorK3Nvf/fdd7rqqqv0xRdf6Ljjjmt0u47EuECEBwAAAAARjUQ8Cu3cuVNHjhzRzp075XQ6tXr1aklSt27dlJKS4pVsHzp0SJLUq1evOp87XhtXckKjjwUAAACAloJEPArdc889eumll9zbAwYMkCQtXrxYI0eObLbzWlJaNVvbAAAAABApeI54FJozZ44Mw/D68ZeEjxw5UoZhNGk0XJJiUzOadDwAAAAAtAQk4giahKzcUIcAAAAAACFHIo6gSc5pH+oQAAAAACDkSMQRNFl53UMdAgAAAACEHIk4gqZN596hDgEAAAAAQo5EHEFhj5GycjuFOgwAAAAACDkScQRFaYIUE8vT8gAAAACARBxBUZYQ6ggAAAAAIDyQiCMoyhMsoQ4BAAAAAMICiTiCwhFHVwMAAAAAiUQcQeKMYUQcAAAAACQScQSJK5auBgAAAAASiTiChEQcAAAAAKqQHSEoXLExoQ4BAAAAAMICiTiCwrCRiAMAAACARCKOIDFiY0MdAgAAAACEBRJxBEecLdQRAAAAAEBYIBFHcNhIxAEAAABAIhFHsMTFhToCAAAAAAgLJOIICmt8QqhDAAAAAICwQCKOoCARBwAAAIAqJOIIipiE5FCHAAAAAABhgUQcQRGTkBjqEAAAAAAgLPBwZzQLwzAkScUupyTJbrGpsLAwlCEhTNjtdpWWlqqwsFA2VtPH/9Av4Av9Av7QN+BLNPWL6u/V1d+5EXksBv96aAZbt27VcccdF+owAAAAgBZr165d6tChQ6jDQCMwIo5mkZmZKUnauXOn0tLSQhwNwklhYaHy8vK0a9cupaamhjochAn6BXyhX8Af+gZ8iaZ+YRiGioqK1K5du1CHgkYiEUezsFqrlh9IS0tr8RdCNE5qaip9A17oF/CFfgF/6BvwJVr6BYNdkY3F2gAAAAAACCIScQAAAAAAgohEHM0iPj5eM2bMUHx8fKhDQZihb8AX+gV8oV/AH/oGfKFfIJKwajoAAAAAAEHEiDgAAAAAAEFEIg4AAAAAQBCRiAMAAAAAEEQk4gAAAAAABBGJOJrF008/rc6dOyshIUFDhw7Vt99+G+qQ0Iw+//xznXvuuWrXrp0sFov+/e9/m/YbhqF77rlHbdu2VWJiosaMGaMff/zRVOfIkSOaOHGiUlNTlZ6erquvvlrFxcVBfBcItFmzZmnw4MFq1aqVWrdurfPPP1+bNm0y1SkvL9eNN96orKwspaSk6MILL9T+/ftNdXbu3Kmzzz5bSUlJat26tW6//XY5HI5gvhUE0LPPPqt+/fopNTVVqampGjZsmD766CP3fvoEJOnBBx+UxWLRLbfc4i6jb0Sne++9VxaLxfTTs2dP9376BSIViTgC7s0339S0adM0Y8YMrVy5Uv3799fpp5+uAwcOhDo0NJOSkhL1799fTz/9tM/9f/nLX/TEE0/oueee07Jly5ScnKzTTz9d5eXl7joTJ07UunXrtGDBAs2bN0+ff/65rrvuumC9BTSDzz77TDfeeKO++eYbLViwQHa7XePGjVNJSYm7zu9//3u9//77evvtt/XZZ59p7969+vWvf+3e73Q6dfbZZ6uyslJff/21XnrpJc2ZM0f33HNPKN4SAqBDhw568MEHtWLFCi1fvlynnXaazjvvPK1bt04SfQLSd999p+eff179+vUzldM3olefPn20b98+98+XX37p3ke/QMQygAAbMmSIceONN7q3nU6n0a5dO2PWrFkhjArBIsl477333Nsul8to06aN8fDDD7vLjh07ZsTHxxtvvPGGYRiGsX79ekOS8d1337nrfPTRR4bFYjH27NkTtNjRvA4cOGBIMj777DPDMKr6gc1mM95++213nQ0bNhiSjKVLlxqGYRgffvihYbVajfz8fHedZ5991khNTTUqKiqC+wbQbDIyMox//vOf9AkYRUVFRvfu3Y0FCxYYI0aMMG6++WbDMLheRLMZM2YY/fv397mPfoFIxog4AqqyslIrVqzQmDFj3GVWq1VjxozR0qVLQxgZQmXbtm3Kz8839Ym0tDQNHTrU3SeWLl2q9PR0DRo0yF1nzJgxslqtWrZsWdBjRvMoKCiQJGVmZkqSVqxYIbvdbuobPXv2VMeOHU1944QTTlBubq67zumnn67CwkL3CCoil9Pp1Ny5c1VSUqJhw4bRJ6Abb7xRZ599tqkPSFwvot2PP/6odu3aqWvXrpo4caJ27twpiX6ByBYb6gDQshw6dEhOp9N0sZOk3Nxcbdy4MURRIZTy8/MlyWefqN6Xn5+v1q1bm/bHxsYqMzPTXQeRzeVy6ZZbbtHw4cPVt29fSVX/7nFxcUpPTzfV9ewbvvpO9T5EpjVr1mjYsGEqLy9XSkqK3nvvPfXu3VurV6+mT0SxuXPnauXKlfruu++89nG9iF5Dhw7VnDlz1KNHD+3bt08zZ87UqaeeqrVr19IvENFIxAEAze7GG2/U2rVrTff1IXr16NFDq1evVkFBgd555x1NnjxZn332WajDQgjt2rVLN998sxYsWKCEhIRQh4MwcuaZZ7pf9+vXT0OHDlWnTp301ltvKTExMYSRAU3D1HQEVHZ2tmJiYrxWq9y/f7/atGkToqgQStX/7rX1iTZt2ngt5udwOHTkyBH6TQtw0003ad68eVq8eLE6dOjgLm/Tpo0qKyt17NgxU33PvuGr71TvQ2SKi4tTt27dNHDgQM2aNUv9+/fX3/72N/pEFFuxYoUOHDigk046SbGxsYqNjdVnn32mJ554QrGxscrNzaVvQJKUnp6u448/Xlu2bOGagYhGIo6AiouL08CBA7Vw4UJ3mcvl0sKFCzVs2LAQRoZQ6dKli9q0aWPqE4WFhVq2bJm7TwwbNkzHjh3TihUr3HUWLVokl8uloUOHBj1mBIZhGLrpppv03nvvadGiRerSpYtp/8CBA2Wz2Ux9Y9OmTdq5c6epb6xZs8b0h5oFCxYoNTVVvXv3Ds4bQbNzuVyqqKigT0Sx0aNHa82aNVq9erX7Z9CgQZo4caL7NX0DklRcXKyffvpJbdu25ZqByBbq1eLQ8sydO9eIj4835syZY6xfv9647rrrjPT0dNNqlWhZioqKjFWrVhmrVq0yJBmPPfaYsWrVKmPHjh2GYRjGgw8+aKSnpxv/+c9/jB9++ME477zzjC5duhhlZWXuNs444wxjwIABxrJly4wvv/zS6N69uzFhwoRQvSUEwA033GCkpaUZS5YsMfbt2+f+KS0tdde5/vrrjY4dOxqLFi0yli9fbgwbNswYNmyYe7/D4TD69u1rjBs3zli9erXx8ccfGzk5Ocadd94ZireEAJg+fbrx2WefGdu2bTN++OEHY/r06YbFYjHmz59vGAZ9Aj+ruWq6YdA3otWtt95qLFmyxNi2bZvx1VdfGWPGjDGys7ONAwcOGIZBv0DkIhFHs3jyySeNjh07GnFxccaQIUOMb775JtQhoRktXrzYkOT1M3nyZMMwqh5h9sc//tHIzc014uPjjdGjRxubNm0ytXH48GFjwoQJRkpKipGammpceeWVRlFRUQjeDQLFV5+QZMyePdtdp6yszJg6daqRkZFhJCUlGRdccIGxb98+Uzvbt283zjzzTCMxMdHIzs42br31VsNutwf53SBQrrrqKqNTp05GXFyckZOTY4wePdqdhBsGfQI/80zE6RvRafz48Ubbtm2NuLg4o3379sb48eONLVu2uPfTLxCpLIZhGKEZiwcAAAAAIPpwjzgAAAAAAEFEIg4AAAAAQBCRiAMAAAAAEEQk4gAAAAAABBGJOAAAAAAAQUQiDgAAAABAEJGIAwAAAAAQRCTiAAAAAAAEEYk4ACDijRw5UhaLRffee2+oQwmp0tJS/fGPf1SvXr2UmJgoi8Uii8Wi1atXhzq0ZnPvvffKYrFo5MiRoQ6lUaZMmSKLxaIpU6aEOhQAQBCRiANAC1WdoFgsFiUlJWnv3r1+627fvt1dd8mSJcELEgE1fvx43Xfffdq4caMsFotyc3OVm5srm80W6tCizpIlS3Tvvfdqzpw5oQ4FABCGSMQBIAqUlZVp5syZoQ4DzWjjxo2aN2+eJOnNN99UaWmp8vPzlZ+frz59+oQ4uuizZMkSzZw5s85EvG3bturRo4fatm0bnMAAAGGBRBwAosSLL76ozZs3hzoMNJM1a9ZIkrKysnTJJZeEOBrU16xZs7Rx40bNmjUr1KEAAIKIRBwAWri8vDz169dPDodD//d//xfqcNBMSktLJUkpKSkhjgQAANSFRBwAWjir1eoebXv33Xf17bffNuj4mvePb9++3W+9zp07y2KxeE3F9Tx+x44duvbaa9WxY0clJCTouOOO0913362SkhL3MWvXrtXll1+uvLw8JSQkqHv37rrvvvtkt9vrjLeyslIPPvig+vXrp+TkZGVkZGjs2LH66KOP6jx27dq1uu6669S9e3clJSUpJSVF/fr101133aVDhw75PMZzsbB3331X48aNU+vWrWW1Whu8gFx5ebkef/xxnXLKKcrIyFBCQoI6deqkSZMm+Vx0rfr81Yt97dixw/15N3YRsK+++kqXX365OnXqpISEBKWlpWnIkCF66KGHVFxcbKprt9uVnZ0ti8WiJ554otZ2X3zxRVksFqWmprr/cCBJ+fn5evLJJ3XeeeepV69eSktLU2Jiorp166ZrrrlG69ata/B7kOq3iF9ti70dPXpUL7zwgi655BKdcMIJyszMdP97XHbZZfrmm2+8jqnu79W3gnz22Wemfw/P35H6LNa2ZMkSXXzxxWrfvr3i4+OVnZ2t0aNHa/bs2XI6nfV6XwsXLtTZZ5+tnJwcJSQkqFevXpo5c6bKy8v9nveTTz7Rr3/9a3Xo0EFxcXFKTU1V165dNW7cOD3yyCM6cuSI32MBAHUwAAAt0owZMwxJRqdOnQzDMIwRI0YYkoxRo0Z51d22bZshyZBkLF682O++bdu2+T1fp06dDEnG7Nmz/R7/7rvvGunp6YYkIzU11YiJiXHvO/XUU43Kykpj3rx5RlJSkiHJSEtLMywWi7vO+PHjfZ67+r3deeedxqmnnmpIMmJjY93nqv6ZMWOG3/gfeughw2q1uusmJSUZcXFx7u22bdsaK1eu9Ps5jxgxwpg2bZohybBYLEZGRoYRExNT6zk97d692+jbt6/7nDabzUhLS3NvW61W44knnjAd8/DDDxu5ublGamqqu05ubq7753e/+129z+90Oo3f/e53ps8sJSXF9O/Uo0cPY/v27abjbrzxRkOSMWjQoFrbHzlypCHJmDJliql88uTJ7vZjY2ONzMxMIzY21l0WHx9vvPPOOz7brPn5e6ruF7X9G9R2fPU+SUZMTIyRkZFhxMfHu8ssFovxt7/9zXTMzp07jdzcXCM5Odn9b1jz3yM3N9eYO3eu13ufPHmyz/h+//vfm86Xnp5u+vc47bTTjMLCwlrf11/+8hfDYrG4j6/5OzVq1CjD4XB4HT9z5kxTP0hKSjJSUlJMZZ7XCgBA/ZGIA0AL5ZmIL1261P0F+qOPPjLVDVYinp6ebowePdpYt26dYRiGUVpaajzxxBPuxOLuu+820tLSjPHjx7uTvaKiIuOuu+5yt7FgwQKvc1cnXGlpaUZ8fLzx3HPPGWVlZYZhVCVGF110kfv4//znP17H//Of/3Qnnffff7+xb98+wzAMw+FwGMuXLzdOO+00Q5LRoUMHo6ioyOfnXJ2k3HHHHcaBAwcMwzCM8vJyr6TVH4fDYQwdOtT9Pl599VWjoqLCMAzD+Omnn4xzzjnHnYx9+OGHXsfPnj3b9O/dGHfffbchyWjdurXx9NNPG4cPHzYMwzAqKyuNxYsXGwMGDDAkGSeddJLhdDrdxy1btsz9+W7YsMFn2zt27HAngIsWLTLt+/Of/2w8/PDDxpo1awy73W4YRtUfBdauXWtMnDjRkGQkJycbe/bs8Wq3ORPx559/3pgxY4axfPly97+Fy+Uytm7datx8882GxWIxYmJi6vwDTW1qS8SffPJJ9+d63XXXuftlcXGx8de//tX9xwpff6CqPn96erphtVqNO++80zh48KBhGIZRUFBg3HPPPe62X3jhBdOx27dvd/9Ratq0aabP/dixY8YXX3xhTJ061Vi+fHmt7w0A4B+JOAC0UJ6JuGEYxgUXXGBIMk488UTD5XK5y4OViPfp08coLy/3OvaKK65w1xk7dqwptmrVI91XX321177qhMtXUmEYVUndL3/5S3cMNRUWFrpHzj/++GOf781utxsDBw40JBl//etfTftqjppOmzbN5/H1MXfuXHc7n3zyic8YqhP1vn37eu1vaiK+bds2IyYmxkhMTDRWr17ts05hYaHRoUMHQ5Lx3nvvmfb16NHDPSvBlwceeMCQZHTs2NHnv29tzj77bEOS8ec//9lrX3Mm4nWpngngq082NREvLS01MjMzDUnGhAkTfB77xBNPuPuMZ1Jcs1/6e/+//vWvDUnGmDFjTOVvvvmmIck4/vjja40dANB43CMOAFHkgQceUExMjFavXq033ngj6Of//e9/r/j4eK/y008/3f16+vTpslgsfuv88MMPftvPy8vTlVde6VVutVp19913S5LWrVvnXmFcqrqn+9ixYxowYIApjppiY2M1YcIESVX3zfpitVp1xx13+I2tLm+++aYkadiwYRo3bpzPGGbMmCGp6l72mu8hEObMmSOn06kzzjhD/fv391mnVatWOv/88yV5fw5XXHGFJOm1116TYRhex77yyiuSpIkTJ/r8963N2WefLUn68ssvG3Rcc2vOuBYsWOC+B9vfPe5Tp051P/bs9ddf91knPj5et912m8995513niTv36n09HRJUlFRkWntBgBA4JCIA0AU6dmzpztR/eMf/1ivxc8CaciQIT7Lc3Nz3a8HDx5ca52jR4/6bb96cS5fTj31VMXGxkqSli9f7i7/6quvJEkbNmxQmzZt/P786U9/klS1GJov3bp1U+vWrf3GVpfqmMaMGeO3zqhRoxQTE+P1HgKh+nOYP39+rZ/D7NmzJXl/DldccYUsFot27typzz77zLRvxYoV2rBhgyRp0qRJPs///fffa+rUqerXr59SU1NltVrdi5tNnTpVkrR79+6Avuf62Lp1q2677TYNHDhQ6enpiomJccd11llnNVtc1f++eXl5Ov74433WiYmJ0WmnnWaq76lPnz5+V9Jv166dJHktujZkyBBlZ2dr3759Gjp0qJ566ilt3LjR5x9YAACNExvqAAAAwXXvvffqtdde09atW/Xcc8/pt7/9bdDO3apVK5/l1QlyferU9seD9u3b+92XkJCgrKws7d+/XwcOHHCX7927V1LVauW1rSBdreZq3zU1JQmX5I6prveQnZ3t9R4CofpzKCkpqdcoqOfn0LFjR40YMUJLlizRK6+8YlqFvHo0fPDgwerZs6dXW0899ZRuvvlmuVwuSZLFYlFaWpp79kRZWZkKCwuDPjr73nvvacKECaqoqHCXpaamKiEhQRaLRZWVlTp69GizxFWf/iBJHTp0MNX35O/3Sfr5d8rhcJjK09PT9cYbb+iyyy7TunXr3NeItLQ0/fKXv9Qll1yi8ePHy2az1e/NAAC8MCIOAFGmffv27i/W9913n9fjqKJN9eOfxo8fL6Nq7ZRaf/w9wq16pDpSVX8Od9xxR70+hyVLlni1UT3a/c4776isrExSVZJXfRtE9fT1mjZs2KBbbrlFLpdLF198sb799luVl5fr6NGjys/PV35+vh577DFJCuqI7OHDhzVlyhRVVFTotNNO05IlS1RaWqqCggLt379f+fn5evvtt4MWT7CNGTNG27Zt08svv6zJkyere/fuKigo0Pvvv68rrrhCAwYM0J49e0IdJgBELBJxAIhC06dPV0ZGhg4cOKBHH3201ro1R6trGzEuKCgIWHyNVVtiUFFRocOHD0syj163adNGkv8p58FSHVNt05zLy8t9vodACMTncNFFFykxMVGFhYX6z3/+I6lqqvuBAwdks9nc99nX9M4778jpdKpXr16aO3euBg8erLi4OFOd/Pz8RsVT3Xcb028//PBDFRYWKiMjQ++//75GjBihxMTEgMRVH/XpDzX3B7o/SFJycrKuuOIKzZkzR5s3b9bu3bv10EMPKSEhwTRSDgBoOBJxAIhCGRkZmj59uiTp0Ucf1cGDB2utW23Xrl0+62zevFnHjh0LaIyN8dlnn/kdNf3iiy/cU3AHDRrkLh8+fLikqvuY9+3b1/xB+lEd08KFC/3WWbJkifs9+LuXvrGqP4dPP/20XlP0fam5mFv1dPTq/5555pnKzs72Oqa6T/Xv319Wq++vJZ9++mmj4qnuu/76rSQtW7bMZ3n1MT169FBSUlKD46p+L40dxa/uD7t379bmzZt91nE6nVq8eLGkwPcHX9q3b68//OEPuvXWWyVVLSgHAGgcEnEAiFK//e1v1aFDBxUVFenPf/6z33rJyck67rjjJFWtMO7L/fff3ywxNtTOnTv10ksveZW7XC498MADkqTevXvrhBNOcO+7+OKLlZ6eLrvdrmnTptWaOLlcrmb7g8Oll14qSVq6dKnmz5/vtd/hcLgXjOvbt6/69u0b0PNfddVVio2N1aFDh9yrs/tTWVnp95aG6unp8+fP148//ugeGfe3SFtaWpokac2aNT4/+48++sjnNPj6qF79/ZNPPvF5H/eiRYu0dOnSWuPavHmzzz9MrF692u9K5VLVveSSGt1fxo4dq6ysLEn+V01//vnn3ff2+5pt0Fg174n3pXpmgL8/nAAA6sYVFACiVGJiovsL/vvvv19r3eov+S+++KKeeeYZ9/2/u3bt0jXXXKM333zT76hhMKWlpemGG27QP/7xD3fytGvXLk2YMME9cnjfffeZjklPT9fjjz8uSZo7d67OPvtsLVu2zL1wmMvl0oYNG/Too4+qT58+mjdvXrPEfuGFF2ro0KGSpEsuuUSvv/66e2G6bdu26cILL3QnjX/5y18Cfv7jjjtOf/zjH93tT5o0SWvXrnXvdzgcWr16tf70pz+pW7duWr16tc92xo4dqzZt2sjhcOiyyy5TWVmZMjIydM455/isf8YZZ0iqeqzcjTfe6F7Bu6SkRM8//7wuuugid0LaUJdccomsVqsOHz6sCRMmuKdxl5WV6aWXXtIFF1ygzMxMn8eOGzdOVqtVR44c0cSJE923PVRWVuqtt97SuHHjal0IrfoPJevWrdPXX3/d4Nhr/n6+8cYbuv7667V//35JVQvlPfHEE7rlllskVa1vMHDgwAafw5+HHnpIZ555pl555RXT1PiKigq99dZbevjhhyX9/Pg2AEAjBO2J5QCAoJoxY4YhyejUqZPfOg6Hw+jZs6chyf2zePFir3pFRUVG79693XWsVquRnp5uSDJsNpvxxhtvGJ06dTIkGbNnzzYdu23bNvdx27Zt8xnH4sWL3XX8mT17tt/3M2LECEOSceeddxq/+MUv3HFlZGSY3tvdd9/tt/1nn33WiIuLc9eNj483srKyDJvNZmrj1VdfNR1X/TmPGDHCb9v1tXv3bqNPnz7uc8XFxbk/5+rP/W9/+5vPY2v7fOrL5XIZf/zjHw2LxeI+Z2JiopGVlWXExMSYPocvv/zSbzvTpk0z1f3Nb35T63kvvfRSU/309HT3+QYOHGg8+eSTft9bXZ//PffcY2o7LS3NiI2NNSQZ559/vnH33Xf7Pf6OO+7wOra6P3Tp0sV47bXX/PZbu91u9OjRw70/IyPD6NSpk9GpUyfj7bffdtebPHmyIcmYPHmyz/h///vfu9uwWCxGRkaGO35JxqhRo4zCwsIGfy6G4f/3rvrYmn0gMzPT1C969epl7Nu3z2/bAIDaMSIOAFEsJibGPWW7NikpKfryyy81bdo0denSRbGxsbLZbO5R2upp1aEWFxenhQsX6oEHHlCPHj1UUVGhtLQ0jR49Wh988EGtU/Cvv/56bdq0Sbfddpv69++v+Ph4HTt2TCkpKRo0aJB++9vfasGCBQGdAuypffv2Wr58uR577DGdfPLJSkxMVGlpqfLy8nTFFVdoxYoV+t3vftds57dYLPrTn/6kH374QVOnTlWvXr0UExOjgoICZWRk6JRTTtHtt9+ur7/+2n1PuS+e09D9TUuv9tprr+nxxx9Xv379FB8fL6fTqRNOOEGzZs3SV1995fc52PUxc+ZMvfLKKzr55JOVnJwsp9OpE088Uc8995z+9a9/1bra/YMPPqiXX35ZQ4YMUWJioux2u7p166b/+7//06pVq9zP4fYlNjZWCxcu1DXXXKMuXbqopKREO3bs0I4dOxr0pILHHntMixYt0oUXXqjc3FwVFxerVatWGjVqlF588UUtWLCg1pH5xrjuuuv097//XRMmTFDfvn2VlJTkXrju1FNP1eOPP66VK1e6F/gDADScxTCC+CwQAAAAAACiHCPiAAAAAAAEEYk4AAAAAABBRCIOAAAAAEAQkYgDAAAAABBEJOIAAAAAAAQRiTgAAAAAAEFEIg4AAAAAQBCRiAMAAAAAEEQk4gAAAAAABBGJOAAAAAAAQUQiDgAAAABAEJGIAwAAAAAQRCTiAAAAAAAEEYk4AAAAAABBRCIOAAAAAEAQkYgDAAAAABBEsY05yOFwyOFwBDoWAAAAAAAiitVqlc1mk8ViqfcxDUrES0tLdejQIZWUlDQ4OAAAAAAAWiKbzaZWrVopOztbMTExdda3GIZh1KfhyspKbdu2TTabTZmZmYqPj29Qxg8AAAAAQEtiGIacTqeKi4tVUFCg+Ph45eXl1ZmM1zsR3717t8rLy9WlS5d6ZfgAAAAAAESLsrIy7dy5U+np6crNza21br0WazMMQ6WlpUpLSyMJBwAAAADAQ2JiolJTU1VUVKS6xrvrlYjb7XY5nU4lJiYGJEAAAAAAAFqaVq1ayW63y26311qvXom4y+WSJEbDAQAAAADwozpnrs6h/WnQc8RZnA0AAAAAAN/qmzM3KBEHAAAAAABNQyIOAAAAAEAQkYgDAAAAABBEJOIBYLFYGvwzcuTIBp9nzpw5Xu1YrValpqZqwIABuvPOO3Xw4MEGxWm1WpWWlqbBgwdr1qxZKi0trTWGkpISPfbYYxo5cqRyc3MVFxen1q1ba8SIEXr00UdVXFzc4PdV06ZNm/Tkk09qypQpOuGEExQbGyuLxaL77ruvSe0ifHTu3FkWi0Vz5swJdSgm27dvr/fv7/bt230eV7Mckae6b9b1U7Pvhmt/RsP9+OOPuummm9S7d28lJycrISFBHTp00ODBg3XTTTfp3XffbfI5lixZ0ujvAI1R/b1hypQpQTkfmt+SJUt07bXXqnfv3srIyJDNZlNWVpaGDBmim266SZ9++qnPRyZNmTIloNeq6mtfsP6/V339jWTV3xc6d+4c6lBqFei+Emj33nuvLBaL7r333lCH0mSxoQ6gJZg8ebJXWX5+vj755BO/+3v27Nno8yUnJ+uiiy6SJDmdTu3YsUNLly7V6tWrNXv2bH3xxRfq3r273+NPP/10tWnTRpLkcDi0a9cuff3111q+fLleffVVffHFF8rMzPQ67quvvtJFF12k/Px8xcfHa/jw4crNzdWBAwf01Vdf6fPPP9fDDz+sd999V8OHD2/Ue3v22Wf1t7/9rVHHAoFy4YUXKiUlxe/+2vYh8g0fPlzdunXzu7+2fYhM//rXv3TZZZepoqJCWVlZGj58uHJycnT06FGtXr1aTz/9tObOnasLL7ww1KEiSh06dEgTJ07U/PnzJUnt27fX8OHDlZaWpoKCAq1du1ZPP/20nn76aQ0YMEArV64MccTRp3PnztqxY4e2bdsW9sk2wgOJeAD4+ovRkiVL3Il4oP+ilJ2d7dXmunXrNGLECO3fv1+33HKLPvjgA7/HT58+3euv8Zs3b9bw4cO1fv16PfDAA3rkkUdM+5ctW6bRo0eroqJCEyZM0JNPPqmsrCz3/qNHj+p3v/udXn31VY0ePVqff/65hgwZ0uD31rdvX912220aMGCATjrpJD3wwAN65ZVXGtwO0BSPPPII/xONYtdccw0jiFFk//79mjx5sioqKnTrrbfqvvvuU0JCgqnOihUr9M4774QoQkS7Y8eO6Re/+IU2bdqknj176plnntGoUaO86q1du1Z//etfNXfu3BBEibq0b99eGzZskM1mC3UoCBMk4v/f3r1HRVXtcQD/DjDDMAICAl5BJRRT0ixRJFERQRGNq4bK00KwRFOsKG+pGaubplfLzGfqSg2f+M5XippggoaioPlOESMN5Z0DDI/53T9Yc2KcGRgeouDvs9ZZS+ecfc6ewzln9m+f/WghunfvjujoaMyePRtHjx6FQqGAsbGx3ulffPFFREZGYt68eTh+/LjaurKyMgQFBUGhUMDf3x+bN2/WaB5kaWmJ2NhYKBQK7NixA0FBQbh+/XqdHzZvv/222v8NDLj3BGOMsSfnwIEDePToEezs7DQqoVV69+6N3r17N3HOGKsSFRWF69evo1OnTkhOToalpaXW7Xr06IHvv/8ekZGRTZxDpg+xWNygFrGs5WlwlKNUEnIfKZr1olRq9qV5kjw9PSESiZCQkKB1fX37PvTs2RMAUF5ejry8vDrnq3pz9eq2bt2KO3fuQCwWY8WKFTr76IhEIixbtgwSiQQZGRnYsmVLnfPQYimVgDyneS9K5VM5dVlZWYiKikKXLl0glUrRunVr9O/fH6tXr0ZlZaXWNESEdevWoU+fPpDJZGjTpg2GDx+O5OTkJu+j+axTkhJ5pXnNelHS07k2mztSKlGRl9esF2qE51J2djYAwMbGps5p8/LyMGvWLHTv3h0ymQxmZmbo3bs3Fi5ciJKSkhrTFhcXY9asWXBycoJUKoWdnR0mTpyIP//8U2eaa9euITw8HA4ODjA2NoaVlRW8vb2xffv2Oue9OXn48GG9l5r+Djk5OfXer1wu17nf+pTBdLl165ZQnvrmm290BuHV1adF4rZt2+Dt7Q0rKysYGxvDwcEBERERuHHjRq1p9+zZgwEDBsDc3BxmZmbw9PTEoUOHtG6bmZmJ//3vf/Dy8kLHjh1hbGwMCwsLDBgwAKtXr4aykcsaxcXFWLBgAVxcXGBmZgaZTIbu3bvj008/RX5+vsb21ftxV1RUYOHChejevTtMTExgbW2NgIAAXLt2TS2NaiyGzMxMAICjo6PauCKq8n5NfcSr94HftGkT+vbtC1NTU9jY2CA4OBh3794FUFW+Wb58OV599VW0atUK1tbWmDBhAh48eKCxz/LycmzatAmhoaHo1q0bzM3NYWJigq5du2L69Om4d+9eQ06tYObMmRCJRJg8ebLObX777TeIRCK0bdsW5eXlwue7d+/G22+/jR49esDS0hJSqRSOjo6IiIjA9evX65SP2uKn2sp/9+7dQ3R0NJydnYXnuaurK5YvX64RGzWWBr8Rzy8uQ++5xxojL09N6qdD0MZU/7fHz6qioiIAgKGhIaytreucPiUlBUDV2/Xq9u7dCwDw8fERgnVd2rZtCx8fHxw4cAD79u3T2j/+uVSSByzq/LRz0TAzbgGt6n5dNcTZs2fh6+uLvLw8dOzYEaNHj0ZhYSESEhKQnJyMPXv2YN++fZBIJGrppk6dilWrVsHAwAADBw5Eu3btcOnSJXh4eOD9999v0u/wrCtQFGBQ3KCnnY0GSQxMhJVUc1wLVrPKggLcdK/feB7Pii7JSTDSMqZJXXTs2BFAVUHx+PHj8Pb21ivd7du34eXlhczMTNjY2GDEiBEoLy/HiRMn8PHHHyMuLg7Hjh3TGjiVlZXB29sbFy9ehKenJ1xcXHDq1CmsW7cOhw4dwsmTJzXGejl48CDGjh2L0tJSdO3aFf7+/njw4AESExPx888/48iRI/j+++8bdC6eVba2tvVOu3z5ckydOlXrOmdnZ+Tk5NRrvzExMToL/AMHDsTly5frtd/HHThwAEqlEpaWlvDz82uUfVZHRJgwYQJiY2NhZGQEDw8P2Nra4vz581i/fj3i4uKwa9cu+Pr6ak2/dOlSfPPNN+jTpw/8/Pxw69YtJCYmIjExEUuXLkVUVJTa9hs3bsScOXPg6OiIF198Ef3798f9+/dx+vRpJCUlIT4+Hjt37myUgdny8vLg7e2NtLQ0mJubw8vLC2KxGImJiZg3bx62bNmCn3/+WWdXtMDAQOzfvx+DBg1Cz549kZKSgh07duCnn35CfHw8+vXrB6Bq3JCwsDDs3LkTcrlcY5yZ2srO1c2cORNfffUVPDw8MHz4cKSkpGDbtm1ISkpCeno6Jk+ejH379sHT0xOdOnVCUlISfvjhB1y4cAFnz55VKw9lZ2fjzTffROvWreHs7IyePXtCLpcjLS0Ny5Ytw7Zt25CcnNzgcU/Cw8OxYMECxMXFYcmSJRpdewBg/fr1AIDx48ertZYNCAiAsbExXnrpJXh5eaGiogK//fYb1q9fj+3btyM+Ph7u7u4Nyp8+Tp48idGjRyM/Px8vvPAChg4dCoVCgZSUFERFRWH//v04cOBAo3cr4KbpLYiqX7ivr6/eF0pFRQWysrIQGxuLTZs2QSaTYcaMGWrbpKamAtC/htXV1RUHDhzAuXPn6pB7xtQpFAqMGzcOeXl5mDx5MpYuXSpc17dv34a3tzeOHDmCzz//HPPmzRPS7du3D6tWrYKpqSmOHDmi9gBfvHgxPvzwwyb/LoyxZ9fo0aNhb2+PP//8E0OHDsWgQYPg7e0NFxcXuLq66nxTHhISgszMTIwcORJbtmxBq1atAFS9vfX19cX58+cxbdo0bN68WSPt6dOn4eTkhKtXrwoVAaWlpRg/fjx27dqFt956C6dPnxa2z87ORmhoKEpLSzF37lzMmjVLCFTOnTsHHx8frFu3Dq+99hreeeedxj5F7ClSlcFcXFyeSHe91atXIzY2FtbW1jh69CheffVVAFUB+ueff47PP/8cwcHBuHHjhtZ7YcmSJcJbV5W4uDgEBwcjOjoagwcPRo8ePYR1w4YNw+jRo9U+A6reRo4YMQK7d+/Gzp07MW7cuAZ/t3fffRdpaWlwc3PDwYMHhbGNHj16hICAAPz0008IDQ1FUlKSRtrMzEzI5XKcO3dOaHFaWVmJDz74AMuWLUNwcDCuX78OY2NjDBgwAAMGDEBCQgLkcnmDxplZu3Ytzp07h1deeQUAUFJSAh8fH5w6dQqDBg1CcXExrl27BgcHBwBVrTr69euHixcvYseOHWp/h9atW+PHH3+Er6+vWoBeXl6OmJgYzJ8/H++9916N40rpQ1WhkpSUhL179yIoKEhtfUVFBTZt2gSgKmivbvPmzfDz8xOen0DVtbdq1SpMnToVkyZNwqVLl57oiPl//fUX/P39UVBQgJUrVyIyMlK413JzcxEQEID4+HjMnz8fn332WaMemzvgNnOVlZW4ffs2PvnkE2zZsgUODg5YunRpjWkGDx4sNIERi8VwdHRETEwMfHx8cObMGY1+cKop0dq2batXnlTb1TSVGmO12bFjBzIzM2FnZ4clS5aoVS516tRJ6Mu5bNkylJaWCutUo+5HRUVp1KJGR0fD1dW11mM/3qys+qIqpLCWKzw8vMbpywoKCp52FlkjMjU1xfHjx+Hm5gYiQkJCAubMmYPXX38dtra26NWrF7777ju1rjCnTp3Cr7/+CplMhjVr1qgVIm1sbLBmzRoAVc19s7KytB73q6++EoJwAJBKpVi5ciVkMhnOnDmD5ORkYd3atWtRWFiI3r17Y/bs2WqF0j59+mD27NkAgEWLFjXOSWHPDNUbe10VQunp6ZgwYYLGcurUKb32r/ot/eyzz9R+30QiEWJiYtCzZ08UFBRg7dq1WtOPGjVKLfgDqt4k+/v7o6KiQqNM6urqqhGEA4CdnR0WLlwIoOr3v6Hu3r2LHTt2QCQSYc2aNWoDDJuammLt2rWQSqVITk5Wu9eq+/TTT4UgHKhqcbpo0SLY29sjMzOzUaY0fNx///tfIQgHABMTE0RHRwMALl26hKVLlwpBOFA1gPOUKVMAQGOMJzMzM4wcOVKj1aBYLMaXX34JOzs7HD58GH///XeD8x0REQHgnzff1R08eBAPHjxAnz59NP72gYGBas9PoOrae/fdd9GvXz9cvnwZV69ebXD+arJkyRLk5uZi6tSpmDJlilqFV5s2bRAbGwuxWIzly5drnRqwIfiNeDOUmZmptWaob9++iI+PR+vWrWtMX336MiJCdnY2Lly4gCNHjoCIEBsbq3fQrU1jX6Ts+aTqUxUUFKR14EF/f39YWloiPz8fqamp6N+/PyoqKoQf1McLBiohISE4e/Zsjceuafqy6gVn1jLVNn3Z44Ua1vx17doVZ86cQUpKCg4ePIhff/0V58+fx8OHD5GWloYpU6Zg165dOHjwICQSifB88vX11fp72bt3b7zyyitIT09HYmKixvPIwsICI0eO1Ehna2sLX19f7N69GwkJCUJloup4urp7TZw4ER999BFu3ryJe/fuwc7OrgFngzUnf/zxB3744QeNzz09PTFgwIAa02ZlZeHWrVsAtF9bIpEI4eHh+OCDD3DixAnMmjVLYxtd12RYWBh27dqldTwkhUKB+Ph4nD17Fg8ePIBCoQARCQFhXfsGa3Py5EkolUq4uLioBdMq9vb2GDZsGH788UecOHFCa/Nnbd/N2NgYgYGBWLx4MRISEhASEtLgvFY3YsQIjc9U3VSMjIzg4+Ojc72uPt/p6ek4fvw4MjIyIJfLhX74FRUVUCqV+P3339GrV68G5TsgIADTp0/HsWPHkJWVhfbt2wvrVMG5Klh/3O+//47Dhw/j999/x99//y1UeqrG77h+/TpeeumlBuWvJqoWAYGBgVrX29vbo0uXLrhy5Qpu3ryJF198sdGO3eBA3FImQeqnQxojL0+Npax5FaqqzyOuUChw9epVpKenIyUlBZGRkbVOW6Ft+rKSkhJMnjwZsbGxGDZsGFJTU2FoaAigqrYtKytLuCFqoxow4vHaW23TAVlbW+scpbZFMbGq6mPdnJk0bR9c1YBFjo6OWteLRCI4OjoiPz9f2DYnJ0d4O66rWZg+zcWep+nLLIwtkBiY+LSz0SAWxhaNur/nZfoyQwsLdEnWbJLZnBhaWDTq/vr27St0wyIiXLhwAYsWLcK2bdtw7NgxfPvtt5gxY0atzycA6Ny5M9LT07UOvvbCCy/obGqp2mf1N+m1Hc/CwgJWVlbIy8tDVlZWiwvEtQ1EpS9dlaoAcPXq1Xq/PJDJZDrX/fLLL/XapzaqMX90tTL08/NT+w5DhgzReDOqi+q6atOmDczNzbVu07lzZ7VtH6frmtR2HQPAmTNnEBgYKAw+po1qzKOG0Pcerb5tdRYWFrDQ8XzR9d0ag7bKftU13K5dOxgZaYZuZmZmAKDWOhAA5HI53nzzTezZs6fGYzbG+TY1NcW4ceOwYcMGxMbGCpU2Dx48wMGDByGVShEcHKyWprKyEtOmTcPq1atrvA8bI381uX37NoCqsR1q8/Dhw2crEDcwELWIgc6eJbWNGKltHvHdu3cjMDAQcXFx8PDwwLvvvlunY5qYmGDZsmXYuHEj0tPTcfjwYbz++usAqmr2s7Ky8Ouvv+q1L9Wgb483cddWY+vg4PB8BOIGBk0+0BnT7kn2M2qODEQGPNDZc0pkYNDggc5aMpFIBBcXF2zduhXFxcXYt28f9u7dqzGOypPCrcv+UZ8R7fVRn4Ft9WHViPeVi4sLNm7ciPPnz0OpVDa7aV2rX8fFxcUYPXo0srOzER4ejilTpsDJyQnm5uYwNDTEjRs30LVr12Zz7T+JfNb0963r337mzJnYs2cPunXrhgULFsDV1RXW1tZCqy53d3ecPn260b5HREQENmzYgB9++EEIxDdt2oSKigqMHTtWo2Lj22+/xXfffYd//etfWLx4Mdzd3dG2bVthsLeQkBBs3bq10fKnK75SfT527FiNZvKPq97FoTFw0/SnQHUD6OqToZr+oC78/f3xySefYO7cufjss88QGhpaaxP1x5mbm6NNmzbIycnB1atXhUB81KhR+PHHH3H06FHcv38f7dq107mPv/76C/Hx8QCg0eyuuTxY2bPB3t4ewD81ldpkZGSobdumTRsYGxtDoVAgMzNTa1OmO3fuNH5mGWMtmo+PD/bt2yf019Xn+aRap9q2upqeQ6p11Zt22tvb49q1azqPV1hYKEyZpe14rPny8/PDhx9+iPz8fBw6dKhRR05XXSu5ubkoKirS+la8pusYqPodrt6nWUXbdXzy5ElkZ2fDxcUF69at00hz8+bNOn8HXRp6jxYUFKCgoEDrW3Ft3+1ZpJrWMC4uTmvz/MY830DVG2UnJyfcuHEDSUlJ6N+/v/DiUFuzdFX+Vq9erbWrTl3zV9/4qkOHDrh58yY+/vhj9OnTp07HbKjmVa3WQqhueG2DDxQXF+PEiRP12u/MmTPRrl075ObmYvHixXVOX1hYiNzcXADqTblCQ0Ph4OCA8vJyTJs2TWdATUSYPn06ysvL4eDg0Oj9ZtjzRdV9Ii4uTqO5FVA1b2l+fr4wby9QNQCJajoRXfPYb9269clkmDHWLOlTSaxqRqsqeKueT4cPH9babevChQtIS0uDgYEBPDw8NNYXFBRg//79Gp8/fPgQhw8fVjtG9X9ra1kGQAhqunTpwoF4C+Pk5CT0XY2OjkZhYWGj7bt9+/ZC8+zHW1oCVfeG6vPBgwdr3cfGjRu1fh4bGwtA/TpWVRbpGmtFNbJ2Y/Dw8ICBgQHS0tKQnp6usf7+/fvCvVaX71ZWVoa4uDgA0OjmqQoEn9Sc03WlOt/VB3dTOXLkSL2n7quJalT0DRs2IDU1FZcuXUKHDh20TgtZU/4uX76MtLS0Oh27pvgKgM7R4YcPHw7gn4qBpsSB+FMwZEhVn/oVK1ao9UuRy+WYNGkS/vjjj3rtVyaTYc6cOQCqRgDMz8/XO21JSQmmT58OIoJEIhEuSqDqwbJ161ZIJBLs3r0boaGhQsCukp+fj7CwMOzYsUNte8bqa9y4cejYsSPu3buH6OhotR+2jIwMYRqyqKgotTkrp0+fDqBqbtMzZ86o7fPbb7/Vu4sFY+z5sHLlSoSFhWkdOZmIsHv3bixfvhwAhGl5BgwYADc3N5SUlCAyMhLFxcVCmpycHERGRgrbd+jQQetxP/zwQ7U+pgqFAlOnToVcLkffvn3Rv/8/c7y/8847MDc3x/nz5/Hll1+qVR5cuHABc+fOBYAmazbPmtaKFSvg5OSEmzdvwt3dHYmJ2sf1uHPnTp37LX/00UcAgC+++EItYCUizJ07F2lpabCwsNA5Ld6ePXs0xibauXMndu3aBSMjI7V5xJ2dnQFUje595coVtTRr1qwRAtzG0LFjR4wbNw5EhMjISLVyq6q8XVpaCnd3d53zVH/xxRf47bffhP8rlUp8/PHHyMrKQocOHTBmzBi17VUVdY01h3xDqc73smXL1D6/fv06Jk+e/ESOGRYWBgMDA2zfvh0rVqxQ+0xX/lasWKHWbPz+/ft466236lyh4eXlBQMDAxw5ckTtHiEiLF26VOco9zNmzICFhQUWL16Mr7/+GmVlZRrbZGRkNGpFUfXM1aqkpISuXLlCJSUl+mzOiOjEiRMEgLSd4rKyMurTpw8BoNatW9Prr79Ow4cPJxsbG7K3t6eIiAgCQDExMWrp1q9fTwDIwcFB53HLysqoc+fOBIBmzZqltk6Vn2HDhlFYWBiFhYXRW2+9Rb6+vmRra0sAyMDAgFavXq1134mJicJ2UqmUvL29KSQkhIYMGUJSqZQAkK2tLSUkJNT5fKmkpqaSm5ubsFhbWxMAat++vdrn9+7dq/cx2NPl4OBAAKhTp05qf9PHl9TUVEpJSSErKyvhug8MDKQRI0YI19uwYcNIoVBoHGPSpEkEgAwNDcnT05OCg4OpR48eZGhoSB988AEBoKFDh6qlycjIEO6RMWPGCPeItiU1NVVruoyMjCd9+tgTpLo2+/fvX+Pff/PmzRpp1q9f//Qyzhrkm2++Ee5hGxsb8vHxoZCQEBoxYgS98MILwrrx48dTZWWlkO7WrVvC39/W1pbGjh1Lo0aNInNzcwJALi4ulJeXp3YsVdmgX79+5ObmRjKZjPz8/CggIIDs7OyEfV27dk0jn/v37xeefd26daPg4GDy9vYmIyMjAkDh4eEaaVTlhrCwsEY/b6xpZWdnk7e3t3A9tm/fnvz8/Gj8+PE0ZswY6tmzJ4lEIgJAL7/8Ml26dEktfVhYmNZnlVKppDfffJMAkJGREXl7e1NwcDB17dqVAJCJiQkdOnRIIz+qa//9998nAOTq6kohISHk5uYm5HHx4sUa6UaNGkUASCKRkI+PDwUFBVG3bt1IJBLR7NmzdZZzdZWpa5KTk0OvvPKKUN4ePXo0jR07lmxsbAgAOTo6avxuq37TO3bsSG+88QaJxWIaOnQoBQUFCeXrVq1a0S+//KJxvOXLlxMAMjU1JX9/f5o4cSJNnDhRuJ9V+67r96spHdE/z5VBgwapfb5r1y61ayIoKIi8vLxILBaTl5cXubu7EwA6ceKEWjpd14q+fH19he8jEono1q1bWrc7c+YMSSQSAkBOTk4UEBBAvr6+ZGJiQt27d6c33nhDaz5iYmK0xklERO+9955a+c/f3586d+5MYrGYPvnkE63niagqxlHFHLa2tuTl5UWhoaHk5+cn/N3d3Nz0Pgf6xs4ciD8hNQXiRET5+fk0bdo0at++PYnFYrK3t6dJkyZRdna2zgtMn0CciGjr1q0EgMzMzCgnJ0f4XJWfxxepVEpOTk4UHh5O58+fr3Hff//9N3311Vfk4eFB1tbWZGRkRNbW1jRw4EBauHAhFRUV6XV+dKl+3mpaOOBpvlQ/3rUtqh+Gu3fv0tSpU6lTp04kkUjIzMyM+vXrR6tWraLy8nKtx1AqlbR27VpycXEhqVRKFhYW5OPjQydPnqTY2FgCQMHBwWppqgfUtS179uzRmo6vy+ZN32vzvffe00jDgXjzVVRURHv37qWoqCjq27ev8LtsYmJCnTt3puDgYPrpp5+0ps3NzaWZM2eSs7MzSaVSkslk1KtXL1qwYAEVFxdrbF+9wPzo0SOaMWMGOTo6kkQiobZt29KECRPo7t27OvN65coVCgsLE/JoYWFBgwcPpm3btmndngPxlufYsWMUERFBXbt2JXNzczIyMiJLS0tycXGhyMhIOnr0qFqFkUptwdWWLVvI09OTLCwsSCwWU4cOHWjChAlaK4WI/nn2ZWRk0Pbt26lfv35kampKrVq1ooEDB9L+/fu1pisrK6NFixbRyy+/TDKZjKysrMjHx4fi4+PrHajWRC6X0/z58+nVV18lmUxGUqmUnJ2dadasWRoVZUTqQW95eTnNmzePunXrRsbGxmRlZUVjxoyhy5cvaz1WZWUlzZ8/n7p37y5UmlUvzzR1IE5EdPLkSfL29iZra2uSyWTUo0cPmjdvHikUCho0aNATCcS3b98ufB9tearu4sWLNHLkSGrXrh1JpVLq0qUL/ec//6GioiKd+agpEFcqlfT111+Ts7MzSSQSsrKyon//+9+Umppa43kiqqrsmjNnDrm4uJCZmRlJJBJq3749ubu7U0xMDF28eFHvc6Bv7Cwiqr1zVGlpKTIyMuDo6KjWBJQxxpqbiIgIrF+/Hl9//TWio6OfdnYYY4wx9oy4c+cOHB0d4eDgwIO7snrTN3bmPuKMsRbn8uXLkMvlap8plUqsXbsWGzZs0DqfJWOMMcYYY02Fpy9jjLU4ixYtwvbt29GrVy/Y29tDLpfjypUruHPnDgwNDbFy5coap+FjjDHGGGPsSeJAnDHW4gQGBqKoqAipqalIS0tDRUUFbG1tERgYiPfffx+vvfba084iY4wxxhh7jnEfccYYY4wxxhhjrBFwH3HGGGOMMcYYY+wZxIE4Y4wxxhhjjDHWhDgQZ4wxxhhjjDHGmlCdAnE9upMzxhhjjDHGGGPPJX1jZr0CcUNDQwBAeXl5/XPEGGOMMcYYY4y1YAqFAgBgZFTzBGV6BeJisRjGxsYoLCzkt+KMMcYYY4wxxthjKisrkZeXh1atWtUaiOs1fRkAFBUV4c8//4SpqSlat24NsVgMkUjUKBlmjDHGGGOMMcaaGyJCZWUlSkpKUFhYCKVSiQ4dOsDExKTGdHoH4kBVMJ6TkyO8bmeMMcYYY4wxxp53hoaGkMlksLW1hUQiqXX7OgXiKuXl5aisrKxXBhljjDHGGGOMsZbCwMCgzi3G6xWIM8YYY4wxxhhjrH54HnHGGGOMMcYYY6wJcSDOGGOMMcYYY4w1IQ7EGWOMMcYYY4yxJsSBOGOMMcYYY4wx1oQ4EGeMMcYYY4wxxpoQB+KMMcYYY4wxxlgT4kCcMcYYY4wxxhhrQv8H2vglc8EsDhsAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 800x600 with 1 Axes>"
       ]
@@ -2693,7 +1107,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

Thank you for providing TuRBO as a small tutorial! In the notebook, however, the initial Y values are ignored in the TurboState which seems data inefficient. As this notebook is the starting point for multiple people if they want to compare against or use TuRBO, I believe this should be fixed.

I document my change below as the diff with notebooks is not super readable. :)

Old implementation (from https://botorch.org/tutorials/turbo_1):
```python
X_turbo = get_initial_points(dim, n_init)
Y_turbo = torch.tensor(
    [eval_objective(x) for x in X_turbo], dtype=dtype, device=device
).unsqueeze(-1)

state = TurboState(dim, batch_size=batch_size)
```
Crucially, when updating the `TurboState`, only the most recent Y values (`Y_next`) are considered and, therefore, the initial points are discarded:
```python
def update_state(state, Y_next):
    ...
    state.best_value = max(state.best_value, max(Y_next).item())
```

Long story short: I changed the initialization of the state to also include the initial Y values:
```python
X_turbo = get_initial_points(dim, n_init)
Y_turbo = torch.tensor(
    [eval_objective(x) for x in X_turbo], dtype=dtype, device=device
).unsqueeze(-1)

state = TurboState(dim, batch_size=batch_size, best_value=max(Y_turbo).item())
```
Interestingly, this also (ever so slightly :D ) improves the final performance of TuRBO :)

**OLD**:
<img width="906" alt="image" src="https://github.com/pytorch/botorch/assets/49341051/d8798eef-567e-4dd7-90ab-4ce9eb69a266">

**NEW**:
<img width="904" alt="image" src="https://github.com/pytorch/botorch/assets/49341051/ccead966-8b51-4980-91e6-14430ac3e743">

---
I also added warning supression to the imports to hide my path--I hope that this is ok (I think I also saw this in other notebooks), but I can of course also change this back

Old first code cell:
```python
import os
import math
from dataclasses import dataclass

import torch
from botorch.acquisition import qExpectedImprovement, qLogExpectedImprovement
from botorch.fit import fit_gpytorch_mll
from botorch.generation import MaxPosteriorSampling
from botorch.models import SingleTaskGP
from botorch.optim import optimize_acqf
from botorch.test_functions import Ackley
from botorch.utils.transforms import unnormalize
from torch.quasirandom import SobolEngine

import gpytorch
from gpytorch.constraints import Interval
from gpytorch.kernels import MaternKernel, ScaleKernel
from gpytorch.likelihoods import GaussianLikelihood
from gpytorch.mlls import ExactMarginalLogLikelihood
from gpytorch.priors import HorseshoePrior


device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
dtype = torch.double
SMOKE_TEST = os.environ.get("SMOKE_TEST")
```

New:
```python
import os
import math
import warnings
from dataclasses import dataclass

import torch
from botorch.acquisition import qExpectedImprovement, qLogExpectedImprovement
from botorch.exceptions import BadInitialCandidatesWarning
from botorch.fit import fit_gpytorch_mll
from botorch.generation import MaxPosteriorSampling
from botorch.models import SingleTaskGP
from botorch.optim import optimize_acqf
from botorch.test_functions import Ackley
from botorch.utils.transforms import unnormalize
from torch.quasirandom import SobolEngine

import gpytorch
from gpytorch.constraints import Interval
from gpytorch.kernels import MaternKernel, ScaleKernel
from gpytorch.likelihoods import GaussianLikelihood
from gpytorch.mlls import ExactMarginalLogLikelihood


warnings.filterwarnings("ignore", category=BadInitialCandidatesWarning)
warnings.filterwarnings("ignore", category=RuntimeWarning)

device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
dtype = torch.double
SMOKE_TEST = os.environ.get("SMOKE_TEST")
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I believe this minor change does not need a test plan.

## Related PRs

PR does not change functionality.
