### PR TITLE
Use Standardize by default for SingleTaskGP

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -1091,15 +1091,17 @@ def _get_noiseless_fantasy_model(
     # are used across all batches (by default, a GP with batched training data
     # uses independent hyperparameters for each batch).
 
-    # Don't apply `outcome_transform` and `input_transform` here,
-    # since the data being passed has already been transformed.
-    # So we will instead set them afterwards.
+    # We don't want to use the true `outcome_transform` and `input_transform` here
+    # since the data being passed has already been transformed. We thus pass `None`
+    # and will instead set them afterwards.
     fantasy_model = SingleTaskGP(
         train_X=model.train_inputs[0],
         train_Y=model.train_targets.unsqueeze(-1),
         train_Yvar=model.likelihood.noise_covar.noise.unsqueeze(-1),
         covar_module=deepcopy(model.covar_module),
         mean_module=deepcopy(model.mean_module),
+        outcome_transform=None,
+        input_transform=None,
     )
 
     Yvar = torch.full_like(Y_fantasized, 1e-7)

--- a/botorch/acquisition/multi_objective/max_value_entropy_search.py
+++ b/botorch/acquisition/multi_objective/max_value_entropy_search.py
@@ -64,7 +64,7 @@ class qMultiObjectiveMaxValueEntropy(
         _default_sample_shape: The `sample_shape` for the default sampler.
 
     Example:
-        >>> model = SingleTaskGP(train_X, train_Y)
+        >>> model = SingleTaskGP(train_X, train_Y, outcome_transform=None)
         >>> MESMO = qMultiObjectiveMaxValueEntropy(model, sample_pfs)
         >>> mesmo = MESMO(test_X)
     """

--- a/botorch/models/contextual.py
+++ b/botorch/models/contextual.py
@@ -102,7 +102,12 @@ class LCEAGP(SingleTaskGP):
                 dimension is set to 1 for each categorical variable.
             context_weight_dict: Known population weights of each context.
         """
-        super().__init__(train_X=train_X, train_Y=train_Y, train_Yvar=train_Yvar)
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            outcome_transform=None,
+        )
         self.covar_module = LCEAKernel(
             decomposition=decomposition,
             batch_shape=self._aug_batch_shape,

--- a/botorch/models/converter.py
+++ b/botorch/models/converter.py
@@ -17,6 +17,7 @@ from typing import Optional
 import torch
 from botorch.exceptions import UnsupportedError
 from botorch.exceptions.warnings import BotorchWarning
+from botorch.models import SingleTaskGP
 from botorch.models.gp_regression import HeteroskedasticSingleTaskGP
 from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
@@ -99,7 +100,8 @@ def _check_compatibility(models: ModuleList) -> None:
     # TODO: Add support for outcome transforms.
     if any(getattr(m, "outcome_transform", None) is not None for m in models):
         raise UnsupportedError(
-            "Conversion of models with outcome transforms is currently unsupported."
+            "Conversion of models with outcome transforms is unsupported. "
+            "To fix this error, explicitly pass `outcome_transform=None`.",
         )
 
     # check that each model is single-output
@@ -179,6 +181,11 @@ def model_list_to_batched(model_list: ModelListGP) -> BatchedMultiOutputGPyTorch
         batch_length = len(models)
         covar_module = _batched_kernel(models[0].covar_module, batch_length)
         kwargs["covar_module"] = covar_module
+    # SingleTaskGP uses a default outcome transforms while this converter doesn't
+    # support outcome transforms. We need to explicitly pass down `None` to make
+    # sure no outcome transform is being used.
+    if isinstance(models[0], SingleTaskGP):
+        kwargs["outcome_transform"] = None
 
     # construct the batched GP model
     input_transform = getattr(models[0], "input_transform", None)
@@ -418,6 +425,12 @@ def batched_multi_output_to_single_output(
         kwargs["train_Yvar"] = noise_covar.noise.clone().unsqueeze(-1)
     if isinstance(batch_mo_model, SingleTaskMultiFidelityGP):
         kwargs.update(batch_mo_model._init_args)
+    # SingleTaskGP uses a default outcome transforms while this converter doesn't
+    # support outcome transforms. We need to explicitly pass down `None` to make
+    # sure no outcome transform is being used.
+    if isinstance(batch_mo_model, SingleTaskGP):
+        kwargs["outcome_transform"] = None
+
     single_outcome_model = batch_mo_model.__class__(
         input_transform=input_transform, **kwargs
     )

--- a/test/models/test_converter.py
+++ b/test/models/test_converter.py
@@ -14,6 +14,7 @@ from botorch.models import (
     SingleTaskMultiFidelityGP,
 )
 from botorch.models.converter import (
+    _batched_kernel,
     batched_multi_output_to_single_output,
     batched_to_model_list,
     DEPRECATION_MESSAGE,
@@ -24,7 +25,7 @@ from botorch.models.transforms.outcome import Standardize
 from botorch.models.utils.gpytorch_modules import get_matern_kernel_with_gamma_prior
 from botorch.utils.test_helpers import SimpleGPyTorchModel
 from botorch.utils.testing import BotorchTestCase
-from gpytorch.kernels import MaternKernel, RBFKernel
+from gpytorch.kernels import MaternKernel, RBFKernel, ScaleKernel
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
 from gpytorch.priors import LogNormalPrior
@@ -99,14 +100,22 @@ class TestConverters(BotorchTestCase):
             self.assertIsInstance(list_gp, ModelListGP)
             self.assertIsInstance(list_gp.models[0].input_transform, AppendFeatures)
 
+    def test_batched_kernel(self):
+        covar_module = ScaleKernel(MaternKernel(nu=2.5, ard_num_dims=3))
+        batched_covar_module = _batched_kernel(covar_module, 2)
+        self.assertEqual(
+            batched_covar_module.base_kernel.lengthscale.shape, torch.Size([2, 1, 3])
+        )
+        self.assertEqual(batched_covar_module.outputscale.shape, torch.Size([2]))
+
     def test_model_list_to_batched(self):
         for dtype in (torch.float, torch.double):
             # basic test
             train_X = torch.rand(10, 2, device=self.device, dtype=dtype)
             train_Y1 = train_X.sum(dim=-1, keepdim=True)
             train_Y2 = (train_X[:, 0] - train_X[:, 1]).unsqueeze(-1)
-            gp1 = SingleTaskGP(train_X, train_Y1)
-            gp2 = SingleTaskGP(train_X, train_Y2)
+            gp1 = SingleTaskGP(train_X, train_Y1, outcome_transform=None)
+            gp2 = SingleTaskGP(train_X, train_Y2, outcome_transform=None)
             list_gp = ModelListGP(gp1, gp2)
             batch_gp = model_list_to_batched(list_gp)
             self.assertIsInstance(batch_gp, SingleTaskGP)
@@ -116,7 +125,9 @@ class TestConverters(BotorchTestCase):
                 batch_gp = model_list_to_batched(ModelListGP(gp1))
             self.assertEqual(batch_gp._num_outputs, 1)
             # test mixing different likelihoods
-            gp2 = SingleTaskGP(train_X, train_Y1, torch.ones_like(train_Y1))
+            gp2 = SingleTaskGP(
+                train_X, train_Y1, torch.ones_like(train_Y1), outcome_transform=None
+            )
             with self.assertRaises(UnsupportedError):
                 model_list_to_batched(ModelListGP(gp1, gp2))
             # test non-batched models
@@ -126,11 +137,11 @@ class TestConverters(BotorchTestCase):
                 model_list_to_batched(ModelListGP(gp1_, gp2_))
             # test list of multi-output models
             train_Y = torch.cat([train_Y1, train_Y2], dim=-1)
-            gp2 = SingleTaskGP(train_X, train_Y)
+            gp2 = SingleTaskGP(train_X, train_Y, outcome_transform=None)
             with self.assertRaises(UnsupportedError):
                 model_list_to_batched(ModelListGP(gp1, gp2))
             # test different training inputs
-            gp2 = SingleTaskGP(2 * train_X, train_Y2)
+            gp2 = SingleTaskGP(2 * train_X, train_Y2, outcome_transform=None)
             with self.assertRaises(UnsupportedError):
                 model_list_to_batched(ModelListGP(gp1, gp2))
             # check scalar agreement
@@ -144,7 +155,7 @@ class TestConverters(BotorchTestCase):
             with self.assertRaises(UnsupportedError):
                 model_list_to_batched(ModelListGP(gp1, gp2))
             # check tensor shape agreement
-            gp2 = SingleTaskGP(train_X, train_Y2)
+            gp2 = SingleTaskGP(train_X, train_Y2, outcome_transform=None)
             gp2.likelihood.noise_covar.raw_noise = torch.nn.Parameter(
                 torch.tensor([[0.42]], device=self.device, dtype=dtype)
             )
@@ -157,19 +168,32 @@ class TestConverters(BotorchTestCase):
             with self.assertRaises(NotImplementedError):
                 model_list_to_batched(ModelListGP(gp2))
             # test custom likelihood
-            gp2 = SingleTaskGP(train_X, train_Y2, likelihood=GaussianLikelihood())
+            gp2 = SingleTaskGP(
+                train_X,
+                train_Y2,
+                likelihood=GaussianLikelihood(),
+                outcome_transform=None,
+            )
             with self.assertRaises(NotImplementedError):
                 model_list_to_batched(ModelListGP(gp2))
             # test non-default kernel
-            gp1 = SingleTaskGP(train_X, train_Y1, covar_module=MaternKernel())
-            gp2 = SingleTaskGP(train_X, train_Y2, covar_module=MaternKernel())
+            gp1 = SingleTaskGP(
+                train_X, train_Y1, covar_module=MaternKernel(), outcome_transform=None
+            )
+            gp2 = SingleTaskGP(
+                train_X, train_Y2, covar_module=MaternKernel(), outcome_transform=None
+            )
             list_gp = ModelListGP(gp1, gp2)
             batch_gp = model_list_to_batched(list_gp)
             self.assertEqual(type(batch_gp.covar_module), MaternKernel)
             # test error when component GPs have different kernel types
             # added types for both default and non-default kernels for clarity
-            gp1 = SingleTaskGP(train_X, train_Y1, covar_module=MaternKernel())
-            gp2 = SingleTaskGP(train_X, train_Y2, covar_module=RBFKernel())
+            gp1 = SingleTaskGP(
+                train_X, train_Y1, covar_module=MaternKernel(), outcome_transform=None
+            )
+            gp2 = SingleTaskGP(
+                train_X, train_Y2, covar_module=RBFKernel(), outcome_transform=None
+            )
             list_gp = ModelListGP(gp1, gp2)
             with self.assertRaises(UnsupportedError):
                 model_list_to_batched(list_gp)
@@ -177,8 +201,12 @@ class TestConverters(BotorchTestCase):
             train_X = torch.rand(10, 2, device=self.device, dtype=dtype)
             train_Y1 = train_X.sum(dim=-1, keepdim=True)
             train_Y2 = (train_X[:, 0] - train_X[:, 1]).unsqueeze(-1)
-            gp1_ = SingleTaskGP(train_X, train_Y1, torch.rand_like(train_Y1))
-            gp2_ = SingleTaskGP(train_X, train_Y2, torch.rand_like(train_Y2))
+            gp1_ = SingleTaskGP(
+                train_X, train_Y1, torch.rand_like(train_Y1), outcome_transform=None
+            )
+            gp2_ = SingleTaskGP(
+                train_X, train_Y2, torch.rand_like(train_Y2), outcome_transform=None
+            )
             list_gp = ModelListGP(gp1_, gp2_)
             batch_gp = model_list_to_batched(list_gp)
             self.assertIsInstance(batch_gp.likelihood, FixedNoiseGaussianLikelihood)
@@ -198,8 +226,12 @@ class TestConverters(BotorchTestCase):
                     [[0.0, 0.0], [1.0, 1.0]], device=self.device, dtype=dtype
                 ),
             )
-            gp1_ = SingleTaskGP(train_X, train_Y1, input_transform=input_tf)
-            gp2_ = SingleTaskGP(train_X, train_Y2, input_transform=input_tf)
+            gp1_ = SingleTaskGP(
+                train_X, train_Y1, input_transform=input_tf, outcome_transform=None
+            )
+            gp2_ = SingleTaskGP(
+                train_X, train_Y2, input_transform=input_tf, outcome_transform=None
+            )
             list_gp = ModelListGP(gp1_, gp2_)
             batch_gp = model_list_to_batched(list_gp)
             self.assertIsInstance(batch_gp.input_transform, Normalize)
@@ -210,8 +242,12 @@ class TestConverters(BotorchTestCase):
             input_tf3 = AppendFeatures(
                 feature_set=torch.rand(2, 1, device=self.device, dtype=dtype)
             )
-            gp1_ = SingleTaskGP(train_X, train_Y1, input_transform=input_tf3)
-            gp2_ = SingleTaskGP(train_X, train_Y2, input_transform=input_tf3)
+            gp1_ = SingleTaskGP(
+                train_X, train_Y1, input_transform=input_tf3, outcome_transform=None
+            )
+            gp2_ = SingleTaskGP(
+                train_X, train_Y2, input_transform=input_tf3, outcome_transform=None
+            )
             list_gp = ModelListGP(gp1_, gp2_).eval()
             batch_gp = model_list_to_batched(list_gp)
             self.assertIsInstance(batch_gp, SingleTaskGP)
@@ -223,8 +259,12 @@ class TestConverters(BotorchTestCase):
                     [[-1.0, -1.0], [1.0, 1.0]], device=self.device, dtype=dtype
                 ),
             )
