### PR TITLE
[Easy, hotfix] Remove deterministic posterior and sampler from documentation

### DIFF
--- a/sphinx/source/posteriors.rst
+++ b/sphinx/source/posteriors.rst
@@ -34,11 +34,6 @@ GPyTorch Posterior
 .. automodule:: botorch.posteriors.gpytorch
     :members:
 
-Determinstic Posterior
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: botorch.posteriors.deterministic
-    :members:
-
 Ensemble Posterior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.posteriors.ensemble

--- a/sphinx/source/sampling.rst
+++ b/sphinx/source/sampling.rst
@@ -12,11 +12,6 @@ Monte-Carlo Sampler API
 .. automodule:: botorch.sampling.base
     :members:
 
-Deterministic Sampler
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: botorch.sampling.deterministic
-    :members:
-
 Index Sampler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.sampling.index_sampler


### PR DESCRIPTION
## Motivation

The CI is broken after merging #2391 and #2409. It passed on the pull requests, but there may have been a Meta-internal change that never got reflected on the OSS CI, and these changes didn't wind up merged.

## Test Plan

`sphinx-build -WT --keep-going sphinx/source sphinx/build` no longer errors