### PR TITLE
Pin codecov uploader version to 0.6.0

### DIFF
--- a/.github/workflows/reusable_test_pip.yml
+++ b/.github/workflows/reusable_test_pip.yml
@@ -52,4 +52,5 @@ jobs:
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
+        version: v0.6.0  # TODO: Unpin after codecov issue with 0.7.0 is resolved: https://github.com/codecov/codecov-cli/issues/460#issuecomment-2183042570
         files: ./botorch_cov.xml,./botorch_community_cov.xml


### PR DESCRIPTION
Changes have made upload from forked repos fail, see https://github.com/codecov/codecov-cli/issues/460#issuecomment-2183042570 for details. Pinning for now until resolved.