### PR TITLE
Update `sample_all_priors` to support wider set of priors

### DIFF
--- a/botorch/optim/utils/model_utils.py
+++ b/botorch/optim/utils/model_utils.py
@@ -161,7 +161,12 @@ def sample_all_priors(model: GPyTorchModel, max_retries: int = 100) -> None:
             )
         for i in range(max_retries):
             try:
-                setting_closure(module, prior.sample(closure(module).shape))
+                # Set sample shape, so that the prior samples have the same shape
+                # as `closure(module)` without having to be repeated.
+                closure_shape = closure(module).shape
+                prior_shape = prior._extended_shape()
+                sample_shape = closure_shape[: -len(prior_shape)]
+                setting_closure(module, prior.sample(sample_shape=sample_shape))
                 break
             except NotImplementedError:
                 warn(


### PR DESCRIPTION
Summary:
Addresses https://github.com/pytorch/botorch/issues/780

Previously, this would pass in `closure(module).shape` as the `sample_shape`, which only worked if the prior was a univariate distribution. `Distribution.sample` produces samples of shape `Distribution._extended_shape(sample_shape) = sample_shape + Distribution._extended_shape()`, so we can calculate the `sample_shape` required to support both univariate and multivariate / batched priors.

Differential Revision: D58377495