-            gp1_ = SingleTaskGP(train_X, train_Y1, input_transform=input_tf)
-            gp2_ = SingleTaskGP(train_X, train_Y2, input_transform=input_tf2)
+            gp1_ = SingleTaskGP(
+                train_X, train_Y1, input_transform=input_tf, outcome_transform=None
+            )
+            gp2_ = SingleTaskGP(
+                train_X, train_Y2, input_transform=input_tf2, outcome_transform=None
+            )
             list_gp = ModelListGP(gp1_, gp2_)
             with self.assertRaisesRegex(UnsupportedError, "have the same"):
                 model_list_to_batched(list_gp)
@@ -237,8 +277,12 @@ class TestConverters(BotorchTestCase):
                 ),
                 batch_shape=torch.Size([3]),
             )
-            gp1_ = SingleTaskGP(train_X, train_Y1, input_transform=input_tf2)
-            gp2_ = SingleTaskGP(train_X, train_Y2, input_transform=input_tf2)
+            gp1_ = SingleTaskGP(
+                train_X, train_Y1, input_transform=input_tf2, outcome_transform=None
+            )
+            gp2_ = SingleTaskGP(
+                train_X, train_Y2, input_transform=input_tf2, outcome_transform=None
+            )
             list_gp = ModelListGP(gp1_, gp2_)
             with self.assertRaises(UnsupportedError):
                 model_list_to_batched(list_gp)
