### PR TITLE
`NumericsWarning` for Legacy EI

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -24,6 +24,7 @@ import torch
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.exceptions import UnsupportedError
+from botorch.exceptions.warnings import legacy_ei_numerics_warning
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model import Model
@@ -311,9 +312,9 @@ class ExpectedImprovement(AnalyticAcquisitionFunction):
         >>> EI = ExpectedImprovement(model, best_f=0.2)
         >>> ei = EI(test_X)
 
-    NOTE: It is *strongly* recommended to use LogExpectedImprovement instead of regular
-    EI, because it solves the vanishing gradient problem by taking special care of
-    numerical computations and can lead to substantially improved BO performance.
+    NOTE: It is strongly recommended to use LogExpectedImprovement instead of regular
+    EI, as it can lead to substantially improved BO performance through improved
+    numerics. See https://arxiv.org/abs/2310.20708 for details.
     """
 
     def __init__(
@@ -334,6 +335,7 @@ class ExpectedImprovement(AnalyticAcquisitionFunction):
                 single-output posterior is required.
             maximize: If True, consider the problem a maximization problem.
         """
+        legacy_ei_numerics_warning(legacy_name=type(self).__name__)
         super().__init__(model=model, posterior_transform=posterior_transform)
         self.register_buffer("best_f", torch.as_tensor(best_f))
         self.maximize = maximize
@@ -358,7 +360,7 @@ class ExpectedImprovement(AnalyticAcquisitionFunction):
 
 
 class LogExpectedImprovement(AnalyticAcquisitionFunction):
-    r"""Logarithm of single-outcome Expected Improvement (analytic).
+    r"""Single-outcome Log Expected Improvement (analytic).
 
     Computes the logarithm of the classic Expected Improvement acquisition function, in
     a numerically robust manner. In particular, the implementation takes special care
@@ -520,6 +522,10 @@ class ConstrainedExpectedImprovement(AnalyticAcquisitionFunction):
         >>> constraints = {0: (0.0, None)}
         >>> cEI = ConstrainedExpectedImprovement(model, 0.2, 1, constraints)
         >>> cei = cEI(test_X)
+
+    NOTE: It is strongly recommended to use LogConstrainedExpectedImprovement instead
+    of regular CEI, as it can lead to substantially improved BO performance through
+    improved numerics. See https://arxiv.org/abs/2310.20708 for details.
     """
 
     def __init__(
@@ -542,6 +548,7 @@ class ConstrainedExpectedImprovement(AnalyticAcquisitionFunction):
                 bounds on that output (resp. interpreted as -Inf / Inf if None)
             maximize: If True, consider the problem a maximization problem.
         """
+        legacy_ei_numerics_warning(legacy_name=type(self).__name__)
         # Use AcquisitionFunction constructor to avoid check for posterior transform.
         super(AnalyticAcquisitionFunction, self).__init__(model=model)
         self.posterior_transform = None
@@ -676,6 +683,10 @@ class NoisyExpectedImprovement(ExpectedImprovement):
         >>> model = SingleTaskGP(train_X, train_Y, train_Yvar=train_Yvar)
         >>> NEI = NoisyExpectedImprovement(model, train_X)
         >>> nei = NEI(test_X)
+
+    NOTE: It is strongly recommended to use LogNoisyExpectedImprovement instead
+    of regular NEI, as it can lead to substantially improved BO performance through
+    improved numerics. See https://arxiv.org/abs/2310.20708 for details.
     """
 
     def __init__(
@@ -696,6 +707,7 @@ class NoisyExpectedImprovement(ExpectedImprovement):
                 complexity and performance).
             maximize: If True, consider the problem a maximization problem.
         """
+        legacy_ei_numerics_warning(legacy_name=type(self).__name__)
         # sample fantasies
         from botorch.sampling.normal import SobolQMCNormalSampler
 

--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -43,6 +43,7 @@ from botorch.acquisition.utils import (
     repeat_to_match_aug_dim,
 )
 from botorch.exceptions.errors import UnsupportedError
+from botorch.exceptions.warnings import legacy_ei_numerics_warning
 from botorch.models.model import Model
 from botorch.sampling.base import MCSampler
 from botorch.utils.objective import compute_smoothed_feasibility_indicator
@@ -348,6 +349,10 @@ class qExpectedImprovement(SampleReducingMCAcquisitionFunction):
         >>> sampler = SobolQMCNormalSampler(1024)
         >>> qEI = qExpectedImprovement(model, best_f, sampler)
         >>> qei = qEI(test_X)
+
+    NOTE: It is strongly recommended to use qLogExpectedImprovement instead
+    of regular qEI, as it can lead to substantially improved BO performance through
+    improved numerics. See https://arxiv.org/abs/2310.20708 for details.
     """
 
     def __init__(
@@ -387,6 +392,7 @@ class qExpectedImprovement(SampleReducingMCAcquisitionFunction):
                 approximation to the constraint indicators. For more details, on this
                 parameter, see the docs of `compute_smoothed_feasibility_indicator`.
         """
