### PR TITLE
Speed up Constrained MOBO tutorial in smoke-test mode

### DIFF
--- a/tutorials/constrained_multi_objective_bo.ipynb
+++ b/tutorials/constrained_multi_objective_bo.ipynb
@@ -393,7 +393,7 @@
         "warnings.filterwarnings(\"ignore\", category=BadInitialCandidatesWarning)\n",
         "warnings.filterwarnings(\"ignore\", category=RuntimeWarning)\n",
         "\n",
-        "N_BATCH = 20 if not SMOKE_TEST else 5\n",
+        "N_BATCH = 20 if not SMOKE_TEST else 1\n",
         "MC_SAMPLES = 128 if not SMOKE_TEST else 16\n",
         "verbose = True\n",
         "\n",


### PR DESCRIPTION
Summary: This PR reduces the number of BayesOpt iterations to 1 in smoke-test mode.

Differential Revision: D61085444