@@ -278,6 +322,7 @@ class TestConverters(BotorchTestCase):
             covar_module=RBFKernel(
                 ard_num_dims=2, lengthscale_prior=LogNormalPrior(3.0, 6.0)
             ),
+            outcome_transform=None,
         )
         gp2 = SingleTaskGP(
             train_X=train_X,
@@ -285,6 +330,7 @@ class TestConverters(BotorchTestCase):
             covar_module=RBFKernel(
                 ard_num_dims=2, lengthscale_prior=LogNormalPrior(2.0, 4.0)
             ),
+            outcome_transform=None,
         )
         with self.assertRaisesRegex(
             UnsupportedError, "All scalars must have the same value."
@@ -298,7 +344,7 @@ class TestConverters(BotorchTestCase):
             train_Y2 = train_X[:, 0] - train_X[:, 1]
             train_Y = torch.stack([train_Y1, train_Y2], dim=-1)
             # SingleTaskGP
-            batch_gp = SingleTaskGP(train_X, train_Y)
+            batch_gp = SingleTaskGP(train_X, train_Y, outcome_transform=None)
             list_gp = batched_to_model_list(batch_gp)
             batch_gp_recov = model_list_to_batched(list_gp)
             sd_orig = batch_gp.state_dict()
@@ -306,7 +352,9 @@ class TestConverters(BotorchTestCase):
             self.assertTrue(set(sd_orig) == set(sd_recov))
             self.assertTrue(all(torch.equal(sd_orig[k], sd_recov[k]) for k in sd_orig))
             # Observed noise
-            batch_gp = SingleTaskGP(train_X, train_Y, torch.rand_like(train_Y))
+            batch_gp = SingleTaskGP(
+                train_X, train_Y, torch.rand_like(train_Y), outcome_transform=None
+            )
             list_gp = batched_to_model_list(batch_gp)
             batch_gp_recov = model_list_to_batched(list_gp)
             sd_orig = batch_gp.state_dict()
@@ -338,7 +386,7 @@ class TestConverters(BotorchTestCase):
                 ],
                 dim=1,
             )