+        legacy_ei_numerics_warning(legacy_name=type(self).__name__)
         super().__init__(
             model=model,
             sampler=sampler,
@@ -428,6 +434,10 @@ class qNoisyExpectedImprovement(
         >>> sampler = SobolQMCNormalSampler(1024)
         >>> qNEI = qNoisyExpectedImprovement(model, train_X, sampler)
         >>> qnei = qNEI(test_X)
+
+    NOTE: It is strongly recommended to use qLogNoisyExpectedImprovement instead
+    of regular qNEI, as it can lead to substantially improved BO performance through
+    improved numerics. See https://arxiv.org/abs/2310.20708 for details.
     """
 
     def __init__(
@@ -484,6 +494,7 @@ class qNoisyExpectedImprovement(
         the incremental qNEI from the new point. This would greatly increase
         efficiency for large batches.
         """
+        legacy_ei_numerics_warning(legacy_name=type(self).__name__)
         super().__init__(
             model=model,
             sampler=sampler,

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -36,6 +36,7 @@ from botorch.acquisition.multi_objective.objective import (
     MCMultiOutputObjective,
 )
 from botorch.exceptions.errors import UnsupportedError
+from botorch.exceptions.warnings import legacy_ei_numerics_warning
 from botorch.models.model import Model
 from botorch.models.transforms.input import InputPerturbation
 from botorch.sampling.base import MCSampler
@@ -199,6 +200,7 @@ class qExpectedHypervolumeImprovement(
             fat: A Boolean flag indicating whether to use the heavy-tailed approximation
                 of the constraint indicator.
         """
+        legacy_ei_numerics_warning(legacy_name=type(self).__name__)
         if len(ref_point) != partitioning.num_outcomes:
             raise ValueError(
                 "The length of the reference point must match the number of outcomes. "
@@ -408,6 +410,7 @@ class qNoisyExpectedHypervolumeImprovement(
             marginalize_dim: A batch dimension that should be marginalized. For example,
                 this is useful when using a batched fully Bayesian model.
         """
+        legacy_ei_numerics_warning(legacy_name=type(self).__name__)
         MultiObjectiveMCAcquisitionFunction.__init__(
             self,
             model=model,

--- a/botorch/exceptions/warnings.py
+++ b/botorch/exceptions/warnings.py
@@ -7,6 +7,7 @@
 r"""
 Botorch Warnings.
 """
+import warnings
 
 
 class BotorchWarning(Warning):
@@ -34,7 +35,7 @@ class CostAwareWarning(BotorchWarning):
 
 
 class OptimizationWarning(BotorchWarning):
-    r"""Optimization-releated warnings."""
+    r"""Optimization-related warnings."""
 
     pass
 
@@ -55,6 +56,47 @@ class UserInputWarning(BotorchWarning):
     r"""Warning raised when a potential issue is detected with user provided inputs."""
 
     pass
+
+
+class NumericsWarning(BotorchWarning):
+    r"""Warning raised when numerical issues are detected."""
+
+    pass
+
+
+def legacy_ei_numerics_warning(legacy_name: str) -> None:
+    """Raises a warning for legacy EI acquisition functions that are known to have
+    numerical issues and should be replaced with the LogEI version for virtually all
+    use-cases except for explicit benchmarking of the numerical issues of legacy EI.
+
+    Args:
+        legacy_name: The name of the legacy EI acquisition function.
+        logei_name: The name of the associated LogEI acquisition function.
+    """
+    legacy_to_logei = {
+        "ExpectedImprovement": "LogExpectedImprovement",
+        "ConstrainedExpectedImprovement": "LogConstrainedExpectedImprovement",
+        "NoisyExpectedImprovement": "LogNoisyExpectedImprovement",
+        "qExpectedImprovement": "qLogExpectedImprovement",
+        "qNoisyExpectedImprovement": "qLogNoisyExpectedImprovement",
+        "qExpectedHypervolumeImprovement": "qLogExpectedHypervolumeImprovement",
+        "qNoisyExpectedHypervolumeImprovement": (
+            "qLogNoisyExpectedHypervolumeImprovement"
+        ),
+    }
+    # Only raise the warning if the legacy name is in the mapping. It can fail to be in
+    # the mapping if the legacy acquisition function derives from a legacy EI class,
+    # e.g. MOMF, which derives from qEHVI, but there is not corresponding LogMOMF yet.
+    if legacy_name in legacy_to_logei:
+        logei_name = legacy_to_logei[legacy_name]
+        msg = (
+            f"{legacy_name} has known numerical issues that lead to suboptimal "
+            "optimization performance. It is strongly recommended to simply replace"
+            f"\n\n\t {legacy_name} \t --> \t {logei_name} \n\n"
+            "instead, which fixes the issues and has the same "
+            "API. See https://arxiv.org/abs/2310.20708 for details."
+        )
+        warnings.warn(msg, NumericsWarning, stacklevel=2)
 
 
 def _get_single_precision_warning(dtype_str: str) -> str:

--- a/test/acquisition/test_analytic.py
+++ b/test/acquisition/test_analytic.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+from warnings import catch_warnings, simplefilter
 
 import torch
 from botorch.acquisition import qAnalyticProbabilityOfImprovement
@@ -31,6 +32,7 @@ from botorch.acquisition.objective import (
     ScalarizedPosteriorTransform,
 )
 from botorch.exceptions import UnsupportedError
+from botorch.exceptions.warnings import NumericsWarning
 from botorch.models import SingleTaskGP
 from botorch.posteriors import GPyTorchPosterior
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
@@ -70,180 +72,185 @@ class TestAnalyticAcquisitionFunction(BotorchTestCase):
 
 
 class TestExpectedImprovement(BotorchTestCase):
+
     def test_expected_improvement(self):
+        mean = torch.tensor([[-0.5]], device=self.device)
+        variance = torch.ones(1, 1, device=self.device)
+        model = MockModel(MockPosterior(mean=mean, variance=variance))
+        with self.assertWarnsRegex(NumericsWarning, ".* LogExpectedImprovement .*"):
+            ExpectedImprovement(model=model, best_f=0.0)
+
         for dtype in (torch.float, torch.double):
-            mean = torch.tensor([[-0.5]], device=self.device, dtype=dtype)
-            variance = torch.ones(1, 1, device=self.device, dtype=dtype)
-            mm = MockModel(MockPosterior(mean=mean, variance=variance))
+            with catch_warnings():
+                simplefilter("ignore", category=NumericsWarning)
+                self._test_expected_improvement(dtype=dtype)
 
-            # basic test
-            module = ExpectedImprovement(model=mm, best_f=0.0)
-            log_module = LogExpectedImprovement(model=mm, best_f=0.0)
-            X = torch.empty(1, 1, device=self.device, dtype=dtype)  # dummy
-            ei, log_ei = module(X), log_module(X)
-            ei_expected = torch.tensor(0.19780, device=self.device, dtype=dtype)
-            self.assertAllClose(ei, ei_expected, atol=1e-4)
-            self.assertAllClose(log_ei, ei_expected.log(), atol=1e-4)
-
-            # test maximize
-            module = ExpectedImprovement(model=mm, best_f=0.0, maximize=False)
-            log_module = LogExpectedImprovement(model=mm, best_f=0.0, maximize=False)
-            X = torch.empty(1, 1, device=self.device, dtype=dtype)  # dummy
-            ei, log_ei = module(X), log_module(X)
-            ei_expected = torch.tensor(0.6978, device=self.device, dtype=dtype)
-            self.assertAllClose(ei, ei_expected, atol=1e-4)
-            self.assertAllClose(log_ei, ei_expected.log(), atol=1e-4)
-            with self.assertRaises(UnsupportedError):
-                module.set_X_pending(None)
-            with self.assertRaises(UnsupportedError):
-                log_module.set_X_pending(None)
-            # test posterior transform (single-output)
-            mean = torch.tensor([0.5], device=self.device, dtype=dtype)
-            covar = torch.tensor([[0.16]], device=self.device, dtype=dtype)
-            mvn = MultivariateNormal(mean, covar)
-            p = GPyTorchPosterior(mvn)
-            mm = MockModel(p)
-            weights = torch.tensor([0.5], device=self.device, dtype=dtype)
-            transform = ScalarizedPosteriorTransform(weights)
-            ei = ExpectedImprovement(
-                model=mm, best_f=0.0, posterior_transform=transform
-            )
-            log_ei = LogExpectedImprovement(
-                model=mm, best_f=0.0, posterior_transform=transform
-            )
-            X = torch.rand(1, 2, device=self.device, dtype=dtype)
-            ei_expected = torch.tensor(0.2601, device=self.device, dtype=dtype)
-            self.assertAllClose(ei(X), ei_expected, atol=1e-4)
-            self.assertAllClose(log_ei(X), ei_expected.log(), atol=1e-4)
-
-            # test posterior transform (multi-output)
-            mean = torch.tensor([[-0.25, 0.5]], device=self.device, dtype=dtype)
-            covar = torch.tensor(
-                [[[0.5, 0.125], [0.125, 0.5]]], device=self.device, dtype=dtype
-            )
-            mvn = MultitaskMultivariateNormal(mean, covar)
-            p = GPyTorchPosterior(mvn)
-            mm = MockModel(p)
-            weights = torch.tensor([2.0, 1.0], device=self.device, dtype=dtype)
-            transform = ScalarizedPosteriorTransform(weights)
-            ei = ExpectedImprovement(
-                model=mm, best_f=0.0, posterior_transform=transform
-            )
-            log_ei = LogExpectedImprovement(
-                model=mm, best_f=0.0, posterior_transform=transform
-            )
-            X = torch.rand(1, 2, device=self.device, dtype=dtype)
-            ei_expected = torch.tensor([0.6910], device=self.device, dtype=dtype)
-            self.assertAllClose(ei(X), ei_expected, atol=1e-4)
-            self.assertAllClose(log_ei(X), ei_expected.log(), atol=1e-4)
-
-            # making sure we compare the lower branch of _log_ei_helper to _ei_helper
-            z = torch.tensor(-2.13, dtype=dtype, device=self.device)
-            self.assertAllClose(_log_ei_helper(z), _ei_helper(z).log(), atol=1e-6)
-
-            # numerical stress test for log EI
-            digits = 100 if dtype == torch.float64 else 20
-            zero = torch.tensor([0], dtype=dtype, device=self.device)
-            ten = torch.tensor(10, dtype=dtype, device=self.device)
-            digits_tensor = torch.arange(0, digits, dtype=dtype, device=self.device)
-            large_z = ten ** (digits_tensor)
-            small_z = ten ** (-digits_tensor)
-            # flipping the appropriate tensors so that elements are in increasing order
-            test_z = [-large_z.flip(-1), -small_z, zero, small_z.flip(-1), large_z]
-            for z in test_z:
-                z.requires_grad = True
-                y = _log_ei_helper(z)  # noqa
-                # check that y isn't NaN of Inf
-                self.assertFalse(y.isnan().any())
-                self.assertFalse(y.isinf().any())
-                # function values should increase with z
-                self.assertTrue((y.diff() >= 0).all())
-                # lets check the backward pass
-                y.sum().backward()
-                # check that gradients aren't NaN of Inf
-                g = z.grad
-                self.assertFalse(g.isnan().any())
-                self.assertFalse(g.isinf().any())
-                self.assertTrue((g >= 0).all())  # gradient is positive for all z
-
+        z = torch.tensor(-2.13, dtype=torch.float16, device=self.device)
         with self.assertRaises(TypeError):
-            _log_ei_helper(z.to(dtype=torch.float16))
+            _log_ei_helper(z)
+
+    def _test_expected_improvement(self, dtype: torch.dtype) -> None:
+        mean = torch.tensor([[-0.5]], device=self.device, dtype=dtype)
+        variance = torch.ones(1, 1, device=self.device, dtype=dtype)
+        mm = MockModel(MockPosterior(mean=mean, variance=variance))
+
+        # basic test
+        module = ExpectedImprovement(model=mm, best_f=0.0)
+        log_module = LogExpectedImprovement(model=mm, best_f=0.0)
+        X = torch.empty(1, 1, device=self.device, dtype=dtype)  # dummy
+        ei, log_ei = module(X), log_module(X)
+        ei_expected = torch.tensor(0.19780, device=self.device, dtype=dtype)
+        self.assertAllClose(ei, ei_expected, atol=1e-4)
+        self.assertAllClose(log_ei, ei_expected.log(), atol=1e-4)
+
+        # test maximize
+        module = ExpectedImprovement(model=mm, best_f=0.0, maximize=False)
+        log_module = LogExpectedImprovement(model=mm, best_f=0.0, maximize=False)
+        X = torch.empty(1, 1, device=self.device, dtype=dtype)  # dummy
+        ei, log_ei = module(X), log_module(X)
+        ei_expected = torch.tensor(0.6978, device=self.device, dtype=dtype)
+        self.assertAllClose(ei, ei_expected, atol=1e-4)
+        self.assertAllClose(log_ei, ei_expected.log(), atol=1e-4)
+        with self.assertRaises(UnsupportedError):
+            module.set_X_pending(None)
+        with self.assertRaises(UnsupportedError):
+            log_module.set_X_pending(None)
+        # test posterior transform (single-output)
+        mean = torch.tensor([0.5], device=self.device, dtype=dtype)
+        covar = torch.tensor([[0.16]], device=self.device, dtype=dtype)
+        mvn = MultivariateNormal(mean, covar)
+        p = GPyTorchPosterior(mvn)
+        mm = MockModel(p)
+        weights = torch.tensor([0.5], device=self.device, dtype=dtype)
+        transform = ScalarizedPosteriorTransform(weights)
+        ei = ExpectedImprovement(model=mm, best_f=0.0, posterior_transform=transform)
+        log_ei = LogExpectedImprovement(
+            model=mm, best_f=0.0, posterior_transform=transform
+        )
+        X = torch.rand(1, 2, device=self.device, dtype=dtype)
+        ei_expected = torch.tensor(0.2601, device=self.device, dtype=dtype)
+        self.assertAllClose(ei(X), ei_expected, atol=1e-4)
+        self.assertAllClose(log_ei(X), ei_expected.log(), atol=1e-4)
+
+        # test posterior transform (multi-output)
+        mean = torch.tensor([[-0.25, 0.5]], device=self.device, dtype=dtype)
+        covar = torch.tensor(
+            [[[0.5, 0.125], [0.125, 0.5]]], device=self.device, dtype=dtype
+        )
+        mvn = MultitaskMultivariateNormal(mean, covar)
+        p = GPyTorchPosterior(mvn)
+        mm = MockModel(p)
+        weights = torch.tensor([2.0, 1.0], device=self.device, dtype=dtype)
+        transform = ScalarizedPosteriorTransform(weights)
+        ei = ExpectedImprovement(model=mm, best_f=0.0, posterior_transform=transform)
+        log_ei = LogExpectedImprovement(
+            model=mm, best_f=0.0, posterior_transform=transform
+        )
+        X = torch.rand(1, 2, device=self.device, dtype=dtype)
+        ei_expected = torch.tensor([0.6910], device=self.device, dtype=dtype)
+        self.assertAllClose(ei(X), ei_expected, atol=1e-4)
+        self.assertAllClose(log_ei(X), ei_expected.log(), atol=1e-4)
+
+        # making sure we compare the lower branch of _log_ei_helper to _ei_helper
+        z = torch.tensor(-2.13, dtype=dtype, device=self.device)
+        self.assertAllClose(_log_ei_helper(z), _ei_helper(z).log(), atol=1e-6)
+
+        # numerical stress test for log EI
+        digits = 100 if dtype == torch.float64 else 20
+        zero = torch.tensor([0], dtype=dtype, device=self.device)
+        ten = torch.tensor(10, dtype=dtype, device=self.device)
+        digits_tensor = torch.arange(0, digits, dtype=dtype, device=self.device)
+        large_z = ten ** (digits_tensor)
+        small_z = ten ** (-digits_tensor)
+        # flipping the appropriate tensors so that elements are in increasing order
+        test_z = [-large_z.flip(-1), -small_z, zero, small_z.flip(-1), large_z]
+        for z in test_z:
+            z.requires_grad = True
+            y = _log_ei_helper(z)  # noqa
+            # check that y isn't NaN of Inf
+            self.assertFalse(y.isnan().any())
+            self.assertFalse(y.isinf().any())
+            # function values should increase with z
+            self.assertTrue((y.diff() >= 0).all())
+            # lets check the backward pass
+            y.sum().backward()
+            # check that gradients aren't NaN of Inf
+            g = z.grad
+            self.assertFalse(g.isnan().any())
+            self.assertFalse(g.isinf().any())
+            self.assertTrue((g >= 0).all())  # gradient is positive for all z
 
     def test_expected_improvement_batch(self):
         for dtype in (torch.float, torch.double):
-            mean = torch.tensor([-0.5, 0.0, 0.5], device=self.device, dtype=dtype).view(
-                3, 1, 1
-            )
-            variance = torch.ones(3, 1, 1, device=self.device, dtype=dtype)
-            mm = MockModel(MockPosterior(mean=mean, variance=variance))
-            module = ExpectedImprovement(model=mm, best_f=0.0)
-            log_module = LogExpectedImprovement(model=mm, best_f=0.0)
-            X = torch.empty(3, 1, 1, device=self.device, dtype=dtype)  # dummy
-            ei, log_ei = module(X), log_module(X)
-            ei_expected = torch.tensor(
-                [0.19780, 0.39894, 0.69780], device=self.device, dtype=dtype
-            )
-            self.assertAllClose(ei, ei_expected, atol=1e-4)
-            self.assertAllClose(log_ei, ei_expected.log(), atol=1e-4)
-            # check for proper error if multi-output model
-            mean2 = torch.rand(3, 1, 2, device=self.device, dtype=dtype)
-            variance2 = torch.rand(3, 1, 2, device=self.device, dtype=dtype)
-            mm2 = MockModel(MockPosterior(mean=mean2, variance=variance2))
-            with self.assertRaises(UnsupportedError):
-                ExpectedImprovement(model=mm2, best_f=0.0)
-            with self.assertRaises(UnsupportedError):
-                LogExpectedImprovement(model=mm2, best_f=0.0)
-            # test posterior transform (single-output)
-            mean = torch.tensor([[[0.5]], [[0.25]]], device=self.device, dtype=dtype)
-            covar = torch.tensor(
-                [[[[0.16]]], [[[0.125]]]], device=self.device, dtype=dtype
-            )
-            mvn = MultivariateNormal(mean, covar)
-            p = GPyTorchPosterior(mvn)
-            mm = MockModel(p)
-            weights = torch.tensor([0.5], device=self.device, dtype=dtype)
-            transform = ScalarizedPosteriorTransform(weights)
-            ei = ExpectedImprovement(
-                model=mm, best_f=0.0, posterior_transform=transform
-            )
-            log_ei = LogExpectedImprovement(
-                model=mm, best_f=0.0, posterior_transform=transform
-            )
-            X = torch.rand(2, 1, 2, device=self.device, dtype=dtype)
-            ei_expected = torch.tensor(
-                [[0.2601], [0.1500]], device=self.device, dtype=dtype
-            )
-            self.assertAllClose(ei(X), ei_expected, atol=1e-4)
-            self.assertAllClose(log_ei(X), ei(X).log(), atol=1e-4)
+            with catch_warnings():
+                simplefilter("ignore", category=NumericsWarning)
+                self._test_expected_improvement_batch(dtype=dtype)
 
-            # test posterior transform (multi-output)
-            mean = torch.tensor(
-                [[[-0.25, 0.5]], [[0.2, -0.1]]], device=self.device, dtype=dtype
-            )
-            covar = torch.tensor(
-                [[[0.5, 0.125], [0.125, 0.5]], [[0.25, -0.1], [-0.1, 0.25]]],
-                device=self.device,
-                dtype=dtype,
-            )
-            mvn = MultitaskMultivariateNormal(mean, covar)
-            p = GPyTorchPosterior(mvn)
-            mm = MockModel(p)
-            weights = torch.tensor([2.0, 1.0], device=self.device, dtype=dtype)
-            transform = ScalarizedPosteriorTransform(weights)
-            ei = ExpectedImprovement(
-                model=mm, best_f=0.0, posterior_transform=transform
-            )
-            log_ei = LogExpectedImprovement(
-                model=mm, best_f=0.0, posterior_transform=transform
-            )
-            X = torch.rand(2, 1, 2, device=self.device, dtype=dtype)
-            ei_expected = torch.tensor(
-                [0.6910, 0.5371], device=self.device, dtype=dtype
-            )
-            self.assertAllClose(ei(X), ei_expected, atol=1e-4)
-            self.assertAllClose(log_ei(X), ei_expected.log(), atol=1e-4)
+    def _test_expected_improvement_batch(self, dtype):
+        mean = torch.tensor([-0.5, 0.0, 0.5], device=self.device, dtype=dtype).view(
+            3, 1, 1
+        )
+        variance = torch.ones(3, 1, 1, device=self.device, dtype=dtype)
+        mm = MockModel(MockPosterior(mean=mean, variance=variance))
+        module = ExpectedImprovement(model=mm, best_f=0.0)
+        log_module = LogExpectedImprovement(model=mm, best_f=0.0)
+        X = torch.empty(3, 1, 1, device=self.device, dtype=dtype)  # dummy
+        ei, log_ei = module(X), log_module(X)
+        ei_expected = torch.tensor(
+            [0.19780, 0.39894, 0.69780], device=self.device, dtype=dtype
+        )
+        self.assertAllClose(ei, ei_expected, atol=1e-4)
+        self.assertAllClose(log_ei, ei_expected.log(), atol=1e-4)
+        # check for proper error if multi-output model
+        mean2 = torch.rand(3, 1, 2, device=self.device, dtype=dtype)
+        variance2 = torch.rand(3, 1, 2, device=self.device, dtype=dtype)
+        mm2 = MockModel(MockPosterior(mean=mean2, variance=variance2))
+        with self.assertRaises(UnsupportedError):
+            ExpectedImprovement(model=mm2, best_f=0.0)
+        with self.assertRaises(UnsupportedError):
+            LogExpectedImprovement(model=mm2, best_f=0.0)
+        # test posterior transform (single-output)
+        mean = torch.tensor([[[0.5]], [[0.25]]], device=self.device, dtype=dtype)
+        covar = torch.tensor([[[[0.16]]], [[[0.125]]]], device=self.device, dtype=dtype)
+        mvn = MultivariateNormal(mean, covar)
+        p = GPyTorchPosterior(mvn)
+        mm = MockModel(p)
+        weights = torch.tensor([0.5], device=self.device, dtype=dtype)
+        transform = ScalarizedPosteriorTransform(weights)
+        ei = ExpectedImprovement(model=mm, best_f=0.0, posterior_transform=transform)
+        log_ei = LogExpectedImprovement(
+            model=mm, best_f=0.0, posterior_transform=transform
+        )
+        X = torch.rand(2, 1, 2, device=self.device, dtype=dtype)
+        ei_expected = torch.tensor(
+            [[0.2601], [0.1500]], device=self.device, dtype=dtype
+        )
+        self.assertAllClose(ei(X), ei_expected, atol=1e-4)
+        self.assertAllClose(log_ei(X), ei(X).log(), atol=1e-4)
 
-        # test bad posterior transform class
+        # test posterior transform (multi-output)
+        mean = torch.tensor(
+            [[[-0.25, 0.5]], [[0.2, -0.1]]], device=self.device, dtype=dtype
+        )
+        covar = torch.tensor(
+            [[[0.5, 0.125], [0.125, 0.5]], [[0.25, -0.1], [-0.1, 0.25]]],
+            device=self.device,
+            dtype=dtype,
+        )
+        mvn = MultitaskMultivariateNormal(mean, covar)
+        p = GPyTorchPosterior(mvn)
+        mm = MockModel(p)
+        weights = torch.tensor([2.0, 1.0], device=self.device, dtype=dtype)
+        transform = ScalarizedPosteriorTransform(weights)
+        ei = ExpectedImprovement(model=mm, best_f=0.0, posterior_transform=transform)
+        log_ei = LogExpectedImprovement(
+            model=mm, best_f=0.0, posterior_transform=transform
+        )
+        X = torch.rand(2, 1, 2, device=self.device, dtype=dtype)
+        ei_expected = torch.tensor([0.6910, 0.5371], device=self.device, dtype=dtype)
+        self.assertAllClose(ei(X), ei_expected, atol=1e-4)
+        self.assertAllClose(log_ei(X), ei_expected.log(), atol=1e-4)
+
         with self.assertRaises(UnsupportedError):
             ExpectedImprovement(
                 model=mm, best_f=0.0, posterior_transform=IdentityMCObjective()
@@ -599,211 +606,228 @@ class TestUpperConfidenceBound(BotorchTestCase):
 
 class TestConstrainedExpectedImprovement(BotorchTestCase):
     def test_constrained_expected_improvement(self):
-        for dtype in (torch.float, torch.double):
-            # one constraint
-            mean = torch.tensor(
-                [[-0.5, 0.0]], device=self.device, dtype=dtype
-            ).unsqueeze(dim=-2)
-            variance = torch.ones(1, 2, device=self.device, dtype=dtype).unsqueeze(
-                dim=-2
-            )
-            mm = MockModel(MockPosterior(mean=mean, variance=variance))
-            kwargs = {
-                "model": mm,
-                "best_f": 0.0,
-                "objective_index": 0,
-                "constraints": {1: [None, 0]},
-            }
-            module = ConstrainedExpectedImprovement(**kwargs)
-            log_module = LogConstrainedExpectedImprovement(**kwargs)
-
-            # test initialization
-            for k in [
-                "con_lower_inds",
-                "con_upper_inds",
-                "con_both_inds",
-                "con_both",
-                "con_lower",
-                "con_upper",
-            ]:
-                self.assertIn(k, module._buffers)
-                self.assertIn(k, log_module._buffers)
-
-            X = torch.empty(1, 1, device=self.device, dtype=dtype)  # dummy
-            ei = module(X)
-            ei_expected_unconstrained = torch.tensor(
-                [0.19780], device=self.device, dtype=dtype
-            )
-            ei_expected = ei_expected_unconstrained * 0.5
-            self.assertAllClose(ei, ei_expected, atol=1e-4)
-            log_ei = log_module(X)
-            self.assertAllClose(log_ei, ei.log(), atol=1e-5)
-            # testing LogCEI and CEI for lower, upper, and simultaneous bounds
-            for bounds in [[None, 0], [0, None], [0, 1]]:
-                kwargs["constraints"] = {1: bounds}
-                module = ConstrainedExpectedImprovement(**kwargs)
-                log_module = LogConstrainedExpectedImprovement(**kwargs)
-                ei, log_ei = module(X), log_module(X)
-                self.assertAllClose(log_ei, ei.log(), atol=1e-5)
-
-            constructors = [
-                ConstrainedExpectedImprovement,
-                LogConstrainedExpectedImprovement,
-            ]
-            for constructor in constructors:
-                # check that error raised if no constraints
-                with self.assertRaises(ValueError):
-                    module = constructor(
-                        model=mm, best_f=0.0, objective_index=0, constraints={}
-                    )
-
-                # check that error raised if objective is a constraint
-                with self.assertRaises(ValueError):
-                    module = constructor(
-                        model=mm,
-                        best_f=0.0,
-                        objective_index=0,
-                        constraints={0: [None, 0]},
-                    )
-
-                # check that error raised if constraint lower > upper
-                with self.assertRaises(ValueError):
-                    module = constructor(
-                        model=mm, best_f=0.0, objective_index=0, constraints={0: [1, 0]}
-                    )
-
-            # three constraints
-            N = torch.distributions.Normal(loc=0.0, scale=1.0)
-            a = N.icdf(torch.tensor(0.75))  # get a so that P(-a <= N <= a) = 0.5
-            mean = torch.tensor(
-                [[-0.5, 0.0, 5.0, 0.0]], device=self.device, dtype=dtype
-            ).unsqueeze(dim=-2)
-            variance = torch.ones(1, 4, device=self.device, dtype=dtype).unsqueeze(
-                dim=-2
-            )
-            mm = MockModel(MockPosterior(mean=mean, variance=variance))
-            kwargs = {
-                "model": mm,
-                "best_f": 0.0,
-                "objective_index": 0,
-                "constraints": {1: [None, 0], 2: [5.0, None], 3: [-a, a]},
-            }
-            module = ConstrainedExpectedImprovement(**kwargs)
-            log_module = LogConstrainedExpectedImprovement(**kwargs)
-            X = torch.empty(1, 1, device=self.device, dtype=dtype)  # dummy
-            ei = module(X)
-            ei_expected_unconstrained = torch.tensor(
-                [0.19780], device=self.device, dtype=dtype
-            )
-            ei_expected = ei_expected_unconstrained * 0.5 * 0.5 * 0.5
-            self.assertAllClose(ei, ei_expected, atol=1e-4)
-            # testing log module with regular implementation
-            log_ei = log_module(X)
-            self.assertAllClose(log_ei, ei_expected.log(), atol=1e-4)
-            # test maximize
-            kwargs = {
-                "model": mm,
-                "best_f": 0.0,
-                "objective_index": 0,
-                "constraints": {1: [None, 0]},
-                "maximize": False,
-            }
-            module_min = ConstrainedExpectedImprovement(**kwargs)
-            log_module_min = LogConstrainedExpectedImprovement(**kwargs)
-            ei_min = module_min(X)
-            ei_expected_unconstrained_min = torch.tensor(
-                [0.6978], device=self.device, dtype=dtype
-            )
-            ei_expected_min = ei_expected_unconstrained_min * 0.5
-            self.assertAllClose(ei_min, ei_expected_min, atol=1e-4)
-            log_ei_min = log_module_min(X)
-            self.assertAllClose(log_ei_min, ei_min.log(), atol=1e-4)
-
-            # test invalid onstraints
-            for constructor in constructors:
-                with self.assertRaises(ValueError):
-                    constructor(
-                        model=mm,
-                        best_f=0.0,
-                        objective_index=0,
-                        constraints={1: [1.0, -1.0]},
-                    )
-
-            # numerical stress test for _compute_log_prob_feas, which gets added to
-            # log_ei in the forward pass, a quantity we already tested above
-            # the limits here are determined by the largest power of ten x, such that
-            #                          x - (b - a) < x
-            # evaluates to true. In this test, the bounds are a, b = -digits, digits.
-            digits = 10 if dtype == torch.float64 else 5
-            zero = torch.tensor([0], dtype=dtype, device=self.device)
-            ten = torch.tensor(10, dtype=dtype, device=self.device)
-            digits_tensor = 1 + torch.arange(
-                -digits, digits, dtype=dtype, device=self.device
-            )
-            X_positive = ten ** (digits_tensor)
-            # flipping -X_positive so that elements are in increasing order
-            means = torch.cat((-X_positive.flip(-1), zero, X_positive)).unsqueeze(-1)
-            means.requires_grad = True
-            log_module = LogConstrainedExpectedImprovement(
-                model=mm,
+        mean = torch.tensor([[-0.5]], device=self.device)
+        variance = torch.ones(1, 1, device=self.device)
+        model = MockModel(MockPosterior(mean=mean, variance=variance))
+        with self.assertWarnsRegex(
+            NumericsWarning, ".* LogConstrainedExpectedImprovement .*"
+        ):
+            ConstrainedExpectedImprovement(
+                model=model,
                 best_f=0.0,
-                objective_index=1,
-                constraints={0: [-5, 5]},
+                objective_index=0,
+                constraints={1: [None, 0]},
             )
-            log_prob = _compute_log_prob_feas(
-                log_module, means=means, sigmas=torch.ones_like(means)
-            )
-            log_prob.sum().backward()
-            self.assertFalse(log_prob.isnan().any())
-            self.assertFalse(log_prob.isinf().any())
-            self.assertFalse(means.grad.isnan().any())
-            self.assertFalse(means.grad.isinf().any())
-            # probability of feasibility increases until X = 0, decreases from there on
-            prob_diff = log_prob.diff()
-            k = len(X_positive)
-            eps = 1e-6 if dtype == torch.float32 else 1e-15
-            self.assertTrue((prob_diff[:k] > -eps).all())
-            self.assertTrue((means.grad[:k] > -eps).all())
-            # probability has stationary point at zero
-            mean_grad_at_zero = means.grad[len(X_positive)]
-            self.assertTrue(
-                torch.allclose(mean_grad_at_zero, torch.zeros_like(mean_grad_at_zero))
-            )
-            # probability increases again
-            self.assertTrue((prob_diff[-k:] < eps).all())
-            self.assertTrue((means.grad[-k:] < eps).all())
+
+        for dtype in (torch.float, torch.double):
+            with catch_warnings():
+                simplefilter("ignore", category=NumericsWarning)
+                self._test_constrained_expected_improvement(dtype=dtype)
+
+    def _test_constrained_expected_improvement(self, dtype: torch.dtype) -> None:
+        # one constraint
+        mean = torch.tensor([[-0.5, 0.0]], device=self.device, dtype=dtype).unsqueeze(
+            dim=-2
+        )
+        variance = torch.ones(1, 2, device=self.device, dtype=dtype).unsqueeze(dim=-2)
+        mm = MockModel(MockPosterior(mean=mean, variance=variance))
+        kwargs = {
+            "model": mm,
+            "best_f": 0.0,
+            "objective_index": 0,
+            "constraints": {1: [None, 0]},
+        }
+        module = ConstrainedExpectedImprovement(**kwargs)
+        log_module = LogConstrainedExpectedImprovement(**kwargs)
+
+        # test initialization
+        for k in [
+            "con_lower_inds",
+            "con_upper_inds",
+            "con_both_inds",
+            "con_both",
+            "con_lower",
+            "con_upper",
+        ]:
+            self.assertIn(k, module._buffers)
+            self.assertIn(k, log_module._buffers)
+
+        X = torch.empty(1, 1, device=self.device, dtype=dtype)  # dummy
+        ei = module(X)
+        ei_expected_unconstrained = torch.tensor(
+            [0.19780], device=self.device, dtype=dtype
+        )
+        ei_expected = ei_expected_unconstrained * 0.5
+        self.assertAllClose(ei, ei_expected, atol=1e-4)
+        log_ei = log_module(X)
+        self.assertAllClose(log_ei, ei.log(), atol=1e-5)
+        # testing LogCEI and CEI for lower, upper, and simultaneous bounds
+        for bounds in [[None, 0], [0, None], [0, 1]]:
+            kwargs["constraints"] = {1: bounds}
+            module = ConstrainedExpectedImprovement(**kwargs)
+            log_module = LogConstrainedExpectedImprovement(**kwargs)
+            ei, log_ei = module(X), log_module(X)
+            self.assertAllClose(log_ei, ei.log(), atol=1e-5)
+
+        constructors = [
+            ConstrainedExpectedImprovement,
+            LogConstrainedExpectedImprovement,
+        ]
+        for constructor in constructors:
+            # check that error raised if no constraints
+            with self.assertRaises(ValueError):
+                module = constructor(
+                    model=mm, best_f=0.0, objective_index=0, constraints={}
+                )
+
+            # check that error raised if objective is a constraint
+            with self.assertRaises(ValueError):
+                module = constructor(
+                    model=mm,
+                    best_f=0.0,
+                    objective_index=0,
+                    constraints={0: [None, 0]},
+                )
+
+            # check that error raised if constraint lower > upper
+            with self.assertRaises(ValueError):
+                module = constructor(
+                    model=mm, best_f=0.0, objective_index=0, constraints={0: [1, 0]}
+                )
+
+        # three constraints
+        N = torch.distributions.Normal(loc=0.0, scale=1.0)
+        a = N.icdf(torch.tensor(0.75))  # get a so that P(-a <= N <= a) = 0.5
+        mean = torch.tensor(
+            [[-0.5, 0.0, 5.0, 0.0]], device=self.device, dtype=dtype
+        ).unsqueeze(dim=-2)
+        variance = torch.ones(1, 4, device=self.device, dtype=dtype).unsqueeze(dim=-2)
+        mm = MockModel(MockPosterior(mean=mean, variance=variance))
+        kwargs = {
+            "model": mm,
+            "best_f": 0.0,
+            "objective_index": 0,
+            "constraints": {1: [None, 0], 2: [5.0, None], 3: [-a, a]},
+        }
+        module = ConstrainedExpectedImprovement(**kwargs)
+        log_module = LogConstrainedExpectedImprovement(**kwargs)
+        X = torch.empty(1, 1, device=self.device, dtype=dtype)  # dummy
+        ei = module(X)
+        ei_expected_unconstrained = torch.tensor(
+            [0.19780], device=self.device, dtype=dtype
+        )
+        ei_expected = ei_expected_unconstrained * 0.5 * 0.5 * 0.5
+        self.assertAllClose(ei, ei_expected, atol=1e-4)
+        # testing log module with regular implementation
+        log_ei = log_module(X)
+        self.assertAllClose(log_ei, ei_expected.log(), atol=1e-4)
+        # test maximize
+        kwargs = {
+            "model": mm,
+            "best_f": 0.0,
+            "objective_index": 0,
+            "constraints": {1: [None, 0]},
+            "maximize": False,
+        }
+        module_min = ConstrainedExpectedImprovement(**kwargs)
+        log_module_min = LogConstrainedExpectedImprovement(**kwargs)
+        ei_min = module_min(X)
+        ei_expected_unconstrained_min = torch.tensor(
+            [0.6978], device=self.device, dtype=dtype
+        )
+        ei_expected_min = ei_expected_unconstrained_min * 0.5
+        self.assertAllClose(ei_min, ei_expected_min, atol=1e-4)
+        log_ei_min = log_module_min(X)
+        self.assertAllClose(log_ei_min, ei_min.log(), atol=1e-4)
+
+        # test invalid onstraints
+        for constructor in constructors:
+            with self.assertRaises(ValueError):
+                constructor(
+                    model=mm,
+                    best_f=0.0,
+                    objective_index=0,
+                    constraints={1: [1.0, -1.0]},
+                )
+
+        # numerical stress test for _compute_log_prob_feas, which gets added to
+        # log_ei in the forward pass, a quantity we already tested above
+        # the limits here are determined by the largest power of ten x, such that
+        #                          x - (b - a) < x
+        # evaluates to true. In this test, the bounds are a, b = -digits, digits.
+        digits = 10 if dtype == torch.float64 else 5
+        zero = torch.tensor([0], dtype=dtype, device=self.device)
+        ten = torch.tensor(10, dtype=dtype, device=self.device)
+        digits_tensor = 1 + torch.arange(
+            -digits, digits, dtype=dtype, device=self.device
+        )
+        X_positive = ten ** (digits_tensor)
+        # flipping -X_positive so that elements are in increasing order
+        means = torch.cat((-X_positive.flip(-1), zero, X_positive)).unsqueeze(-1)
+        means.requires_grad = True
+        log_module = LogConstrainedExpectedImprovement(
+            model=mm,
+            best_f=0.0,
+            objective_index=1,
+            constraints={0: [-5, 5]},
+        )
+        log_prob = _compute_log_prob_feas(
+            log_module, means=means, sigmas=torch.ones_like(means)
+        )
+        log_prob.sum().backward()
+        self.assertFalse(log_prob.isnan().any())
+        self.assertFalse(log_prob.isinf().any())
+        self.assertFalse(means.grad.isnan().any())
+        self.assertFalse(means.grad.isinf().any())
+        # probability of feasibility increases until X = 0, decreases from there on
+        prob_diff = log_prob.diff()
+        k = len(X_positive)
+        eps = 1e-6 if dtype == torch.float32 else 1e-15
+        self.assertTrue((prob_diff[:k] > -eps).all())
+        self.assertTrue((means.grad[:k] > -eps).all())
+        # probability has stationary point at zero
+        mean_grad_at_zero = means.grad[len(X_positive)]
+        self.assertTrue(
+            torch.allclose(mean_grad_at_zero, torch.zeros_like(mean_grad_at_zero))
+        )
+        # probability increases again
+        self.assertTrue((prob_diff[-k:] < eps).all())
+        self.assertTrue((means.grad[-k:] < eps).all())
 
     def test_constrained_expected_improvement_batch(self):
         for dtype in (torch.float, torch.double):
-            mean = torch.tensor(
-                [[-0.5, 0.0, 5.0, 0.0], [0.0, 0.0, 5.0, 0.0], [0.5, 0.0, 5.0, 0.0]],
-                device=self.device,
-                dtype=dtype,
-            ).unsqueeze(dim=-2)
-            variance = torch.ones(3, 4, device=self.device, dtype=dtype).unsqueeze(
-                dim=-2
-            )
-            N = torch.distributions.Normal(loc=0.0, scale=1.0)
-            a = N.icdf(torch.tensor(0.75))  # get a so that P(-a <= N <= a) = 0.5
-            mm = MockModel(MockPosterior(mean=mean, variance=variance))
-            kwargs = {
-                "model": mm,
-                "best_f": 0.0,
-                "objective_index": 0,
-                "constraints": {1: [None, 0], 2: [5.0, None], 3: [-a, a]},
-            }
-            module = ConstrainedExpectedImprovement(**kwargs)
-            log_module = LogConstrainedExpectedImprovement(**kwargs)
-            X = torch.empty(3, 1, 1, device=self.device, dtype=dtype)  # dummy
-            ei, log_ei = module(X), log_module(X)
-            self.assertTrue(ei.shape == torch.Size([3]))
-            self.assertTrue(log_ei.shape == torch.Size([3]))
-            ei_expected_unconstrained = torch.tensor(
-                [0.19780, 0.39894, 0.69780], device=self.device, dtype=dtype
-            )
-            ei_expected = ei_expected_unconstrained * 0.5 * 0.5 * 0.5
-            self.assertAllClose(ei, ei_expected, atol=1e-4)
-            self.assertAllClose(log_ei, ei.log(), atol=1e-4)
+            with catch_warnings():
+                simplefilter("ignore", category=NumericsWarning)
+                self._test_constrained_expected_improvement_batch(dtype=dtype)
+
+    def _test_constrained_expected_improvement_batch(self, dtype: torch.dtype) -> None:
+        mean = torch.tensor(
+            [[-0.5, 0.0, 5.0, 0.0], [0.0, 0.0, 5.0, 0.0], [0.5, 0.0, 5.0, 0.0]],
+            device=self.device,
+            dtype=dtype,
+        ).unsqueeze(dim=-2)
+        variance = torch.ones(3, 4, device=self.device, dtype=dtype).unsqueeze(dim=-2)
+        N = torch.distributions.Normal(loc=0.0, scale=1.0)
+        a = N.icdf(torch.tensor(0.75))  # get a so that P(-a <= N <= a) = 0.5
+        mm = MockModel(MockPosterior(mean=mean, variance=variance))
+        kwargs = {
+            "model": mm,
+            "best_f": 0.0,
+            "objective_index": 0,
+            "constraints": {1: [None, 0], 2: [5.0, None], 3: [-a, a]},
+        }
+        module = ConstrainedExpectedImprovement(**kwargs)
+        log_module = LogConstrainedExpectedImprovement(**kwargs)
+        X = torch.empty(3, 1, 1, device=self.device, dtype=dtype)  # dummy
+        ei, log_ei = module(X), log_module(X)
+        self.assertTrue(ei.shape == torch.Size([3]))
+        self.assertTrue(log_ei.shape == torch.Size([3]))
+        ei_expected_unconstrained = torch.tensor(
+            [0.19780, 0.39894, 0.69780], device=self.device, dtype=dtype
+        )
+        ei_expected = ei_expected_unconstrained * 0.5 * 0.5 * 0.5
+        self.assertAllClose(ei, ei_expected, atol=1e-4)
+        self.assertAllClose(log_ei, ei.log(), atol=1e-4)
 
 
 class TestNoisyExpectedImprovement(BotorchTestCase):
@@ -833,82 +857,93 @@ class TestNoisyExpectedImprovement(BotorchTestCase):
         return model
 
     def test_noisy_expected_improvement(self):
+        model = self._get_model(dtype=torch.float64)
+        X_observed = model.train_inputs[0]
+        nfan = 5
+        with self.assertWarnsRegex(
+            NumericsWarning, ".* LogNoisyExpectedImprovement .*"
+        ):
+            NoisyExpectedImprovement(model, X_observed, num_fantasies=nfan)
+
         for dtype in (torch.float, torch.double):
-            model = self._get_model(dtype=dtype)
-            X_observed = model.train_inputs[0]
-            nfan = 5
-            nEI = NoisyExpectedImprovement(model, X_observed, num_fantasies=nfan)
-            LogNEI = LogNoisyExpectedImprovement(model, X_observed, num_fantasies=nfan)
-            # before assigning, check that the attributes exist
-            self.assertTrue(hasattr(LogNEI, "model"))
-            self.assertTrue(hasattr(LogNEI, "best_f"))
-            self.assertIsInstance(LogNEI.model, SingleTaskGP)
-            self.assertIsInstance(LogNEI.model.likelihood, FixedNoiseGaussianLikelihood)
-            LogNEI.model = nEI.model  # let the two share their values and fantasies
-            LogNEI.best_f = nEI.best_f
+            with catch_warnings():
+                simplefilter("ignore", category=NumericsWarning)
+                self._test_noisy_expected_imrpovement(dtype)
 
-            X_test = torch.tensor(
-                [[[0.25]], [[0.75]]],
-                device=X_observed.device,
-                dtype=dtype,
-            )
-            X_test_log = X_test.clone()
-            X_test.requires_grad = True
-            X_test_log.requires_grad = True
-            val = nEI(X_test)
-            # testing logNEI yields the same result (also checks dtype)
-            log_val = LogNEI(X_test_log)
-            exp_log_val = log_val.exp()
-            # notably, val[1] is usually zero in this test, which is precisely what
-            # gives rise to problems during optimization, and what logNEI avoids
-            # since it generally takes a large negative number (<-2000) and has
-            # strong gradient signals in this regime.
-            rtol = 1e-12 if dtype == torch.double else 1e-6
-            atol = rtol
-            self.assertAllClose(exp_log_val, val, atol=atol, rtol=rtol)
-            # test basics
-            self.assertEqual(val.dtype, dtype)
-            self.assertEqual(val.device.type, X_observed.device.type)
-            self.assertEqual(val.shape, torch.Size([2]))
-            # test values
-            self.assertGreater(val[0].item(), 8e-5)
-            self.assertLess(val[1].item(), 1e-6)
-            # test gradient
-            val.sum().backward()
-            self.assertGreater(X_test.grad[0].abs().item(), 8e-6)
-            # testing gradient through exp of log computation
-            exp_log_val.sum().backward()
-            # testing that first gradient element coincides. The second is in the
-            # regime where the naive implementation looses accuracy.
-            atol = 2e-5 if dtype == torch.float32 else 1e-12
-            rtol = atol
-            self.assertAllClose(
-                X_test.grad[0], X_test_log.grad[0], atol=atol, rtol=rtol
-            )
+    def _test_noisy_expected_imrpovement(self, dtype: torch.dtype) -> None:
+        model = self._get_model(dtype=dtype)
+        X_observed = model.train_inputs[0]
+        nfan = 5
+        nEI = NoisyExpectedImprovement(model, X_observed, num_fantasies=nfan)
+        LogNEI = LogNoisyExpectedImprovement(model, X_observed, num_fantasies=nfan)
+        # before assigning, check that the attributes exist
+        self.assertTrue(hasattr(LogNEI, "model"))
+        self.assertTrue(hasattr(LogNEI, "best_f"))
+        self.assertIsInstance(LogNEI.model, SingleTaskGP)
+        self.assertIsInstance(LogNEI.model.likelihood, FixedNoiseGaussianLikelihood)
+        LogNEI.model = nEI.model  # let the two share their values and fantasies
+        LogNEI.best_f = nEI.best_f
 
-            # test inferred noise model
-            other_model = SingleTaskGP(X_observed, model.train_targets.unsqueeze(-1))
-            for constructor in (
-                NoisyExpectedImprovement,
-                LogNoisyExpectedImprovement,
-            ):
-                with self.assertRaises(UnsupportedError):
-                    constructor(other_model, X_observed, num_fantasies=5)
-                # Test constructor with minimize
-                acqf = constructor(model, X_observed, num_fantasies=5, maximize=False)
-                # test evaluation without gradients enabled
-                with torch.no_grad():
-                    acqf(X_test)
+        X_test = torch.tensor(
+            [[[0.25]], [[0.75]]],
+            device=X_observed.device,
+            dtype=dtype,
+        )
+        X_test_log = X_test.clone()
+        X_test.requires_grad = True
+        X_test_log.requires_grad = True
+        val = nEI(X_test)
+        # testing logNEI yields the same result (also checks dtype)
+        log_val = LogNEI(X_test_log)
+        exp_log_val = log_val.exp()
+        # notably, val[1] is usually zero in this test, which is precisely what
+        # gives rise to problems during optimization, and what logNEI avoids
+        # since it generally takes a large negative number (<-2000) and has
+        # strong gradient signals in this regime.
+        rtol = 1e-12 if dtype == torch.double else 1e-6
+        atol = rtol
+        self.assertAllClose(exp_log_val, val, atol=atol, rtol=rtol)
+        # test basics
+        self.assertEqual(val.dtype, dtype)
+        self.assertEqual(val.device.type, X_observed.device.type)
+        self.assertEqual(val.shape, torch.Size([2]))
+        # test values
+        self.assertGreater(val[0].item(), 8e-5)
+        self.assertLess(val[1].item(), 1e-6)
+        # test gradient
+        val.sum().backward()
+        self.assertGreater(X_test.grad[0].abs().item(), 8e-6)
+        # testing gradient through exp of log computation
+        exp_log_val.sum().backward()
+        # testing that first gradient element coincides. The second is in the
+        # regime where the naive implementation looses accuracy.
+        atol = 2e-5 if dtype == torch.float32 else 1e-12
+        rtol = atol
+        self.assertAllClose(X_test.grad[0], X_test_log.grad[0], atol=atol, rtol=rtol)
 
-                # testing gradients are only propagated if X_observed requires them
-                # i.e. kernel hyper-parameters are not tracked through to best_f
-                X_observed.requires_grad = False
-                acqf = constructor(model, X_observed, num_fantasies=5)
-                self.assertFalse(acqf.best_f.requires_grad)
+        # test inferred noise model
+        other_model = SingleTaskGP(X_observed, model.train_targets.unsqueeze(-1))
+        for constructor in (
+            NoisyExpectedImprovement,
+            LogNoisyExpectedImprovement,
+        ):
+            with self.assertRaises(UnsupportedError):
+                constructor(other_model, X_observed, num_fantasies=5)
+            # Test constructor with minimize
+            acqf = constructor(model, X_observed, num_fantasies=5, maximize=False)
+            # test evaluation without gradients enabled
+            with torch.no_grad():
+                acqf(X_test)
 
-                X_observed.requires_grad = True
-                acqf = constructor(model, X_observed, num_fantasies=5)
-                self.assertTrue(acqf.best_f.requires_grad)
+            # testing gradients are only propagated if X_observed requires them
+            # i.e. kernel hyper-parameters are not tracked through to best_f
+            X_observed.requires_grad = False
+            acqf = constructor(model, X_observed, num_fantasies=5)
+            self.assertFalse(acqf.best_f.requires_grad)
+
+            X_observed.requires_grad = True
+            acqf = constructor(model, X_observed, num_fantasies=5)
+            self.assertTrue(acqf.best_f.requires_grad)
 
 
 class TestScalarizedPosteriorMean(BotorchTestCase):

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -10,6 +10,7 @@ from functools import partial
 from itertools import product
 from math import pi
 from unittest import mock
+from warnings import catch_warnings, simplefilter
 
 import torch
 from botorch import settings
@@ -30,6 +31,7 @@ from botorch.acquisition.objective import (
 )
 from botorch.acquisition.utils import prune_inferior_points
 from botorch.exceptions import BotorchWarning, UnsupportedError
+from botorch.exceptions.warnings import NumericsWarning
 from botorch.models import SingleTaskGP
 from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.low_rank import sample_cached_cholesky
@@ -92,338 +94,384 @@ class TestMCAcquisitionFunction(BotorchTestCase):
 
 class TestQExpectedImprovement(BotorchTestCase):
     def test_q_expected_improvement(self):
+        mean = torch.tensor([[-0.5]], device=self.device)
+        variance = torch.ones(1, 1, device=self.device)
+        model = MockModel(MockPosterior(mean=mean, variance=variance))
+        with self.assertWarnsRegex(NumericsWarning, ".* qLogExpectedImprovement .*"):
+            qExpectedImprovement(model=model, best_f=0.0)
+
         for dtype in (torch.float, torch.double):
-            tkwargs = {"device": self.device, "dtype": dtype}
-            # the event shape is `b x q x t` = 1 x 1 x 1
-            samples = torch.zeros(1, 1, 1, **tkwargs)
-            mm = MockModel(MockPosterior(samples=samples))
-            # X is `q x d` = 1 x 1. X is a dummy and unused b/c of mocking
-            X = torch.zeros(1, 1, **tkwargs)
+            with self.subTest(dtype=dtype):
+                with catch_warnings():
+                    simplefilter("ignore", category=NumericsWarning)
+                    self._test_q_expected_improvement(dtype)
 
-            # basic test
-            sampler = IIDNormalSampler(sample_shape=torch.Size([2]))
-            acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
-            # test initialization
-            for k in ["objective", "sampler"]:
-                self.assertIn(k, acqf._modules)
+    def _test_q_expected_improvement(self, dtype: torch.dtype) -> None:
+        tkwargs = {"device": self.device, "dtype": dtype}
+        # the event shape is `b x q x t` = 1 x 1 x 1
+        samples = torch.zeros(1, 1, 1, **tkwargs)
+        mm = MockModel(MockPosterior(samples=samples))
+        # X is `q x d` = 1 x 1. X is a dummy and unused b/c of mocking
+        X = torch.zeros(1, 1, **tkwargs)
 
-            res = acqf(X)
-            self.assertEqual(res.item(), 0.0)
+        # basic test
+        sampler = IIDNormalSampler(sample_shape=torch.Size([2]))
+        acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
+        # test initialization
+        for k in ["objective", "sampler"]:
+            self.assertIn(k, acqf._modules)
 
-            # test shifting best_f value
-            acqf = qExpectedImprovement(model=mm, best_f=-1, sampler=sampler)
-            res = acqf(X)
-            self.assertEqual(res.item(), 1.0)
+        res = acqf(X)
+        self.assertEqual(res.item(), 0.0)
 
-            # basic test, no resample
-            sampler = IIDNormalSampler(sample_shape=torch.Size([2]), seed=12345)
-            acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
-            res = acqf(X)
-            self.assertEqual(res.item(), 0.0)
-            self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 1, 1]))
-            bs = acqf.sampler.base_samples.clone()
-            res = acqf(X)
-            self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+        # test shifting best_f value
+        acqf = qExpectedImprovement(model=mm, best_f=-1, sampler=sampler)
+        res = acqf(X)
+        self.assertEqual(res.item(), 1.0)
 
-            # basic test, qmc
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([2]))
-            acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
-            res = acqf(X)
-            self.assertEqual(res.item(), 0.0)
-            self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 1, 1]))
-            bs = acqf.sampler.base_samples.clone()
-            acqf(X)
-            self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+        # basic test, no resample
+        sampler = IIDNormalSampler(sample_shape=torch.Size([2]), seed=12345)
+        acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
+        res = acqf(X)
+        self.assertEqual(res.item(), 0.0)
+        self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 1, 1]))
+        bs = acqf.sampler.base_samples.clone()
+        res = acqf(X)
+        self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
 
