### PR TITLE
Unpin numpy from <2.0

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -62,8 +62,6 @@ jobs:
       run: |
         # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
         conda config --set solver classic
-        # avoid issues with numpy 2.0 on windows builds and in tensorboard
-        conda install -y "numpy<2.0"
         conda install -y setuptools_scm conda-build conda-verify anaconda-client
         conda install -y scipy sphinx pytest flake8 multipledispatch
         conda install -y -c pytorch pytorch cpuonly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
-        pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
         pip install git+https://github.com/cornellius-gp/linear_operator.git
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[test]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,8 +81,6 @@ jobs:
       run: |
         # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
         conda config --set solver classic
-        # avoid issues with numpy 2.0 on windows builds and in tensorboard
-        conda install -y "numpy<2.0"
         conda install -y scipy multipledispatch setuptools_scm conda-build conda-verify
         conda config --set anaconda_upload no
         conda install -y -c pytorch-nightly pytorch cpuonly

--- a/.github/workflows/reusable_test_pip.yml
+++ b/.github/workflows/reusable_test_pip.yml
@@ -36,7 +36,7 @@ jobs:
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
-        pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
         pip install git+https://github.com/cornellius-gp/linear_operator.git
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install .[test]

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -43,7 +43,7 @@ jobs:
     - if: ${{ !inputs.use_stable_pytorch_gpytorch }}
       name: Install latest PyTorch & GPyTorch
       run: |
-        pip install torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
         pip install git+https://github.com/cornellius-gp/linear_operator.git
         pip install git+https://github.com/cornellius-gp/gpytorch.git
     - if: ${{ inputs.use_stable_pytorch_gpytorch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,6 @@ jobs:
       run: |
         # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
         conda config --set solver classic
-        # avoid issues with numpy 2.0 on windows builds and in tensorboard
-        conda install -y "numpy<2.0"
         conda install pytorch torchvision -c pytorch
         conda install -y pip scipy sphinx pytest flake8
         pip install git+https://github.com/cornellius-gp/linear_operator.git

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -33,8 +33,6 @@ jobs:
       run: |
         # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
         conda config --set solver classic
-        # avoid issues with numpy 2.0 on windows builds and in tensorboard
-        conda install -y "numpy<2.0"
         conda install -y -c pytorch pytorch cpuonly
         conda install -y pip scipy pytest
         conda install -y -c gpytorch gpytorch

--- a/environment.yml
+++ b/environment.yml
@@ -10,4 +10,3 @@ dependencies:
   - scipy
   - multipledispatch
   - pyro-ppl>=1.8.4
-  - numpy<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ torch>=1.13.1
 pyro-ppl>=1.8.4
 gpytorch==1.12
 linear_operator==0.5.2
-numpy<2.0


### PR DESCRIPTION
This unpins numpy from <2.0, which was done as a temporary workaround in #2382 to avoid issues with windows builds. 

The underlying issue was an incompatibility between pytorch 2.4.0 windows builds and numpy 2.0. Pointed pip to the updated pytorch pip index to pick up newer 2.5.0 dev versions to resolve the issue: https://github.com/pytorch/botorch/pull/2459#issuecomment-2267577174

There is still the issue of existing torch release windows binaries potentially not being compatible with numpy 2.0, but that shouldn't be something that we need to handle.