-            batched_mo_model = SingleTaskGP(train_X, train_Y)
+            batched_mo_model = SingleTaskGP(train_X, train_Y, outcome_transform=None)
             with self.assertWarnsRegex(DeprecationWarning, DEPRECATION_MESSAGE):
                 batched_so_model = batched_multi_output_to_single_output(
                     batched_mo_model
@@ -360,8 +408,12 @@ class TestConverters(BotorchTestCase):
                 batched_multi_output_to_single_output(gp2)
             # test observed noise
             train_X = torch.rand(10, 2, device=self.device, dtype=dtype)
-            batched_mo_model = SingleTaskGP(train_X, train_Y, torch.rand_like(train_Y))
-            batched_so_model = batched_multi_output_to_single_output(batched_mo_model)
+            batched_mo_model = SingleTaskGP(
+                train_X, train_Y, torch.rand_like(train_Y), outcome_transform=None
+            )
+            batched_so_model = batched_multi_output_to_single_output(
+                batched_mo_model,
+            )
             self.assertIsInstance(batched_so_model, SingleTaskGP)
             self.assertIsInstance(
                 batched_so_model.likelihood, FixedNoiseGaussianLikelihood
@@ -381,7 +433,9 @@ class TestConverters(BotorchTestCase):
                     [[0.0, 0.0], [1.0, 1.0]], device=self.device, dtype=dtype
                 ),
             )