-            # basic test for X_pending and warning
-            acqf.set_X_pending()
-            self.assertIsNone(acqf.X_pending)
-            acqf.set_X_pending(None)
-            self.assertIsNone(acqf.X_pending)
-            acqf.set_X_pending(X)
-            self.assertEqual(acqf.X_pending, X)
-            mm._posterior._samples = torch.zeros(1, 2, 1, **tkwargs)
-            res = acqf(X)
-            X2 = torch.zeros(1, 1, 1, **tkwargs, requires_grad=True)
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
-                acqf.set_X_pending(X2)
-                self.assertEqual(acqf.X_pending, X2)
-                self.assertEqual(
-                    sum(issubclass(w.category, BotorchWarning) for w in ws), 1
-                )
+        # basic test, qmc
+        sampler = SobolQMCNormalSampler(sample_shape=torch.Size([2]))
+        acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
+        res = acqf(X)
+        self.assertEqual(res.item(), 0.0)
+        self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 1, 1]))
+        bs = acqf.sampler.base_samples.clone()
+        acqf(X)
+        self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+
+        # basic test for X_pending and warning
+        acqf.set_X_pending()
+        self.assertIsNone(acqf.X_pending)
+        acqf.set_X_pending(None)
+        self.assertIsNone(acqf.X_pending)
+        acqf.set_X_pending(X)
+        self.assertEqual(acqf.X_pending, X)
+        mm._posterior._samples = torch.zeros(1, 2, 1, **tkwargs)
+        res = acqf(X)
+        X2 = torch.zeros(1, 1, 1, **tkwargs, requires_grad=True)
+        with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            acqf.set_X_pending(X2)
+            self.assertEqual(acqf.X_pending, X2)
+            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
     def test_q_expected_improvement_batch(self):
         for dtype in (torch.float, torch.double):
