### PR TITLE
Deprecate gp_sampling module in favor of pathwise sampling

### DIFF
--- a/botorch/models/deterministic.py
+++ b/botorch/models/deterministic.py
@@ -19,8 +19,8 @@ particular fidelity parameter that directly encodes the fidelity of the
 observation. `GenericDeterministicModel` supports arbitrary deterministic
 functions, while `AffineFidelityCostModel` is a particular cost model for
 multi-fidelity optimization. Other use cases of deterministic models include
-representing approximate GP sample paths, e.g. random Fourier features obtained
-with `get_gp_samples`, which allows them to be substituted in acquisition
+representing approximate GP sample paths, e.g. Matheron paths obtained
+with `get_matheron_path_model`, which allows them to be substituted in acquisition
 functions or in other places where a `Model` is expected.
 """
 

--- a/botorch/sampling/pathwise/__init__.py
+++ b/botorch/sampling/pathwise/__init__.py
@@ -18,6 +18,7 @@ from botorch.sampling.pathwise.paths import (
 )
 from botorch.sampling.pathwise.posterior_samplers import (
     draw_matheron_paths,
+    get_matheron_path_model,
     MatheronPath,
 )
 from botorch.sampling.pathwise.prior_samplers import draw_kernel_feature_paths
@@ -28,6 +29,7 @@ __all__ = [
     "draw_matheron_paths",
     "draw_kernel_feature_paths",
     "gen_kernel_features",
+    "get_matheron_path_model",
     "gaussian_update",
     "GeneralizedLinearPath",
     "KernelEvaluationMap",

--- a/botorch/utils/gp_sampling.py
+++ b/botorch/utils/gp_sampling.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import warnings
 from copy import deepcopy
 from math import pi
 from typing import List, Optional
@@ -41,6 +42,14 @@ class GPDraw(Module):
         Args:
             model: The Model defining the GP prior.
         """
