### PR TITLE
Unpin codecov uploader version

### DIFF
--- a/.github/workflows/reusable_test_pip.yml
+++ b/.github/workflows/reusable_test_pip.yml
@@ -52,5 +52,4 @@ jobs:
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
-        version: v0.6.0  # TODO: Unpin after codecov issue with 0.7.0 is resolved: https://github.com/codecov/codecov-cli/issues/460#issuecomment-2183042570
         files: ./botorch_cov.xml,./botorch_community_cov.xml


### PR DESCRIPTION
Summary: This was pinned in https://github.com/pytorch/botorch/pull/2385 to fix an issue with a broken codecov uploader 0.7.0, which has now been resolved in 0.7.1: https://github.com/codecov/codecov-cli/issues/460?fbclid=IwZXh0bgNhZW0CMTEAAR1eI0bTYdm2jo6U1pLxYmKhAZNMSM44cmmFGvHlbc6znyo865kT93BP-FI_aem_C4OVKZs7oZvZmMsajYIUFA#issuecomment-2183053541

Differential Revision: D59112225