-            # the event shape is `b x q x t` = 2 x 2 x 1
-            samples = torch.zeros(2, 2, 1, device=self.device, dtype=dtype)
-            samples[0, 0, 0] = 1.0
-            mm = MockModel(MockPosterior(samples=samples))
+            with self.subTest(dtype=dtype):
+                with catch_warnings():
+                    simplefilter("ignore", category=NumericsWarning)
+                    self._test_q_expected_improvement_batch(dtype)
 
-            # X is a dummy and unused b/c of mocking
-            X = torch.zeros(2, 2, 1, device=self.device, dtype=dtype)
+    def _test_q_expected_improvement_batch(self, dtype: torch.dtype) -> None:
+        # the event shape is `b x q x t` = 2 x 2 x 1
+        samples = torch.zeros(2, 2, 1, device=self.device, dtype=dtype)
+        samples[0, 0, 0] = 1.0
+        mm = MockModel(MockPosterior(samples=samples))
 
-            # test batch mode
-            sampler = IIDNormalSampler(sample_shape=torch.Size([2]))
-            acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
-            res = acqf(X)
-            self.assertEqual(res[0].item(), 1.0)
-            self.assertEqual(res[1].item(), 0.0)
+        # X is a dummy and unused b/c of mocking
+        X = torch.zeros(2, 2, 1, device=self.device, dtype=dtype)
 