-            batched_mo_model = SingleTaskGP(train_X, train_Y, input_transform=input_tf)
+            batched_mo_model = SingleTaskGP(
+                train_X, train_Y, input_transform=input_tf, outcome_transform=None
+            )
             batch_so_model = batched_multi_output_to_single_output(batched_mo_model)
             self.assertIsInstance(batch_so_model.input_transform, Normalize)
             self.assertTrue(
@@ -392,7 +446,7 @@ class TestConverters(BotorchTestCase):
                 feature_set=torch.rand(2, 1, device=self.device, dtype=dtype)
             )
             batched_mo_model = SingleTaskGP(
-                train_X, train_Y, input_transform=input_tf
+                train_X, train_Y, input_transform=input_tf, outcome_transform=None
             ).eval()
             batch_so_model = batched_multi_output_to_single_output(batched_mo_model)
             self.assertIsInstance(batch_so_model.input_transform, AppendFeatures)
@@ -405,7 +459,9 @@ class TestConverters(BotorchTestCase):
                 ),
                 batch_shape=torch.Size([2]),
             )
-            batched_mo_model = SingleTaskGP(train_X, train_Y, input_transform=input_tf)
+            batched_mo_model = SingleTaskGP(
+                train_X, train_Y, input_transform=input_tf, outcome_transform=None
+            )
             batch_so_model = batched_multi_output_to_single_output(batched_mo_model)
             self.assertIsInstance(batch_so_model.input_transform, Normalize)
             self.assertTrue(

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -362,6 +362,7 @@ class TestModelListGP(BotorchTestCase):
         model_s1 = SingleTaskGP(
             train_X=train_x_raw,
             train_Y=train_y,
+            outcome_transform=None,
         )
         model_list_gp = ModelListGP(model_s1, model2, deepcopy(model_s1))
         model_list_gp.posterior(train_x_raw)

--- a/test/optim/utils/test_acquisition_utils.py
+++ b/test/optim/utils/test_acquisition_utils.py
@@ -174,15 +174,11 @@ class TestGetXBaseline(BotorchTestCase):
 
             # set train inputs
             model.train_inputs = (X_train,)
-            X = get_X_baseline(
-                acq_function=acqf,
-            )
+            X = get_X_baseline(acq_function=acqf)
             self.assertTrue(torch.equal(X, X_train))
             # test that we fail back to train_inputs if X_baseline is an empty tensor
             acqf.register_buffer("X_baseline", X_train[:0])
-            X = get_X_baseline(
-                acq_function=acqf,
-            )
+            X = get_X_baseline(acq_function=acqf)
             self.assertTrue(torch.equal(X, X_train))
 
             # test acquisition function without X_baseline or model
@@ -206,9 +202,7 @@ class TestGetXBaseline(BotorchTestCase):
                 sampler=IIDNormalSampler(sample_shape=torch.Size([2])),
                 cache_root=False,
             )
