### PR TITLE
Pin numpy to <2.0

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -62,6 +62,8 @@ jobs:
       run: |
         # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
         conda config --set solver classic
+        # avoid issues with numpy 2.0 on windows builds and in tensorboard
+        conda install -y "numpy<2.0"
         conda install -y setuptools_scm conda-build conda-verify anaconda-client
         conda install -y scipy sphinx pytest flake8 multipledispatch
         conda install -y -c pytorch pytorch cpuonly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,6 +81,8 @@ jobs:
       run: |
         # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
         conda config --set solver classic
+        # avoid issues with numpy 2.0 on windows builds and in tensorboard
+        conda install -y "numpy<2.0"
         conda install -y scipy multipledispatch setuptools_scm conda-build conda-verify
         conda config --set anaconda_upload no
         conda install -y -c pytorch-nightly pytorch cpuonly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,8 @@ jobs:
       run: |
         # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
         conda config --set solver classic
+        # avoid issues with numpy 2.0 on windows builds and in tensorboard
+        conda install -y "numpy<2.0"
         conda install pytorch torchvision -c pytorch
         conda install -y pip scipy sphinx pytest flake8
         pip install git+https://github.com/cornellius-gp/linear_operator.git

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -33,6 +33,8 @@ jobs:
       run: |
         # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
         conda config --set solver classic
+        # avoid issues with numpy 2.0 on windows builds and in tensorboard
+        conda install -y "numpy<2.0"
         conda install -y -c pytorch pytorch cpuonly
         conda install -y pip scipy pytest
         conda install -y -c gpytorch gpytorch

--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,4 @@ dependencies:
   - scipy
   - multipledispatch
   - pyro-ppl>=1.8.4
+  - numpy<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ torch>=1.13.1
 pyro-ppl>=1.8.4
 gpytorch==1.11
 linear_operator==0.5.1
+numpy<2.0


### PR DESCRIPTION
The update caused some issues on windows tests, pinning this until this is root-caused & fixed. Failures: https://github.com/pytorch/botorch/actions/runs/9546224666/job/26308628524, https://github.com/pytorch/botorch/actions/runs/9551785679/job/26326926744?pr=2381