-            # test batch model, batched best_f values
-            sampler = IIDNormalSampler(sample_shape=torch.Size([3]))
-            acqf = qExpectedImprovement(
-                model=mm, best_f=torch.Tensor([0, 0]), sampler=sampler
-            )
-            res = acqf(X)
-            self.assertEqual(res[0].item(), 1.0)
-            self.assertEqual(res[1].item(), 0.0)
+        # test batch mode
+        sampler = IIDNormalSampler(sample_shape=torch.Size([2]))
+        acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
+        res = acqf(X)
+        self.assertEqual(res[0].item(), 1.0)
+        self.assertEqual(res[1].item(), 0.0)
 
-            # test shifting best_f value
-            acqf = qExpectedImprovement(model=mm, best_f=-1, sampler=sampler)
-            res = acqf(X)
-            self.assertEqual(res[0].item(), 2.0)
-            self.assertEqual(res[1].item(), 1.0)
+        # test batch model, batched best_f values
+        sampler = IIDNormalSampler(sample_shape=torch.Size([3]))
+        acqf = qExpectedImprovement(
+            model=mm, best_f=torch.Tensor([0, 0]), sampler=sampler
+        )
+        res = acqf(X)
+        self.assertEqual(res[0].item(), 1.0)
+        self.assertEqual(res[1].item(), 0.0)
 
