### PR TITLE
Clarify incompatibility of inter-point constraints w/ `get_polytope_samples`

### DIFF
--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -841,7 +841,13 @@ def normalize_sparse_linear_constraints(
     new_constraints = []
     for index, coefficient, rhs in constraints:
         if index.ndim != 1:
-            raise ValueError("`indices` must be a one-dimensional tensor.")
+            raise ValueError(
+                "`indices` must be a one-dimensional tensor. This method does not "
+                "support the kind of 'inter-point constraints' that are supported by "
+                "`optimize_acqf()`. To achieve this behavior, you need define the "
+                "problem on the joint space over `q` points and impose use constraints,"
+                "see https://github.com/pytorch/botorch/issues/2468#issuecomment-2287706461"  # noqa: E501
+            )
         lower, upper = bounds[:, index]
         s = upper - lower
         new_constraints.append(

--- a/test/utils/test_sampling.py
+++ b/test/utils/test_sampling.py
@@ -206,6 +206,13 @@ class TestSampleUtils(BotorchTestCase):
             )
             expected_rhs = 0.5
             self.assertAlmostEqual(new_constraints[0][-1], expected_rhs)
+            with self.assertRaisesRegex(
+                ValueError, "`indices` must be a one-dimensional tensor."
+            ):
+                normalize_sparse_linear_constraints(
+                    bounds,
+                    [(torch.tensor([[1, 2], [3, 4]]), torch.tensor([1.0, 1.0]), 1.0)],
+                )
 
     def test_normalize_sparse_linear_constraints_wrong_dtype(self):
         for dtype in (torch.float, torch.double):


### PR DESCRIPTION
Adds more detail to the expected tensor sizes in the docstrings, raises an explicit `ValueError` if those don't match. 

This addresses #2468