+        warnings.warn(
+            "`GPDraw` is deprecated and will be removed in v0.13 release. "
+            "For drawing GP sample paths, we recommend using pathwise "
+            "sampling code found in `botorch/sampling/pathwise`. We recommend "
+            "`get_matheron_path_model` for most use cases.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__()
         self._model = deepcopy(model)
         self._num_outputs = self._model.num_outputs
@@ -429,6 +438,14 @@ def get_gp_samples(
         A `GenericDeterministicModel` that evaluates `n_samples` sampled functions.
         If `n_samples > 1`, this will be a batched model.
     """
+    warnings.warn(
+        "`get_gp_samples` is deprecated and will be removed in v0.13 release. "
+        "For drawing GP sample paths, we recommend using pathwise "
+        "sampling code found in `botorch/sampling/pathwise`. We recommend "
+        "`get_matheron_path_model` for most use cases.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     # Get transforms from the model.
     intf = getattr(model, "input_transform", None)
     octf = getattr(model, "outcome_transform", None)

--- a/test/acquisition/multi_objective/test_utils.py
+++ b/test/acquisition/multi_objective/test_utils.py
@@ -24,7 +24,7 @@ from botorch.exceptions.errors import UnsupportedError
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.transforms.outcome import Standardize
-from botorch.utils.gp_sampling import get_gp_samples
+from botorch.sampling.pathwise import get_matheron_path_model
 from botorch.utils.multi_objective import is_non_dominated
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
 from torch import Tensor
@@ -306,11 +306,7 @@ class TestThompsonSampling(BotorchTestCase):
                 **tkwargs,
             )
 
-            model_sample = get_gp_samples(
-                model=model,
-                num_outputs=num_objectives,
-                n_samples=1,
-            )
+            model_sample = get_matheron_path_model(model=model)
 
             input_dim = X.shape[-1]
             # fake bounds

--- a/test/sampling/pathwise/test_posterior_samplers.py
+++ b/test/sampling/pathwise/test_posterior_samplers.py
@@ -7,12 +7,15 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from typing import Any, Dict
 
 import torch
 from botorch.models import ModelListGP, SingleTaskGP, SingleTaskVariationalGP
+from botorch.models.deterministic import GenericDeterministicModel
 from botorch.models.transforms.input import Normalize
 from botorch.models.transforms.outcome import Standardize
 from botorch.sampling.pathwise import draw_matheron_paths, MatheronPath, PathList
+from botorch.sampling.pathwise.posterior_samplers import get_matheron_path_model
 from botorch.sampling.pathwise.utils import get_train_inputs
 from botorch.utils.test_helpers import get_sample_moments, standardize_moments
 from botorch.utils.testing import BotorchTestCase
@@ -24,7 +27,7 @@ from torch.nn.functional import pad
 class TestPosteriorSamplers(BotorchTestCase):
     def setUp(self, suppress_input_warnings: bool = True) -> None:
         super().setUp(suppress_input_warnings=suppress_input_warnings)
-        tkwargs = {"device": self.device, "dtype": torch.float64}
+        tkwargs: Dict[str, Any] = {"device": self.device, "dtype": torch.float64}
         torch.manual_seed(0)
 
         base = MaternKernel(nu=2.5, ard_num_dims=2, batch_shape=Size([]))
@@ -66,6 +69,8 @@ class TestPosteriorSamplers(BotorchTestCase):
             input_transform=input_transform,
             outcome_transform=outcome_transform,
         ).to(**tkwargs)
+
+        self.tkwargs = tkwargs
 
     def test_draw_matheron_paths(self):
         for seed, model in enumerate(
@@ -122,3 +127,53 @@ class TestPosteriorSamplers(BotorchTestCase):
         tol = atol * (num_features**-0.5 + sample_shape.numel() ** -0.5)
         for exact, estimate in zip(exact_moments, sample_moments):
             self.assertTrue(exact.allclose(estimate, atol=tol, rtol=0))
+
+    def test_get_matheron_path_model(self) -> None:
+        model_list = ModelListGP(self.inferred_noise_gp, self.observed_noise_gp)
+        moo_model = SingleTaskGP(
+            train_X=torch.rand(5, 2, **self.tkwargs),
+            train_Y=torch.rand(5, 2, **self.tkwargs),
+        )
+
+        test_X = torch.rand(5, 2, **self.tkwargs)
+        batch_test_X = torch.rand(3, 5, 2, **self.tkwargs)
+        sample_shape = Size([2])
+        sample_shape_X = torch.rand(3, 2, 5, 2, **self.tkwargs)
+        for model in (self.inferred_noise_gp, moo_model, model_list):
+            path_model = get_matheron_path_model(model=model)
+            self.assertFalse(path_model._is_ensemble)
+            self.assertIsInstance(path_model, GenericDeterministicModel)
+            for X in (test_X, batch_test_X):
+                self.assertEqual(
+                    model.posterior(X).mean.shape, path_model.posterior(X).mean.shape
+                )
+            path_model = get_matheron_path_model(model=model, sample_shape=sample_shape)
+            self.assertTrue(path_model._is_ensemble)
+            self.assertEqual(
+                path_model.posterior(sample_shape_X).mean.shape,
+                sample_shape_X.shape[:-1] + Size([model.num_outputs]),
+            )
+
+    def test_get_matheron_path_model_batched(self) -> None:
+        model = SingleTaskGP(
+            train_X=torch.rand(4, 5, 2, **self.tkwargs),
+            train_Y=torch.rand(4, 5, 2, **self.tkwargs),
+        )
+        model._is_ensemble = True
+        path_model = get_matheron_path_model(model=model)
+        self.assertTrue(path_model._is_ensemble)
+        test_X = torch.rand(5, 2, **self.tkwargs)
+        # This mimics the behavior of the acquisition functions unsqueezing the
+        # model batch dimension for ensemble models.
+        batch_test_X = torch.rand(3, 1, 5, 2, **self.tkwargs)
+        # Explicitly matching X for completeness.
+        complete_test_X = torch.rand(3, 4, 5, 2, **self.tkwargs)
+        for X in (test_X, batch_test_X, complete_test_X):
+            self.assertEqual(
+                model.posterior(X).mean.shape, path_model.posterior(X).mean.shape
+            )
+
+        # Test with sample_shape.
+        path_model = get_matheron_path_model(model=model, sample_shape=Size([2, 6]))
+        test_X = torch.rand(3, 2, 6, 4, 5, 2, **self.tkwargs)
+        self.assertEqual(path_model.posterior(test_X).mean.shape, test_X.shape)

--- a/test/utils/test_gp_sampling.py
+++ b/test/utils/test_gp_sampling.py
@@ -190,7 +190,10 @@ class TestGPDraw(BotorchTestCase):
             tkwargs = {"device": self.device, "dtype": dtype}
             model, _, _ = _get_model(**tkwargs)
             mean = model.mean_module.raw_constant.detach().clone()
-            gp = GPDraw(model)
+            with self.assertWarnsRegex(
+                DeprecationWarning, "is deprecated and will be removed"
+            ):
+                gp = GPDraw(model)
             # test initialization
             self.assertIsNone(gp.Xs)
             self.assertIsNone(gp.Ys)
@@ -547,16 +550,19 @@ class TestRandomFourierFeatures(BotorchTestCase):
                 )
                 with torch.random.fork_rng():
                     torch.manual_seed(0)
-                    gp_samples = get_gp_samples(
-                        model=(
-                            batched_to_model_list(model)
-                            if ((not use_batch_model) and (m > 1))
-                            else model
-                        ),
-                        num_outputs=m,
-                        n_samples=n_samples,
-                        num_rff_features=512,
-                    )
+                    with self.assertWarnsRegex(
+                        DeprecationWarning, "is deprecated and will be removed"
+                    ):
+                        gp_samples = get_gp_samples(
+                            model=(
+                                batched_to_model_list(model)
+                                if ((not use_batch_model) and (m > 1))
+                                else model
+                            ),
+                            num_outputs=m,
+                            n_samples=n_samples,
+                            num_rff_features=512,
+                        )
                 samples = gp_samples.posterior(X).mean
                 self.assertEqual(samples.shape[0], n_samples)
                 if batched_inputs:


### PR DESCRIPTION
Summary: GP sampling functionality has been superseded by pathwise sampling, which has been in BoTorch for quite some time now. Marking it for deprecation in v0.13.

Differential Revision: D59815658