-            # test batch mode
-            sampler = IIDNormalSampler(sample_shape=torch.Size([2]), seed=12345)
-            acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
-            res = acqf(X)  # 1-dim batch
-            self.assertEqual(res[0].item(), 1.0)
-            self.assertEqual(res[1].item(), 0.0)
-            self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 2, 1]))
-            bs = acqf.sampler.base_samples.clone()
-            acqf(X)
-            self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
-            res = acqf(X.expand(2, 2, 1))  # 2-dim batch
-            self.assertEqual(res[0].item(), 1.0)
-            self.assertEqual(res[1].item(), 0.0)
-            # the base samples should have the batch dim collapsed
-            self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 2, 1]))
-            bs = acqf.sampler.base_samples.clone()
-            acqf(X.expand(2, 2, 1))
-            self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+        # test shifting best_f value
+        acqf = qExpectedImprovement(model=mm, best_f=-1, sampler=sampler)
+        res = acqf(X)
+        self.assertEqual(res[0].item(), 2.0)
+        self.assertEqual(res[1].item(), 1.0)
 
-            # test batch mode, qmc
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([2]))
-            acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
-            res = acqf(X)
-            self.assertEqual(res[0].item(), 1.0)
-            self.assertEqual(res[1].item(), 0.0)
-            self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 2, 1]))
-            bs = acqf.sampler.base_samples.clone()
-            acqf(X)
-            self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+        # test batch mode
+        sampler = IIDNormalSampler(sample_shape=torch.Size([2]), seed=12345)
+        acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
+        res = acqf(X)  # 1-dim batch
+        self.assertEqual(res[0].item(), 1.0)
+        self.assertEqual(res[1].item(), 0.0)
+        self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 2, 1]))
+        bs = acqf.sampler.base_samples.clone()
+        acqf(X)
+        self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+        res = acqf(X.expand(2, 2, 1))  # 2-dim batch
+        self.assertEqual(res[0].item(), 1.0)
+        self.assertEqual(res[1].item(), 0.0)
+        # the base samples should have the batch dim collapsed
+        self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 2, 1]))
+        bs = acqf.sampler.base_samples.clone()
+        acqf(X.expand(2, 2, 1))
+        self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+
+        # test batch mode, qmc
+        sampler = SobolQMCNormalSampler(sample_shape=torch.Size([2]))
+        acqf = qExpectedImprovement(model=mm, best_f=0, sampler=sampler)
+        res = acqf(X)
+        self.assertEqual(res[0].item(), 1.0)
+        self.assertEqual(res[1].item(), 0.0)
+        self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 2, 1]))
+        bs = acqf.sampler.base_samples.clone()
+        acqf(X)
+        self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
 
 
 class TestQNoisyExpectedImprovement(BotorchTestCase):
     def test_q_noisy_expected_improvement(self):
         for dtype in (torch.float, torch.double):
-            # the event shape is `b x q x t` = 1 x 2 x 1
-            samples_noisy = torch.tensor([0.0, 1.0], device=self.device, dtype=dtype)
-            samples_noisy = samples_noisy.view(1, 2, 1)
-            # X_baseline is `q' x d` = 1 x 1
-            X_baseline = torch.zeros(1, 1, device=self.device, dtype=dtype)
-            mm_noisy = MockModel(MockPosterior(samples=samples_noisy))
-            # X is `q x d` = 1 x 1
-            X = torch.zeros(1, 1, device=self.device, dtype=dtype)
+            with self.subTest(dtype=dtype):
+                with catch_warnings():
+                    simplefilter("ignore", category=NumericsWarning)
+                    self._test_q_noisy_expected_improvement(dtype)
 
-            # basic test
-            sampler = IIDNormalSampler(sample_shape=torch.Size([2]))
-            acqf = qNoisyExpectedImprovement(
+    def _test_q_noisy_expected_improvement(self, dtype: torch.dtype) -> None:
+        # the event shape is `b x q x t` = 1 x 2 x 1
+        samples_noisy = torch.tensor([0.0, 1.0], device=self.device, dtype=dtype)
+        samples_noisy = samples_noisy.view(1, 2, 1)
+        # X_baseline is `q' x d` = 1 x 1
+        X_baseline = torch.zeros(1, 1, device=self.device, dtype=dtype)
+        mm_noisy = MockModel(MockPosterior(samples=samples_noisy))
+        # X is `q x d` = 1 x 1
+        X = torch.zeros(1, 1, device=self.device, dtype=dtype)
+
+        # basic test
+        sampler = IIDNormalSampler(sample_shape=torch.Size([2]))
+        with self.assertWarnsRegex(
+            NumericsWarning, ".* qLogNoisyExpectedImprovement .*"
+        ):
+            qNoisyExpectedImprovement(
                 model=mm_noisy,
                 X_baseline=X_baseline,
                 sampler=sampler,
                 prune_baseline=False,
                 cache_root=False,
             )
-            res = acqf(X)
-            self.assertEqual(res.item(), 1.0)
 
-            # basic test
-            sampler = IIDNormalSampler(sample_shape=torch.Size([2]), seed=12345)
-            acqf = qNoisyExpectedImprovement(
-                model=mm_noisy,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                prune_baseline=False,
-                cache_root=False,
-            )
-            res = acqf(X)
-            self.assertEqual(res.item(), 1.0)
-            self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 2, 1]))
-            bs = acqf.sampler.base_samples.clone()
-            acqf(X)
-            self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+        acqf = qNoisyExpectedImprovement(
+            model=mm_noisy,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            prune_baseline=False,
+            cache_root=False,
+        )
+        res = acqf(X)
+        self.assertEqual(res.item(), 1.0)
 
