### PR TITLE
Moved qBayesianActiveLearning and FullyBayesianAcquisitionFunction to…

### DIFF
--- a/botorch/acquisition/__init__.py
+++ b/botorch/acquisition/__init__.py
@@ -25,6 +25,9 @@ from botorch.acquisition.analytic import (
     qAnalyticProbabilityOfImprovement,
     UpperConfidenceBound,
 )
+from botorch.acquisition.bayesian_active_learning import (
+    qBayesianActiveLearningByDisagreement,
+)
 from botorch.acquisition.cost_aware import (
     GenericCostAwareUtility,
     InverseCostWeightedUtility,
@@ -98,6 +101,7 @@ __all__ = [
     "ProbabilityOfImprovement",
     "ProximalAcquisitionFunction",
     "UpperConfidenceBound",
+    "qBayesianActiveLearningByDisagreement",
     "qAnalyticProbabilityOfImprovement",
     "qExpectedImprovement",
     "qExpectedUtilityOfBestOption",

--- a/botorch/acquisition/bayesian_active_learning.py
+++ b/botorch/acquisition/bayesian_active_learning.py
@@ -1,0 +1,85 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from botorch.acquisition.acquisition import AcquisitionFunction, MCSamplerMixin
+from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
+from botorch.models.model import Model
+from botorch.utils.transforms import concatenate_pending_points, t_batch_mode_transform
+from torch import Tensor
+
+
+class FullyBayesianAcquisitionFunction(AcquisitionFunction):
+    def __init__(self, model: Model):
+        """Base class for acquisition functions which require a Fully Bayesian
+        model treatment.
+
+        Args:
+            model: A fully bayesian single-outcome model.
+        """
+        if model._is_fully_bayesian:
+            super().__init__(model)
+
+        else:
+            raise ValueError(
+                "Fully Bayesian acquisition functions require "
+                "a SaasFullyBayesianSingleTaskGP to run."
+            )
+
+
+class qBayesianActiveLearningByDisagreement(
+    FullyBayesianAcquisitionFunction, MCSamplerMixin
+):
+    def __init__(
+        self,
+        model: SaasFullyBayesianSingleTaskGP,
+        X_pending: Optional[Tensor] = None,
+    ) -> None:
+        """Batch implementation [kirsch2019batchbald]_ of BALD [houlsby2011bald]_,
+        which maximizes the mutual information between the next observation and the
+        hyperparameters of the model. Computed by informational lower bound.
+
+        Args:
+            model: A fully bayesian single-outcome model.
+            X_pending: A `batch_shape, m x d`-dim Tensor of `m` design points.
+        """
+        super().__init__(model)
+        self.set_X_pending(X_pending)
+
+    @concatenate_pending_points
+    @t_batch_mode_transform()
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Evaluate qBayesianActiveLearningByDisagreement on the candidate set `X`.
+
+        Args:
+            X: `batch_shape x q x D`-dim Tensor of input points.
+
+        Returns:
+            A `batch_shape x num_models`-dim Tensor of BALD values.
+        """
+        return self._compute_lower_bound_information_gain(X)
+
+    def _compute_lower_bound_information_gain(self, X: Tensor) -> Tensor:
+        r"""Evaluates the lower bounded information gain on the candidate set `X`.
+
+        Args:
+            X: `batch_shape x q x D`-dim Tensor of input points.
+
+        Returns:
+            A `batch_shape x num_models`-dim Tensor of information gains.
+        """
+        posterior = self.model.posterior(X, observation_noise=True)
+        marg_covar = posterior.mixture_covariance_matrix
+        cond_variances = posterior.variance
+
+        prev_entropy = torch.logdet(marg_covar).unsqueeze(-1)
+        # squeeze excess dim and mean over q-batch
+        post_ub_entropy = torch.log(cond_variances).squeeze(-1).mean(-1)
+
+        return prev_entropy - post_ub_entropy

--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -39,6 +39,9 @@ from botorch.acquisition.analytic import (
     ProbabilityOfImprovement,
     UpperConfidenceBound,
 )
+from botorch.acquisition.bayesian_active_learning import (
+    qBayesianActiveLearningByDisagreement,
+)
 from botorch.acquisition.cost_aware import InverseCostWeightedUtility
 from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
 from botorch.acquisition.joint_entropy_search import qJointEntropySearch
@@ -1667,5 +1670,17 @@ def construct_inputs_qJES(
         "X_pending": X_pending,
         "estimation_type": estimation_type,
         "num_samples": num_samples,
+    }
+    return inputs
+
+
+@acqf_input_constructor(qBayesianActiveLearningByDisagreement)
+def construct_inputs_BALD(
+    model: Model,
+    X_pending: Optional[Tensor] = None,
+):
+    inputs = {
+        "model": model,
+        "X_pending": X_pending,
     }
     return inputs

--- a/botorch_community/acquisition/__init__.py
+++ b/botorch_community/acquisition/__init__.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from botorch_community.acquisition.bayesian_active_learning import (
-    qBayesianActiveLearningByDisagreement,
     qBayesianQueryByComittee,
     qBayesianVarianceReduction,
     qStatisticalDistanceActiveLearning,
@@ -17,7 +16,6 @@ from botorch_community.acquisition.input_constructors import (  # noqa F401
 from botorch_community.acquisition.scorebo import qSelfCorrectingBayesianOptimization
 
 __all__ = [
-    "qBayesianActiveLearningByDisagreement",
     "qBayesianQueryByComittee",
     "qBayesianVarianceReduction",
     "qSelfCorrectingBayesianOptimization",

--- a/botorch_community/acquisition/input_constructors.py
+++ b/botorch_community/acquisition/input_constructors.py
@@ -20,7 +20,6 @@ from botorch.acquisition.input_constructors import acqf_input_constructor
 from botorch.acquisition.utils import get_optimal_samples
 from botorch.models.model import Model
 from botorch_community.acquisition.bayesian_active_learning import (
-    qBayesianActiveLearningByDisagreement,
     qBayesianQueryByComittee,
     qBayesianVarianceReduction,
     qStatisticalDistanceActiveLearning,
@@ -34,18 +33,6 @@ from torch import Tensor
     qBayesianVarianceReduction,
 )
 def construct_inputs_BAL(
-    model: Model,
-    X_pending: Optional[Tensor] = None,
-):
-    inputs = {
-        "model": model,
-        "X_pending": X_pending,
-    }
-    return inputs
-
-
-@acqf_input_constructor(qBayesianActiveLearningByDisagreement)
-def construct_inputs_BALD(
     model: Model,
     X_pending: Optional[Tensor] = None,
 ):

--- a/botorch_community/acquisition/scorebo.py
+++ b/botorch_community/acquisition/scorebo.py
@@ -26,14 +26,14 @@ from typing import Optional
 import torch
 from botorch import settings
 from botorch.acquisition.acquisition import MCSamplerMixin
+from botorch.acquisition.bayesian_active_learning import (
+    FullyBayesianAcquisitionFunction,
+)
 from botorch.models.fully_bayesian import MCMC_DIM, SaasFullyBayesianSingleTaskGP
 from botorch.models.gp_regression import MIN_INFERRED_NOISE_LEVEL
 from botorch.models.utils import fantasize as fantasize_flag
 from botorch.utils.transforms import concatenate_pending_points, t_batch_mode_transform
-from botorch_community.acquisition.bayesian_active_learning import (
-    DISTANCE_METRICS,
-    FullyBayesianAcquisitionFunction,
-)
+from botorch_community.acquisition.bayesian_active_learning import DISTANCE_METRICS
 from torch import Tensor
 
 # The lower bound on the CDF value of the max-values

--- a/sphinx/source/acquisition.rst
+++ b/sphinx/source/acquisition.rst
@@ -21,6 +21,12 @@ Analytic Acquisition Function API
 .. autoclass:: AnalyticAcquisitionFunction
     :members:
 
+Bayesian Active Learning API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. currentmodule:: botorch.acquisition.bayesian_active_learning
+    :members:
+    :exclude-members: FullyBayesianAcquisitionFunction
+
 Cached Cholesky Acquisition Function API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.acquisition.cached_cholesky

--- a/test/acquisition/test_bayesian_active_learning.py
+++ b/test/acquisition/test_bayesian_active_learning.py
@@ -1,0 +1,127 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from itertools import product
+
+import torch
+from botorch.acquisition.bayesian_active_learning import (
+    FullyBayesianAcquisitionFunction,
+    qBayesianActiveLearningByDisagreement,
+)
+from botorch.models import SingleTaskGP
+from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
+from botorch.models.transforms.outcome import Standardize
+from botorch.utils.testing import BotorchTestCase
+
+
+def _get_mcmc_samples(num_samples: int, dim: int, infer_noise: bool, **tkwargs):
+
+    mcmc_samples = {
+        "lengthscale": torch.rand(num_samples, 1, dim, **tkwargs),
+        "outputscale": torch.rand(num_samples, **tkwargs),
+        "mean": torch.randn(num_samples, **tkwargs),
+    }
+    if infer_noise:
+        mcmc_samples["noise"] = torch.rand(num_samples, 1, **tkwargs)
+    return mcmc_samples
+
+
+def get_model(
+    train_X,
+    train_Y,
+    num_models,
+    standardize_model,
+    infer_noise,
+    **tkwargs,
+):
+    num_objectives = train_Y.shape[-1]
+
+    if standardize_model:
+        outcome_transform = Standardize(m=num_objectives)
+    else:
+        outcome_transform = None
+
+    mcmc_samples = _get_mcmc_samples(
+        num_samples=num_models,
+        dim=train_X.shape[-1],
+        infer_noise=infer_noise,
+        **tkwargs,
+    )
+
+    model = SaasFullyBayesianSingleTaskGP(
+        train_X=train_X,
+        train_Y=train_Y,
+        outcome_transform=outcome_transform,
+    )
+    model.load_mcmc_samples(mcmc_samples)
+
+    return model
+
+
+class TestFullyBayesianActuisitionFunction(BotorchTestCase):
+    def test_abstract_raises(self):
+        with self.assertRaises(TypeError):
+            FullyBayesianAcquisitionFunction()
+
+
+class TestQBayesianActiveLearningByDisagreement(BotorchTestCase):
+    def test_q_bayesian_active_learning_by_disagreement(self):
+        torch.manual_seed(1)
+        tkwargs = {"device": self.device}
+        num_objectives = 1
+        num_models = 3
+        for (
+            dtype,
+            standardize_model,
+            infer_noise,
+        ) in product(
+            (torch.float, torch.double),
+            (False, True),  # standardize_model
+            (True,),  # infer_noise - only one option avail in PyroModels
+        ):
+            tkwargs["dtype"] = dtype
+            input_dim = 2
+            train_X = torch.rand(4, input_dim, **tkwargs)
+            train_Y = torch.rand(4, num_objectives, **tkwargs)
+
+            model = get_model(
+                train_X,
+                train_Y,
+                num_models,
+                standardize_model,
+                infer_noise,
+                **tkwargs,
+            )
+
+            # test acquisition
+            X_pending_list = [None, torch.rand(2, input_dim, **tkwargs)]
+            for i in range(len(X_pending_list)):
+                X_pending = X_pending_list[i]
+
+                acq = qBayesianActiveLearningByDisagreement(
+                    model=model,
+                    X_pending=X_pending,
+                )
+
+                test_Xs = [
+                    torch.rand(4, 1, input_dim, **tkwargs),
+                    torch.rand(4, 3, input_dim, **tkwargs),
+                    torch.rand(4, 5, 1, input_dim, **tkwargs),
+                    torch.rand(4, 5, 3, input_dim, **tkwargs),
+                ]
+
+                for j in range(len(test_Xs)):
+                    acq_X = acq.forward(test_Xs[j])
+                    acq_X = acq(test_Xs[j])
+                    # assess shape
+                    self.assertTrue(acq_X.shape == test_Xs[j].shape[:-2])
+
+        # Support with non-fully bayesian models is not possible. Thus, we
+        # throw an error.
+        non_fully_bayesian_model = SingleTaskGP(train_X, train_Y)
+        with self.assertRaises(ValueError):
+            acq = qBayesianActiveLearningByDisagreement(
+                model=non_fully_bayesian_model,
+            )


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/botorch/pull/2448

Moved BALD and FB Acquisition function to BoTorch to enable its use in Ax.

Differential Revision: D59701373
