### PR TITLE
Simplify qMultiObjectiveMaxValueEntropy.__init__

### DIFF
--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -123,19 +123,20 @@ class MaxValueBase(AcquisitionFunction, ABC):
         Returns:
             A `batch_shape`-dim Tensor of MVE values at the given design points `X`.
         """
-        # Compute the posterior, posterior mean, variance and std
+        # Compute the posterior, posterior mean, variance and std.
         posterior = self.model.posterior(
             X.unsqueeze(-3),
             observation_noise=False,
             posterior_transform=self.posterior_transform,
         )
-        # batch_shape x num_fantasies x (m) x 1
+        # batch_shape x num_fantasies x (m)
         mean = self.weight * posterior.mean.squeeze(-1).squeeze(-1)
         variance = posterior.variance.clamp_min(CLAMP_LB).view_as(mean)
         ig = self._compute_information_gain(
             X=X, mean_M=mean, variance_M=variance, covar_mM=variance.unsqueeze(-1)
         )
-        return ig.mean(dim=0)  # average over fantasies
+        # Average over fantasies, ig is of shape `num_fantasies x batch_shape x (m)`.
+        return ig.mean(dim=0)
 
     def set_X_pending(self, X_pending: Optional[Tensor] = None) -> None:
         r"""Set pending design points.

--- a/botorch/acquisition/multi_objective/max_value_entropy_search.py
+++ b/botorch/acquisition/multi_objective/max_value_entropy_search.py
@@ -109,10 +109,6 @@ class qMultiObjectiveMaxValueEntropy(
             model_list_to_batched(model) if isinstance(model, ModelListGP) else model
         )
         self._init_model = batched_mo_model
-        self.mo_model = batched_mo_model
-        self.model = batched_multi_output_to_single_output(
-            batch_mo_model=batched_mo_model
-        )
         self.fantasies_sampler = SobolQMCNormalSampler(
             sample_shape=torch.Size([num_fantasies])
         )
@@ -121,12 +117,8 @@ class qMultiObjectiveMaxValueEntropy(
         self.maximize = True
         self.weight = 1.0
         self.sample_pareto_frontiers = sample_pareto_frontiers
-
-        # this avoids unnecessary model conversion if X_pending is None
-        if X_pending is None:
-            self._sample_max_values()
-        else:
-            self.set_X_pending(X_pending)
+        # Set X_pending, register converted model and sample max values.
+        self.set_X_pending(X_pending)
         # This avoids attribute errors in qMaxValueEntropy code.
         self.posterior_transform = None
 


### PR DESCRIPTION
Summary:
I tried to see if I could eliminate the use of model converter code in `qMultiObjectiveMaxValueEntropy` with a reasonable time investment, but couldn't go much further than this.

The in-line comments about tensor shapes do not appear to be fully accurate, particularly those in `qMaxValueEntropy._compute_information_gain`. They seem to have been written for the multi-fidelity case and are confusing when viewed without that context. I may revisit this later.

Differential Revision: D59834357