-            # basic test, qmc
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([2]))
-            acqf = qNoisyExpectedImprovement(
-                model=mm_noisy,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                prune_baseline=False,
-                cache_root=False,
-            )
-            res = acqf(X)
-            self.assertEqual(res.item(), 1.0)
-            self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 2, 1]))
-            bs = acqf.sampler.base_samples.clone()
-            acqf(X)
-            self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+        # basic test
+        sampler = IIDNormalSampler(sample_shape=torch.Size([2]), seed=12345)
+        acqf = qNoisyExpectedImprovement(
+            model=mm_noisy,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            prune_baseline=False,
+            cache_root=False,
+        )
+        res = acqf(X)
+        self.assertEqual(res.item(), 1.0)
+        self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 2, 1]))
+        bs = acqf.sampler.base_samples.clone()
+        acqf(X)
+        self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
 
-            # basic test for X_pending and warning
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([2]))
-            samples_noisy_pending = torch.tensor(
-                [1.0, 0.0, 0.0], device=self.device, dtype=dtype
-            )
-            samples_noisy_pending = samples_noisy_pending.view(1, 3, 1)
-            mm_noisy_pending = MockModel(MockPosterior(samples=samples_noisy_pending))
-            acqf = qNoisyExpectedImprovement(
-                model=mm_noisy_pending,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                prune_baseline=False,
-                cache_root=False,
-            )
-            acqf.set_X_pending()
-            self.assertIsNone(acqf.X_pending)
-            acqf.set_X_pending(None)
-            self.assertIsNone(acqf.X_pending)
-            acqf.set_X_pending(X)
-            self.assertEqual(acqf.X_pending, X)
-            res = acqf(X)
-            X2 = torch.zeros(
-                1, 1, 1, device=self.device, dtype=dtype, requires_grad=True
-            )
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
-                acqf.set_X_pending(X2)
-                self.assertEqual(acqf.X_pending, X2)
-                self.assertEqual(
-                    sum(issubclass(w.category, BotorchWarning) for w in ws), 1
-                )
+        # basic test, qmc
+        sampler = SobolQMCNormalSampler(sample_shape=torch.Size([2]))
+        acqf = qNoisyExpectedImprovement(
+            model=mm_noisy,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            prune_baseline=False,
+            cache_root=False,
+        )
+        res = acqf(X)
+        self.assertEqual(res.item(), 1.0)
+        self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 2, 1]))
+        bs = acqf.sampler.base_samples.clone()
+        acqf(X)
+        self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+
+        # basic test for X_pending and warning
+        sampler = SobolQMCNormalSampler(sample_shape=torch.Size([2]))
+        samples_noisy_pending = torch.tensor(
+            [1.0, 0.0, 0.0], device=self.device, dtype=dtype
+        )
+        samples_noisy_pending = samples_noisy_pending.view(1, 3, 1)
+        mm_noisy_pending = MockModel(MockPosterior(samples=samples_noisy_pending))
+        acqf = qNoisyExpectedImprovement(
+            model=mm_noisy_pending,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            prune_baseline=False,
+            cache_root=False,
+        )
+        acqf.set_X_pending()
+        self.assertIsNone(acqf.X_pending)
+        acqf.set_X_pending(None)
+        self.assertIsNone(acqf.X_pending)
+        acqf.set_X_pending(X)
+        self.assertEqual(acqf.X_pending, X)
+        res = acqf(X)
+        X2 = torch.zeros(1, 1, 1, device=self.device, dtype=dtype, requires_grad=True)
+        with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            acqf.set_X_pending(X2)
+            self.assertEqual(acqf.X_pending, X2)
+            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
     def test_q_noisy_expected_improvement_batch(self):
         for dtype in (torch.float, torch.double):
-            # the event shape is `b x q x t` = 2 x 3 x 1
-            samples_noisy = torch.zeros(2, 3, 1, device=self.device, dtype=dtype)
-            samples_noisy[0, -1, 0] = 1.0
-            mm_noisy = MockModel(MockPosterior(samples=samples_noisy))
-            # X is `q x d` = 1 x 1
-            X = torch.zeros(2, 2, 1, device=self.device, dtype=dtype)
-            X_baseline = torch.zeros(1, 1, device=self.device, dtype=dtype)
+            with self.subTest(dtype=dtype):
+                with catch_warnings():
+                    simplefilter("ignore", category=NumericsWarning)
+                    self._test_q_noisy_expected_improvement_batch(dtype)
 
-            # test batch mode
-            sampler = IIDNormalSampler(sample_shape=torch.Size([2]))
-            acqf = qNoisyExpectedImprovement(
-                model=mm_noisy,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                prune_baseline=False,
-                cache_root=False,
-            )
-            res = acqf(X)
-            self.assertEqual(res[0].item(), 1.0)
-            self.assertEqual(res[1].item(), 0.0)
+    def _test_q_noisy_expected_improvement_batch(self, dtype: torch.dtype) -> None:
+        # the event shape is `b x q x t` = 2 x 3 x 1
+        samples_noisy = torch.zeros(2, 3, 1, device=self.device, dtype=dtype)
+        samples_noisy[0, -1, 0] = 1.0
+        mm_noisy = MockModel(MockPosterior(samples=samples_noisy))
+        # X is `q x d` = 1 x 1
+        X = torch.zeros(2, 2, 1, device=self.device, dtype=dtype)
+        X_baseline = torch.zeros(1, 1, device=self.device, dtype=dtype)
 
-            # test batch mode
-            sampler = IIDNormalSampler(sample_shape=torch.Size([2]), seed=12345)
-            acqf = qNoisyExpectedImprovement(
-                model=mm_noisy,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                prune_baseline=False,
-                cache_root=False,
-            )
-            res = acqf(X)  # 1-dim batch
-            self.assertEqual(res[0].item(), 1.0)
-            self.assertEqual(res[1].item(), 0.0)
-            self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 3, 1]))
-            bs = acqf.sampler.base_samples.clone()
-            acqf(X)
-            self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
-            res = acqf(X.expand(2, 2, 1))  # 2-dim batch
-            self.assertEqual(res[0].item(), 1.0)
-            self.assertEqual(res[1].item(), 0.0)
-            # the base samples should have the batch dim collapsed
-            self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 3, 1]))
-            bs = acqf.sampler.base_samples.clone()
-            acqf(X.expand(2, 2, 1))
-            self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+        # test batch mode
+        sampler = IIDNormalSampler(sample_shape=torch.Size([2]))
+        acqf = qNoisyExpectedImprovement(
+            model=mm_noisy,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            prune_baseline=False,
+            cache_root=False,
+        )
+        res = acqf(X)
+        self.assertEqual(res[0].item(), 1.0)
+        self.assertEqual(res[1].item(), 0.0)
 
-            # test batch mode, qmc
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([2]))
-            acqf = qNoisyExpectedImprovement(
-                model=mm_noisy,
-                X_baseline=X_baseline,
-                sampler=sampler,
-                prune_baseline=False,
-                cache_root=False,
-            )
-            res = acqf(X)
-            self.assertEqual(res[0].item(), 1.0)
-            self.assertEqual(res[1].item(), 0.0)
-            self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 3, 1]))
-            bs = acqf.sampler.base_samples.clone()
-            acqf(X)
-            self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+        # test batch mode
+        sampler = IIDNormalSampler(sample_shape=torch.Size([2]), seed=12345)
+        acqf = qNoisyExpectedImprovement(
+            model=mm_noisy,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            prune_baseline=False,
+            cache_root=False,
+        )
+        res = acqf(X)  # 1-dim batch
+        self.assertEqual(res[0].item(), 1.0)
+        self.assertEqual(res[1].item(), 0.0)
+        self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 3, 1]))
+        bs = acqf.sampler.base_samples.clone()
+        acqf(X)
+        self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+        res = acqf(X.expand(2, 2, 1))  # 2-dim batch
+        self.assertEqual(res[0].item(), 1.0)
+        self.assertEqual(res[1].item(), 0.0)
+        # the base samples should have the batch dim collapsed
+        self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 3, 1]))
+        bs = acqf.sampler.base_samples.clone()
+        acqf(X.expand(2, 2, 1))
+        self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
+
+        # test batch mode, qmc
+        sampler = SobolQMCNormalSampler(sample_shape=torch.Size([2]))
+        acqf = qNoisyExpectedImprovement(
+            model=mm_noisy,
+            X_baseline=X_baseline,
+            sampler=sampler,
+            prune_baseline=False,
+            cache_root=False,
+        )
+        res = acqf(X)
+        self.assertEqual(res[0].item(), 1.0)
+        self.assertEqual(res[1].item(), 0.0)
+        self.assertEqual(acqf.sampler.base_samples.shape, torch.Size([2, 1, 3, 1]))
+        bs = acqf.sampler.base_samples.clone()
+        acqf(X)
+        self.assertTrue(torch.equal(acqf.sampler.base_samples, bs))
 
     def test_prune_baseline(self):
+        for dtype in (torch.float, torch.double):
+            with self.subTest(dtype=dtype):
+                with catch_warnings():
+                    simplefilter("ignore", category=NumericsWarning)
+                    self._test_prune_baseline(dtype)
+
+    def _test_prune_baseline(self, dtype: torch.dtype) -> None:
         no = "botorch.utils.testing.MockModel.num_outputs"
         prune = "botorch.acquisition.monte_carlo.prune_inferior_points"
         constraints = [lambda Y: Y[..., 1] + 0.1]
         # only the last sample if feasible and it has the worst objective value