-            X = get_X_baseline(
-                acq_function=acqf,
-            )
+            X = get_X_baseline(acq_function=acqf)
             self.assertTrue(torch.equal(X, acqf.X_baseline))
             # test qEHVI without train_inputs
             acqf = qExpectedHypervolumeImprovement(
@@ -232,21 +226,17 @@ class TestGetXBaseline(BotorchTestCase):
                     Y=Y_train,
                 ),
             )
-            X = get_X_baseline(
-                acq_function=acqf,
-            )
+            X = get_X_baseline(acq_function=acqf)
             self.assertTrue(torch.equal(X, X_train))
 
             # test MESMO for which we need to use
             # `acqf.mo_model`
-            batched_mo_model = SingleTaskGP(X_train, Y_train)
+            batched_mo_model = SingleTaskGP(X_train, Y_train, outcome_transform=None)
             acqf = qMultiObjectiveMaxValueEntropy(
                 batched_mo_model,
                 sample_pareto_frontiers=lambda model: torch.rand(10, 2, **tkwargs),
             )
-            X = get_X_baseline(
-                acq_function=acqf,
-            )
+            X = get_X_baseline(acq_function=acqf)
             self.assertTrue(torch.equal(X, X_train))
             # test that if there is an input transform that is applied
             # to the train_inputs when the model is in eval mode, we
@@ -257,7 +247,5 @@ class TestGetXBaseline(BotorchTestCase):
             model.eval()
             self.assertFalse(torch.equal(model.train_inputs[0], X_train))
             acqf = qExpectedImprovement(model, best_f=0.0)
-            X = get_X_baseline(
-                acq_function=acqf,
-            )
+            X = get_X_baseline(acq_function=acqf)
             self.assertTrue(torch.equal(X, X_train))

--- a/test/utils/test_sampling.py
+++ b/test/utils/test_sampling.py
@@ -541,9 +541,8 @@ class TestDelaunayPolytopeSampler(PolytopeSamplerTestBase, BotorchTestCase):
 
 class TestOptimizePosteriorSamples(BotorchTestCase):
     def test_optimize_posterior_samples(self):
-        # Restrict the random seed to prevent flaky failures.
-        seed = torch.randint(high=5, size=(1,)).item()
-        torch.manual_seed(seed)
+        # Fix the random seed to prevent flaky failures.
+        torch.manual_seed(1)
         dims = 2
         dtype = torch.float64
         eps = 1e-6

--- a/test_community/models/test_gp_regression_multisource.py
+++ b/test_community/models/test_gp_regression_multisource.py
@@ -124,12 +124,14 @@ class TestAugmentedSingleTaskGP(BotorchTestCase):
             true_y,
             covar_module=get_matern_kernel_with_gamma_prior(x.shape[-1]),
             likelihood=get_gaussian_likelihood_with_gamma_prior(),
+            outcome_transform=None,
         )
         model1 = SingleTaskGP(
             x,
             y,
             covar_module=get_matern_kernel_with_gamma_prior(x.shape[-1]),
             likelihood=get_gaussian_likelihood_with_gamma_prior(),
+            outcome_transform=None,
         )
 
         res = _get_reliable_observations(model0, model1, x)


### PR DESCRIPTION
Summary: D60080819 recently updated the default `SingleTaskGP` BoTorch priors. One significant change was to remove the use of an outputscale, which may not work well if the outputs aren't standardized. This diff changes the SingleTaskGP to use Standardize by default if no outcome transforms are specified (this allows users to explicitly pass in None if they don't want to use any transforms).

Differential Revision: D60492937
