### PR TITLE
Make (Log)NoisyExpectedImprovement create a correct fantasy model with non-default SingleTaskGP

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -601,7 +601,7 @@ class LogNoisyExpectedImprovement(AnalyticAcquisitionFunction):
 
     def __init__(
         self,
-        model: GPyTorchModel,
+        model: SingleTaskGP,
         X_observed: Tensor,
         num_fantasies: int = 20,
         maximize: bool = True,
@@ -651,6 +651,7 @@ class LogNoisyExpectedImprovement(AnalyticAcquisitionFunction):
         """
         # add batch dimension for broadcasting to fantasy models
         mean, sigma = self._mean_and_sigma(X.unsqueeze(-3))
+        print("Mean and sigma:", mean, sigma)
         u = _scaled_improvement(mean, sigma, self.best_f, self.maximize)
         log_ei = _log_ei_helper(u) + sigma.log()
         # this is mathematically - though not numerically - equivalent to log(mean(ei))
@@ -680,7 +681,7 @@ class NoisyExpectedImprovement(ExpectedImprovement):
 
     def __init__(
         self,
-        model: GPyTorchModel,
+        model: SingleTaskGP,
         X_observed: Tensor,
         num_fantasies: int = 20,
         maximize: bool = True,
@@ -1068,24 +1069,93 @@ def _get_noiseless_fantasy_model(
             "Only SingleTaskGP models with known observation noise "
             "are currently supported for fantasy-based NEI & LogNEI."
         )
+    
+    # # initialize a copy of SingleTaskGP on the original training inputs
+    # # this makes SingleTaskGP a non-batch GP, so that the same hyperparameters
+    # # are used across all batches (by default, a GP with batched training data
+    # # uses independent hyperparameters for each batch).
+    # fantasy_model = SingleTaskGP(
+    #     train_X=model.train_inputs[0],
+    #     train_Y=model.train_targets.unsqueeze(-1),
+    #     train_Yvar=model.likelihood.noise_covar.noise.unsqueeze(-1),
+    # )
+    # # update training inputs/targets to be batch mode fantasies
+    # fantasy_model.set_train_data(
+    #     inputs=batch_X_observed, targets=Y_fantasized, strict=False
+    # )
+    # # use noiseless fantasies
+    # fantasy_model.likelihood.noise_covar.noise = torch.full_like(Y_fantasized, 1e-7)
+    # # load hyperparameters from original model
+    # state_dict = deepcopy(model.state_dict())
+    # fantasy_model.load_state_dict(state_dict)
+    # return fantasy_model
+
+
+    # # initialize a copy of SingleTaskGP on the original training inputs
+    # # this makes SingleTaskGP a non-batch GP, so that the same hyperparameters
+    # # are used across all batches (by default, a GP with batched training data
+    # # uses independent hyperparameters for each batch).
+    # fantasy_model = deepcopy(model)
+    # # update training inputs/targets to be batch mode fantasies
+    # fantasy_model.set_train_data(
+    #     inputs=batch_X_observed, targets=Y_fantasized, strict=False
+    # )
+    # # use noiseless fantasies
+    # fantasy_model.likelihood.noise_covar.noise = torch.full_like(Y_fantasized, 1e-7)
+    # # load hyperparameters from original model
+    # state_dict = deepcopy(model.state_dict())
+    # fantasy_model.load_state_dict(state_dict)
+    # return fantasy_model
+
+
+
+
+    outcome_transform = deepcopy(getattr(model, "outcome_transform", None))
     # initialize a copy of SingleTaskGP on the original training inputs
     # this makes SingleTaskGP a non-batch GP, so that the same hyperparameters
     # are used across all batches (by default, a GP with batched training data
     # uses independent hyperparameters for each batch).
+    # print(model.train_inputs[0])
+    # exit()
+    # from botorch.models.transforms.outcome import Standardize
     fantasy_model = SingleTaskGP(
         train_X=model.train_inputs[0],
         train_Y=model.train_targets.unsqueeze(-1),
         train_Yvar=model.likelihood.noise_covar.noise.unsqueeze(-1),
+        covar_module=deepcopy(model.covar_module),
+        mean_module=deepcopy(model.mean_module),
+        outcome_transform=outcome_transform,
+        input_transform=deepcopy(getattr(model, "input_transform", None))
     )
+
+    if outcome_transform is not None:
+        outcome_transform.means = outcome_transform.means.expand(batch_X_observed.size(0), *outcome_transform.means.shape)
+        outcome_transform.stdvs = outcome_transform.stdvs.expand(batch_X_observed.size(0), *outcome_transform.stdvs.shape)
+        outcome_transform._stdvs_sq = outcome_transform._stdvs_sq.expand(batch_X_observed.size(0), *outcome_transform._stdvs_sq.shape)
+
+    Yvar = torch.full_like(Y_fantasized, 1e-7)
+    # Need to transform the outcome just as in the SingleTaskGP constructor.
+    if outcome_transform is not None:
+        # Need to unsqueeze for BoTorch and then squeeze again for GPyTorch
+        print("OLD Y_fantasized:", Y_fantasized)
+        Y_fantasized, Yvar = outcome_transform(Y_fantasized.unsqueeze(-1), Yvar.unsqueeze(-1))
+        Y_fantasized = Y_fantasized.squeeze(-1)
+        Yvar = Yvar.squeeze(-1)
+        print("NEW Y_fantasized:", Y_fantasized)
+
     # update training inputs/targets to be batch mode fantasies
     fantasy_model.set_train_data(
         inputs=batch_X_observed, targets=Y_fantasized, strict=False
     )
     # use noiseless fantasies
-    fantasy_model.likelihood.noise_covar.noise = torch.full_like(Y_fantasized, 1e-7)
-    # load hyperparameters from original model
-    state_dict = deepcopy(model.state_dict())
-    fantasy_model.load_state_dict(state_dict)
+    fantasy_model.likelihood.noise_covar.noise = Yvar
+
+    # This calls _set_transformed_inputs
+    # Need to do this AFTER setting all the data
+    # so that the right data is transformed
+    fantasy_model.eval()
+    
+
     return fantasy_model
 
 

--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -437,9 +437,7 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
         self.eval()  # make sure model is in eval mode
         # input transforms are applied at `posterior` in `eval` mode, and at
         # `model.forward()` at the training time
-        print("posterior: ORIGINAL INPUTS:", X)
         X = self.transform_inputs(X)
-        print("posterior: NEW INPUTS:", X)
         with gpt_posterior_settings():
             # insert a dimension for the output dimension
             if self._num_outputs > 1:

--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -437,7 +437,9 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
         self.eval()  # make sure model is in eval mode
         # input transforms are applied at `posterior` in `eval` mode, and at
         # `model.forward()` at the training time
+        print("posterior: ORIGINAL INPUTS:", X)
         X = self.transform_inputs(X)
+        print("posterior: NEW INPUTS:", X)
         with gpt_posterior_settings():
             # insert a dimension for the output dimension
             if self._num_outputs > 1:

--- a/test/acquisition/test_analytic.py
+++ b/test/acquisition/test_analytic.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 import math
 
 import torch
@@ -36,6 +37,7 @@ from botorch.posteriors import GPyTorchPosterior
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
 from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
+from botorch.models.transforms import Normalize, Standardize
 
 
 NEI_NOISE = [
@@ -807,7 +809,12 @@ class TestConstrainedExpectedImprovement(BotorchTestCase):
 
 
 class TestNoisyExpectedImprovement(BotorchTestCase):
-    def _get_model(self, dtype=torch.float):
+    def _get_model(self,
+                   dtype=torch.float,
+                   outcome_transform=None,
+                   input_transform=None,
+                   low_x=0.0,
+                   hi_x=1.0):
         state_dict = {
             "mean_module.raw_constant": torch.tensor([-0.0066]),
             "covar_module.raw_outputscale": torch.tensor(1.0143),
@@ -819,22 +826,44 @@ class TestNoisyExpectedImprovement(BotorchTestCase):
             "covar_module.outputscale_prior.concentration": torch.tensor(2.0),
             "covar_module.outputscale_prior.rate": torch.tensor(0.1500),
         }
-        train_x = torch.linspace(0, 1, 10, device=self.device, dtype=dtype).unsqueeze(
-            -1
-        )
+        train_x = torch.linspace(
+            low_x, hi_x, 10, device=self.device, dtype=dtype).unsqueeze(-1)
         train_y = torch.sin(train_x * (2 * math.pi))
         noise = torch.tensor(NEI_NOISE, device=self.device, dtype=dtype)
         train_y += noise
+        print("train_y ORIGINAL:", train_y)
         train_yvar = torch.full_like(train_y, 0.25**2)
-        model = SingleTaskGP(train_X=train_x, train_Y=train_y, train_Yvar=train_yvar)
-        model.load_state_dict(state_dict)
+        model = SingleTaskGP(train_X=train_x, train_Y=train_y, train_Yvar=train_yvar,
+                             outcome_transform=outcome_transform,
+                             input_transform=input_transform)
+        model.load_state_dict(state_dict, strict=False)
         model.to(train_x)
         model.eval()
+        print("DA model.train_inputs::::::", model.train_inputs)
         return model
 
     def test_noisy_expected_improvement(self):
-        for dtype in (torch.float, torch.double):
-            model = self._get_model(dtype=dtype)
+        for dtype, use_octf, use_intf, bounds in itertools.product(
+            (torch.float, torch.double),
+            (False, True),
+            (False, True),
+            (torch.tensor([[-5.05], [3.1]]), torch.tensor([[0.0], [1.0]]))
+        ):
+            octf = Standardize(m=1) if use_octf else None
+            intf = (
+                Normalize(d=1,
+                          bounds=bounds.to(device=self.device, dtype=dtype),
+                          transform_on_train=True)
+                if use_intf
+                else None
+            )
+            low_x = bounds[0].item() if use_intf else 0.0
+            hi_x = bounds[1].item() if use_intf else 1.0
+            model = self._get_model(dtype=dtype,
+                                    outcome_transform=octf,
+                                    input_transform=intf,
+                                    low_x=low_x,
+                                    hi_x=hi_x)
             X_observed = model.train_inputs[0]
             nfan = 5
             nEI = NoisyExpectedImprovement(model, X_observed, num_fantasies=nfan)
@@ -844,11 +873,23 @@ class TestNoisyExpectedImprovement(BotorchTestCase):
             self.assertTrue(hasattr(LogNEI, "best_f"))
             self.assertIsInstance(LogNEI.model, SingleTaskGP)
             self.assertIsInstance(LogNEI.model.likelihood, FixedNoiseGaussianLikelihood)
+            # Make sure _get_noiseless_fantasy_model gives them
+            # the same state_dict 
+            self.assertEqual(LogNEI.model.state_dict(), model.state_dict())
+            # if use_octf is not None:
+            #     means = LogNEI.model.train_targets.mean(dim=-1)
+            #     self.assertAllClose(torch.zeros_like(means),
+            #                         means)
+            #     stdevs = LogNEI.model.train_targets.std(dim=-1)
+            #     self.assertAllClose(stdevs,
+            #                         torch.ones_like(stdevs))
+            
             LogNEI.model = nEI.model  # let the two share their values and fantasies
             LogNEI.best_f = nEI.best_f
 
             X_test = torch.tensor(
-                [[[0.25]], [[0.75]]],
+                [[[0.25 * (hi_x - low_x) + low_x]],
+                 [[0.75 * (hi_x - low_x) + low_x]]],
                 device=X_observed.device,
                 dtype=dtype,
             )
@@ -872,7 +913,7 @@ class TestNoisyExpectedImprovement(BotorchTestCase):
             self.assertEqual(val.shape, torch.Size([2]))
             # test values
             self.assertGreater(val[0].item(), 8e-5)
-            self.assertLess(val[1].item(), 1e-6)
+            self.assertLess(val[1].item(), 1e-6, msg=f"{dtype=}, {use_octf=}, {use_intf=}, {bounds=}")
             # test gradient
             val.sum().backward()
             self.assertGreater(X_test.grad[0].abs().item(), 8e-6)
@@ -885,6 +926,9 @@ class TestNoisyExpectedImprovement(BotorchTestCase):
             self.assertAllClose(
                 X_test.grad[0], X_test_log.grad[0], atol=atol, rtol=rtol
             )
+
+            # if use_octf:
+            #     self.assertAllClose()
 
             # test inferred noise model
             other_model = SingleTaskGP(X_observed, model.train_targets.unsqueeze(-1))


### PR DESCRIPTION

## Motivation

In `botorch/acquisition/analytic.py`, the `LogNoisyExpectedImprovement` and `NoisyExpectedImprovement` use the function `_get_noiseless_fantasy_model` in order to repeatedly sample from fantasy model. But `_get_noiseless_fantasy_model` only works for default GP (i.e. with default Matern kernel) & also with no input or outcome transforms.
I think that it would make sense if this code were written to work with any kind of `SingleTaskGP`, not just the default one with no input and outcome transforms.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Since the code is now meant to work even if there are input or outcome transforms or different covar_module or mean_module, I updated the test code to try all these things, as well as try different input bounds to make sure the input transform is working correctly. However, the tests now fail, specifically when either the input data range is not [0,1], or when the kernel is the RBF kernel (not Matern). I believe that the tests failing when RBF is used is simply because certain constants were used in the code that are only valid for particular GP settings. However, I think that when the code fails due to input range not being [0,1], this might be a slight problem with the code -- or might not -- I'm not completely sure.

I also added a line that makes sure that the state_dict() is the same between the original model and fantasy model.

## Related PRs

I put this in an issue #2412 and was told that it is OK if not all the tests pass.