-
-        for dtype in (torch.float, torch.double):
-            samples = torch.tensor(
-                [[1.0, 1.0], [0.0, 0.0], [-1.0, -1.0]],
-                device=self.device,
-                dtype=dtype,
+        samples = torch.tensor(
+            [[1.0, 1.0], [0.0, 0.0], [-1.0, -1.0]],
+            device=self.device,
+            dtype=dtype,
+        )
+        mm = MockModel(
+            MockPosterior(
+                samples=samples,
             )
+        )
+        X_baseline = torch.zeros(3, 1, device=self.device, dtype=dtype)
+        objective = GenericMCObjective(objective=lambda Y, X: Y[..., 0])
+        with mock.patch(no, new_callable=mock.PropertyMock) as mock_num_outputs:
+            mock_num_outputs.return_value = 2
+            with mock.patch(prune, wraps=prune_inferior_points) as mock_prune:
+                acqf = qNoisyExpectedImprovement(
+                    model=mm,
+                    X_baseline=X_baseline,
+                    prune_baseline=True,
+                    cache_root=False,
+                    objective=objective,
+                    constraints=constraints,
+                )
+            mock_prune.assert_called_once()
+            self.assertIs(mock_prune.call_args[1]["constraints"], constraints)
+            self.assertTrue(torch.equal(acqf.X_baseline, X_baseline[[-1]]))
+            # test marginalize_dim
+            samples2 = torch.stack([samples, samples * 2], dim=0)
             mm = MockModel(
                 MockPosterior(
-                    samples=samples,
+                    samples=samples2,
                 )
             )
-            X_baseline = torch.zeros(3, 1, device=self.device, dtype=dtype)
-            objective = GenericMCObjective(objective=lambda Y, X: Y[..., 0])
-            with mock.patch(no, new_callable=mock.PropertyMock) as mock_num_outputs:
-                mock_num_outputs.return_value = 2
-                with mock.patch(prune, wraps=prune_inferior_points) as mock_prune:
-                    acqf = qNoisyExpectedImprovement(
-                        model=mm,
-                        X_baseline=X_baseline,
-                        prune_baseline=True,
-                        cache_root=False,
-                        objective=objective,
-                        constraints=constraints,
-                    )
-                mock_prune.assert_called_once()
-                self.assertIs(mock_prune.call_args[1]["constraints"], constraints)
-                self.assertTrue(torch.equal(acqf.X_baseline, X_baseline[[-1]]))
-                # test marginalize_dim
-                samples2 = torch.stack([samples, samples * 2], dim=0)
-                mm = MockModel(
-                    MockPosterior(
-                        samples=samples2,
-                    )
+            with mock.patch(prune, wraps=prune_inferior_points) as mock_prune:
+                acqf = qNoisyExpectedImprovement(
+                    model=mm,
+                    X_baseline=X_baseline,
+                    prune_baseline=True,
+                    cache_root=False,
+                    marginalize_dim=-3,
+                    objective=objective,
+                    constraints=constraints,
                 )
-                with mock.patch(prune, wraps=prune_inferior_points) as mock_prune:
-                    acqf = qNoisyExpectedImprovement(
-                        model=mm,
-                        X_baseline=X_baseline,
-                        prune_baseline=True,
-                        cache_root=False,
-                        marginalize_dim=-3,
-                        objective=objective,
-                        constraints=constraints,
-                    )
-                mock_prune.assert_called_once()
-                _, kwargs = mock_prune.call_args
-                self.assertIs(kwargs["constraints"], constraints)
-                self.assertTrue(torch.equal(acqf.X_baseline, X_baseline[[-1]]))
-                self.assertEqual(kwargs["marginalize_dim"], -3)
+            mock_prune.assert_called_once()
+            _, kwargs = mock_prune.call_args
+            self.assertIs(kwargs["constraints"], constraints)
+            self.assertTrue(torch.equal(acqf.X_baseline, X_baseline[[-1]]))
+            self.assertEqual(kwargs["marginalize_dim"], -3)
 
     def test_cache_root(self):
+        with catch_warnings():
+            simplefilter("ignore", category=NumericsWarning)
+            self._test_cache_root()
+
+    def _test_cache_root(self):
+
         sample_cached_path = (
             "botorch.acquisition.cached_cholesky.sample_cached_cholesky"
         )
@@ -950,110 +998,113 @@ class TestMCAcquisitionFunctionWithConstraints(BotorchTestCase):
     def test_mc_acquisition_function_with_constraints(self):
         for dtype in (torch.float, torch.double):
             with self.subTest(dtype=dtype):
-                num_samples, n, q, d, m = 5, 4, 1, 3, 1
-                X = torch.randn(n, q, d, device=self.device, dtype=dtype)
-                samples = torch.randn(
-                    num_samples, n, q, m, device=self.device, dtype=dtype
-                )
-                mm = MockModel(MockPosterior(samples=samples))
-                nei_args = {
-                    "model": mm,
-                    "X_baseline": X,
-                    "prune_baseline": False,
-                }
-                for acqf_constructor in [
-                    partial(qProbabilityOfImprovement, model=mm, best_f=0.0),
-                    partial(qExpectedImprovement, model=mm, best_f=0.0),
-                    # cache_root=True not supported by MockModel, see test_cache_root
-                    partial(qNoisyExpectedImprovement, cache_root=False, **nei_args),
-                    partial(qNoisyExpectedImprovement, cache_root=True, **nei_args),
-                ]:
-                    acqf = acqf_constructor()
-                    mm._posterior._samples = (
-                        torch.cat((samples, samples), dim=-2)
-                        if isinstance(acqf, qNoisyExpectedImprovement)
-                        else samples
-                    )
-                    with self.subTest(acqf_class=type(acqf)):
-                        for con in [feasible_con, infeasible_con]:
-                            cacqf = acqf_constructor(constraints=[con])
-                            # for NEI test
-                            target = "botorch.acquisition.utils.get_infeasible_cost"
-                            inf_cost = torch.tensor(3, device=self.device, dtype=dtype)
-                            with mock.patch(target, return_value=inf_cost):
-                                vals = cacqf(X)
-                            # NOTE: this is only true for q = 1
-                            expected_vals = acqf(X) * (con(samples) < 0).squeeze()
-                            self.assertAllClose(vals, expected_vals)
+                with catch_warnings():
+                    simplefilter("ignore", category=NumericsWarning)
+                    self._test_mc_acquisition_function_with_constraints(dtype=dtype)
 
-                        with self.assertRaisesRegex(
-                            ValueError,
-                            "ConstrainedMCObjective as well as constraints passed",
-                        ):
-                            acqf_constructor(
-                                constraints=[feasible_con],
-                                objective=ConstrainedMCObjective(
-                                    objective=IdentityMCObjective,
-                                    constraints=[feasible_con],
-                                ),
-                            )
-                # Forcing negative samples, which will throw an error with simple
-                # regret because the acquisition utility is negative.
-                samples = -torch.rand(n, q, m, device=self.device, dtype=dtype)
-                mm = MockModel(MockPosterior(samples=samples))
-                cacqf = NegativeReducingMCAcquisitionFunction(
-                    model=mm, constraints=[feasible_con]
-                )
+    def _test_mc_acquisition_function_with_constraints(self, dtype: torch.dtype):
+        num_samples, n, q, d, m = 5, 4, 1, 3, 1
+        X = torch.randn(n, q, d, device=self.device, dtype=dtype)
+        samples = torch.randn(num_samples, n, q, m, device=self.device, dtype=dtype)
+        mm = MockModel(MockPosterior(samples=samples))
+        nei_args = {
+            "model": mm,
+            "X_baseline": X,
+            "prune_baseline": False,
+        }
+        for acqf_constructor in [
+            partial(qProbabilityOfImprovement, model=mm, best_f=0.0),
+            partial(qExpectedImprovement, model=mm, best_f=0.0),
+            # cache_root=True not supported by MockModel, see test_cache_root
+            partial(qNoisyExpectedImprovement, cache_root=False, **nei_args),
+            partial(qNoisyExpectedImprovement, cache_root=True, **nei_args),
+        ]:
+            acqf = acqf_constructor()
+            mm._posterior._samples = (
+                torch.cat((samples, samples), dim=-2)
+                if isinstance(acqf, qNoisyExpectedImprovement)
+                else samples
+            )
+            with self.subTest(acqf_class=type(acqf)):
+                for con in [feasible_con, infeasible_con]:
+                    cacqf = acqf_constructor(constraints=[con])
+                    # for NEI test
+                    target = "botorch.acquisition.utils.get_infeasible_cost"
+                    inf_cost = torch.tensor(3, device=self.device, dtype=dtype)
+                    with mock.patch(target, return_value=inf_cost):
+                        vals = cacqf(X)
+                    # NOTE: this is only true for q = 1
+                    expected_vals = acqf(X) * (con(samples) < 0).squeeze()
+                    self.assertAllClose(vals, expected_vals)
+
                 with self.assertRaisesRegex(
                     ValueError,
-                    "Constraint-weighting requires unconstrained "
-                    "acquisition values to be non-negative",
+                    "ConstrainedMCObjective as well as constraints passed",
                 ):
-                    cacqf(X)
+                    acqf_constructor(
+                        constraints=[feasible_con],
+                        objective=ConstrainedMCObjective(
+                            objective=IdentityMCObjective,
+                            constraints=[feasible_con],
+                        ),
+                    )
+        # Forcing negative samples, which will throw an error with simple
+        # regret because the acquisition utility is negative.
+        samples = -torch.rand(n, q, m, device=self.device, dtype=dtype)
+        mm = MockModel(MockPosterior(samples=samples))
+        cacqf = NegativeReducingMCAcquisitionFunction(
+            model=mm, constraints=[feasible_con]
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "Constraint-weighting requires unconstrained "
+            "acquisition values to be non-negative",
+        ):
+            cacqf(X)
 
-                # Test highlighting both common and different behavior of the old
-                # `ConstrainedMCObjective` and new `constraints` implementation.
-                # 1. Highlighting difference:
-                q = 1
-                samples = torch.randn(n, q, m, device=self.device, dtype=dtype)
-                mm = MockModel(MockPosterior(samples=samples))
-                constrained_objective = ConstrainedMCObjective(
-                    objective=IdentityMCObjective(),
-                    constraints=[infeasible_con],
-                    infeasible_cost=0.0,
-                )
-                # The old `ConstrainedMCObjective`-based implementation does not scale
-                # the best_f value by the feasibility indicator, while the new
-                # `constraints`-based implementation does. Therefore, the old version
-                # yields an acquisition value of 1, even though the constraint is not
-                # satisfied.
-                best_f = -1.0
-                old_acqf = qExpectedImprovement(
-                    model=mm, best_f=best_f, objective=constrained_objective
-                )
-                new_acqf = qExpectedImprovement(
-                    model=mm, best_f=best_f, constraints=[infeasible_con]
-                )
-                old_val = old_acqf(X)
-                self.assertAllClose(old_val, torch.ones_like(old_val))
-                new_val = new_acqf(X)
-                self.assertAllClose(new_val, torch.zeros_like(new_val))
+        # Test highlighting both common and different behavior of the old
+        # `ConstrainedMCObjective` and new `constraints` implementation.
+        # 1. Highlighting difference:
+        q = 1
+        samples = torch.randn(n, q, m, device=self.device, dtype=dtype)
+        mm = MockModel(MockPosterior(samples=samples))
+        constrained_objective = ConstrainedMCObjective(
+            objective=IdentityMCObjective(),
+            constraints=[infeasible_con],
+            infeasible_cost=0.0,
+        )
+        # The old `ConstrainedMCObjective`-based implementation does not scale
+        # the best_f value by the feasibility indicator, while the new
+        # `constraints`-based implementation does. Therefore, the old version
+        # yields an acquisition value of 1, even though the constraint is not
+        # satisfied.
+        best_f = -1.0
+        old_acqf = qExpectedImprovement(
+            model=mm, best_f=best_f, objective=constrained_objective
+        )
+        new_acqf = qExpectedImprovement(
+            model=mm, best_f=best_f, constraints=[infeasible_con]
+        )
+        old_val = old_acqf(X)
+        self.assertAllClose(old_val, torch.ones_like(old_val))
+        new_val = new_acqf(X)
+        self.assertAllClose(new_val, torch.zeros_like(new_val))
 
-                # 2. Highlighting commonality:
-                # When best_f = 0 and infeasible_cost = 0, both implementations yield
-                # the same results.
-                constrained_objective = ConstrainedMCObjective(
-                    objective=IdentityMCObjective(),
-                    constraints=[feasible_con],
-                    infeasible_cost=0.0,
-                )
-                best_f = 0.0
-                old_acqf = qExpectedImprovement(
-                    model=mm, best_f=best_f, objective=constrained_objective
-                )
-                new_acqf = qExpectedImprovement(
-                    model=mm, best_f=best_f, constraints=[feasible_con]
-                )
-                old_val = old_acqf(X)
-                new_val = new_acqf(X)
-                self.assertAllClose(new_val, old_val)
+        # 2. Highlighting commonality:
+        # When best_f = 0 and infeasible_cost = 0, both implementations yield
+        # the same results.
+        constrained_objective = ConstrainedMCObjective(
+            objective=IdentityMCObjective(),
+            constraints=[feasible_con],
+            infeasible_cost=0.0,
+        )
+        best_f = 0.0
+        old_acqf = qExpectedImprovement(
+            model=mm, best_f=best_f, objective=constrained_objective
+        )
+        new_acqf = qExpectedImprovement(
+            model=mm, best_f=best_f, constraints=[feasible_con]
+        )
+        old_val = old_acqf(X)
+        new_val = new_acqf(X)
+        self.assertAllClose(new_val, old_val)


### PR DESCRIPTION
Summary:
This commit adds a `NumericsWarning` and the`legacy_ei_numerics_warning` helper, which raises the following warning message for EI, and similar for other legacy EI variants:
```
NumericsWarning: ExpectedImprovement has known numerical issues that lead to suboptimal optimization performance.
It is strongly recommended to simply replace

         ExpectedImprovement     -->     LogExpectedImprovement

instead, which fixes the issues and has the same API. See https://arxiv.org/abs/2310.20708 for details.
```

Differential Revision: D59598723
