### PR TITLE
Reduce runtime of baxus tutorial in smoke test

### DIFF
--- a/tutorials/baxus.ipynb
+++ b/tutorials/baxus.ipynb
@@ -28,7 +28,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[KeOps] Warning : Cuda libraries were not detected on the system ; using cpu only mode\n",
       "Running on cpu\n"
      ]
     }
@@ -113,9 +112,9 @@
    "outputs": [],
    "source": [
     "fun = branin_emb\n",
-    "dim = 500\n",
+    "dim = 500 if not SMOKE_TEST else 50\n",
     "\n",
-    "n_init = 10\n",
+    "n_init = 10 if not SMOKE_TEST else 4\n",
     "max_cholesky_size = float(\"inf\")  # Always use Cholesky"
    ]
   },
@@ -228,9 +227,9 @@
     {
      "data": {
       "text/plain": [
-       "tensor([[ 0.,  0.,  1.,  0.,  1.,  1.,  1.,  0.,  0.,  0.],\n",
-       "        [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  1.,  1., -1.],\n",
-       "        [-1.,  1.,  0., -1.,  0.,  0.,  0.,  0.,  0.,  0.]],\n",
+       "tensor([[ 1.,  0.,  1.,  1.,  0.,  0.,  0.,  0.,  0., -1.],\n",
+       "        [ 0.,  0.,  0.,  0.,  1.,  0.,  1.,  0., -1.,  0.],\n",
+       "        [ 0., -1.,  0.,  0.,  0.,  1.,  0., -1.,  0.,  0.]],\n",
        "       dtype=torch.float64)"
       ]
      },
@@ -357,33 +356,33 @@
      "output_type": "stream",
      "text": [
       "S before increase\n",
-      "tensor([[ 0.,  1.,  0.,  0., -1.,  1.,  0., -1.,  0.,  1.],\n",
-      "        [ 1.,  0., -1., -1.,  0.,  0.,  1.,  0., -1.,  0.]],\n",
+      "tensor([[ 1.,  0.,  1., -1.,  1.,  0.,  0.,  0.,  0., -1.],\n",
+      "        [ 0.,  1.,  0.,  0.,  0.,  1., -1.,  1., -1.,  0.]],\n",
       "       dtype=torch.float64)\n",
       "X before increase\n",
-      "tensor([[98, 46],\n",
-      "        [36, 42],\n",
-      "        [55, 24],\n",
-      "        [ 3, 14],\n",
-      "        [87, 17],\n",
-      "        [53, 10],\n",
-      "        [96,  2]])\n",
+      "tensor([[66, 38],\n",
+      "        [22,  2],\n",
+      "        [19, 43],\n",
+      "        [51, 10],\n",
+      "        [16, 62],\n",
+      "        [31, 25],\n",
+      "        [27, 22]])\n",
       "S after increase\n",
-      "tensor([[ 0.,  0.,  0.,  0., -1.,  1.,  0.,  0.,  0.,  0.],\n",
-      "        [ 1.,  0.,  0.,  0.,  0.,  0.,  1.,  0.,  0.,  0.],\n",
-      "        [ 0.,  0.,  0.,  0.,  0.,  0.,  0., -1.,  0.,  1.],\n",
-      "        [ 0.,  1.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],\n",
-      "        [ 0.,  0.,  0., -1.,  0.,  0.,  0.,  0., -1.,  0.],\n",
-      "        [ 0.,  0., -1.,  0.,  0.,  0.,  0.,  0.,  0.,  0.]],\n",
+      "tensor([[ 0.,  0.,  1.,  0.,  0.,  0.,  0.,  0.,  0., -1.],\n",
+      "        [ 0.,  0.,  0.,  0.,  0.,  1.,  0.,  1.,  0.,  0.],\n",
+      "        [ 0.,  0.,  0., -1.,  1.,  0.,  0.,  0.,  0.,  0.],\n",
+      "        [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],\n",
+      "        [ 0.,  1.,  0.,  0.,  0.,  0.,  0.,  0., -1.,  0.],\n",
+      "        [ 0.,  0.,  0.,  0.,  0.,  0., -1.,  0.,  0.,  0.]],\n",
       "       dtype=torch.float64)\n",
       "X after increase\n",
-      "tensor([[98, 46, 98, 98, 46, 46],\n",
-      "        [36, 42, 36, 36, 42, 42],\n",
-      "        [55, 24, 55, 55, 24, 24],\n",
-      "        [ 3, 14,  3,  3, 14, 14],\n",
-      "        [87, 17, 87, 87, 17, 17],\n",
-      "        [53, 10, 53, 53, 10, 10],\n",
-      "        [96,  2, 96, 96,  2,  2]])\n"
+      "tensor([[66, 38, 66, 66, 38, 38],\n",
+      "        [22,  2, 22, 22,  2,  2],\n",
+      "        [19, 43, 19, 19, 43, 43],\n",
+      "        [51, 10, 51, 51, 10, 10],\n",
+      "        [16, 62, 16, 16, 62, 62],\n",
+      "        [31, 25, 31, 31, 25, 25],\n",
+      "        [27, 22, 27, 27, 22, 22]])\n"
      ]
     }
    ],
@@ -441,7 +440,7 @@
    },
    "outputs": [],
    "source": [
-    "def get_initial_points(dim, n_pts, seed=0):\n",
+    "def get_initial_points(dim: int, n_pts: int, seed=0):\n",
     "    sobol = SobolEngine(dimension=dim, scramble=True, seed=seed)\n",
     "    X_init = (\n",
     "        2 * sobol.draw(n=n_pts).to(dtype=dtype, device=device) - 1\n",
@@ -545,116 +544,646 @@
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "iteration 11, d=2)  Best value: -6.42, TR length: 0.4\n",
-      "iteration 12, d=2)  Best value: -4.6, TR length: 0.4\n",
-      "iteration 13, d=2)  Best value: -4.6, TR length: 0.2\n",
-      "iteration 14, d=2)  Best value: -4.6, TR length: 0.1\n",
-      "iteration 15, d=2)  Best value: -3.64, TR length: 0.1\n",
-      "iteration 16, d=2)  Best value: -2.36, TR length: 0.1\n",
-      "iteration 17, d=2)  Best value: -1.73, TR length: 0.2\n",
-      "iteration 18, d=2)  Best value: -1.19, TR length: 0.2\n",
-      "iteration 19, d=2)  Best value: -0.661, TR length: 0.2\n",
-      "iteration 20, d=2)  Best value: -0.518, TR length: 0.4\n",
-      "iteration 21, d=2)  Best value: -0.518, TR length: 0.2\n",
-      "iteration 22, d=2)  Best value: -0.518, TR length: 0.1\n",
-      "iteration 23, d=2)  Best value: -0.518, TR length: 0.05\n",
-      "iteration 24, d=2)  Best value: -0.416, TR length: 0.05\n",
-      "iteration 25, d=2)  Best value: -0.409, TR length: 0.05\n",
-      "iteration 26, d=2)  Best value: -0.409, TR length: 0.025\n",
-      "iteration 27, d=2)  Best value: -0.406, TR length: 0.025\n",
-      "iteration 28, d=2)  Best value: -0.406, TR length: 0.0125\n",
-      "iteration 29, d=2)  Best value: -0.398, TR length: 0.0125\n",
-      "iteration 30, d=2)  Best value: -0.398, TR length: 0.00625\n",
+      "iteration 11, d=2)  Best value: -6.04, TR length: 0.4\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 12, d=2)  Best value: -0.951, TR length: 0.4\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 13, d=2)  Best value: -0.926, TR length: 0.4\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 14, d=2)  Best value: -0.925, TR length: 0.8\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 15, d=2)  Best value: -0.925, TR length: 0.4\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 16, d=2)  Best value: -0.925, TR length: 0.2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 17, d=2)  Best value: -0.925, TR length: 0.1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 18, d=2)  Best value: -0.925, TR length: 0.05\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 19, d=2)  Best value: -0.925, TR length: 0.025\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 20, d=2)  Best value: -0.925, TR length: 0.0125\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 21, d=2)  Best value: -0.925, TR length: 0.00625\n",
       "increasing target space\n",
-      "new dimensionality: 6\n",
-      "iteration 31, d=6)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 32, d=6)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 33, d=6)  Best value: -0.398, TR length: 0.1\n",
-      "iteration 34, d=6)  Best value: -0.398, TR length: 0.05\n",
-      "iteration 35, d=6)  Best value: -0.398, TR length: 0.025\n",
-      "iteration 36, d=6)  Best value: -0.398, TR length: 0.0125\n",
-      "iteration 37, d=6)  Best value: -0.398, TR length: 0.00625\n",
+      "new dimensionality: 6\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 22, d=6)  Best value: -0.475, TR length: 0.8\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 23, d=6)  Best value: -0.475, TR length: 0.4\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 24, d=6)  Best value: -0.475, TR length: 0.2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 25, d=6)  Best value: -0.475, TR length: 0.1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 26, d=6)  Best value: -0.475, TR length: 0.05\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 27, d=6)  Best value: -0.466, TR length: 0.05\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 28, d=6)  Best value: -0.466, TR length: 0.05\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 29, d=6)  Best value: -0.458, TR length: 0.1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 30, d=6)  Best value: -0.455, TR length: 0.1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 31, d=6)  Best value: -0.444, TR length: 0.1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 32, d=6)  Best value: -0.436, TR length: 0.2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 33, d=6)  Best value: -0.423, TR length: 0.2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 34, d=6)  Best value: -0.413, TR length: 0.2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 35, d=6)  Best value: -0.408, TR length: 0.4\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 36, d=6)  Best value: -0.401, TR length: 0.4\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 37, d=6)  Best value: -0.399, TR length: 0.4\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 38, d=6)  Best value: -0.399, TR length: 0.2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 39, d=6)  Best value: -0.399, TR length: 0.1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 40, d=6)  Best value: -0.398, TR length: 0.1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 41, d=6)  Best value: -0.398, TR length: 0.05\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 42, d=6)  Best value: -0.398, TR length: 0.025\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 43, d=6)  Best value: -0.398, TR length: 0.0125\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 44, d=6)  Best value: -0.398, TR length: 0.00625\n",
       "increasing target space\n",
       "new dimensionality: 18\n",
-      "iteration 38, d=18)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 39, d=18)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 40, d=18)  Best value: -0.398, TR length: 0.1\n",
-      "iteration 41, d=18)  Best value: -0.398, TR length: 0.05\n",
-      "iteration 42, d=18)  Best value: -0.398, TR length: 0.025\n",
-      "iteration 43, d=18)  Best value: -0.398, TR length: 0.0125\n",
-      "iteration 44, d=18)  Best value: -0.398, TR length: 0.00625\n",
+      "iteration 45, d=18)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 46, d=18)  Best value: -0.398, TR length: 0.2\n",
+      "iteration 47, d=18)  Best value: -0.398, TR length: 0.1\n",
+      "iteration 48, d=18)  Best value: -0.398, TR length: 0.05\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 49, d=18)  Best value: -0.398, TR length: 0.025\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 50, d=18)  Best value: -0.398, TR length: 0.0125\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/linear_operator/linear_operator/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 51, d=18)  Best value: -0.398, TR length: 0.00625\n",
       "increasing target space\n",
       "new dimensionality: 54\n",
-      "iteration 45, d=54)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 46, d=54)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 47, d=54)  Best value: -0.398, TR length: 0.1\n",
-      "iteration 48, d=54)  Best value: -0.398, TR length: 0.05\n",
-      "iteration 49, d=54)  Best value: -0.398, TR length: 0.025\n",
-      "iteration 50, d=54)  Best value: -0.398, TR length: 0.0125\n",
-      "iteration 51, d=54)  Best value: -0.398, TR length: 0.00625\n",
+      "iteration 52, d=54)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 53, d=54)  Best value: -0.398, TR length: 0.2\n",
+      "iteration 54, d=54)  Best value: -0.398, TR length: 0.1\n",
+      "iteration 55, d=54)  Best value: -0.398, TR length: 0.05\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/balandat/Code/botorch/botorch/optim/fit.py:104: OptimizationWarning: `scipy_minimize` terminated with status OptimizationStatus.FAILURE, displaying original message from `scipy.optimize.minimize`: ABNORMAL_TERMINATION_IN_LNSRCH\n",
+      "  warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iteration 56, d=54)  Best value: -0.398, TR length: 0.025\n",
+      "iteration 57, d=54)  Best value: -0.398, TR length: 0.0125\n",
+      "iteration 58, d=54)  Best value: -0.398, TR length: 0.00625\n",
       "increasing target space\n",
       "new dimensionality: 162\n",
-      "iteration 52, d=162)  Best value: -0.398, TR length: 0.8\n",
-      "iteration 53, d=162)  Best value: -0.398, TR length: 0.8\n",
-      "iteration 54, d=162)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 55, d=162)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 56, d=162)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 57, d=162)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 58, d=162)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 59, d=162)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 60, d=162)  Best value: -0.398, TR length: 0.1\n",
-      "iteration 61, d=162)  Best value: -0.398, TR length: 0.1\n",
-      "iteration 62, d=162)  Best value: -0.398, TR length: 0.1\n",
-      "iteration 63, d=162)  Best value: -0.398, TR length: 0.05\n",
-      "iteration 64, d=162)  Best value: -0.398, TR length: 0.05\n",
-      "iteration 65, d=162)  Best value: -0.398, TR length: 0.05\n",
-      "iteration 66, d=162)  Best value: -0.398, TR length: 0.025\n",
-      "iteration 67, d=162)  Best value: -0.398, TR length: 0.025\n",
-      "iteration 68, d=162)  Best value: -0.398, TR length: 0.025\n",
-      "iteration 69, d=162)  Best value: -0.398, TR length: 0.0125\n",
-      "iteration 70, d=162)  Best value: -0.398, TR length: 0.0125\n",
-      "iteration 71, d=162)  Best value: -0.398, TR length: 0.0125\n",
-      "iteration 72, d=162)  Best value: -0.398, TR length: 0.00625\n",
+      "iteration 59, d=162)  Best value: -0.398, TR length: 0.8\n",
+      "iteration 60, d=162)  Best value: -0.398, TR length: 0.8\n",
+      "iteration 61, d=162)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 62, d=162)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 63, d=162)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 64, d=162)  Best value: -0.398, TR length: 0.2\n",
+      "iteration 65, d=162)  Best value: -0.398, TR length: 0.2\n",
+      "iteration 66, d=162)  Best value: -0.398, TR length: 0.2\n",
+      "iteration 67, d=162)  Best value: -0.398, TR length: 0.1\n",
+      "iteration 68, d=162)  Best value: -0.398, TR length: 0.1\n",
+      "iteration 69, d=162)  Best value: -0.398, TR length: 0.1\n",
+      "iteration 70, d=162)  Best value: -0.398, TR length: 0.05\n",
+      "iteration 71, d=162)  Best value: -0.398, TR length: 0.05\n",
+      "iteration 72, d=162)  Best value: -0.398, TR length: 0.05\n",
+      "iteration 73, d=162)  Best value: -0.398, TR length: 0.025\n",
+      "iteration 74, d=162)  Best value: -0.398, TR length: 0.025\n",
+      "iteration 75, d=162)  Best value: -0.398, TR length: 0.025\n",
+      "iteration 76, d=162)  Best value: -0.398, TR length: 0.0125\n",
+      "iteration 77, d=162)  Best value: -0.398, TR length: 0.0125\n",
+      "iteration 78, d=162)  Best value: -0.398, TR length: 0.0125\n",
+      "iteration 79, d=162)  Best value: -0.398, TR length: 0.00625\n",
       "increasing target space\n",
       "new dimensionality: 485\n",
-      "iteration 73, d=485)  Best value: -0.398, TR length: 0.8\n",
-      "iteration 74, d=485)  Best value: -0.398, TR length: 0.8\n",
-      "iteration 75, d=485)  Best value: -0.398, TR length: 0.8\n",
-      "iteration 76, d=485)  Best value: -0.398, TR length: 0.8\n",
-      "iteration 77, d=485)  Best value: -0.398, TR length: 0.8\n",
-      "iteration 78, d=485)  Best value: -0.398, TR length: 0.8\n",
-      "iteration 79, d=485)  Best value: -0.398, TR length: 0.8\n",
       "iteration 80, d=485)  Best value: -0.398, TR length: 0.8\n",
       "iteration 81, d=485)  Best value: -0.398, TR length: 0.8\n",
-      "iteration 82, d=485)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 83, d=485)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 84, d=485)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 85, d=485)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 86, d=485)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 87, d=485)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 88, d=485)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 82, d=485)  Best value: -0.398, TR length: 0.8\n",
+      "iteration 83, d=485)  Best value: -0.398, TR length: 0.8\n",
+      "iteration 84, d=485)  Best value: -0.398, TR length: 0.8\n",
+      "iteration 85, d=485)  Best value: -0.398, TR length: 0.8\n",
+      "iteration 86, d=485)  Best value: -0.398, TR length: 0.8\n",
+      "iteration 87, d=485)  Best value: -0.398, TR length: 0.8\n",
+      "iteration 88, d=485)  Best value: -0.398, TR length: 0.8\n",
       "iteration 89, d=485)  Best value: -0.398, TR length: 0.4\n",
       "iteration 90, d=485)  Best value: -0.398, TR length: 0.4\n",
       "iteration 91, d=485)  Best value: -0.398, TR length: 0.4\n",
-      "iteration 92, d=485)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 93, d=485)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 94, d=485)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 95, d=485)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 96, d=485)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 97, d=485)  Best value: -0.398, TR length: 0.2\n",
-      "iteration 98, d=485)  Best value: -0.398, TR length: 0.2\n",
+      "iteration 92, d=485)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 93, d=485)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 94, d=485)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 95, d=485)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 96, d=485)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 97, d=485)  Best value: -0.398, TR length: 0.4\n",
+      "iteration 98, d=485)  Best value: -0.398, TR length: 0.4\n",
       "iteration 99, d=485)  Best value: -0.398, TR length: 0.2\n",
       "iteration 100, d=485)  Best value: -0.398, TR length: 0.2\n"
      ]
     }
    ],
    "source": [
-    "evaluation_budget = 100\n",
+    "EVALUATION_BUDGET = 100 if not SMOKE_TEST else 10\n",
+    "NUM_RESTARTS = 10 if not SMOKE_TEST else 2\n",
+    "RAW_SAMPLES = 512 if not SMOKE_TEST else 4\n",
+    "N_CANDIDATES = min(5000, max(2000, 200 * dim)) if not SMOKE_TEST else 4\n",
     "\n",
-    "state = BaxusState(dim=dim, eval_budget=evaluation_budget - n_init)\n",
+    "\n",
+    "state = BaxusState(dim=dim, eval_budget=EVALUATION_BUDGET - n_init)\n",
     "S = embedding_matrix(input_dim=state.dim, target_dim=state.d_init)\n",
     "\n",
     "X_baxus_target = get_initial_points(state.d_init, n_init)\n",
@@ -663,13 +1192,10 @@
     "    [branin_emb(x) for x in X_baxus_input], dtype=dtype, device=device\n",
     ").unsqueeze(-1)\n",
     "\n",
-    "NUM_RESTARTS = 10 if not SMOKE_TEST else 2\n",
-    "RAW_SAMPLES = 512 if not SMOKE_TEST else 4\n",
-    "N_CANDIDATES = min(5000, max(2000, 200 * dim)) if not SMOKE_TEST else 4\n",
     "\n",
     "# Disable input scaling checks as we normalize to [-1, 1]\n",
     "with botorch.settings.validate_input_scaling(False):\n",
-    "    for _ in range(evaluation_budget - n_init):  # Run until evaluation budget depleted\n",
+    "    for _ in range(EVALUATION_BUDGET - n_init):  # Run until evaluation budget depleted\n",
     "        # Fit a GP model\n",
     "        train_Y = (Y_baxus - Y_baxus.mean()) / Y_baxus.std()\n",
     "        likelihood = GaussianLikelihood(noise_constraint=Interval(1e-8, 1e-3))\n",
@@ -744,8 +1270,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## GP-EI\n",
-    "As a baseline, we compare BAxUS to Expected Improvement (EI)"
+    "## GP-LogEI\n",
+    "As a baseline, we compare BAxUS to Log Expected Improvement (LogEI)"
    ]
   },
   {
@@ -759,96 +1285,96 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "11) Best value: -9.02e+00\n",
-      "12) Best value: -9.02e+00\n",
-      "13) Best value: -9.02e+00\n",
-      "14) Best value: -9.02e+00\n",
-      "15) Best value: -9.02e+00\n",
-      "16) Best value: -9.02e+00\n",
-      "17) Best value: -9.02e+00\n",
-      "18) Best value: -9.02e+00\n",
-      "19) Best value: -2.11e+00\n",
-      "20) Best value: -2.11e+00\n",
-      "21) Best value: -2.11e+00\n",
-      "22) Best value: -2.11e+00\n",
-      "23) Best value: -2.11e+00\n",
-      "24) Best value: -2.11e+00\n",
-      "25) Best value: -2.11e+00\n",
-      "26) Best value: -2.11e+00\n",
-      "27) Best value: -2.11e+00\n",
-      "28) Best value: -2.11e+00\n",
-      "29) Best value: -2.11e+00\n",
-      "30) Best value: -2.11e+00\n",
-      "31) Best value: -2.11e+00\n",
-      "32) Best value: -2.11e+00\n",
-      "33) Best value: -2.11e+00\n",
-      "34) Best value: -2.11e+00\n",
-      "35) Best value: -2.11e+00\n",
-      "36) Best value: -2.11e+00\n",
-      "37) Best value: -2.11e+00\n",
-      "38) Best value: -2.11e+00\n",
-      "39) Best value: -2.11e+00\n",
-      "40) Best value: -2.11e+00\n",
-      "41) Best value: -2.11e+00\n",
-      "42) Best value: -2.11e+00\n",
-      "43) Best value: -2.11e+00\n",
-      "44) Best value: -2.11e+00\n",
-      "45) Best value: -2.11e+00\n",
-      "46) Best value: -2.11e+00\n",
-      "47) Best value: -2.11e+00\n",
-      "48) Best value: -2.11e+00\n",
-      "49) Best value: -2.11e+00\n",
-      "50) Best value: -2.11e+00\n",
-      "51) Best value: -2.11e+00\n",
-      "52) Best value: -2.11e+00\n",
-      "53) Best value: -2.11e+00\n",
-      "54) Best value: -2.11e+00\n",
-      "55) Best value: -2.11e+00\n",
-      "56) Best value: -2.11e+00\n",
-      "57) Best value: -2.11e+00\n",
-      "58) Best value: -2.11e+00\n",
-      "59) Best value: -2.11e+00\n",
-      "60) Best value: -2.11e+00\n",
-      "61) Best value: -2.11e+00\n",
-      "62) Best value: -2.11e+00\n",
-      "63) Best value: -2.11e+00\n",
-      "64) Best value: -2.11e+00\n",
-      "65) Best value: -2.11e+00\n",
-      "66) Best value: -2.11e+00\n",
-      "67) Best value: -9.90e-01\n",
-      "68) Best value: -9.90e-01\n",
-      "69) Best value: -9.90e-01\n",
-      "70) Best value: -9.90e-01\n",
-      "71) Best value: -9.90e-01\n",
-      "72) Best value: -9.90e-01\n",
-      "73) Best value: -9.90e-01\n",
-      "74) Best value: -9.90e-01\n",
-      "75) Best value: -9.90e-01\n",
-      "76) Best value: -9.90e-01\n",
-      "77) Best value: -9.90e-01\n",
-      "78) Best value: -9.90e-01\n",
-      "79) Best value: -9.90e-01\n",
-      "80) Best value: -9.90e-01\n",
-      "81) Best value: -9.90e-01\n",
-      "82) Best value: -9.90e-01\n",
-      "83) Best value: -9.90e-01\n",
-      "84) Best value: -9.90e-01\n",
-      "85) Best value: -9.90e-01\n",
-      "86) Best value: -9.90e-01\n",
-      "87) Best value: -9.90e-01\n",
-      "88) Best value: -9.90e-01\n",
-      "89) Best value: -9.90e-01\n",
-      "90) Best value: -9.90e-01\n",
-      "91) Best value: -9.90e-01\n",
-      "92) Best value: -9.90e-01\n",
-      "93) Best value: -9.90e-01\n",
-      "94) Best value: -9.90e-01\n",
-      "95) Best value: -9.90e-01\n",
-      "96) Best value: -9.90e-01\n",
-      "97) Best value: -9.90e-01\n",
-      "98) Best value: -9.90e-01\n",
-      "99) Best value: -9.90e-01\n",
-      "100) Best value: -9.90e-01\n"
+      "11) Best value: -4.16e-01\n",
+      "12) Best value: -4.16e-01\n",
+      "13) Best value: -4.16e-01\n",
+      "14) Best value: -4.16e-01\n",
+      "15) Best value: -4.16e-01\n",
+      "16) Best value: -4.16e-01\n",
+      "17) Best value: -4.16e-01\n",
+      "18) Best value: -4.16e-01\n",
+      "19) Best value: -4.16e-01\n",
+      "20) Best value: -4.16e-01\n",
+      "21) Best value: -4.16e-01\n",
+      "22) Best value: -4.16e-01\n",
+      "23) Best value: -4.16e-01\n",
+      "24) Best value: -4.16e-01\n",
+      "25) Best value: -4.16e-01\n",
+      "26) Best value: -4.16e-01\n",
+      "27) Best value: -4.16e-01\n",
+      "28) Best value: -4.16e-01\n",
+      "29) Best value: -4.16e-01\n",
+      "30) Best value: -4.16e-01\n",
+      "31) Best value: -4.16e-01\n",
+      "32) Best value: -4.16e-01\n",
+      "33) Best value: -4.16e-01\n",
+      "34) Best value: -4.16e-01\n",
+      "35) Best value: -4.16e-01\n",
+      "36) Best value: -4.16e-01\n",
+      "37) Best value: -4.16e-01\n",
+      "38) Best value: -4.16e-01\n",
+      "39) Best value: -4.16e-01\n",
+      "40) Best value: -4.16e-01\n",
+      "41) Best value: -4.14e-01\n",
+      "42) Best value: -4.14e-01\n",
+      "43) Best value: -4.14e-01\n",
+      "44) Best value: -4.14e-01\n",
+      "45) Best value: -4.14e-01\n",
+      "46) Best value: -4.14e-01\n",
+      "47) Best value: -4.14e-01\n",
+      "48) Best value: -4.14e-01\n",
+      "49) Best value: -4.14e-01\n",
+      "50) Best value: -4.14e-01\n",
+      "51) Best value: -4.14e-01\n",
+      "52) Best value: -4.14e-01\n",
+      "53) Best value: -4.14e-01\n",
+      "54) Best value: -4.14e-01\n",
+      "55) Best value: -4.14e-01\n",
+      "56) Best value: -4.14e-01\n",
+      "57) Best value: -4.14e-01\n",
+      "58) Best value: -4.14e-01\n",
+      "59) Best value: -4.14e-01\n",
+      "60) Best value: -4.14e-01\n",
+      "61) Best value: -4.08e-01\n",
+      "62) Best value: -4.08e-01\n",
+      "63) Best value: -4.08e-01\n",
+      "64) Best value: -4.08e-01\n",
+      "65) Best value: -4.02e-01\n",
+      "66) Best value: -4.02e-01\n",
+      "67) Best value: -4.02e-01\n",
+      "68) Best value: -4.02e-01\n",
+      "69) Best value: -4.02e-01\n",
+      "70) Best value: -4.02e-01\n",
+      "71) Best value: -4.02e-01\n",
+      "72) Best value: -4.02e-01\n",
+      "73) Best value: -4.02e-01\n",
+      "74) Best value: -4.02e-01\n",
+      "75) Best value: -4.02e-01\n",
+      "76) Best value: -4.02e-01\n",
+      "77) Best value: -4.02e-01\n",
+      "78) Best value: -4.02e-01\n",
+      "79) Best value: -4.02e-01\n",
+      "80) Best value: -4.02e-01\n",
+      "81) Best value: -4.00e-01\n",
+      "82) Best value: -4.00e-01\n",
+      "83) Best value: -4.00e-01\n",
+      "84) Best value: -4.00e-01\n",
+      "85) Best value: -4.00e-01\n",
+      "86) Best value: -4.00e-01\n",
+      "87) Best value: -4.00e-01\n",
+      "88) Best value: -4.00e-01\n",
+      "89) Best value: -4.00e-01\n",
+      "90) Best value: -4.00e-01\n",
+      "91) Best value: -4.00e-01\n",
+      "92) Best value: -4.00e-01\n",
+      "93) Best value: -4.00e-01\n",
+      "94) Best value: -4.00e-01\n",
+      "95) Best value: -4.00e-01\n",
+      "96) Best value: -4.00e-01\n",
+      "97) Best value: -4.00e-01\n",
+      "98) Best value: -4.00e-01\n",
+      "99) Best value: -4.00e-01\n",
+      "100) Best value: -4.00e-01\n"
      ]
     }
    ],
@@ -857,6 +1383,13 @@
     "Y_ei = torch.tensor(\n",
     "    [branin_emb(x) for x in X_ei], dtype=dtype, device=device\n",
     ").unsqueeze(-1)\n",
+    "bounds = torch.stack(\n",
+    "    [\n",
+    "        -torch.ones(dim, dtype=dtype, device=device),\n",
+    "        torch.ones(dim, dtype=dtype, device=device),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
     "\n",
     "# Disable input scaling checks as we normalize to [-1, 1]\n",
     "with botorch.settings.validate_input_scaling(False):\n",
@@ -879,12 +1412,7 @@
     "        ei = LogExpectedImprovement(model, train_Y.max())\n",
     "        candidate, acq_value = optimize_acqf(\n",
     "            ei,\n",
-    "            bounds=torch.stack(\n",
-    "                [\n",
-    "                    -torch.ones(dim, dtype=dtype, device=device),\n",
-    "                    torch.ones(dim, dtype=dtype, device=device),\n",
-    "                ]\n",
-    "            ),\n",
+    "            bounds=bounds,\n",
     "            q=1,\n",
     "            num_restarts=NUM_RESTARTS,\n",
     "            raw_samples=RAW_SAMPLES,\n",
@@ -946,7 +1474,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAKBCAYAAADKqj3oAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAACWPklEQVR4nOzdd3hUVf7H8c+k90YJhCYovYMBERUQULEiFkRXUVfdnwYbu67o2thVsa9ls+LasIu9IKsiRSxIL9JR6SQBAiE9mczc3x9sxtyZlAkzkztJ3q/nyWPumTPnfic5wfnOaTbDMAwBAAAAgA9CrA4AAAAAQONHYgEAAADAZyQWAAAAAHxGYgEAAADAZyQWAAAAAHxGYgEAAADAZyQWAAAAAHxGYgEAAADAZyQWAAAAAHxGYgEAzciOHTtks9lks9l03HHHWR2O3wTqdR133HGudnfs2OG3dv2pqf5OG5tFixa5fg8jR460OhzAEiQWQBCZNWuW639M3n5dd9119brH/PnzddVVV6lbt26KjY1VSkqK+vXrpzvuuEObN28+prg3bdqkO+64Q/369VNKSopiY2PVrVs3TZ48WfPnz/e6ndpeZ1xcnNLS0tSzZ0+deeaZuvvuu/Xhhx8qPz//mGL2xtVXX13v3wdvLNDYVX2DXNNXRESEWrVqpaFDh+rWW2/VihUrrA4bQBAIszoAAA0jPz9fN9xwg2bPnm0qLy4u1uHDh/Xzzz/rmWee0fTp03XXXXd53e5DDz2k6dOny263m8q3bdumbdu26fXXX9ekSZP0wgsvKD4+/pjjLyoqUlFRkbKysrR582Z9/fXXkqTY2Fhddtllmjp1qnr16nXM7QPwnt1u18GDB3Xw4EEtW7ZMzz77rCZOnKgXX3zRp79zAI0biQUQpHr06KHRo0fXWe/kk0+us47dbteFF16oBQsWuMr69OmjQYMGqbS0VN99952ysrJkt9t19913y26367777quz3fvuu0//+Mc/XNdt27bVqaeeqqioKK1cuVIbNmyQJL3zzjvKzc3VF198obAw7/7ZGT9+vNq1a+e6rqio0OHDh5Wbm6vVq1fr0KFDko4mHC+//LLefPNNPfzww7r99ttls9m8ukd9ePv7qNS1a1e/xwBYISMjw6OspKREe/bs0Y8//qjCwkJJ0uzZs7Vnzx4tWrTI679zAE2MASBovPrqq4YkQ5IxefJkv7V77733utqNiooy3nnnHdPjZWVlxh133OGqY7PZjEWLFtXa5jfffOOqL8m44447jLKyMlOdt99+24iKinLVmT59eq1tVm1v4cKFtdbdsGGDcfPNNxuxsbGm52VkZNT6vPqYPHlyQH4fVtq+fbvrNXXq1MnqcPwmUK+rU6dOrna3b9/ut3b9yd+vfeHChaa/qdoUFhYaU6ZMMdXPzMz0OQYAjRNrLIAmbv/+/Xrqqadc108//bQuu+wyU52IiAg99thjmjhxoiTJMIw6p0NVffyyyy7TY489poiICFOdSZMm6Z///Kfr+oknntDBgweP+bVU1atXLz377LNas2aN+vbt6yrPzMzU888/75d7AKhdbGysnnvuOZ155pmusrfeesvCiABYicQCaOJee+01FRUVSZK6deumG264oca6jz32mEJCjv6zsGTJEq1evbraesuXL9fy5cslSSEhIXrsscdqbPNPf/qTa1pQQUGB3njjjWN6HTU54YQTtHDhQnXo0MFVdvfddwd0UTcAs8svv9z1/caNGy2MBICVSCyAJu6TTz5xfV+5y1FNOnbsqNNPP911/fHHH9fZ5pgxY0xv6t3ZbDZNnjy5zjZ90aJFC7388suu67y8PGVmZvr9Pv4wcuRI1846ixYtkiRlZWVp+vTpGjhwoFJSUhQVFaUePXpo2rRprrUkVe3Zs0d33323Bg4cqOTkZMXHx2vAgAF6+OGHVVJSckxxzZ8/X5MmTdLxxx+v6OhotWrVSqeeeqr+9a9/qaysrF5tFRUV6fnnn9d5552nTp06KSYmRvHx8eratauuvfZa01ofb2RlZelvf/ub+vXrp4SEBCUkJKh37966/fbbtWXLlnq1VamsrEzPPfecTj31VLVq1UrR0dE6/vjjdfnll2vhwoXH1KbUOF57ILRt29b1feUHGdWputParFmzJB39e33mmWd02mmnqV27dgoLC5PNZlNeXp7pufv379err76qyZMnu/5WwsPDlZSUpB49euiaa67RV1995VW8DzzwgCuOBx54QNLRdVyvv/66xowZo3bt2ikyMlJt27bV+PHjNWfOnDrb9Ga72Zq2Bl6xYoWuu+46devWTTExMUpOTtaQIUP08MMP1/rzBIKO1XOxAPzO32ssSkpKjJCQEFebP/74Y53Peeihh1z1hw8fXm2dYcOGueo8/PDDdbb5ww8/uOqHhoYapaWl1daTvF9jUZ2+ffu6nt+vX796P99dINZYjBgxwvQav/rqK6NFixam1171q1OnTsaOHTtcz3/55ZeNyMjIGuv37t3b2L9/f433d5+PX15ebtxwww01tifJ6Nmzp7FlyxavXt97771ntGnTptb2JBnnnnuukZeXV2d7H330kZGUlFRjO5GRkcaLL75Yr3UGGzduNLp3715rfP/3f/9nlJeX12uNRWN47d6ozxqLSq+//rqrfocOHWqsV/Vv6tVXXzW+//57o0OHDtW+vsOHD7ue98wzzxihoaF1/mwlGaeffrpx8ODBWuO9//77XfXvv/9+Y8+ePcbJJ59ca7vXXHON4XA4vPq5jRgxoto67r8rp9Np3HfffaZ/p92/OnfubPz666+1vh4gWLBtAxCk8vLy9P7772vDhg06cuSIEhISlJaWpmHDhqlv375e7Xy0ZcsWOZ1OSUdHDgYOHFjncwYNGuT6ftOmTdXWqVpetX5Nqt7X4XBo69atpnUR/nLJJZfo559/liStX79eeXl5SkpK8vt9/GXNmjW6++67VVJSovbt22v48OGKj4/X1q1b9d1338kwDO3cuVPjxo3Tzz//rNmzZ+uPf/yjpKO7Tg0ZMkRRUVH6+eeftWzZMknShg0bdOWVV+rLL7/0KoY777xT//nPfyRJ/fr104ABA2QYhlauXOma0rJp0yadfvrpWrJkSa2jU//85z/15z//WYZhSJISEhI0bNgwtW/fXg6HQxs2bNCKFStkGIbmzJmjkSNH6ocfflBMTEy17X3xxRe69NJLVVFRIenotLvhw4erW7duKiws1OLFi5WVlaXrr79ezz77rFevd+fOnRo9erSysrJcZb1799agQYNks9m0atUqrV+/XjNnzqwxrsb62gOp6jbWp556qlfP+eWXX3TbbbfpyJEjio+P12mnnaa0tDQdPnxYixcvNtXdt2+fHA6HJKlLly7q2bOnWrVqpaioKOXl5ennn3927UK3YMECjRkzRj/99JMiIyPrjKOwsFBnnXWW1q9fr5iYGJ166qnq0KGDCgoKtHDhQu3fv1+S9Oqrr6p79+668847vXp93pg+fbr+/ve/S5IGDBigvn37Kjw8XGvWrNGqVaskSdu3b9f48eO1atUqdttC8LMyqwFgVnXEoravrl27Gi+99JLhdDprbW/27Nmu56SmpnoVw4YNG0z3cv/0Oycnx/T4pk2bvGq3VatWrue899571dap2u6xjFh89dVXpja++uqrerdRVaBHLCIjI43w8HAjMzPT45PQRYsWmXa8evjhh424uDgjISHB+OCDDzzanT17tukT3W+//bba+1f9xDQ8PNyQZLRo0aLan9Vnn31mJCQkuOqfeeaZNb6ub775xvWpa0REhPHII48YRUVFHvVWr15t9OrVy9XmjTfeWG17Bw8eNFq3bu2q17dvX2Pjxo2mOg6Hw3j00UcNm81mREREePWp/ejRo131EhMTjc8//9yjzty5c43k5GTTz0i1jFg0ltfurfqMWBQXFxt/+ctfXHXDwsKMlStX1li/6t9UWFiYIR3dya2goMBUr7y83PQ38fLLLxvPPfecsWfPnhrbXrt2rXHiiSe62v/HP/5RY92qIxaVI4CTJ082cnNzTfWKioqMSZMmuerGxcUZhYWF1bZZ3xGLiIgIw2azGccff7yxdOlSj7rvvfeeqf+99tprNb4eIFiQWABBxNvEovLr3HPPrfF/coZhGP/+979ddb2dGpSbm2u6x+bNm02Pb9y40fT4oUOHvGq36jSlmTNnVlvH18Rix44dpjZef/31erdRVdU3QT169DAyMjK8/tq6dWu1bVZNLCQZL730Uo33f/DBB011bTabMX/+/BrrX3fddXW+aa36xkaSERISYvzwww81tjlv3jxT/eru73A4jK5du7rqfPTRRzW2ZxiGkZWVZaSmprreuO/evdujzt13321KinNycmpsz/3nVNOb66+//tr0s1ywYEGNbS5evNiw2WymdqtLLBrLa68P98Siuv593XXXGWeddZYp8UxISDC+/PLLWtuu+jclybjuuut8jreqvLw813S0tm3bGhUVFdXWq5pYSDImTZpUY5slJSWm6VrvvvtutfXqm1hUJvV79+6t8d5Vk7azzjqr5hcOBAkSCyCIvPrqq0bHjh2NP//5z8bcuXON3bt3G6WlpUZRUZGxZcsW49///rfRo0cP0/+Yzj///Brn/T722GOuekOHDvUqhuLiYlP7K1asMD2+bNky0+MlJSVetTtkyBDXc5544olq6/iaWBw+fNjUxjPPPFPvNqpyfxNUn6+a4q+aWPTv37/W+//666+mNsePH19r/fnz57vqDh48uNo67m9srrzyyjp/DhMmTHDVv+yyyzwe/+STT7yOsdKMGTNcz3nyySdNjzmdTtNahbrORXBfC1HTm+tLL73UVeeSSy6pM8bLL7+8zsSisbz2+nBPLLz5uuKKK+pc12AY5r+pqKgorz+YqI8bb7zRdY9169ZVW6dqYhEREWFkZWXV2uZf//pXV/2pU6dWW+dYEgv337+7qh/ktGjRota6QDBgVyggiIwfP17bt2/XE088oXHjxql9+/aKjIxUTEyMunXrphtvvFFr167VNddc43rOZ599prfffrva9kpLS13fu58xURP3OcnuuwxVbfNY2z3WnYvqEhcXZ7ouKCgIyH385eKLL6718S5duig2Ntbr+n369HF9v337dq9iuOqqq+qsU3VXr+p2TJo7d67r+6rbjtam6u5j33//vemxTZs2KTs7W5IUFhZWZ5vh4eFe3bdq7PV93TVpLK890N566y0NHDiwXru+nXHGGUpOTq73vfbv36/PPvtMjz76qKZNm6abb75ZU6ZMcX2tWLHCVXfNmjV1tnfKKaeoTZs2tdapuk5sx44d9Y65Jpdcckmtj/fo0UPR0dGSpNzc3KD/Nw1gFRAQRLxZaBwREaGXXnpJv/zyi7777jtJ0qOPPqo//OEPHnWjoqJc35eXl3sVg/vWopX/U6uuzcp23cvqate9TX9x/59uQkKC39qePHmya3tMf6maCNQkKSnJtd1k7969a62bkpLi+t6bczxsNpuGDh1aZ71hw4a5vs/JyVFWVpZpe9ElS5a4vv/www/17bff1tnmkSNHXN/v3r3b9FjV81N69Ojh1d9F1Rirs3fvXh04cMB1fdJJJ9XZ5kknnSSbzeZakF2dxvDafVXd63c4HMrNzdXKlSs1c+ZMffbZZ9q9e7cmTJigF154odbzcioNHjy4XnFs3LhRd955p/773/+6FnLXxZsDOb3ZSKJFixau7/11Rk5iYmKtmyFIR/9Gk5OTXR/G5OfnKz4+3i/3BwKBxAJohEJCQnT//fdrzJgxko7ugLRnzx61b9/eVK/qJ/jejhK413MfBXC/Likp8SqxqNquexv+UvUNm2R+ox2MEhMT66xTdReYuupXrVu5m1BtKs/AqEvl7juVo1UHDhwwJRb79u1zfV91dyBvHT582HRdNQHo2LGjV23UVa9qmzExMWrZsmWdbSYkJCgxMdHjPIWqGsNrD4TQ0FC1bt1a48aN07hx4/TAAw9o+vTpkqRbbrlFI0eOVLdu3Wpto1WrVl7f76uvvtIFF1xQ7zNVvPmE35u/w/DwcNf3dru9XjH4ct9A3RsIFKZCAY3UaaedZvofTnVbw1b9lC0nJ8erdiunYVRyf3Netc1jbTdQb/g3b95suq5reoPVvNky2Jf6danPdqpVp2S5v1lzT+jqyz0JKiwsdH3vbYxV46vOsbTpTbuN4bU3hHvuuceV4JSVlXm1Ba63I5cHDhzQxIkTXUlFp06dNGPGDH3//ffat2+fiouL5XQ6ZRxdN6r777/f9dzK7bZr4++/K29ZdV8gkEgsgEYqPDzc9KlrdUP+3bt3d32/f/9+j/UR1dm1a5fr+5SUFI9PFVu3bm2anrFz58462ywtLTV9EtujR486n3Msli5d6vo+NDRU6enpAblPU1FcXOx13aqn/7qPclR9Y7tq1SrXGzxvv9znrFcd0fI2xrpOJz6WNr1ptzG89oYQFham0aNHu67nz5/vt7ZffPFFVwLXv39/rVu3TtOmTdPw4cPVtm1bRUdHm96ksw4BsA6JBdCIVX1DUd2nlt27d1dIyNE/c8MwvFrIWHkokyT17Nmz2jpVy6vOCfemzdDQ0DqnSByrDz74wPV9//79/brGoik6fPiw6RPymhw8eNCUlLpPI0pNTXV97z7idSyqJrNVE93auK9VqK3N4uJi5ebm1tlmQUFBnSMSjeG1N5Sq0+O8+cDBW1WTlHvuuafOv2t/3htA/ZBYAI3Ub7/9ZlpEmJaW5lEnKirKtEh10aJFdbZbdfFp1d1rqho1atQxt3nyySd7dRpufX399ddav3696/qyyy7z+z2aGsMwTKM8Nam6QDk1NdWjr1VdAP7DDz/4HFfVHXg2b97s1XSjqjFWp127dqY37T/99FOdbf7000+1LtyWGsdrbyhVR1gqP9Dwh6rrWOpaaO1wOPzyewBwbEgsgEbqlVdecX2fmJioAQMGVFtv/Pjxru/r2tVo9+7dpk8Hqz63pja/+eYb7dmzp9Z2q963pjZ9kZubq+uuu8513aJFC914441+v09T9MYbb9RZ5/XXX3d9XzWprHTuuee6vn/llVe8mnJXmx49erjWx1RUVOidd96ptb43dSRz7PV93TVpLK+9IVQdmWzXrp3f2q2apNQ1PeyTTz7xy8gRgGNDYgEECW+mpFT68ccf9eSTT7quL7vsMtOOQFVNnjzZNU1qy5Yteumll2ps984773Rt4zhs2DANGjSo2nrp6emu9QsOh0PTpk2rsc3//Oc/2rp1q6Sjc/O9OT+gPn755Redfvrppukgjz32WMB2nmpq3nzzzVpHLRYuXKgPP/zQdV01gat00UUX6YQTTpAkZWVl6aabbqrzk/5KhYWFHmsEQkJCdO2117qup0+fblqj4+6JJ57w6tyOqrG/9957Wrx4cY11f/jhhxrPh6mqsbz2QFuxYoVr+2tJpvUWvurSpYvr+88++6zGegcOHNDtt9/ut/sCqD8SCyBIfPDBBxoyZIhef/31Gqc/lJaW6tlnn9WYMWNcn4wmJSWZdkFx17p1a02dOtV1fcstt+i9994z1bHb7Zo2bZrpk88ZM2bUGm/Vx9966y1NmzbNYyvE9957T7fddpvr+i9/+YtX23x6Y9OmTbr11ls1YMAArVu3zlU+depU0xsz1Cw8PFwOh0PnnnuuvvnmG4/Hv/jiC1144YWuN8pjx46t9g1jaGionn/+eYWGhkqSXn31VZ1zzjnV7lRWac2aNbrzzjvVoUOHat8Y33777a6+kp2drbFjx3rs+uV0OvXkk0/qb3/7m1cHNY4dO9Y1amEYhsaPH2864K7S119/rfPPP19Op9O081p1GstrD6RvvvlGF1xwgaufhIWF6eabb/Zb++edd57r+xkzZujNN9/0qLNq1SqNGDFCu3fvDopdsoDminMsgCCyfPlyTZ48WWFhYerRo4d69Oih5ORkORwO7d27V0uWLDGtq4iOjtann35qWjRZnXvvvVc//PCDFixYoJKSEk2cOFEPPvigBg0apNLSUi1evFhZWVmu+tOnT9eIESNqbXP06NG655579OCDD0o6ekjfG2+8oVNPPVVRUVFauXKlac3D2LFjdffdd3v9s3jmmWdMi7ErKiqUl5en3NxcrV692mPxbXR0tB599FFNmTLF63vUx9KlS+vd9uOPPx6wwwD9IS0tTRdeeKGefvppjR07Vv3799eAAQNkGIZWrlypDRs2uOq2bdtWL774Yo1tjRkzRs8//7xuvPFGORwO/fe//9WXX36pXr16qV+/fkpISFBxcbGysrK0du3aWj+Fl44uEH/55Zc1YcIEORwOrV27Vr1799Ypp5yibt26qbCwUIsXL3bNv3/88cd166231vmaX375ZQ0bNkw5OTk6fPiwzjnnHPXp00eDBg2SzWbT6tWrXYnq1KlT9eGHH9a5GLixvPZjVV2/dzgcOnTokFauXKlff/3V9NgTTzxR48YPx2Ly5Ml68skntXXrVpWVlenKK6/Uww8/rP79+ysqKkrr1693nbbdv39/nXnmmXrsscf8dn8A9WAACAqvvvqqIcnrryFDhhgbN270uv28vDzj0ksvrbXN8PBw46GHHvK6TafTafzjH/8wwsPDa233sssuM44cOVJne/V5/ZVfcXFxxvXXX29s3rzZ67i9NXny5GOKqfLr8OHDHm2OGDHC9fjChQvrjKFTp06u+tu3b6+zftX7V2f79u2uxzt16mSUl5cbf/zjH2t9Hd27dzc2bdpU570NwzAWLFhgdO3a1eufUe/evY29e/fW2N77779vJCYm1vj8yMhI44UXXvB4XbVZv359nTFef/31Rnl5eb1+/o3htXtj4cKFx9TfU1JSjDfeeKPWtqv+Tb366qtex7RlyxajS5cutd5/+PDhxp49e4z777/fVXb//fdX2543dWr6mYwYMeKY6xzL76q+/wYAVmLEAggSkyZNUrdu3fTjjz/qp59+0q+//qqDBw8qNzdXTqdTiYmJ6ty5s0466SRdfPHFOuWUU+rVfmJiombPnq3rr79er732mpYsWaKsrCyFh4erQ4cOOvPMM/XHP/6xXp802mw23XPPPbrooov00ksv6euvv9bu3btlt9vVtm1bDRs2TJMnT3adEO6L6OhoJSYmKiEhQZ06ddLgwYOVnp6usWPHenV6NKoXHh6ul156SZdccolefvllLV++XFlZWYqNjVXPnj01ceJE3XDDDV7v5DVq1Cht2rRJn3zyib744gv99NNPys7OVn5+vmJiYpSamqoePXro5JNP1rhx42rcdKDSxRdfrJNPPlnPPfecPv/8c+3cuVM2m03t27fXmDFjdOONN6pnz54e50HUpnfv3lq3bp3+85//aPbs2dq8ebOKi4vVtm1bpaen67rrrtPYsWO9bq8xvXZ/sdlsio+PV+vWrTVgwACdeeaZuuyyywK2tqlbt25avXq1MjMz9dFHH2nLli0qLy9XmzZt1LdvX11++eW69NJLXVPSAFjDZhherjIDAAAAgBqweBsAAACAz0gsAAAAAPiMxAIAAACAz0gsAAAAAPiMxAIAAACAz9hu1k+cTqf27dun+Ph42Ww2q8MBAAAATAzDUEFBgdLS0hQS4v/xBRILP9m3b586dOhgdRgAAABArXbv3q327dv7vV0SCz+pPKBr+/btSklJsTgaBBu73a6vv/5aZ5xxhsLDw60OB0GIPoK60EdQF/oI6nLo0CF17tw5YAfLklj4SeX0p/j4eCUkJFgcDYKN3W5XTEyMEhIS+Mce1aKPoC70EdSFPoK62O12SQrYtH0Wb/soMzNTvXr1Unp6utWhAAAAAJYhsfBRRkaGNm7cqOXLl1sdCgAAAGAZEgsAAAAAPiOxAAAAAOAzEgsAAAAAPiOx8BGLtwEAAAASC5+xeBsAAAAgsQAAAADgByQWAAAAAHxGYgEAAADAZyQWAAAAAHxGYgEAAADAZyQWPmK7WQAAAIDEwmdsNwsAAACQWAAAAADwAxILAAAAAD4jsQAAAADgMxILP9uTV2x1CAAAAECDI7Hws//+vN/qEAAAAIAGR2LhZ3PXZ8kwDKvDAAAAABoUiYWP3M+x2JFbpHV7jlgcFQAAANCwSCx85H6OxQlRq/Tx6r0WRwUAAAA0LBILP2sVu1qfr90nu8NpdSgAAABAgyGx8LOSmCzlFpXr+20HrQ4FAAAAaDAkFn62I7pC0bZ8fcR0KAAAADQjJBZ+VmGzqUfcd/p6Q7YKSu1WhwMAAAA0CBKLAIiP3aCyCqe+XJ9tdSgAAABAgyCxCIADsbmSpE/WMB0KAAAAzQOJRQDsibCpddgO/fhrrrKOlFgdDgAAABBwJBYBcnz8DzIM6bM1+6wOBQAAAAg4EosACYn9RZI4LA8AAADNAomFjzIzM9WrVy+lp6ebynfFFMmmCm3OLtCmrHyLogMAAAAaBomFjzIyMrRx40YtX77cVJ4XGqITotZIYtQCAAAATR+JRQC1iTuabHy6Zq8cTsPiaAAAAIDAIbEIoJLYPZKknPwyLfk11+JoAAAAgMAhsQig7VEVirIVSGI6FAAAAJo2Egs/CzV+n/JUHmJTj9gfJElfrs9SSbnDqrAAAACAgCKx8LNeRoTpOiFuvSSpqNyheZtyrAgJAAAACDgSCz87MeEE03VuzAHX96yzAAAAQFNFYuFn6cedYbreFWlTy7DdkqR1e/IsiAgAAAAIPBILP+vZ9VzFuW0te0Lc95KkLdkFKrWzzgIAAABND4mFn4WFRWlIWKKpLDR2mySpwmlowz5O4QYAAEDTQ2IRAMNaDTJd74kplOSUxHQoAAAANE0kFgFwcq+JputDYSHqErVWkrRuzxErQgIAAAACisQiADq0P1nt3JZSpMUtkyStZcQCAAAATRCJRQDYQkI0LCbNVFYec3RnqN8OFOlIid2KsAAAAICACbM6gMYuMzNTmZmZcjjMQxQntx+hD359x3X9W7Rdw1NmyZBNb86do1bxkXW23aFFD6X3u1ph4VF+jxsAAADwJxILH2VkZCgjI0P5+flKTPx9N6ghff+gkF/eltNmkySVhdi0LnWzJOnnQkmFXjSeNV8jN7yuZ//wvWwhDC4BAAAgePFuNUASEzuqjxHuczuLjAJt3PKxHyICAAAAAofEIoAmtD/dL+2s+O1Lv7QDAAAABApToQJowujHVfJVkRZkr9DhsnLTY7GRYQr53zQpd/ucZcoJ/f2xlbkbNTmgkQIAAAC+IbEIIFtIiP4wbqYmOQ31e+ArFZX/vsD7xatO1NheqdU+7/OF9+juXZ+6rlc7jsjpqFBIKL8uAAAABCemQjWA0BCb+rZPNJXVdgL34O7jTdd5ITZt37EwAJEBAAAA/kFi0UD6t08yXa+t5QTutLQT1cZhmMpW/vpFIMICAAAA/ILEooH0c0ss1u3Jk2EY1VeWNCiypel61YG1gQgLAAAA8AsSiwbSv4N5KlResV27DhXXWH9wy/6m61VlBwISFwAAAOAPJBYNpF1StFrERpjKapsONeiEc0zXWaE2Ze1bGZDYAAAAAF+RWDQQm82mfm4LuNfuzquxfpfjTlei022dxdZPAhAZAAAA4DsSiwbUv0OS6bq2naFCQsM0MDTBVLYqe3kAogIAAAB8R2LRgNx3hlq/N18VDmeN9Qen9DJdryreF4iwAAAAAJ+RWDQg96lQJXaHtu0vrLH+oM5jTde/hhrKO7w9ILEBAAAAviCxaEAt4iLVPjnaVFbbdKie3c5TtNs6i1Wb3g9EaAAAAIBPSCwaWH0OygsPj1G/EHMismrvj4EICwAAAPAJiUUDq8/OUJI0KOEE0/Wqwp3+DgkAAADwGYlFA3M/gXtLdoFK7Y4a6w/qONJ0vclmV3HxwQBEBgAAABw7EosG1rd9omy2368rnIY2ZuXXWL9fz4sUZvy+zqLCZtO6TR8GMkQAAACg3kgsGlhcZJhOaBVnKqttOlRMTEv1NMJNZat2LQpAZAAAAMCxI7Go4sILL1RycrIuvvjigN7HfTrUuloWcEvSoLhOputV+b/4OyQAAADAJyQWVdx66616/fXXA36fAR3cFnDXsuWsJA1qd7Lpep2zRHZ7sb/DAgAAAI5ZmNUBBJORI0dq0aJFAb+P+4jFbweKNODvX9dYP97WVur4+3VJiE2XPvGItttPCVCE3muTEKUpp5+gc/ulWR0KAAAALNRkRiwWL16s8847T2lpabLZbPrkk0886mRmZuq4445TVFSUhg4dqmXLljV8oJJ6tI1XeKjNVJZXbK/xa3dRitqXmw/KiwtfXetzGuprc3aBpr63VrtyGUEBAABozprMiEVRUZH69++va6+9VhMmTPB4fPbs2Zo6dapmzpypoUOH6umnn9aZZ56pLVu2qHXr1vW+X1lZmcrKylzX+flHd3ay2+2y2+21PjdEUt92iVq1K8/r+7UsSdSeiN93j7JH76tXvIFUXuHUByt36eZRx1sdStCq7BN19Q00X/QR1IU+grrQR1CXQPeNJpNYjBs3TuPGjavx8aeeekrXX3+9rrnmGknSzJkz9cUXX+iVV17RtGnT6n2/GTNmaPr06R7lCxcuVExMTJ3PPynWpp9DQmR32uqsK0nlRV2kxDWu693RpbKpQkaQ/Arf/fEXdSneYtpKF57mzZtndQgIcvQR1IU+grrQR1CT4uLAzjAJjnelAVZeXq6VK1fqrrvucpWFhIRozJgxWrJkyTG1edddd2nq1Kmu6/z8fHXo0EGjRo1SixYt6nz+2ZKuKbbrlwOFchpGnfULDkfojk1rfr9faIieOadMLdqcdCzh+2zXoRLd9fEG1/X+UpuOG3iKeqclWBJPsLPb7Zo3b57Gjh2r8PDwup+AZoc+grrQR1AX+gjqkpubG9D2m0VicfDgQTkcDqWmpprKU1NTtXnzZtf1mDFjtHbtWhUVFal9+/Z6//33NWzYsGrbjIyMVGRkpEd5eHi413/MrRLD1Sqx7tGNo8bqqfWGsqqszSgt/kHDu17q5fP962TDUOai37TncImr7Iv1ORrQqe6kqjmrT/9A80QfQV3oI6gLfQQ1CXS/aBaJhbe++eYbq0Oo1aDIVvqi4qDr+tW9C/TDG8Mti6d7SoU6xFW4rjfutOnW1yMlL6ZDHW+L0nWhrRRjCw1ghD5qcbx0ylQpOsnqSAAAAIJes0gsWrZsqdDQUOXk5JjKc3Jy1KZNG5/azszMVGZmphwOh0/teGNQq/76Imu+63pPqLTHmV/LMwIs4n9fVRllUt0zu7RA+dp9ZLsePxDYITmf7d8kXfG+1VEAAAAEvSaz3WxtIiIiNHjwYM2f//ubcqfTqfnz59c41clbGRkZ2rhxo5YvX+5rmHU6set5Ab9HQ/o2JtqbHMRav3wjVZRbHQUAAEDQazIjFoWFhfrll19c19u3b9eaNWuUkpKijh07aurUqZo8ebJOPPFEDRkyRE8//bSKiopcu0Q1Bl06j9bo7xM038pRCj8qCQlRfkiIEp1Oq0OpmeGUCrKk5E5WRwIAABDUmkxisWLFCo0aNcp1Xblj0+TJkzVr1ixNnDhRBw4c0H333afs7GwNGDBAX375pceC7mD36CVztXhFpn7L3WR1KJKkUrtDK3YeNpX1apuglFj3OVJHZ0j9O2+NaZQie9j/KTEiJbBB1td3T0oVvy9KV/5eEgsAAIA6NJnEYuTIkTLq2LZ1ypQpmjJlil/v25BrLCQpMipRY0+5u0Hu5a2Lnv9RK6skF8lpabrrgoHV1p393igdLPl9AXp2j7PUvcOIgMdYLz+/Jx3c+vv1kb3WxQIAANBINIs1FoHUkGssgtUFA9JM1/M25qiorKLaum1izIvls4uyAxbXMUtoZ74+stuaOAAAABoREgv47Oy+bRUa8vsesyV2h77ZlFNt3TaxbolFcRAmFoluiUU+IxYAAAB1IbGAz1rGRWr4CS1NZZ+t2VdtXY/EIihHLNqbr5kKBQAAUCcSC/jFBf3N06G+3XpAh4s8t2ltFIlFoltikb/HmjgAAAAaERILH2VmZqpXr15KT0+3OhRLndE7VZFhv3enCqehueuzPOqlxpp34QrOxMJ9jQWJBQAAQF1ILHzE4u2j4qPCNbpna1PZp9VMh3JfvJ1TnFPnbl4Nzn0qVMlhqbzYmlgAAAAaCRIL+M35/c2f9C/bfkj78kpMZe5ToexOuw6VHgp4bPXiPmIhsYAbAACgDiQW8JuR3VspPsp8NMqcdeZRi1bRrRRqCzWVBd3OUBGxUnSyuYzpUAAAALUisYDfRIWHalwf84jEJ6v3maY6hYaEqmW0eQepoFxn4bEzFIkFAABAbUgs4FcXDDBPI9qYla8ff801lTWOnaE4ywIAAKA+SCx8xK5QZid1aaF2SdGmsie/3mIatXBPLHKKqj9Mz1Iep28zYgEAAFAbEgsfsSuUWWiITRmjTjCVrdqVp0VbD7iu3XeGYsQCAACg8SOxgN9dcmJ7dUgxj1r8c95W16iFx1SoYFu8LUmJHczXjFgAAADUisQCfhceGqJbTu9qKlu354jmbTw65alxToXaKwXbeRsAAABBhMQCAXHhwHbq0jLWVPbUvK1yOg2PxGJ/8X45nI6GDK9u7lOh7EVSaZ4loQAAADQGJBYIiLDQEN06xjxqsTm7QP9dn+2RWFQYFcotNe8cZbn4NEk2c9kR1lkAAADUhMQCAXNuvzR1bR1nKvvnN1uVGJGssBDzQXpBt4A7LEKKSzWXsYAbAACgRiQWPmK72ZqFhth0+9huprJf9hfqi3XZSo0xv2kPusRC8pwOdWS3NXEAAAA0AiQWPmK72dqd1buNerZNMJU9M3+bWjeGxKK6BdwAAACoFokFAiokxKapbqMW2w8WyV5mTjaCc8vZ9uZrpkIBAADUKKzuKoBvxvRsrf7tE7V2zxFX2ba9oVKV5Rd7C7JUXF5RazuhITZFhoUGKkxPjFgAAAB4jcQCAWezHV1rcfWrv08XO1IYp6gqicW8rVv06ddf1dGONPz4lnp20kClxEYEKtzfuY9YsMYCAACgRkyFQoMY0a2VBndKdl077Ymmx21hR9yf4sEwpO9/Oaip761xneIdUB5TofZJTmfg7wsAANAIkVigQdhsNv25yloLwyOxKJDk3SF5i7Yc0OtLdvozvOq5T4Vy2qWiA4G/LwAAQCNEYoEGc/IJLXXz6ScoPNQmoyLJ9JjNZvwvufDOQ3M3aWuO9/WPSVxrye28DeXvCew9AQAAGinWWPgoMzNTmZmZcji8+7S9ufvzGd31fyOO16GiMo3/4jGVO8tcj828uot6t+hf7fPW7Tmim95a5bour3DqlndW65OM4YoKD9CC7pBQKSFNytv1e9mRPVK7wYG5HwAAQCPGiIWPOMei/mIjw9QhJVZt49qYyp2heWqfHFPt19l92+ra4Z1N9TdnF+ixL7cENtgE9wXc7AwFAABQHRILWKa+p2//9azu6tEm3lT2yg/b9e3WAK57cD99m7MsAAAAqkViAcu0iTWPWNSVWESFh+rZSQMVGWbutn95f61yC8tqeJaPPM6yYI0FAABAdUgsYJn6jlhIUrfUeN19dk9T2YGCMt354brAbEHrcZYFiQUAAEB1SCxgGfcRi5ziHK+ed9WwThrVvZWp7JtN+/XW0l01PMMHHmdZMBUKAACgOiQWsEx9p0JVstlseuzi/moZZz59+8EvNmr3oWK/xSfJcypUQbbksPv3HgAAAE0AiQUs455Y5JbmqtxR7tVzW8VH6vGLzVvTltqdevMnPx+c5z5iIUMqyPLvPQAAAJoAEgtYxj2xkLyfDiVJo3q01qQhHU1lH6/eK4fTj2stopOlsGhzGessAAAAPJBYwDLx4fGKCYsxlXk7HarStcOPM13vLyjTD78c9DW039ls1SzgZp0FAACAOxILWMZmsx3zOotKXVPj1a99oqnso1V+HlHwOMuCEQsAAAB3JBY+yszMVK9evZSenm51KI2S+5az9ZkKVWnCQPMb/y83ZKuwrMKnuEw4fRsAAKBOJBY+ysjI0MaNG7V8+XKrQ2mUfB2xkKTz+qcpLMTmui61O/Xfn/24wJrTtwEAAOpEYgFLeZxlUVT/EYsWcZEa2b21qeyjVX588+9x+vZu/7UNAADQRJBYwFIeIxbF9R+xkKSLBpnf/C/5LVd7DvvpTAsWbwMAANSJxAKWahPj+1QoSTq9Z2slRIWZyj5ds++Y4zJxTyxKDknlfj6IDwAAoJEjsYCl3Ecs8sryVFJRUu92IsNCdV7/NFPZh6v2yDD8cKaF+1QoScr3U9ICAADQRJBYwFLVHpJ3DOssJGnCIPPIwm8HirR2z5FjasskMk6KMm9pyzoLAAAAMxILWComPEbxEfGmsmNdZzGoY5KOa2E+cM9vZ1okdjBfszMUAACACYkFLOePLWelowfuuY9afLZ2n8ornMccm4vHzlAkFgAAAFWRWMBy/lrALUkXuh2Wl1ds18It+4+5PRdO3wYAAKgViQUslxrr++nblTqkxGhI5xRTmV+mQ3mMWJBYAAAAVEViAcv5c8RC8jzTYsHm/TpcVO5Tm5xlAQAAUDsSC1jOX2ssKo3r21aRYb93bbvD0Jx1Pm4P655Y5O+V/LGVLQAAQBNBYgHLuScWx7rdbKWEqHCd0dvc5oerfBxhcJ8KVV4olfphK1sAAIAmgsQClnNPLArsBSqyF/nU5gS36VBrdudpS3bBsTeYkOZZxjoLAAAAFxILH2VmZqpXr15KT0+3OpRGKzUm1aPM1+lQp57QUi3jIk1lL3z767E3GBYpxbY2l3GWBQAAgAuJhY8yMjK0ceNGLV++3OpQGq2osCglRyabynxNLMJCQ3T5EPOhdp+u3adducXH3qjHAm5GLAAAACqRWCAo+HsBtyRdPbyzosNDXdcOp6GZi30YtfA4y4IRCwAAgEphVgcASEfPsth0aJPrem/hXpVWlPrUZkykNHFIG836cYer7IOV2/V/IzuodXxU/RuMbyvZbL9fr3pD2vmDV091GobSDx2S/WCmHFXbCBCbpEgF/j7wn1DD0CmHDin04L/N/Qz4n6DqIxFx0sA/SL3HWxsHgKBCYoGg4L7O4sWfX9SLP7/ol7bje5ivz/nMh8aO6+BWUI9tbFtLUpYPN6+fTna7Ht1/UL3L7Q12Txy7EEktJMm3fQvQhAVdH/llnpSyWGrb3+pIAAQJpkIhKLhPhYLvdoaH69EWyXVXBIBjte1rqyMAEERILBAUuiV3szqEJmldZKRKrZ4yAaDp2r+p7joAmg2mQiEoDEsbprGdxmreznlWh9KkOGw2bR75Zw2IqeYcDgQVh8Oh9Rs2qE/v3goNDa37CWh2gqKP7FkhrX379+ucjdbEASAokVggKISHhOupkU/pcOlhFdoL/d7+joNFuuqVZaayP512vK44qaPf71WdiooKLVq4SCNHjVRYWGD/7KbMn6Lfjvzmut7QuosG9LwioPeE75x2u3bkzFWvwWcrNDzc6nAQhIKij6T2NicWudukinIpLMKaeAAEFRILBJXkqGQlR/l/XUCHeOnMbkX6csPv29h+sLRYt41MU1R44D/5s9vtSglNUfu49goP8BuCvi37mhOLgxsCej8AzUgrt90wnBVHk4vU3tbEAyCosMYCzUbGqBNM1wcLy/Xusl0WRRM4fVr2MV2vz11vUSQAmpzoJCnB7bBQ1lkA+B8SCzQbfdsn6rRurUxl/1n8m8ornBZFFBi9W5g/OdxxZIcKy/0/vQxAM9W6p/k6h1FRAEeRWKBZmeI2arHvSKk+Wd20TtDuntJdYSG/z3I0ZJgOHwQAn6T2Ml8zYgHgf0gs0KwM6ZyiIcelmMqe//ZXOZ2GRRH5X0RohLomdTWVsc4CgN+0dk8s+PcFwFEkFmh2bhp1vOl6+8EiLd1+yKJoAoN1FgACxj2xyNsllRVYEwuAoEJigWZnRLdW6p4abyr7dE3Tmg7lvs5i/UESCwB+0rKbZHPbTW//ZmtiARBUSCzQ7NhsNo0f2M5UNvfnLJVVOCyKyP/cRyz2Fu5VXmmeNcEAaFrCo6QW5pFf7eegPAAkFmimzh9gPok6v7RCi7YcsCga/+uS1EWRoZGmsg25zIMG4CfuO0ORWAAQiQWaqXZJ0RrS2byIuylNhwoPCVePFPNBViQWAPymtduBeCQWAERigWbsArdRi2827Vd+qd2iaPzPYwE36ywA+IvHWRYkFgBILEzmzJmj7t27q2vXrnrppZesDgcBdk7ftgoPtbmuyyuc+mp9toUR+Zf7Am62nAXgN6luIxbFB6XCpjOdFMCxIbH4n4qKCk2dOlULFizQ6tWr9fjjjys3N9fqsBBASTERGtGttans0zX7LIrG/3q3NP+Pf3/Jfu0v3m9RNACalOTjpLBocxnnWQDNHonF/yxbtky9e/dWu3btFBcXp3Hjxunrr7+2OiwE2PiB5ulQP/56UPvzSy2Kxr+OSzhOseGxpjJGLQD4RUio1Kq7uYwTuIFmr8kkFosXL9Z5552ntLQ02Ww2ffLJJx51MjMzddxxxykqKkpDhw7VsmXLXI/t27dP7dr9vgVpu3bttHdv01nMi+qN7pGq2Ijf92N3GtJna5vGqEWILUS9WpgPsmIBNwC/cT8oL4d/X4DmLszqAPylqKhI/fv317XXXqsJEyZ4PD579mxNnTpVM2fO1NChQ/X000/rzDPP1JYtW9S6detqWqxdWVmZysrKXNf5+fmSJLvdLru96SwAburCbNIZvVrr4zVZrrJP1+zV5JM6+PU+lX2ioftGj+QeWp693HX984Gf6Z9Byqo+gsYj2PpISMvuqnpMnjNnoxxBEltzFWx9BMEn0H2jySQW48aN07hx42p8/KmnntL111+va665RpI0c+ZMffHFF3rllVc0bdo0paWlmUYo9u7dqyFDhtTY3owZMzR9+nSP8oULFyomJsaHV4KG1qbMJlX53+PPe/M168O5ah1d83OO1bx58/zfaC3Ky8tN12uy1+iLL76QzWar4RmwWkP3ETQ+wdJHWuUX6OQq187s9Zr7xRzJ1mQmQzRawdJHEHyKi4sD2r7NMAwjoHewgM1m08cff6zx48dLOvrmKiYmRh988IGrTJImT56svLw8ffrpp6qoqFDPnj21aNEiJSYmavDgwfrxxx/VokWLau9R3YhFhw4dlJWVVeNzEJwqHE6d8vhi5Rb9/iZ8ysguunX0CX67h91u17x58zR27FiFh4f7rd267Cnco/M/O99UNuf8OUqLS6vhGbCKVX0EjUfQ9ZGCLIU/29dUZM9YKSV1siggBF0fQdDJzc1V27ZtdeTIESUkJPi9/SYzYlGbgwcPyuFwKDU11VSempqqzZs3S5LCwsL05JNPatSoUXI6nfrrX/9aa4IQGRmpyMhIj/Lw8HD+mBuZ8HDpvP5pmvXjDlfZnJ+z9ecze/j9k/2G7h/HJR2nxMhEHSk74irbfGSzOiXzP/5gxb8hqEvQ9JHkDlJUklSa5yoKz90qtfLfhzI4NkHTRxB0At0vGK+s4vzzz9fWrVv1yy+/6IYbbrA6HDSg8QPbma535BZr7Z4jNdRuPGw2m+d5FizgBuAPNpvneRacwA00a80isWjZsqVCQ0OVk5NjKs/JyVGbNm18ajszM1O9evVSenq6T+3AWv3bJ+q4Fua1MZ+sbhq7gnFQHoCAcT+Bm8QCaNaaRWIRERGhwYMHa/78+a4yp9Op+fPna9iwYT61nZGRoY0bN2r58uV1V0bQstlsOn+AedRizrp9qnA4LYrIf/q07GO63pi7UU6j8b8uAEHAfctZzrIAmrUmk1gUFhZqzZo1WrNmjSRp+/btWrNmjXbt2iVJmjp1ql588UW99tpr2rRpk2688UYVFRW5dokCxg8wL2g+WFiuH39t/Kevu49YFNoLtTN/p0XRAGhS3BOLg1ulivLq6wJo8prM4u0VK1Zo1KhRruupU6dKOrrz06xZszRx4kQdOHBA9913n7KzszVgwAB9+eWXHgu60Xx1aRWnfu0Tta7K2opP1uzVad1aWRiV71JjU9UqupUOlBxwla0/uF6dEztbGBWAJsF9KpSzQsr9RUrtVX19AE1akxmxGDlypAzD8PiaNWuWq86UKVO0c+dOlZWVaenSpRo6dKh1ASMond/fPGoxb2OOnM7GvyOz+6jFxlzmQQPwg+gkKcE8jZR1FkDz1WQSC6uweLtpOauPeTF/QWmF9uaVWBSN//RuaU4s1h9cb1EkAJocj3UWJBZAc0Vi4SMWbzct7ZKiFR9lniG4bX+BRdH4j/uIxeZDm1XhrLAoGgBNivt0qBwSC6C5IrEAqrDZbOraOs5Uti2n0KJo/Md9xKLUUapf8361KBoATQpnWQD4nyazeBvwl26p8Vq1K891vbUJJBYpUSlKi03TvqJ9rrL7frxPLaNbWhgVqnI6nTpQeEBfLvpSISF85lOX8JBwndruVE3oOkE2m83qcJo39xGLvJ1SWYEUGW9NPAAsQ2Lho8zMTGVmZsrhcFgdCvyka6r5f4ZNYSqUdHTUompiwQLu4LRl3xarQ2g05u+ar8iwSJ3b5VyrQ2neWnaXbCFS1fNxDmyR2p9oXUwALMHHYj5ijUXT0y3VcypUU9gZqm/LvlaHAPjd4j2LrQ4B4VFSyvHmspwN1sQCwFIkFoCbbm4jFiV2R5PYGerszmcrISLB6jAAv8ouyrY6BEie51ZwAjfQLDEVCnDTOj5SCVFhyi/9fdekbfsL1CElxsKofJcam6oPzvtAi/YsUrG92Opw4MbpdGrz5s3q0aMHayxqsSN/hz755RPXdVZRlnXB4Hete0kbP/39ej8jFkBzRGIBuLHZbOqaGq+VOw+7yrbmFOr0Ho3/lPa2cW01qcckq8NANex2u+bumKuze52t8PBwq8MJWhtzN5oSiwPFB1ThrFBYCP87s5T7Au6sddKKV6yJpRkLcTjU6eB6hazaL4WGWh0OgsGAP0hhEQ12O/4lBqrRLTXOLbFoGgu4gcaubWxb07XDcOhgyUG1iW1TwzPQIFq7bTlbmifNud2SUJqzUEkDJGm3tXEgiPS5uEETC8bbfcTJ201T19ZuO0M1gS1ngaYgKTJJUaFRpjKmQwWBlM5SWFTd9QA0aSQWPmJXqKbJfQH3L/ubxs5QQGNns9k8RieyCkksLBcSKp0wxuooAFiMqVBANdy3nC2xO7TncIk6tmjcC7iBpqBNbBvtyN/hus4uZmeooHD+c1JcKidvW8hpGDp86JCSU1IUwsGRkI4m/Q2IxAKoRqv4SCVGh+tIid1Vtm1/AYkFEATc11kwYhEkYlKkc5+yOopmzWG36/u5c3X22WcrhE0gYAGmQgHVsNlsHqMWW1lnAQQF96lQnGUBAMGBxAKowQkeC7jZGQoIBh4jFizeBoCgQGIB1MBjxGI/iQUQDDxGLFhjAQBBgcTCR2w323SxMxQQnNwTiyNlRzhNHgCCAImFj9hutunq6jZiUWp3as/hEouiAVCpusPwWGcBANYjsQBq0CouUkkx5l01OIEbsF50WLSSI5NNZSQWAGA9EgugBjabTd3cFnCzzgIIDh6H5LGAGwAsR2IB1OIEt+lQ29hyFggKJBYAEHxILIBadGvtfpYFIxZAMGDLWQAIPiQWQC2q2xnKwc5QgOXcE4ucohyLIgEAVCKxAGrR1S2xKKtwas9htrUErMZUKAAIPiQWPuIci6atZVyEkj12hmKdBWA1j0PyirJlGIwmAoCVSCx8xDkWTZvNZvMYtWCdBWA996lQ5c5yHSo9ZFE0AACJxAKoU9fW7jtDkVgAVmsZ3VJhtjBTGWdZAIC1SCyAOrgv4GYqFGC90JBQtY5pbSpjnQUAWIvEAqhDV7ezLH49wM5QQDBgATcABBcSC6AO7iMWZRVO7T7EzlCA1drGmddZMBUKAKxFYgHUoWVcpFJiI0xlLOAGrNcmhhELAAgmJBaAFzwWcO9nnQVgNfedoRixAABrkVgAXnBfZ8GIBWA996lQjFgAgLVILAAvsDMUEHxSY1JN1wdLDqrcUW5RNAAAEgvAC11bmxMLdoYCrOc+YiFJOcU5FkQCAJBILHyWmZmpXr16KT093epQEEDd3KZClVc4tYudoQBLxYfHKzY81lTGOgsAsI7PiUWXLl100kkneV3/1FNP1fHHH+/rbYNGRkaGNm7cqOXLl1sdCgKoRVykWrAzFBBUbDYbC7gBIIj4nFjs2LFDu3bt8rr+nj17tGPHDl9vCzQ49wXc20gsAMulxprXWbCAGwCs0+BToSoqKhQSwgwsND7u6yxYwA1Yz33EgsQCAKzToO/wS0pKtH//fsXHx9ddGQgy7ussNmXlWxQJgEokFgAQPMLq+4Rdu3Z5TGUqLy/Xd999J8OofpccwzCUl5ent956S3a7XX379j2mYAEr9W6XaLretr9QecXlSoqJqOEZAAKtTaz59O2cInaFAgCr1DuxePXVV/X3v//dVHb48GGNHDmyzucahiGbzaY//elP9b0tYLk+aYmKDAtRWYXTVbZy52GN7play7MABJL7iMW+wn2u/9cAABrWMU2FMgzD9WWz2UzX1X1JUkJCgoYPH67XX39dl19+uV9fBNAQIsJCNKBDkqls2Y5D1gQDQJLniEVxRbEK7GysAABWqHdicf/998vpdLq+DMNQmzZtTGXuXw6HQ4cPH9Z3332nK664IhCvA2gQQzqnmK6XbyexAKyUGpMqm8yjE2w5CwDWqPdUKHdXXXWVkpKS/BAKEPzSjzMnFj/vPaJSu0NR4aEWRQQ0bxGhEWoR3UIHSw66yrKLstUtuZuFUQFA8+RzYjFr1iw/hAE0DgM7JinEJjn/t0+B3WFoze48ndSlhbWBAc1Y29i2psQiq5CdoQDACn7dbtbpdGr58uX64IMP9Prrr/uzaSAoxEeFq1dagqlsBessAEu5r7Ngy1kAsIbfEovnnntObdu21UknnaSJEyfqmmuuMT1++PBh9enTRz169FBODtsBovE6sZN5OtSyHYctigSA5JlYZBezxgIArOCXxCIjI0O33XabDhw4oPj4+Gq3+UtOTtagQYO0bds2vf/++/64LWAJ9wXcq3YelsNZ/RkuAALP45A8pkIBgCV8Tiy+/PJLPf/884qLi9PHH3+svLw8tWrVqtq6l19+uQzD0DfffOPrbQHLnHhcsum6sKyCU7gBC7knFuwKBQDW8DmxmDlzpmw2m/7+97/rggsuqLXusGHDJEk///yzr7cNGpmZmerVq5fS09OtDgUNpHV8lI5rEWMqW846C8Ay7lOh9hfvl8PpsCgaAGi+fE4sli5dKkm69tpr66ybmJiohIQEZWc3nU+TMjIytHHjRi1fvtzqUNCA3LedJbEArOOeWFQYFaZdogAADcPnxOLQoUNKTExUfHy8dzcMCZHT6fT1toClPBOLw65T5gE0rJSoFEWERJjK2BkKABqez4lFQkKC8vPzZbfb66x76NAhHTlyRC1btvT1toCl0t0WcB8oKNPO3GKLogGatxBbiOfOUKyzAIAG53Ni0bdvXxmG4ZoSVZt33nlHhmHoxBNP9PW2gKWOaxGjlnGRprJlTIcCLENiAQDW8zmxuPjii2UYhh544IFapzitXbtW99xzj2w2myZNmuTrbQFL2Ww2pbvtDsVBeYB1OCQPAKznc2Jx/fXXq1evXlq4cKHGjh2rOXPmyOE4uhvHtm3bNG/ePN1yyy06+eSTdeTIEZ100km65JJLfA4csFp16ywAWMPjLAsSCwBocGG+NhAeHq4vvvhCZ511lhYuXKhFixa5HuvRo4fre8Mw1LdvX3344YfVHqAHNDbuB+VtP1ikAwVlahUfWcMzAAQKU6EAwHp+OXm7U6dOWrlypaZPn66OHTvKMAzTV1pamh544AH9+OOPatOmTd0NAo1Ajzbxio0INZUxHQqwBofkAYD1fB6xqBQTE6N7771X9957r/bt26d9+/bJ4XCoTZs26tSpk79uAwSNsNAQDeqUrO+2/b5f/rIdhzSub9tangUgENwTi8Nlh1VSUaLosGiLIgKA5sfnxOL000+XzWbTf/7zHx1//PGSpLS0NKWlpfkcHBDs0o9LMSUWK1hnAVjCfSqUdHTUonNiZwuiAYDmyefE4vvvv1d4eLgrqQCaE/cF3Bv2HVFhWYXiIv02GAjACzHhMUqISFB+eb6r7C/f/kVx4XEWRuVfTsOpwwWH9cG8DxRi88tMZjQx9BG4e37M84oJj2mw+/n87ic1NVWFhYX+iAVodAZ0SFJ4qE12x9FTt52GtGrnYZ3WrZXFkQHNT9vYtqbEYuvhrRZGEzg7D+y0OgQEOfoIKjmNmo+CCASf09nTTjtN+fn52rZtmz/iARqV6IhQ9WmXaCpjATdgjY4JHa0OAQCaNZ8Ti7/85S8KCwvTn//8ZxmG4Y+YgEZliNt0KE7gBqxxSbdLFGZjGiIAWMXnf4EHDhyod955R1dffbWGDx+uO+64QyeffLJat27NeRVoFtKPS9ELi39zXa/ZnafyCqciwpjfCjSkYWnD9OEFH2rN/jWqcFZYHY7fORwOrV+/Xn369FFoaGjdT0CzQx+Bu8jQhj1by+fEomrHXbp0qS6++OI6n2Oz2VRR0fT+0UfzNLhTsum61O7UM/O3qnV8lKvM4XBoQ5ZNuT/tqvc/9q3iIzWqe2tFR/A/CaAuXRK7qEtiF6vDCAi73a6YbTE6u+vZCg8PtzocBCH6CKzmc2LB9Cc0d8mxEeqWGqetOb9vYpC58Ndqaobqwx2bj+keQzun6N0bTmIUEAAABC2fE4uFCxf6Iw6gUTvxuBRTYuFvS7cf0i/7C9U1NT5g9wAAAPCFz4nFiBEj/BEH0KhdPLi93lm2S4EcwNtzuITEAgAABC22z6jiwgsv1KJFizR69Gh98MEHVoeDRmRQx2T9+/JB+mj1XhWU2j0eNwxDubm5atGihdfTmTbszVdB2e9rkfYXlPotXgAAAH8jsaji1ltv1bXXXqvXXnvN6lDQCI3r21bj+rat9jG73a65c+fq7LPTvV5Qd+2s5Vqweb/ren9+mV/iBAAACASfE4vFixfXq35UVJSSkpJ0/PHHB91WaCNHjtSiRYusDgOQJLWON28Rt7+AxAIAAAQvnxOLkSNHHtNONVFRURo9erT++te/6pRTTqmz/uLFi/X4449r5cqVysrK0scff6zx48eb6mRmZurxxx9Xdna2+vfvr+eee05Dhgypd2xAMPBMLJgKBQAAgpdfTvAyDKPeXyUlJZozZ45GjhypZ555ps57FBUVqX///srMzKz28dmzZ2vq1Km6//77tWrVKvXv319nnnmm9u//fSrJgAED1KdPH4+vffv2+ePHAPhVq4Qo0zUjFgAAIJj5PGLhdDo1Z84cTZ48Wampqbrjjjs0cuRItWvXTpK0d+9eLVq0SE888YRycnL0+uuv6+STT9by5cv16KOPasGCBfrzn/+sU089VYMGDarxPuPGjdO4ceNqfPypp57S9ddfr2uuuUaSNHPmTH3xxRd65ZVXNG3aNEnSmjVrfH25LmVlZSor+/2NXn5+vqSjc+ntds/Fu2jeKvtEffpGi2jzn+f+/FL6VhN2LH0EzQt9BHWhj6Auge4bPicWq1ev1iWXXKJTTjlFc+bMUWSkefpG586d1blzZ11xxRU655xzdPHFF2vp0qUaO3asxo4dq3PPPVdz585VZmamXn755WOKoby8XCtXrtRdd93lKgsJCdGYMWO0ZMkSn15fTWbMmKHp06d7lC9cuFAxMTEBuScav3nz5nldd0eBVPVPNPtIib74Yq44I69pq08fQfNEH0Fd6COoSXFxcUDb9zmxmDFjhsrLy5WZmemRVFQVERGhf/3rX+rZs6dmzJiht99+W5I0ffp0zZ07t96LwKs6ePCgHA6HUlNTTeWpqanavNn7k47HjBmjtWvXqqioSO3bt9f777+vYcOGVVv3rrvu0tSpU13X+fn56tChg0aNGqUWLVoc2wtBk2W32zVv3jyNHTvW612h9uWV6J/rv3NdOwybho8aq6QY756PxuVY+giaF/oI6kIfQV1yc3MD2r7PicX333+vhIQEdevWrc663bt3V2JiomnnpcGDBysqKioo1jl88803XteNjIysNpEKDw/njxk1qk//aJvsuWva4VKHWiUyItaU8W8I6kIfQV3oI6hJoPuFz4u3Dx8+rLKyMhleHDnsdDpVWlqqw4cPm8qjo6OPaWepSi1btlRoaKhycnJM5Tk5OWrTps0xtwtYKSIsRMluoxOcZQEAAIKVz4lFWlqaysrK9Pnnn9dZd86cOSorK1NaWpqrrDLRaNWq1THHEBERocGDB2v+/PmuMqfTqfnz59c4lclfMjMz1atXL6Wnpwf0PmieWse77wzFlrMAACA4+ZxYnH/++TIMQ9dff71+/PHHGustWbJEN9xwg2w2m84//3xX+YYNGyRJXbp0qfU+hYWFWrNmjWtnp+3bt2vNmjXatWuXJGnq1Kl68cUX9dprr2nTpk268cYbVVRU5NolKlAyMjK0ceNGLV++PKD3QfPUOoFD8gAAQOPg8xqLe+65R++9956ysrJ02mmn6bTTTtOIESOUlpYmm82mffv2adGiRVq8eLGcTqfatm2re+65x/X8N998U5I0evToWu+zYsUKjRo1ynVduXB68uTJmjVrliZOnKgDBw7ovvvuU3Z2tgYMGKAvv/zSY0E30Ji0cj8kj6lQAAAgSPmcWLRo0UILFy7UxRdfrPXr12vRokX69ttvTXUq11/07t1bH3zwgWnXpAsuuEAjR47USSedVOt9Ro4cWec6jilTpmjKlCnH+EqA4MNUKAAA0Fj4nFhIUrdu3bRq1SrNnj1b77//vlatWqUDBw5Iklq1aqVBgwbp4osv1sSJEz1Wo48cOdIfIVgmMzNTmZmZcjgcVoeCJqi1+4gFU6EAAECQ8ktiIUlhYWG64oordMUVV/iryUYhIyNDGRkZys/PV2JiotXhoIlxX2NxgMQCAAAEKZ8XbwMIHI+pUPlMhQIAAMHJbyMWlQ4cOKCdO3equLhYp512mr+bB5oV96lQReUOFZVVKDbS73+6AAAAPvHbiMVnn32mQYMGqU2bNho6dKhOP/100+OHDx/WWWedpbPOOktHjhzx122BJs19KpTEOgsAABCc/JJYPPLII7rwwgu1Zs0aGYbh+qoqOTlZ0dHRmjdvnj744AN/3DYocEAeAikmIkxxbqMTTIcCAADByOfE4qefftLf/vY3hYWF6Z///KcOHjxY49kRf/jDH2QYhubNm+frbYMGB+Qh0NgZCgAANAY+JxbPPPOMJOmuu+7SrbfeqpSUlBrrjhgxQpK0evVqX28LNBseh+SRWAAAgCDkc2Lxww8/SJJXB9O1bNlSsbGx2rdvn6+3BZqN1gkckgcAAIKfz4nF/v37FR8fr5YtW3pVPzIyUuXl5b7eFmg23KdCHchnxAIAAAQfnxOL2NhYFRcXe3XydGFhofLy8mqdLgXAjDUWAACgMfA5sejevbscDofWrVtXZ91PPvlETqdTAwYM8PW2QYNdoRBo7lvOMhUKAAAEI58Ti/PPP1+GYWjGjBm11tuzZ4+mTZsmm82miy66yNfbBg12hUKgeZy+zYgFAAAIQj4nFlOmTFG7du304Ycf6qqrrtL69etdj9ntdm3btk1PPfWUBg8erH379qlbt26aPHmyr7cFmg33qVB5xXaVVdQ99RAAAKAhhdVdpXZxcXH6/PPPdeaZZ+rNN9/UW2+95XosKur3T1oNw1BaWpo++eQThYeH+3pboNlwH7GQpAMFZWqfHGNBNAAAANXzy8nbAwYM0Nq1a3XNNdcoMjLSdPq2YRgKDw/X1VdfrRUrVqh79+7+uCXQbCREhykizPynynQoAAAQbHwesajUpk0bvfzyy/r3v/+tlStXat++fXI4HGrTpo3S09MVE3P001W73a4XXnjBq3MvAEg2m02t4yO153CJq2w/W84CAIAg47fEolJkZKROPvlkj3KHw6GXX35ZDz30kPbu3dtkEovMzExlZmZ6td0ucKzcE4sD7AwFAACCjE9ToYqLi7V27VqtWrVKhw8frraOYRiaNWuWunXrphtvvFG7d++WYRi+3DaosCsUGgI7QwEAgGB3TInFkSNHNHnyZLVo0UKDBg1Senq6WrVqpQkTJigrK8tVb9GiRerXr5/++Mc/avv27ZKkCy64QEuXLvVP9EAz4XGWBVOhAABAkKn3VKiKigqNHTtWK1euNI08GIahTz/9VFu3btWqVav03HPP6c4775TT6VRoaKgmTpyou+66S7179/brCwCaA/ctZ3OYCgUAAIJMvROL1157TStWrJAknX766TrrrLNkGIa++uorLViwQJs2bdKf/vQnvfbaa7LZbLrqqqt03333qUuXLn4PHmguPKZCMWIBAACCTL0Ti/fff182m03XX3+9Zs6c6Sq/4447dMMNN+ill17S66+/ruTkZH300UcaMWKEXwMGmqNW7lOhWGMBAACCTL3XWPz888+SpHvuucfjsXvvvdf1/SOPPEJSAfiJ+1So3KIyVTicFkUDAADgqd6JRW5urmJiYtS+fXuPxzp06OA6r+L888/3PToAkjynQhmGlFtUblE0AAAAnuqdWJSXlys+Pr7GxysfS01NPfaoAJi0iI1QaIjNVMY6CwAAEEx8OscCRw/I69Wrl9LT060OBU1YSIhNLeMiTGX72RkKAAAEERILH3FAHhoKh+QBAIBgVu9doSQpJydHoaGhtdap7XGbzaaKiopjuTXQbLkv4GYqFAAACCbHlFhUPRgPQMPwOH2bqVAAACCI1DuxuP/++wMRB4A6tGIqFAAACGIkFkAj4TEVisQCAAAEERZvA42Ee2JxIJ+pUAAAIHiQWACNROsE81SoA4VlrHcCAABBg8QCaCTcRyzsDkOHi+0WRQMAAGBGYgE0Ei3jIj3K2BkKAAAECxILH3HyNhpKRFiIUmLdTt/mLAsAABAkSCx8xMnbaEjsDAUAAIIViQXQiLTySCyYCgUAAIIDiQXQiLR2PySPqVAAACBIkFgAjUjrBLezLJgKBQAAggSJBdCIeK6xYCoUAAAIDiQWQCPiMRWKEQsAABAkSCyARsR9KtT+fE7fBgAAwYHEAmhE3KdCldgdKiyrsCgaAACA35FYAI2I+1QoielQAAAgOJBYAI1IdESo4iPDTGVsOQsAAIIBiQXQyLRyX2fBzlAAACAIkFgAjYz7OgvOsgAAAMGAxAJoZNhyFgAABCMSC6CR8TgkL5+pUAAAwHokFj7KzMxUr169lJ6ebnUoaCY8zrJgxAIAAAQBEgsfZWRkaOPGjVq+fLnVoaCZYCoUAAAIRiQWQCPDVCgAABCMSCyARsZ9KlR+aYV2Hyq2KBoAAICjSCyARqZTi1jFR5kPyXt72S6LogEAADiKxAJoZMJDQ3TRoPamsveW71Z5hdOiiAAAAEgsgEbp8qEdTde5ReX6ckO2RdEAAACQWACNUrfUeA3pnGIqe/OnnRZFAwAAQGIBNFp/OKmT6XrZ9kPallNgUTQAAKC5I7EAGqmzerdRi9gIU9lbS1nEDQAArEFiATRSEWEhujS9g6nsw5V7VFxeYVFEAACgOSOxABqxy4d0lM32+3VBWYU+X7vPuoAAAECzRWIBNGIdUmI0slsrU9mbPzEdCgAANDwSC6CRu2KoeRH3z3uPaO3uPGuCAQAAzRaJBdDIjerRWu2Sok1lbD0LAAAaGokF0MiFhtg0aYh5Effn6/bpSLHdoogAAEBzRGIBNAGXpndQWMjvq7hL7U59uGqPhREBAIDmhsQCaAJax0fpzN5tTGVvLd0pwzAsiggAADQ3YVYHAMA/rjipo774Oct1/euBIt345irFRIaa6oWF2DTs+BYaP6CdbFX3qgUAAPABiQXQRAzr0kJdWsXqtwNFrrIvN2RXW/e9FXuUW1iu607t0lDhAQCAJo6pUEATYbPZPLaerc0z32xTXnF5ACMCAADNCYnF/+zevVsjR45Ur1691K9fP73//vtWhwTU26UnttdxLWK8qltQVqH/LP4twBEBAIDmgqlQ/xMWFqann35aAwYMUHZ2tgYPHqyzzz5bsbGxVocGeC0+Klyz/zRMn6/dpwMFZR6PL9txSKt35bmuZ/24Q9ee0lkt4yIbMEoAANAUkVj8T9u2bdW2bVtJUps2bdSyZUsdOnSIxAKNTmpCVI1rJ349UKixT30r5/82iyoud2jmol91z7m9GjBCAADQFDWaqVCLFy/Weeedp7S0NNlsNn3yyScedTIzM3XccccpKipKQ4cO1bJly47pXitXrpTD4VCHDh3qrgw0Ise3itOEQe1NZW/8tFPZR0otiggAADQVjWbEoqioSP3799e1116rCRMmeDw+e/ZsTZ06VTNnztTQoUP19NNP68wzz9SWLVvUunVrSdKAAQNUUVHh8dyvv/5aaWlpkqRDhw7pqquu0osvvlhrPGVlZSor+32qSX5+viTJbrfLbufEY5hV9olg6Bs3jThOn6zeq4r/DVuUVTj13PyteuC8nhZH1rwFUx9BcKKPoC70EdQl0H3DZjTCE7RsNps+/vhjjR8/3lU2dOhQpaen61//+pckyel0qkOHDrr55ps1bdo0r9otKyvT2LFjdf311+vKK6+ste4DDzyg6dOne5S//fbbionxbvEsYJX3fgvRDzm/D1iG2gzdM9ChFJZaAADQZBUXF+vyyy/XkSNHlJCQ4Pf2G82IRW3Ky8u1cuVK3XXXXa6ykJAQjRkzRkuWLPGqDcMwdPXVV+v000+vM6mQpLvuuktTp051Xefn56tDhw4aNWqUWrRoUf8XgSbNbrdr3rx5Gjt2rMLDw60ORwOPlGrM09+rvMIpSXIYNm20ddLDZ/e2OLLmK9j6CIIPfQR1oY+gLrm5uQFtv0kkFgcPHpTD4VBqaqqpPDU1VZs3b/aqjR9++EGzZ89Wv379XOs33njjDfXt27fa+pGRkYqM9Px4Nzw8nD9m1ChY+kfHluG6YmhHvfrDDlfZR6v36aZRXdW5JRsWWClY+giCF30EdaGPoCaB7hdNIrHwh1NOOUVOp9PqMIAGc+PI4/Xust0qsTskSQ6noWe+2aqnLxtocWQAAKAxajS7QtWmZcuWCg0NVU5Ojqk8JydHbdq0Cei9MzMz1atXL6Wnpwf0PoC/tY6P0uSTjzOVfbp2n7blFFgTEAAAaNSaRGIRERGhwYMHa/78+a4yp9Op+fPna9iwYQG9d0ZGhjZu3Kjly5cH9D5AIPzptC6Ki/x94NIwpL/P2ag56/Z5fC3asl9FZZ67qgEAAEiNaCpUYWGhfvnlF9f19u3btWbNGqWkpKhjx46aOnWqJk+erBNPPFFDhgzR008/raKiIl1zzTUWRg0Et+TYCP3xlM56Zv42V9l32w7qu20Hq61/fKtYfZwxXAlRzN0FAABmjSaxWLFihUaNGuW6rtyRafLkyZo1a5YmTpyoAwcO6L777lN2drYGDBigL7/80mNBNwCzP57aWbN+3KEjJXXvbf3rgSIt3LxfFwxo1wCRAQCAxqTRJBYjR45UXUduTJkyRVOmTGmgiI7KzMxUZmamHA5Hg94X8JeEqHBljDpeD8/1bge1nHxO6QYAAJ4aTWIRrDIyMpSRkaH8/HwlJiZaHQ5wTK47pYtKyp2atylbZXbz7mjZR0pVUGVtRUEp6ywAAIAnEgsACgmx6dYxXXXrmK4ej935wTrNXrHbdU1iAQAAqtMkdoUCEDhxUebPHwrZGQoAAFSDxAJAreLdEouC0roXeQMAgOaHxMJHHJCHpq7qORcSIxYAAKB6JBY+4oA8NHXuIxaFrLEAAADVILEAUKt4t8PwWLwNAACqQ2IBoFbuU6EKmAoFAACqQWIBoFYeu0IxYgEAAKpBYgGgVgluiUWJ3SG7w1lDbQAA0FyRWPiIXaHQ1MVFhnuUFTEdCgAAuCGx8BG7QqGpc58KJbGAGwAAeCKxAFCr2IhQ2WzmMhILAADgjsQCQK1sNhuH5AEAgDqRWACoU7xHYmG3KBIAABCsSCwA1IlD8gAAQF1ILADUyX0BN4kFAABwR2LhI7abRXPAGgsAAFAXEgsfsd0smoN4jxEL1lgAAAAzEgsAdXJPLAqZCgUAANyQWACok/tUqAKmQgEAADckFgDqxK5QAACgLiQWAOrksXibxAIAALghsQBQJ/ftZtkVCgAAuCOxAFCnBHaFAgAAdSCx8BHnWKA5iIs0r7FgxAIAALgjsfAR51igOfA8x4LEAgAAmJFYAKiT+xqLsgqnyiucFkUDAACCEYkFgDrFu+0KJTEdCgAAmJFYAKiT+zkWElvOAgAAMxILAHWKCg9RaIjNVJbPzlAAAKAKEgsAdbLZbJ6H5DEVCgAAVEFiAcAr7jtDMRUKAABURWIBwCvuIxYFZUyFAgAAvyOxAOAVRiwAAEBtSCwAeMV9Z6h8EgsAAFAFiYWPMjMz1atXL6Wnp1sdChBQLN4GAAC1IbHwUUZGhjZu3Kjly5dbHQoQUO6nbzMVCgAAVEViAcAr7mssCjjHAgAAVEFiAcAr8UyFAgAAtSCxAOAVj+1mmQoFAACqILEA4BX3XaFILAAAQFUkFgC84rF4m6lQAACgChILAF5hjQUAAKgNiQUAr3hOhbLLMAyLogEAAMGGxAKAV9ynQtkdhsoqnBZFAwAAgg2JBQCvuO8KJTEdCgAA/I7EAoBX3A/Ik9gZCgAA/I7EAoBXIsNCFB5qM5UVklgAAID/IbEA4BWbzeZ5SF6Z3aJoAABAsCGxAOA1DskDAAA1IbHwUWZmpnr16qX09HSrQwECzn3EgqlQAACgEomFjzIyMrRx40YtX77c6lCAgOP0bQAAUBMSCwBeS3BLLApKWWMBAACOIrEA4DXPxduMWAAAgKNILAB4zWMqFGssAADA/5BYAPAau0IBAICakFgA8JrHrlBMhQIAAP9DYgHAa+6Lt5kKBQAAKpFYAPCa+xqLfHaFAgAA/0NiAcBrcZHmNRZMhQIAAJVILAB4LZ4D8gAAQA1ILAB4zeMci9IKGYZhUTQAACCYkFgA8Jr7iIXDaajU7rQoGgAAEExILAB4zf0cC0kqKGMBNwAAILEAUA+xkaEeZRySBwAAJBILAPUQGRaqiDDzPxucZQEAACQSCwD15H5IHiMWAABAIrEAUE/uO0MVssYCAACIxAJAPbmfvs2IBQAAkEgsANRTvNvp2yQWAABAIrFwycvL04knnqgBAwaoT58+evHFF60OCQhK7iMWnL4NAAAkKazuKs1DfHy8Fi9erJiYGBUVFalPnz6aMGGCWrRoYXVoQFCJ91hjQWIBAAAYsXAJDQ1VTEyMJKmsrEyGYcgwDIujAoKP++nbBaUs3gYAAI0osVi8eLHOO+88paWlyWaz6ZNPPvGok5mZqeOOO05RUVEaOnSoli1bVq975OXlqX///mrfvr3uuOMOtWzZ0k/RA00Hi7cBAEB1Gs1UqKKiIvXv31/XXnutJkyY4PH47NmzNXXqVM2cOVNDhw7V008/rTPPPFNbtmxR69atJUkDBgxQRYXnm6Cvv/5aaWlpSkpK0tq1a5WTk6MJEybo4osvVmpqarXxlJWVqayszHWdn58vSbLb7bLb+QQXZpV9oin0jWi3A/IKSujz/tCU+ggCgz6CutBHUJdA9w2b0Qjn+9hsNn388ccaP368q2zo0KFKT0/Xv/71L0mS0+lUhw4ddPPNN2vatGn1vsdNN92k008/XRdffHG1jz/wwAOaPn26R/nbb7/tmlIFNEXfZ9v0/vZQ13XneEO39XFYGBEAAPBGcXGxLr/8ch05ckQJCQl+b7/RjFjUpry8XCtXrtRdd93lKgsJCdGYMWO0ZMkSr9rIyclRTEyM4uPjdeTIES1evFg33nhjjfXvuusuTZ061XWdn5+vDh06aNSoUSz4hge73a558+Zp7NixCg8Pr/sJQaxibZbe3/6z6zo8Ol5nn32yhRE1DU2pjyAw6COoC30EdcnNzQ1o+00isTh48KAcDofHtKXU1FRt3rzZqzZ27typG264wbVo++abb1bfvn1rrB8ZGanIyEiP8vDwcP6YUaOm0D+SYs39vqjc0ehfUzBpCn0EgUUfQV3oI6hJoPtFk0gs/GHIkCFas2aN1WEAQS8+yvyPUj67QgEAADWiXaFq07JlS4WGhionJ8dUnpOTozZt2gT03pmZmerVq5fS09MDeh8gWMRVc45FI1yqBQAA/KxJJBYREREaPHiw5s+f7ypzOp2aP3++hg0bFtB7Z2RkaOPGjVq+fHlA7wMEC/dzLAxDKi5n8TYAAM1do5kKVVhYqF9++cV1vX37dq1Zs0YpKSnq2LGjpk6dqsmTJ+vEE0/UkCFD9PTTT6uoqEjXXHONhVEDTY97YiEdPcsiNrLR/HMCAAACoNG8E1ixYoVGjRrluq7ckWny5MmaNWuWJk6cqAMHDui+++5Tdna2BgwYoC+//LLGcygAHJvqEojCMrukqIYPBgAABI1Gk1iMHDmyznncU6ZM0ZQpUxooIqB5Cg8NUVR4iErtTlcZp28DAIAmscbCSizeRnPkvjMUiQUAACCx8BGLt9EcxVezMxQAAGjeSCwA1Fuc2wLuQkYsAABo9kgsANSb+85QHJIHAABILADUW3WH5AEAgOaNxMJHLN5Gc+S+eJupUAAAgMTCRyzeRnPkPmLBrlAAAIDEAkC9ua+xYCoUAAAgsQBQb+6JRQGJBQAAzR6JBYB6i4t0PyCPXaEAAGjuSCx8xOJtNEecYwEAANyRWPiIxdtojlhjAQAA3JFYAKi3eHaFAgAAbkgsANSbx1Sosgo5nYZF0QAAgGBAYgGg3twPyJOkonJGLQAAaM5ILADUm/sBeRLToQAAaO5ILADUW3WJBQu4AQBo3kgsfMR2s2iOQkNsio0INZVxlgUAAM0biYWP2G4WzZX7Am6mQgEA0LyRWAA4Ju7ToZgKBQBA80ZiAeCYuO8MxYgFAADNG4kFgGPicfo2iQUAAM0aiQWAY+I+FaqAqVAAADRrJBYAjon7iAW7QgEA0LyRWAA4JnGR5jUWTIUCAKB5I7HwEedYoLly326WXaEAAGjeSCx8xDkWaK4SOMcCAABUQWIB4JiweBsAAFRFYgHgmHhMhWLxNgAAzRqJBYBjwgF5AACgKhILAMfEfSoUi7cBAGjeSCwAHBP3cyyKyx1yOA2LogEAAFYjsQBwTNwTC4mzLAAAaM483xkAgBfcp0JJ0to9eWqdEGlBNI1fhb1C+4qkLdkFCgvnn2Z4oo+gLvQRuOvaOl6hIbYGux+9DsAxiY0Ik80mGVVmP131yjLrAmoSwvTouiVWB4GgRh9BXegj+N3PD5zhsdlKIDEVCsAxCQmxKS6CzyYAAMBRJBY+yszMVK9evZSenm51KECD69E23uoQAABAkODjRh9lZGQoIyND+fn5SkxMtDocoEH9/YI++vN7a7U5O9/qUJoEwzBkszXcXFg0PvQR1IU+AiuRWAA4Zj3bJmjuradaHUaTYLfbNXfuXJ199tkKD2+4+bBoPOgjqAt9BFZjKhQAAAAAn5FYAAAAAPAZiQUAAAAAn5FYAAAAAPAZiQUAAAAAn5FYAAAAAPAZiQUAAAAAn5FYAAAAAPAZiQUAAAAAn5FYAAAAAPAZiQUAAAAAn5FYAAAAAPAZiYWPMjMz1atXL6Wnp1sdCgAAAGAZEgsfZWRkaOPGjVq+fLnVoQAAAACWIbEAAAAA4DMSCwAAAAA+I7EAAAAA4DMSCwAAAAA+C7M6gKbCMAxJUkFBgcLDwy2OBsHGbreruLhY+fn59A9Uiz6CutBHUBf6COpSUFAg6ff3rf5GYuEnubm5kqTOnTtbHAkAAABQs9zcXCUmJvq9XRILP0lJSZEk7dq1KyC/KDRu+fn56tChg3bv3q2EhASrw0EQoo+gLvQR1IU+grocOXJEHTt2dL1v9TcSCz8JCTm6XCUxMZE/ZtQoISGB/oFa0UdQF/oI6kIfQV0q37f6vd2AtAoAAACgWSGxAAAAAOAzEgs/iYyM1P3336/IyEirQ0EQon+gLvQR1IU+grrQR1CXQPcRmxGo/aYAAAAANBuMWAAAAADwGYkFAAAAAJ+RWAAAAADwGYkFAAAAAJ+RWPhBZmamjjvuOEVFRWno0KFatmyZ1SHBIjNmzFB6erri4+PVunVrjR8/Xlu2bDHVKS0tVUZGhlq0aKG4uDhddNFFysnJsShiWOmRRx6RzWbTbbfd5iqjf2Dv3r36wx/+oBYtWig6Olp9+/bVihUrXI8bhqH77rtPbdu2VXR0tMaMGaNt27ZZGDEaksPh0L333qvOnTsrOjpaxx9/vP7xj3+o6l489JHmZfHixTrvvPOUlpYmm82mTz75xPS4N/3h0KFDuuKKK5SQkKCkpCT98Y9/VGFhYb1jIbHw0ezZszV16lTdf//9WrVqlfr3768zzzxT+/fvtzo0WODbb79VRkaGfvrpJ82bN092u11nnHGGioqKXHVuv/12ff7553r//ff17bffat++fZowYYKFUcMKy5cv1wsvvKB+/fqZyukfzdvhw4c1fPhwhYeH67///a82btyoJ598UsnJya46jz32mJ599lnNnDlTS5cuVWxsrM4880yVlpZaGDkayqOPPqrnn39e//rXv7Rp0yY9+uijeuyxx/Tcc8+56tBHmpeioiL1799fmZmZ1T7uTX+44oortGHDBs2bN09z5szR4sWLdcMNN9Q/GAM+GTJkiJGRkeG6djgcRlpamjFjxgwLo0Kw2L9/vyHJ+Pbbbw3DMIy8vDwjPDzceP/99111Nm3aZEgylixZYlWYaGAFBQVG165djXnz5hkjRowwbr31VsMw6B8wjDvvvNM45ZRTanzc6XQabdq0MR5//HFXWV5enhEZGWm88847DREiLHbOOecY1157ralswoQJxhVXXGEYBn2kuZNkfPzxx65rb/rDxo0bDUnG8uXLXXX++9//Gjabzdi7d2+97s+IhQ/Ky8u1cuVKjRkzxlUWEhKiMWPGaMmSJRZGhmBx5MgRSVJKSookaeXKlbLb7aY+06NHD3Xs2JE+04xkZGTonHPOMfUDif4B6bPPPtOJJ56oSy65RK1bt9bAgQP14osvuh7fvn27srOzTX0kMTFRQ4cOpY80EyeffLLmz5+vrVu3SpLWrl2r77//XuPGjZNEH4GZN/1hyZIlSkpK0oknnuiqM2bMGIWEhGjp0qX1ul+Yf8Jung4ePCiHw6HU1FRTeWpqqjZv3mxRVAgWTqdTt912m4YPH64+ffpIkrKzsxUREaGkpCRT3dTUVGVnZ1sQJRrau+++q1WrVmn58uUej9E/8Ntvv+n555/X1KlTdffdd2v58uW65ZZbFBERocmTJ7v6QXX/36GPNA/Tpk1Tfn6+evToodDQUDkcDj300EO64oorJIk+AhNv+kN2drZat25tejwsLEwpKSn17jMkFkCAZGRkaP369fr++++tDgVBYvfu3br11ls1b948RUVFWR0OgpDT6dSJJ56ohx9+WJI0cOBArV+/XjNnztTkyZMtjg7B4L333tNbb72lt99+W71799aaNWt02223KS0tjT4CyzEVygctW7ZUaGiox44tOTk5atOmjUVRIRhMmTJFc+bM0cKFC9W+fXtXeZs2bVReXq68vDxTffpM87By5Urt379fgwYNUlhYmMLCwvTtt9/q2WefVVhYmFJTU+kfzVzbtm3Vq1cvU1nPnj21a9cuSXL1A/6/03zdcccdmjZtmi677DL17dtXV155pW6//XbNmDFDEn0EZt70hzZt2nhsOlRRUaFDhw7Vu8+QWPggIiJCgwcP1vz5811lTqdT8+fP17BhwyyMDFYxDENTpkzRxx9/rAULFqhz586mxwcPHqzw8HBTn9myZYt27dpFn2kGRo8erZ9//llr1qxxfZ144om64oorXN/TP5q34cOHe2xRvXXrVnXq1EmS1LlzZ7Vp08bUR/Lz87V06VL6SDNRXFyskBDz27fQ0FA5nU5J9BGYedMfhg0bpry8PK1cudJVZ8GCBXI6nRo6dGj9bujT0nMY7777rhEZGWnMmjXL2Lhxo3HDDTcYSUlJRnZ2ttWhwQI33nijkZiYaCxatMjIyspyfRUXF7vq/N///Z/RsWNHY8GCBcaKFSuMYcOGGcOGDbMwalip6q5QhkH/aO6WLVtmhIWFGQ899JCxbds246233jJiYmKMN99801XnkUceMZKSkoxPP/3UWLdunXHBBRcYnTt3NkpKSiyMHA1l8uTJRrt27Yw5c+YY27dvNz766COjZcuWxl//+ldXHfpI81JQUGCsXr3aWL16tSHJeOqpp4zVq1cbO3fuNAzDu/5w1llnGQMHDjSWLl1qfP/990bXrl2NSZMm1TsWEgs/eO6554yOHTsaERERxpAhQ4yffvrJ6pBgEUnVfr366quuOiUlJcZNN91kJCcnGzExMcaFF15oZGVlWRc0LOWeWNA/8Pnnnxt9+vQxIiMjjR49ehj/+c9/TI87nU7j3nvvNVJTU43IyEhj9OjRxpYtWyyKFg0tPz/fuPXWW42OHTsaUVFRRpcuXYy//e1vRllZmasOfaR5WbhwYbXvPSZPnmwYhnf9ITc315g0aZIRFxdnJCQkGNdcc41RUFBQ71hshlHlqEYAAAAAOAassQAAAADgMxILAAAAAD4jsQAAAADgMxILAAAAAD4jsQAAAADgMxILAAAAAD4jsQAAAADgMxILAAAAAD4jsQCAABg5cqRsNpseeOABq0OxVHFxse6991717NlT0dHRstlsstlsWrNmjdWhBcwDDzwgm82mkSNHWh3KMbn66qtls9l09dVXWx0KgEaGxAJAg6l8w2Wz2RQTE6N9+/bVWHfHjh2uuosWLWq4IOFXEydO1IMPPqjNmzfLZrMpNTVVqampCg8Ptzq0ZmfRokV64IEHNGvWLKtDAdBEkVgAsERJSYmmT59udRgIoM2bN2vOnDmSpNmzZ6u4uFjZ2dnKzs5W7969LY6u+Vm0aJGmT59eZ2LRtm1bde/eXW3btm2YwAA0GSQWACzzyiuvaOvWrVaHgQD5+eefJUktWrTQpZdeanE08NaMGTO0efNmzZgxw+pQADQyJBYAGlyHDh3Ur18/VVRU6O6777Y6HARIcXGxJCkuLs7iSAAADYHEAkCDCwkJcX0a+uGHH2rZsmX1en7V9Rc7duyosd5xxx0nm83mMfXD/fk7d+7U9ddfr44dOyoqKkrHH3+87rnnHhUVFbmes379ev3hD39Qhw4dFBUVpa5du+rBBx+U3W6vM97y8nI98sgj6tevn2JjY5WcnKyxY8fqv//9b53PXb9+vW644QZ17dpVMTExiouLU79+/fS3v/1NBw8erPY57ouHP/zwQ51xxhlq3bq1QkJC6r2gvLS0VE8//bROPvlkJScnKyoqSp06ddJVV11V7SLsyvtXLv7duXOn6+d9rIuCf/jhB/3hD39Qp06dFBUVpcTERA0ZMkSPPvqoCgsLTXXtdrtatmwpm82mZ599ttZ2X3nlFdlsNiUkJLgSIUnKzs7Wc889pwsuuEA9e/ZUYmKioqOjdcIJJ+i6667Thg0b6v0aJO8W9de2+Pvw4cN6+eWXdemll6pv375KSUlx/T4uv/xy/fTTTx7PqezvlVMPv/32W9Pvw/1vxJvF24sWLdIll1yidu3aKTIyUi1bttTo0aP16quvyuFwePW65s+fr3POOUetWrVSVFSUevbsqenTp6u0tLTG+3711VeaMGGC2rdvr4iICCUkJKhLly4644wz9MQTT+jQoUM1PhdAAzAAoIHcf//9hiSjU6dOhmEYxogRIwxJxqhRozzqbt++3ZBkSDIWLlxY42Pbt2+v8X6dOnUyJBmvvvpqjc//8MMPjaSkJEOSkZCQYISGhroeO/XUU43y8nJjzpw5RkxMjCHJSExMNGw2m6vOxIkTq7135Wu76667jFNPPdWQZISFhbnuVfl1//331xj/o48+aoSEhLjqxsTEGBEREa7rtm3bGqtWrarx5zxixAhj6tSphiTDZrMZycnJRmhoaK33dLdnzx6jT58+rnuGh4cbiYmJruuQkBDj2WefNT3n8ccfN1JTU42EhARXndTUVNfXLbfc4vX9HQ6Hccstt5h+ZnFxcabfU/fu3Y0dO3aYnpeRkWFIMk488cRa2x85cqQhybj66qtN5ZMnT3a1HxYWZqSkpBhhYWGussjISOODDz6ots2qP393lf2itt9Bbc+vfEySERoaaiQnJxuRkZGuMpvNZjzzzDOm5+zatctITU01YmNjXb/Dqr+P1NRU49133/V47ZMnT642vttvv910v6SkJNPv4/TTTzfy8/NrfV2PPfaYYbPZXM+v+jc1atQoo6KiwuP506dPN/WDmJgYIy4uzlTm/m8FgIZFYgGgwbgnFkuWLHG9Ifjvf/9rqttQiUVSUpIxevRoY8OGDYZhGEZxcbHx7LPPut4o3XPPPUZiYqIxceJE15vXgoIC429/+5urjXnz5nncu/INZGJiohEZGWnMnDnTKCkpMQzj6Bu9iy++2PX8Tz/91OP5L730kutN9EMPPWRkZWUZhmEYFRUVxooVK4zTTz/dkGS0b9/eKCgoqPbnXPmm68477zT2799vGIZhlJaWerwJr0lFRYUxdOhQ1+t48803jbKyMsMwDOPXX381zj33XNeby7lz53o8/9VXXzX9vo/FPffcY0gyWrdubWRmZhq5ubmGYRhGeXm5sXDhQmPgwIGGJGPQoEGGw+FwPW/p0qWun++mTZuqbXvnzp2uN7QLFiwwPfaPf/zDePzxx42ff/7ZsNvthmEcTXLWr19vXHHFFYYkIzY21ti7d69Hu4FMLF544QXj/vvvN1asWOH6XTidTuO3334zbr31VsNmsxmhoaF1Jpy1qS2xeO6551w/1xtuuMHVLwsLC41//vOfruSruoS78v5JSUlGSEiIcddddxkHDhwwDMMwjhw5Ytx3332utl9++WXTc3fs2OFKsqdOnWr6uefl5RnfffedcdNNNxkrVqyo9bUBCCwSCwANxj2xMAzDuPDCCw1JxoABAwyn0+kqb6jEonfv3kZpaanHc6+88kpXnbFjx5piq1Q5EvHHP/7R47HKN5DVvUkyjKNvUk877TRXDFXl5+e7Rja+/PLLal+b3W43Bg8ebEgy/vnPf5oeq/qp9tSpU6t9vjfeffddVztfffVVtTFUJh59+vTxeNzXxGL79u1GaGioER0dbaxZs6baOvn5+Ub79u0NScbHH39seqx79+6uUaPqPPzww4Yko2PHjtX+fmtzzjnnGJKMf/zjHx6PBTKxqEvlSE11fdLXxKK4uNhISUkxJBmTJk2q9rnPPvusq8+4v8mv2i9rev0TJkwwJBljxowxlc+ePduQZHTr1q3W2AFYizUWACz18MMPKzQ0VGvWrNE777zT4Pe//fbbFRkZ6VF+5plnur6fNm2abDZbjXXWrVtXY/sdOnTQNddc41EeEhKie+65R5K0YcMG1w5K0tE1EXl5eRo4cKApjqrCwsI0adIkSUfnnVcnJCREd955Z42x1WX27NmSpGHDhumMM86oNob7779f0tG1IFVfgz/MmjVLDodDZ511lvr3719tnfj4eI0fP16S58/hyiuvlCS99dZbMgzD47lvvPGGJOmKK66o9vdbm3POOUeS9P3339freYEWyLjmzZvnWsNQ0xqRm266ybVN7dtvv11tncjISP3lL3+p9rELLrhAkuffVFJSkiSpoKDAtPYJQHAhsQBgqR49erjeeN97771eLYb2pyFDhlRbnpqa6vo+PT291jqHDx+usf3KxbrVOfXUUxUWFiZJWrFihav8hx9+kCRt2rRJbdq0qfHr73//u6Sji6Orc8IJJ6h169Y1xlaXypjGjBlTY51Ro0YpNDTU4zX4Q+XP4euvv6715/Dqq69K8vw5XHnllbLZbNq1a5e+/fZb02MrV67Upk2bJElXXXVVtfdfu3atbrrpJvXr108JCQkKCQlxLXa+6aabJEl79uzx62v2xm+//aa//OUvGjx4sJKSkhQaGuqK6+yzzw5YXJW/3w4dOqhbt27V1gkNDdXpp59uqu+ud+/eNe4UlpaWJkkei7CHDBmili1bKisrS0OHDtW//vUvbd68udqEEYB1wqwOAAAeeOABvfXWW/rtt980c+ZM3XzzzQ127/j4+GrLK9/we1OntmSoXbt2NT4WFRWlFi1aKCcnR/v373eVV55IXlpaWusOOZWq7mZUlS9JhSRXTHW9hpYtW3q8Bn+o/DkUFRV59Sm1+8+hY8eOGjFihBYtWqQ33njDtMtS5WhFenq6evTo4dHWv/71L916661yOp2SJJvNpsTERNfoVklJifLz8xv80/OPP/5YkyZNUllZmassISFBUVFRstlsKi8v1+HDhwMSlzf9QZLat29vqu+upr8n6fe/qYqKClN5UlKS3nnnHV1++eXasGGD69+IxMREnXbaabr00ks1ceJETnQHLMaIBQDLtWvXzvVG4cEHH/TYPrS5qdyuc+LEiTKOroWr9aumLXcrRxIaq8qfw5133unVz2HRokUebVSORnzwwQcqKSmRdPRNa+W0u8rpUlVt2rRJt912m5xOpy655BItW7ZMpaWlOnz4sOvk8KeeekqSGvQT89zcXF199dUqKyvT6aefrkWLFqm4uFhHjhxRTk6OsrOz9f777zdYPA1tzJgx2r59u15//XVNnjxZXbt21ZEjR/T555/ryiuv1MCBA7V3716rwwSaNRILAEFh2rRpSk5O1v79+/Xkk0/WWrfqaEJtn+gfOXLEb/Edq9re6JSVlSk3N1eSeXShTZs2kmqe4tRQKmOqbVpNaWlpta/BH/zxc7j44osVHR2t/Px8ffrpp5KOTq3av3+/wsPDXetUqvrggw/kcDjUs2dPvfvuu0pPT1dERISpTnZ29jHFU9l3j6Xfzp07V/n5+UpOTtbnn3+uESNGKDo62i9xecOb/lD1cX/3B0mKjY3VlVdeqVmzZmnr1q3as2ePHn30UUVFRZlGMgBYg8QCQFBITk7WtGnTJElPPvmkDhw4UGvdSrt37662ztatW5WXl+fXGI/Ft99+W+On2t99951ryseJJ57oKh8+fLiko+sAsrKyAh9kDSpjmj9/fo11Fi1a5HoNNa1FOVaVP4dvvvnGqylh1am6uLty+lPlf8eNG6eWLVt6PKeyT/Xv318hIdX/b/Kbb745pngq+25N/VaSli5dWm155XO6d++umJiYesdV+VqOdZSlsj/s2bNHW7durbaOw+HQwoULJfm/P1SnXbt2+utf/6o///nPko4uMAdgHRILAEHj5ptvVvv27VVQUKB//OMfNdaLjY3V8ccfL+noDkrVeeihhwISY33t2rVLr732mke50+nUww8/LEnq1auX+vbt63rskksuUVJSkux2u6ZOnVrrG0Gn0xmwBOqyyy6TJC1ZskRff/21x+MVFRWuBeR9+vRRnz59/Hr/a6+9VmFhYTp48KBr96malJeX1ziFrnI61Ndff61t27a5Ri5qWrSdmJgoSfr555+r/dn/97//rXbalTcqd7f66quvql0HsWDBAi1ZsqTWuLZu3VptorVmzZoad2KSjq7FkHTM/WXs2LFq0aKFpJp3hXrhhRdca2OqGw06VlXXlFSncuSmpkQQQMPgLxBA0IiOjna9Yfn8889rrVv5puWVV17Rv//9b9f8+d27d+u6667T7Nmza/xUtyElJibqxhtv1Isvvuh6M7h7925NmjTJ9cnugw8+aHpOUlKSnn76aUnSu+++q3POOUdLly51LSR2Op3atGmTnnzySfXu3Vtz5swJSOwXXXSRhg4dKkm69NJL9fbbb7sWqm/fvl0XXXSR603wY4895vf7H3/88br33ntd7V911VVav3696/GKigqtWbNGf//733XCCSdozZo11bYzduxYtWnTRhUVFbr88stVUlKi5ORknXvuudXWP+ussyQd3QY4IyPDtUNRUVGRXnjhBV188cWuN9j1demllyokJES5ubmaNGmSa9pQSUmJXnvtNV144YVKSUmp9rlnnHGGQkJCdOjQIV1xxRWuaXbl5eV67733dMYZZ9S6MLoy8duwYYN+/PHHesde9e/znXfe0f/93/8pJydH0tGF888++6xuu+02SUfXBw0ePLje96jJo48+qnHjxumNN94wTcUqKyvTe++9p8cff1zS79vtArBIg52YAaDZq+6APHcVFRVGjx49XAdpqZoD8gzj6OnXvXr1ctUJCQlxHSoXHh5uvPPOO14dkFfTAXsLFy501alJbQfAVR6EdtdddxmnnHKKK67k5GTTa7vnnntqbP/55583IiIiXHUjIyONFi1aGOHh4aY23nzzTdPzfDlgzd2ePXuM3r17u+4VERHh+jlX/tyfeeaZap/rj5O3nU6nce+997pOyJZkREdHGy1atHCdjl759f3339fYztSpU011//SnP9V638suu8xUPykpyXW/wYMHu06gru611fXzr3rCtP53qnnlidXjx493nTZe3fPvvPNOj+dW9ofOnTsbb731Vo391m63uw4NlGQkJycbnTp1Mjp16mS8//77rnq1nbxtGIZx++23u9qw2WxGcnKyK35JxqhRo4z8/Px6/1wMo+a/u6qH61X2gZSUFFO/6Nmzp+skcADWYMQCQFAJDQ11TRGqTVxcnL7//ntNnTpVnTt3VlhYmMLDw12foldO47FaRESE5s+fr4cffljdu3dXWVmZEhMTNXr0aH3xxRe1Tvn6v//7P23ZskV/+ctf1L9/f0VGRiovL09xcXE68cQTdfPNN2vevHl+nXLirl27dlqxYoWeeuopnXTSSYqOjlZxcbE6dOigK6+8UitXrtQtt9wSsPvbbDb9/e9/17p163TTTTepZ8+eCg0N1ZEjR5ScnKyTTz5Zd9xxh3788UfXmozquE97qmkaVKW33npLTz/9tPr166fIyEg5HA717dtXM2bM0A8//FDjOQzemD59ut544w2ddNJJio2NlcPh0IABAzRz5kx99NFHte7m9cgjj+j111/XkCFDFB0dLbvdrhNOOEF33323Vq9e7ToHojphYWGaP3++rrvuOnXu3FlFRUXauXOndu7cWa+d2J566iktWLBAF110kVJTU1VYWKj4+HiNGjVKr7zyiubNm1fryMmxuOGGG/Sf//xHkyZNUp8+fRQTE+NayH7qqafq6aef1qpVq1wL/gFYw2YYnC4DAAAAwDeMWAAAAADwGYkFAAAAAJ+RWAAAAADwGYkFAAAAAJ+RWAAAAADwGYkFAAAAAJ+RWAAAAADwGYkFAAAAAJ+RWAAAAADwGYkFAAAAAJ+RWAAAAADwGYkFAAAAAJ+RWAAAAADwGYkFAAAAAJ+RWAAAAADwGYkFAAAAAJ+FWR0AUF+GYchut8vpdFodCgAAARESEqLw8HDZbDarQwG8RmKBRsPhcOjgwYMqKCiQ3W63OhwAAAIqPDxc8fHxatmypUJDQ60OB6iTzTAMw+oggLo4HA7t3r1bZWVlSkxMVFxcnEJDQ/kkBwDQ5BiGIYfDocLCQh05ckSRkZHq0KEDyQWCHokFGoWcnBzl5eWpY8eOio6OtjocAAAaRElJiXbt2qWkpCSlpqZaHQ5QKxZvI+gZhqGCggIlJiaSVAAAmpXo6GglJCSooKBAfBaMYEdigaBnt9tlt9sVFxdndSgAADS4+Ph41/8LgWBGYoGgV7n7E3NLAQDNUeX//9gNEcGOxAKNBgu1AQDNEf//Q2NBYgEAAADAZyQWAAAAAHxGYgEAAADAZyQWQBNx3HHHyWazeXzFxcWpf//+uuuuu5Sbm1tnO7fccovruZ9//rnf43zggQdks9k0cuTIWustWrTIFUd1Vq1apWuvvVYnnHCCoqOjFRMTo06dOmn48OH6y1/+onnz5vk9djSsmvq0+9esWbM8nlO1DI3Xtm3bNGXKFPXq1UuxsbGKiopS+/btlZ6erilTpujDDz/0+R6V/9bU9W+Sv8yaNUs2m01XX311g9wPaEhhVgcAwL+GDx+uE044QdLRHUT27dunH3/8UY888ohef/11fffdd+rSpUu1zy0rK9Nbb73lun7llVd03nnnNUjc9fHcc8/ptttuk9PpVLt27TRq1CglJyfrwIEDWrVqlX788UctWrRIY8eOtTpU+EHVPl2d2h5D4/XRRx/p8ssvV1lZmVq0aKHhw4erVatWOnz4sNasWaPMzEy9++67uuiii6wOFcD/kFgATcx1113n8UlYdna2RowYoa1bt+qvf/2rPvjgg2qf+/HHH+vQoUNKS0tTVlaW5syZo5ycnKA67XXdunWupOKf//ynbr75ZtNWxE6nU99//72+//57C6OEP1XXp9G05eTkaPLkySorK9Of//xnPfjgg4qKijLVWblyZY3/lgGwBlOhgGagTZs2uuOOOyRJ8+fPr7Heyy+/LEm69dZbNWLECFVUVOj1119vkBi99f7778vpdGrYsGG67bbbPM43CQkJ0Wmnnaa7777boggB+GrOnDkqLCxUWlqannjiCY+kQpIGDx6sGTNmWBAdgJowYoFGzek0dLi43OowfJYcE6GQkMDuU96mTRtJUkVFRbWP79ixQ/Pnz1dYWJiuuuoqpaWladGiRXrllVdcSUlVv/32mwYNGqT8/Hx98cUXGjdunOnxffv2acCAATpw4IDeffddTZw40S+vIycnR5LUunVrv7QXdJxOqeSQ1VH4JjpFCuFzq/pyGk7lleVZHYZPkiKTFGLz/Xdf+XfeqlWrej/30KFDeuKJJ/Tpp59q+/btCg0NVbdu3TRx4kTdfPPNio6OrvG5xcXFevDBB/Xee+9pz549SklJ0bhx4/T3v/9d7dq1q/Y5mzdv1qOPPqoFCxYoOztbsbGxGjhwoP70pz/p0ksvrXf8QGNGYoFG7XBxuQY/+I3VYfhs5T1j1CIuMqD3WLZsmSSpd+/e1T7+yiuvyDAMnX322WrTpo0uuugiTZkyRZs3b9aPP/6ok08+2VS/S5cueuWVV3TRRRfpqquu0urVq9W+fXtJksPh0GWXXaYDBw7opptu8ltSIUkdO3aUdHTkZf369erTp4/f2g4KJYekx4+3Ogrf3PGrFNvS6iganbyyPI2YPcLqMHzy7cRvlRKV4nM7lX/n69ev1/z58zV69Givnvfbb7/p9NNP186dO9WqVSudffbZstvtWrhwoe68807Nnj1b33zzjZKTkz2eW15ertGjR2vdunUaOXKkBg0apO+//16vvPKK5s6dq8WLF6tr166m53zxxRe6+OKLVVpaqu7du2vChAnav3+/vv32Wy1YsEBfffWVayQYaA74SAlowpxOp/bu3at//etfeuyxxxQaGqp77rmn2nqVu+hce+21kqTo6GhddtllklTj/xgnTJigW2+9VQcPHtRll13mGg3529/+pu+++06DBg3SU0895dfXNHnyZMXHx6uwsFADBw7UOeeco8cee0zffPONjhw54td7AbDG+PHj1a5dOzkcDo0dO1ajRo3Sgw8+qLlz5+rAgQM1Pu/yyy/Xzp07df7552v79u364IMP9Omnn+rXX3/VoEGDtGrVKk2ZMqXa5y5ZskQHDx7Upk2b9MUXX+i9997Tb7/9posuukjZ2dm66qqrTPVzcnJ0xRVXqLS0VA8++KA2bdqkd955R/Pnz9dPP/2k5ORkvfLKK3rxxRf9+rMBghmJBdDEXHPNNa5tOENDQ9W+fXvdfPPN6tevn7799lude+65Hs/5+uuvtXv3bqWmpuqcc85xlf/xj3+UJL333nsqLCys9n6PP/64hg4dqh9++EF/+9vfNHfuXD322GNKTEzU+++/r8hI/47EdOjQQV9//bV69OihiooKzZ07V3feeafGjh2rlJQUDR8+XLNnz/brPWGtqn26uq+8vDyrQ4SfxcXFaf78+Ro6dKgMw9CiRf/f3r2HNPX+cQB/7+Jys77tK7XsIiYRVgah1bpSKb9EKKp/Qkpp3aREuhcRWkFFF7oRWXSzcFEpUdhNhaKUbGbxmxpl9wuVdtFMJWfltuf3h+zk3Kz4rdTp+wUHZOc553x2cDv7nPM8nycX69evx5QpU6DT6RAWFoZDhw7BZrNJ2+Tn56OwsBAajQZHjhyBn5+ftK5nz544cuQIACA9PR1v3751e9xdu3ZJT0sAwNfXFwcPHoRGo8Ht27dhMpmkdUePHkVNTQ2GDx+OpKQkp9LYI0aMQFJSEoDG70iizoJdoYg6mOalOSsrK3Hv3j3cvXsXK1aswKlTp1we5x87dgwAMGfOHCiVP74WRo4ciaFDh+L+/fvIyMiQEo2mfHx8kJGRgfDwcOzcuROHDh2CEAKpqaktlrX11OjRo/HgwQPk5eUhJycHd+/ehdlsRk1NDUwmE0wmE7KzszmXQQfxq3KzKpWqFaOh1hISEoLbt2/jzp07uHLlCgoLC2E2m1FRUYHi4mIkJCTg3LlzuHLlClQqFXJzcwEA0dHRbivZDR8+HMOGDUNJSQny8vIQGxvrtF6r1WLatGku2+l0OkRHR+P8+fPIzc2VuoU6jmcwGNzGv2DBAqxevRpPnz5FeXk5+vTp48HZIPIOTCzIq/2rUeG/yf9p6zA89q/mz/0wclea02q1YsOGDdi2bRsmTpyIx48fo1u3bgCAiooKXLx4EcCPblBNzZ8/HytXrsTx48fdJhYAEBQUhP379yM2Nha1tbVISEhosba8466eEOKn7+NX6+VyOSIiIhAREQGgcVxHQUEBNm3ahKtXryItLQ1TpkzBzJkzf7qfdkft3zhGwZupPe9j31RnKTer7aJFXkxeW4fhEW0X7R/fp16vh16vB9D4vVBUVISdO3ciPT0d165dw759+7BmzRqUlZUBAIKDg1vc14ABA1BSUiK1bcoxuaI7jn02fdLxq+NptVr4+/ujqqoKb9++ZWJBnQITC/Jqcrnsrw967giUSiW2bNmCo0eP4t27dzAajUhMTAQAnDx5Eg0NDVAqlVi4cKHLto4uUCaTCY8ePcKgQYNc2gghnCbWM5vNaGhogI+Pj0tbR/eEurq6n8bsOG7Xrl1/6z0qFAqMHz8e2dnZ0Ov1MJvNyMzM9L7EQi7nwOdOSi6T/5GBzx2ZTCZDeHg4zpw5A4vFgosXLyIzM9Nt5bq/4Vc3PIg6O46xIOok5HI5+vfvDwB4+PCh9LpjYLbVasWtW7dclpKSEpe2ze3YsQNZWVkYPHgwxowZg8LCQqxdu9ZtW0f/5efPn//0Iv306VOn9r9LoVAgMjISQGM3MCLqmKKiogD8+Jw7ysG+ePGixW0c69yVjn316lWL2znWOSrf/c7xampqUFVV1eLxiDoiJhZEnYTdbpcujo6nAAUFBSgtLUWXLl3w+fNnCCHcLllZWQAan240nwfj5s2bSE5OhkajwdmzZ5GRkQF/f3/s3bsXFy5ccIljwoQJUCqVqK6uxvXr11uM1zGjriNJcPidO4avX78G4PwjgIi8x//zOZ80aRIAICcnR5oHo6mioiIUFxdLk2g2V11djUuXLrm8XlFRgZycHKdjNP07LS3NbXzHjx8HAAwcOJCJBXUaTCyIOgGr1Yrk5GTpzp5jgKLjCcT06dOh1Wpb3D4qKgoBAQH48OEDLl++LL1eUVGBWbNmwWaz4cCBAwgNDUVgYCDS0tIgk8kwb948l7uAAQEB0mDHxYsX48mTJy6xbty4EQUFBfD19cWyZcuc1iclJWHJkiW4d++e2/d5+PBhKSlxlMslIu9y8OBBGAwGpypMDkIInD9/HikpKQB+fM7Hjx+PUaNGob6+HosWLYLFYpG2qaysxKJFi6T2gYGBbo+7atUqp3EU3759Q2JiIurq6qDX6zFu3DhpXXx8PP755x+YzWZs3brVKRkqKirCli1bAKDVumkRtQccY0HUwRw7dkyqVgIAnz59QklJCd68eQOg8Yf52LFj8eXLF6ksa0tVTRwUCgVmz56NPXv2IDU1FTNmzIDdbkdcXBzKyspgMBicBtdOnToVK1euxO7duxETE4P8/Hyn8Rb79u3D8+fPkZubi9DQUIwaNQpBQUGwWCy4c+cOysvLoVarYTQaXaoBWSwWpKSkICUlBX379sWwYcOg1Wql9/n+/XsAwLp16zB58mRPTiW1E83/p5uLiorC7NmzWy8g+usaGhpgNBphNBrRs2dPhIWFoUePHqiurkZpaal0wyIuLs6pqMTp06cRGRmJCxcuIDg4GBMmTJAmyKutrUV4eLiUkDQ3ZswY2O12hISEIDIyEhqNBvn5+SgvL4dOp4PRaHRq36tXL5w6dQozZ85EUlISTp48ibCwMGmCPKvVinnz5iE+Pv6vnSeidkcQtXP19fWitLRU1NfXt3Uo7VpQUJAA4LKoVCoRFBQkYmJixI0bN6T2qampAoAICAgQVqv1l/svLi4WAIRCoRBlZWVi8+bNAoAYMmSIqKurc2n//ft3MXr0aAFALF++3GW91WoVaWlpIjo6Wuh0OqFUKkXXrl1FaGioWLp0qXj27JnbOCorK0V6erqIj48X4eHhonfv3kKpVAo/Pz8xaNAgMX/+fGEymX7/xFG71dL/dPNl2bJlLtucOHGizeImz9XW1orMzEyxZMkSodfrRb9+/YSPj49Qq9ViwIABYtasWSI7O9vttp8+fRLr1q0TgwcPFr6+vkKj0YiwsDCxfft2YbFYXNrfuHFDABATJ04UX758EWvWrBHBwcFCpVKJXr16iblz54rXr1+3GGtpaakwGAxSjFqtVkRERIj09HS37U+cOCEACIPB8Nvng9dB8hYyIVjigNq3r1+/4uXLlwgODoavr29bh0NERNSqeB0kb8ExFkRERERE5DEmFkRERERE5DEmFkRERERE5DEmFkRERERE5DEmFkRERERE5DEmFkRERERE5DEmFkRERERE5DEmFuQ1OOUKERF1Rrz+kbdgYkHtnlKpBAB8+/atjSMhIiJqfY7rn+N6SNReMbGgdk+pVMLPzw9VVVWw2WxtHQ4REVGrsdlsqKqqgp+fHxMLavdkgs/XyAtYLBa8efMGCoUC3bt3h1qthkKhgEwma+vQiIiI/ighBGw2G+rr61FTUwO73Y7AwECo1eq2Do3op5hYkNf4/v07Pn78CIvFwicXRETU4SkUCmg0Guh0OqhUqrYOh+iXmFiQ1xFCoKGhAXa7va1DISIi+ivkcjl8fHz4ZJ68ChMLIiIiIiLyGAdvExERERGRx5hYEBERERGRx5hYEBERERGRx5hYEBERERGRx5hYEBERERGRx5hYEBERERGRx5hYEBERERGRx/4HwokjdsvGjRIAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAKBCAYAAADKqj3oAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAACh4ElEQVR4nOzdd3yT1f4H8M+TNE33pi2FMmWVPQriYovoVXEioFa4justrl69ggu5Dq7zhyOKA8EtjisqTqYoMgtFoGzK7C7dM03O7w/sQ5+MJm2SPkn7eb9efdnn5OQ837SnmG/OkoQQAkRERERERC7QqB0AERERERH5PiYWRERERETkMiYWRERERETkMiYWRERERETkMiYWRERERETkMiYWRERERETkMiYWRERERETkMiYWRERERETkMiYWRERERETkMiYWRETtyLFjxyBJEiRJQrdu3dQOx2089bq6desmt3vs2DG3tetObfV36mvWr18v/x7Gjh2rdjhEqmBiQeRFli1bJv+Pydmv22+/vVn3WLNmDW699Vb07t0bwcHBiIqKwqBBg/DQQw9h//79LYp73759eOihhzBo0CBERUUhODgYvXv3RkpKCtasWeN0O029zpCQECQkJKBfv36YPHkyHnnkEXz11VcoKytrUczOuO2225r9++AbC/J1jd8g2/vy9/dHhw4dMGrUKNx3333Yvn272mETkRfwUzsAImodZWVluPPOO7F8+XJFeVVVFYqLi7F792688sorWLBgAebNm+d0u8888wwWLFgAo9GoKD906BAOHTqEDz74ANOnT8dbb72F0NDQFsdfWVmJyspK5OTkYP/+/fjll18AAMHBwbjpppuQlpaGpKSkFrdPRM4zGo0oLCxEYWEhtm7dildffRXTpk3DO++849LfORH5NiYWRF6qb9++mDBhgsN6F1xwgcM6RqMR11xzDdauXSuXDRgwAMOGDUNNTQ1+++035OTkwGg04pFHHoHRaMQTTzzhsN0nnngCTz31lHzdsWNHXHzxxQgICEB6ejr27t0LAPj0009RVFSE77//Hn5+zv2zM3XqVHTq1Em+rq+vR3FxMYqKirBz506cOXMGwNmEY8mSJfjoo4/w7LPP4oEHHoAkSU7dozmc/X006NWrl9tjIFJDamqqVVl1dTVOnTqFP/74AxUVFQCA5cuX49SpU1i/fr3Tf+dE1MYIIvIaS5cuFQAEAJGSkuK2dh9//HG53YCAAPHpp58qHq+trRUPPfSQXEeSJLF+/fom21y9erVcH4B46KGHRG1traLOJ598IgICAuQ6CxYsaLLNxu2tW7euybp79+4V99xzjwgODlY8LzU1tcnnNUdKSopHfh9qysrKkl9T165d1Q7HbTz1urp27Sq3m5WV5bZ23cndr33dunWKv6mmVFRUiDlz5ijqGwwGl2MgIt/ENRZEbVx+fj5efvll+XrRokW46aabFHX8/f3x/PPPY9q0aQAAIYTD6VCNH7/pppvw/PPPw9/fX1Fn+vTp+L//+z/5+sUXX0RhYWGLX0tjSUlJePXVV5GRkYGBAwfK5QaDAW+++aZb7kFETQsODsZrr72GyZMny2Uff/yxihERkZqYWBC1ce+//z4qKysBAL1798add95pt+7zzz8PjebsPwubNm3Czp07bdbbtm0btm3bBgDQaDR4/vnn7bZ51113ydOCysvL8eGHH7boddhz3nnnYd26dUhMTJTLHnnkEY8u6iYipRkzZsjfZ2ZmqhgJEamJiQVRG7dixQr5+4Zdjuzp0qULxo8fL19//fXXDtucOHGi4k29JUmSkJKS4rBNV0RHR2PJkiXydUlJCQwGg9vv4w5jx46Vd9ZZv349ACAnJwcLFizA0KFDERUVhYCAAPTt2xdz586V15I0durUKTzyyCMYOnQoIiMjERoaiiFDhuDZZ59FdXV1i+Jas2YNpk+fjp49eyIwMBAdOnTAxRdfjNdffx21tbXNaquyshJvvvkmrrzySnTt2hVBQUEIDQ1Fr169MHv2bMVaH2fk5OTg0UcfxaBBgxAWFoawsDD0798fDzzwAA4cONCsthrU1tbitddew8UXX4wOHTogMDAQPXv2xIwZM7Bu3boWtQn4xmv3hI4dO8rfN3yQYUvjndaWLVsG4Ozf6yuvvIJLLrkEnTp1gp+fHyRJQklJieK5+fn5WLp0KVJSUuS/FZ1Oh4iICPTt2xezZs3Czz//7FS8Tz75pBzHk08+CeDsOq4PPvgAEydORKdOnaDX69GxY0dMnToVK1eudNimM9vN2tsaePv27bj99tvRu3dvBAUFITIyEiNHjsSzzz7b5M+TyOuoPReLiM5x9xqL6upqodFo5Db/+OMPh8955pln5PoXXnihzTqjR4+W6zz77LMO29y4caNcX6vVipqaGpv1AOfXWNgycOBA+fmDBg1q9vMteWKNxZgxYxSv8eeffxbR0dGK1974q2vXruLYsWPy85csWSL0er3d+v379xf5+fl27285H7+urk7ceeeddtsDIPr16ycOHDjg1Ov7/PPPRXx8fJPtARB/+9vfRElJicP2/ve//4mIiAi77ej1evHOO+80a51BZmam6NOnT5Px/eMf/xB1dXXNWmPhC6/dGc1ZY9Hggw8+kOsnJibardf4b2rp0qXi999/F4mJiTZfX3Fxsfy8V155RWi1Woc/WwBi/PjxorCwsMl458+fL9efP3++OHXqlLjggguabHfWrFnCZDI59XMbM2aMzTqWvyuz2SyeeOIJxb/Tll/du3cXR44cafL1EHkLbttA5KVKSkrwxRdfYO/evSgtLUVYWBgSEhIwevRoDBw40Kmdjw4cOACz2Qzg7MjB0KFDHT5n2LBh8vf79u2zWadxeeP69jS+r8lkwsGDBxXrItzlhhtuwO7duwEAe/bsQUlJCSIiItx+H3fJyMjAI488gurqanTu3BkXXnghQkNDcfDgQfz2228QQuD48eOYMmUKdu/ejeXLl+Pvf/87gLO7To0cORIBAQHYvXs3tm7dCgDYu3cvbrnlFvz0009OxfDwww/j7bffBgAMGjQIQ4YMgRAC6enp8pSWffv2Yfz48di0aVOTo1P/93//h3/9618QQgAAwsLCMHr0aHTu3Bkmkwl79+7F9u3bIYTAypUrMXbsWGzcuBFBQUE22/v+++9x4403or6+HsDZaXcXXnghevfujYqKCmzYsAE5OTm444478Oqrrzr1eo8fP44JEyYgJydHLuvfvz+GDRsGSZKwY8cO7NmzB4sXL7Ybl6++dk9qvI31xRdf7NRzDh8+jPvvvx+lpaUIDQ3FJZdcgoSEBBQXF2PDhg2KutnZ2TCZTACAHj16oF+/fujQoQMCAgJQUlKC3bt3y7vQrV27FhMnTsTmzZuh1+sdxlFRUYHLLrsMe/bsQVBQEC6++GIkJiaivLwc69atQ35+PgBg6dKl6NOnDx5++GGnXp8zFixYgP/85z8AgCFDhmDgwIHQ6XTIyMjAjh07AABZWVmYOnUqduzYwd22yPupmdUQkVLjEYumvnr16iXeffddYTabm2xv+fLl8nPi4uKcimHv3r2Ke1l++p2Xl6d4fN++fU6126FDB/k5n3/+uc06jdttyYjFzz//rGjj559/bnYbjXl6xEKv1wudTicMBoPVJ6Hr169X7Hj17LPPipCQEBEWFia+/PJLq3aXL1+u+ET3119/tXn/xp+Y6nQ6AUBER0fb/Fl9++23IiwsTK4/efJku69r9erV8qeu/v7+4r///a+orKy0qrdz506RlJQkt3n33XfbbK+wsFDExsbK9QYOHCgyMzMVdUwmk3juueeEJEnC39/fqU/tJ0yYINcLDw8X3333nVWdH374QURGRip+RmhixMJXXruzmjNiUVVVJR588EG5rp+fn0hPT7dbv/HflJ+fnwDO7uRWXl6uqFdXV6f4m1iyZIl47bXXxKlTp+y2vWvXLjFixAi5/aeeespu3cYjFg0jgCkpKaKoqEhRr7KyUkyfPl2uGxISIioqKmy22dwRC39/fyFJkujZs6fYsmWLVd3PP/9c0f/ef/99u6+HyFswsSDyIs4mFg1ff/vb3+z+T04IId544w25rrNTg4qKihT32L9/v+LxzMxMxeNnzpxxqt3G05QWL15ss46ricWxY8cUbXzwwQfNbqOxxm+C+vbtK1JTU53+OnjwoM02GycWAMS7775r9/5PP/20oq4kSWLNmjV2699+++0O37Q2fmMDQGg0GrFx40a7ba5atUpR39b9TSaT6NWrl1znf//7n932hBAiJydHxMXFyW/cT548aVXnkUceUSTFeXl5dtuz/DnZe3P9yy+/KH6Wa9eutdvmhg0bhCRJinZtJRa+8tqbwzKxsNW/b7/9dnHZZZcpEs+wsDDx008/Ndl2478pAOL22293Od7GSkpK5OloHTt2FPX19TbrNU4sAIjp06fbbbO6uloxXeuzzz6zWa+5iUVDUn/69Gm7926ctF122WX2XziRl2BiQeRFli5dKrp06SL+9a9/iR9++EGcPHlS1NTUiMrKSnHgwAHxxhtviL59+yr+x3TVVVfZnff7/PPPy/VGjRrlVAxVVVWK9rdv3654fOvWrYrHq6urnWp35MiR8nNefPFFm3VcTSyKi4sVbbzyyivNbqMxyzdBzfmyF3/jxGLw4MFN3v/IkSOKNqdOndpk/TVr1sh1hw8fbrOO5RubW265xeHP4dprr5Xr33TTTVaPr1ixwukYGyxcuFB+zksvvaR4zGw2K9YqODoXwXIthL031zfeeKNc54YbbnAY44wZMxwmFr7y2pvDMrFw5mvmzJkO1zUIofybCggIcPqDiea4++675Xv8+eefNus0Tiz8/f1FTk5Ok23++9//luunpaXZrNOSxMLy92+p8Qc50dHRTdYl8gbcFYrIi0ydOhVZWVl48cUXMWXKFHTu3Bl6vR5BQUHo3bs37r77buzatQuzZs2Sn/Ptt9/ik08+sdleTU2N/L3lGRP2WM5JttxlqHGbLW23pTsXORISEqK4Li8v98h93OX6669v8vEePXogODjY6foDBgyQv8/KynIqhltvvdVhnca7etnaMemHH36Qv2+87WhTGu8+9vvvvyse27dvH3JzcwEAfn5+DtvU6XRO3bdx7M193fb4ymv3tI8//hhDhw5t1q5vl156KSIjI5t9r/z8fHz77bd47rnnMHfuXNxzzz2YM2eO/LV9+3a5bkZGhsP2LrroIsTHxzdZp/E6sWPHjjU7ZntuuOGGJh/v27cvAgMDAQBFRUVe/28aEVcBEXkRZxYa+/v7491338Xhw4fx22+/AQCee+453HzzzVZ1AwIC5O/r6uqcisFya9GG/6nZarOhXcsyR+1atukulv/TDQsLc1vbKSkp8vaY7tI4EbAnIiJC3m6yf//+TdaNioqSv3fmHA9JkjBq1CiH9UaPHi1/n5eXh5ycHMX2ops2bZK//+qrr/Drr786bLO0tFT+/uTJk4rHGp+f0rdvX6f+LhrHaMvp06dRUFAgX59//vkO2zz//PMhSZK8INsWX3jtrrL1+k0mE4qKipCeno7Fixfj22+/xcmTJ3HttdfirbfeavK8nAbDhw9vVhyZmZl4+OGH8eOPP8oLuR1x5kBOZzaSiI6Olr931xk54eHhTW6GAJz9G42MjJQ/jCkrK0NoaKhb7k/kCUwsiHyQRqPB/PnzMXHiRABnd0A6deoUOnfurKjX+BN8Z0cJLOtZjgJYXldXVzuVWDRu17INd2n8hg1QvtH2RuHh4Q7rNN4FxlH9xnUbdhNqSsMZGI407L7TMFpVUFCgSCyys7Pl7xvvDuSs4uJixXXjBKBLly5OteGoXuM2g4KCEBMT47DNsLAwhIeHW52n0JgvvHZP0Gq1iI2NxZQpUzBlyhQ8+eSTWLBgAQDg3nvvxdixY9G7d+8m2+jQoYPT9/v5559x9dVXN/tMFWc+4Xfm71Cn08nfG43GZsXgyn09dW8iT+FUKCIfdckllyj+h2Nra9jGn7Ll5eU51W7DNIwGlm/OG7fZ0nY99YZ///79imtH0xvU5syWwa7Ud6Q526k2npJl+WbNMqFrLsskqKKiQv7e2Rgbx2dLS9p0pl1feO2t4bHHHpMTnNraWqe2wHV25LKgoADTpk2Tk4quXbti4cKF+P3335GdnY2qqiqYzWaIs+tGMX/+fPm5DdttN8Xdf1fOUuu+RJ7ExILIR+l0OsWnrraG/Pv06SN/n5+fb7U+wpYTJ07I30dFRVl9qhgbG6uYnnH8+HGHbdbU1Cg+ie3bt6/D57TEli1b5O+1Wi2Sk5M9cp+2oqqqyum6jU//tRzlaPzGdseOHfIbPGe/LOesNx7RcjZGR6cTt6RNZ9r1hdfeGvz8/DBhwgT5es2aNW5r+5133pETuMGDB+PPP//E3LlzceGFF6Jjx44IDAxUvEnnOgQi9TCxIPJhjd9Q2PrUsk+fPtBozv6ZCyGcWsjYcCgTAPTr189mncbljeeEO9OmVqt1OEWipb788kv5+8GDB7t1jUVbVFxcrPiE3J7CwkJFUmo5jSguLk7+3nLEqyUaJ7ONE92mWK5VaKrNqqoqFBUVOWyzvLzc4YiEL7z21tJ4epwzHzg4q3GS8thjjzn8u3bnvYmoeZhYEPmoo0ePKhYRJiQkWNUJCAhQLFJdv369w3YbLz5tvHtNY+PGjWtxmxdccIFTp+E21y+//II9e/bI1zfddJPb79HWCCEUozz2NF6gHBcXZ9XXGi8A37hxo8txNd6BZ//+/U5NN2ocoy2dOnVSvGnfvHmzwzY3b97c5MJtwDdee2tpPMLS8IGGOzRex+JoobXJZHLL74GIWoaJBZGPeu+99+Tvw8PDMWTIEJv1pk6dKn/vaFejkydPKj4dbPxce22uXr0ap06darLdxve116YrioqKcPvtt8vX0dHRuPvuu91+n7boww8/dFjngw8+kL9vnFQ2+Nvf/iZ//9577zk15a4pffv2ldfH1NfX49NPP22yvjN1AGXszX3d9vjKa28NjUcmO3Xq5LZ2GycpjqaHrVixwi0jR0TUMkwsiLyEM1NSGvzxxx946aWX5OubbrpJsSNQYykpKfI0qQMHDuDdd9+12+7DDz8sb+M4evRoDBs2zGa95ORkef2CyWTC3Llz7bb59ttv4+DBgwDOzs135vyA5jh8+DDGjx+vmA7y/PPPe2znqbbmo48+anLUYt26dfjqq6/k68YJXIPrrrsO5513HgAgJycH//znPx1+0t+goqLCao2ARqPB7Nmz5esFCxYo1uhYevHFF506t6Nx7J9//jk2bNhgt+7GjRvtng/TmK+8dk/bvn27vP01AMV6C1f16NFD/v7bb7+1W6+goAAPPPCA2+5LRM3HxILIS3z55ZcYOXIkPvjgA7vTH2pqavDqq69i4sSJ8iejERERil1QLMXGxiItLU2+vvfee/H5558r6hiNRsydO1fxyefChQubjLfx4x9//DHmzp1rtRXi559/jvvvv1++fvDBB53a5tMZ+/btw3333YchQ4bgzz//lMvT0tIUb8zIPp1OB5PJhL/97W9YvXq11ePff/89rrnmGvmN8qRJk2y+YdRqtXjzzTeh1WoBAEuXLsUVV1xhc6eyBhkZGXj44YeRmJho843xAw88IPeV3NxcTJo0yWrXL7PZjJdeegmPPvqoUwc1Tpo0SR61EEJg6tSpigPuGvzyyy+46qqrYDabFTuv2eIrr92TVq9ejauvvlruJ35+frjnnnvc1v6VV14pf79w4UJ89NFHVnV27NiBMWPG4OTJk16xSxZRe8VzLIi8yLZt25CSkgI/Pz/07dsXffv2RWRkJEwmE06fPo1NmzYp1lUEBgbim2++USyatOXxxx/Hxo0bsXbtWlRXV2PatGl4+umnMWzYMNTU1GDDhg3IycmR6y9YsABjxoxpss0JEybgsccew9NPPw3g7CF9H374IS6++GIEBAQgPT1dseZh0qRJeOSRR5z+WbzyyiuKxdj19fUoKSlBUVERdu7cabX4NjAwEM899xzmzJnj9D2aY8uWLc1u+4UXXvDYYYDukJCQgGuuuQaLFi3CpEmTMHjwYAwZMgRCCKSnp2Pv3r1y3Y4dO+Kdd96x29bEiRPx5ptv4u6774bJZMKPP/6In376CUlJSRg0aBDCwsJQVVWFnJwc7Nq1q8lP4YGzC8SXLFmCa6+9FiaTCbt27UL//v1x0UUXoXfv3qioqMCGDRvk+fcvvPAC7rvvPoevecmSJRg9ejTy8vJQXFyMK664AgMGDMCwYcMgSRJ27twpJ6ppaWn46quvHC4G9pXX3lK2+r3JZMKZM2eQnp6OI0eOKB578cUX7W780BIpKSl46aWXcPDgQdTW1uKWW27Bs88+i8GDByMgIAB79uyRT9sePHgwJk+ejOeff95t9yeiZhBE5BWWLl0qADj9NXLkSJGZmel0+yUlJeLGG29ssk2dTieeeeYZp9s0m83iqaeeEjqdrsl2b7rpJlFaWuqwvea8/oavkJAQcccdd4j9+/c7HbezUlJSWhRTw1dxcbFVm2PGjJEfX7duncMYunbtKtfPyspyWL/x/W3JysqSH+/atauoq6sTf//735t8HX369BH79u1zeG8hhFi7dq3o1auX0z+j/v37i9OnT9tt74svvhDh4eF2n6/X68Vbb71l9bqasmfPHocx3nHHHaKurq5ZP39feO3OWLduXYv6e1RUlPjwww+bbLvx39TSpUudjunAgQOiR48eTd7/wgsvFKdOnRLz58+Xy+bPn2+zPWfq2PuZjBkzpsV1WvK7au6/AURq4ogFkZeYPn06evfujT/++AObN2/GkSNHUFhYiKKiIpjNZoSHh6N79+44//zzcf311+Oiiy5qVvvh4eFYvnw57rjjDrz//vvYtGkTcnJyoNPpkJiYiMmTJ+Pvf/97sz5plCQJjz32GK677jq8++67+OWXX3Dy5EkYjUZ07NgRo0ePRkpKinxCuCsCAwMRHh6OsLAwdO3aFcOHD0dycjImTZrk1OnRZJtOp8O7776LG264AUuWLMG2bduQk5OD4OBg9OvXD9OmTcOdd97p9E5e48aNw759+7BixQp8//332Lx5M3Jzc1FWVoagoCDExcWhb9++uOCCCzBlyhS7mw40uP7663HBBRfgtddew3fffYfjx49DkiR07twZEydOxN13341+/fpZnQfRlP79++PPP//E22+/jeXLl2P//v2oqqpCx44dkZycjNtvvx2TJk1yuj1feu3uIkkSQkNDERsbiyFDhmDy5Mm46aabPLa2qXfv3ti5cycMBgP+97//4cCBA6irq0N8fDwGDhyIGTNm4MYbb5SnpBGROiQhnFxlRkREREREZAcXbxMRERERkcuYWBARERERkcuYWBARERERkcuYWBARERERkcuYWBARERERkcu43aybmM1mZGdnIzQ0FJIkqR0OEREREZGCEALl5eVISEiARuP+8QUmFm6SnZ2NxMREtcMgIiIiImrSyZMn0blzZ7e3y8TCRQaDAQaDAfX19QCArKwsREVFqRwVeSOj0YhffvkFl156KXQ6ndrhkJdh/yBH2EfIEfYRcuTMmTPo3r27xw6WZWLhotTUVKSmpqKsrAzh4eEIDQ1FWFiY2mGRFzIajQgKCkJYWBj/wScr7B/kCPsIOcI+Qo4YjUYA8Ni0fS7eJiIiIiIilzGxICIiIiIilzGxICIiIiIilzGxcJHBYEBSUhKSk5PVDoWIiIiISDVMLFyUmpqKzMxMbNu2Te1QiIiIiIhUw8SCiIiIiIhcxsSCiIiIiIhcxsSCiIiIiIhcxsSCiIiIiIhcxsTCRdwVioiIiIiIiYXLuCsUERERERETCyIiIiIicgMmFkRERERE5DImFkRERERE5DImFkRERERE5DImFkRERERE5DImFm5WXVWkdghERERERK2OiYWLLM+xWJf+msoRERERERG1PiYWLrI8x2Jj3haVIyIiIiIian1MLNxsq6kc1VVn1A6DiIiIiKhVMbFwsxqNhM273lM7DCIiIiKiVsXEwgPWHftJ7RCIiIiIiFoVEwsP+LUmF6b6OrXDICIiIiJqNUwsPOCMRsLufV+oHQYRERERUathYuEhaw9+pXYIRERERESthomFh6wrPax2CERERERErYaJhYssD8hrcEwrkHVsvTpBERERERG1MiYWLrI8IK+xdbs/UCEiIiIiIqLWx8TCg9YVZagdAhERERFRq2Bi4UG7UIfCwv1qh0FERERE5HFMLNwsyGyWvxeShA0Z76oYDRERERFR62Bi4WbdqwIV1+uy/1ApEiIiIiKi1sPEws3MFb0V15tMZaiqKlQpGiIiIiKi1sHEws32l4+FVgj5ulYjYVPGEhUjIiIiIiLyPCYWblYjdUDPaj9F2bf7f1ApGiIiIiKi1sHEws2euioJgZXdFGXpKMT3u46rExARERERUStgYuFmk/vHYeyA2xRlpVoN3vruDezPLVMnKCIiIiIiD2Ni4QG3XzYVPYySoiwiZCve+z1LpYiIiIiIiDyLiYWHTIzqq7jOCy7AwTyOWBARERFR2+TnuAo1xWAwwGAwwGQyKcrH95uGt7c+KV9n+0sYWfs4Fn0V43TbkQFRmDzsbsR3HOqucImIiIiIPIKJhYtSU1ORmpqKsrIyhIeHy+VJfa5B7Kb5yNeemxK1NbQIWyuKnG+8Anj/xz/w9XU/IDy8izvDJiIiIiJyK06F8hBJo8FFAZ1cbqdAK+Hbjc+4ISIiIiIiIs9hYuFB05MfgL9ZOK7owKbCXW6IhoiIiIjIczgVyoP69roMPf73OwICfoVZUwcA6BCqR6BO2+TzCusrsRnV8vV2UwWMtZXQ6YM9Gi8RERERUUsxsfCwqsDJ2JY9Wr5+7rqBmJbc9HqJ4jNHMObbqyGks+szqjUSMvYtR/KQ2R6NlYiIiIiopTgVysPiwgIU17mltQ6fExnVE32FMufbdPRHt8ZFREREROROTCw8zDKxyCuvcep5o8N6Kq43lR52W0xERERERO7GxMLD4sL0iuv8MucSiwu6T1Zc75WMKC055q6wiIiIiIjciomFh1mNWJQ5ngoFAEP7T0dAox2lhCRhy+6P3BobEREREZG7MLHwMMsRizwnRyz89aEYrlHuAvXHqQ1ui4uIiIiIyJ2YWHhYbKhyxKKwohb1JrNTzx0dM0hxvbk6B8Ls3HOJiIiIiFoTEwsPs5wKZRZAUWWdU88d3edaxfVpLXDy1B9ui42IiIiIyF2YWHhYdLA/tBpJUebsdKhePSYjxqQ8uXvTvs/dFhsRERERkbswsfAwjUZCbKjlOgvnFnBLGg3O13dQlP2Rn+622IiIiIiI3IWJRSuwOiTPyRELABjdcbTiemt9KeqNzj+fiIiIiKg1MLFoBS09ywIARg+Yqbiu0EjYc+B/bomLiIiIiMhdmFi0AuuzLJxPLDrE9sd5ZuWvadPh790SFxERERGRuzCxaOSaa65BZGQkrr/+ere229JD8hqMDummuN5Ust/VkIiIiIiI3IqJRSP33XcfPvjgA7e3a714u3lrJEZ3naC4/hO1qCjPcTkuIiIiIiJ3YWLRyNixYxEaGur2di1HLPLLmzdiMXzADOjEuW1nTZKEbXs+dktsRERERETu0GYSiw0bNuDKK69EQkICJEnCihUrrOoYDAZ069YNAQEBGDVqFLZu3doqsVkmFmcq61Bbb3L6+UFBMRgKZRubTqxzS2xERERERO7gp3YA7lJZWYnBgwdj9uzZuPbaa60eX758OdLS0rB48WKMGjUKixYtwuTJk3HgwAHExsY2+361tbWorT038lBWVgYAMBqNMBqNirpRgVqr5+cUV6JTRKDT9xsVmYStJTvl602VJ6zuQ96t4ffF3xvZwv5BjrCPkCPsI+SIp/uGJIQQjqv5FkmS8PXXX2Pq1Kly2ahRo5CcnIzXX38dAGA2m5GYmIh77rkHc+fOleutX78er7/+Or788ssm7/Hkk09iwYIFVuWffPIJgoKCFGVCAA9t0cIozp3Aff+AenRvxqyr0oqteKH+W0XZYwGzERDQw/lGiIiIiKjdqqqqwowZM1BaWoqwsDC3t99mRiyaUldXh/T0dMybN08u02g0mDhxIjZt2tSiNufNm4e0tDT5uqysDImJiRg3bhyio6Ot6r904DecLK6Wr3v0H4YpA+Kdvp+pfiLe/uwblGrOJSeayJO4fNycFsVPrc9oNGLVqlWYNGkSdDqd2uGQl2H/IEfYR8gR9hFypKioyKPtt4vEorCwECaTCXFxcYryuLg47N9/buvWiRMnYteuXaisrETnzp3xxRdfYPTo0ZbNAQD0ej30er1VuU6ns/nHHB8eoEgsiqrqm/VHr9PpcL4uCj+biuWyNTkbcd6+5U634RH+QUBEV0DTvOU6HYM7Ij7Y+cSqLbHXR4gA9g9yjH2EHGEfIXs83S/aRWLhrNWrVzf7OQaDAQaDASZT04uxY108ywIARscl4+fsX+TrjajCxp3PNbsdb/GPwf9A6pBUtcMgIiIiIjdoM7tCNSUmJgZarRZ5eXmK8ry8PMTHu/apeWpqKjIzM7Ft27Ym68WFWmw528yzLABgdP/pzX6ON3t397sorytXOwwiIiIicoN2kVj4+/tj+PDhWLNmjVxmNpuxZs0au1Od3C0uzOKQvPLmJxYJCSMwyNx2hjbrzfU4UXZC7TCIiIiIyA3azFSoiooKHD58WL7OyspCRkYGoqKi0KVLF6SlpSElJQUjRozAyJEjsWjRIlRWVmLWrFmtEp/lWRYtmQoFAE+NfRHPb5iHP82V7gir5Sw3E9MFAH7Wa04sVRorYRZm+fpUxSn0j+nv7uiIiIiIqJW1mcRi+/btGDdunHzdsGNTSkoKli1bhmnTpqGgoABPPPEEcnNzMWTIEPz0009WC7qby/k1FhYjFi2YCgUAPbqPx+LuW1r0XLf64jZg79fnri95CBj/mMOnzf55Nrblnps2ll2R7YHgiIiIiKi1tZnEYuzYsXB0JMecOXMwZ457t2dNTU1FamoqysrKEB4ebrdevMWIRXlNParq6hHk76O/Aj+Lw/3qnUuUEoITFNenK067KyIiIiIiUlG7WGPhDSx3hQJaPh3KK+gsXo/RucSiU2gnxfWpilPuioiIiIiIVMTEopWE6P0QoleOTrR0OpRX8LNILOqrbdez0Dmks+L6dDlHLIiIiIjaAiYWrchd6yy8gmVi4eyIRYhyxCKnMsfhFDYiIiIi8n5MLFxkMBiQlJSE5ORkh3Wtz7Lw5alQLVtjYZlY1JpqUVhd6K6oiIiIiEglTCxc5OwBeYCNsyx8esTCYmtZJxOLDkEdoNMoz+LgAm4iIiIi38fEohVZnWVR7sMjFpa7Qjk5FUojaZAQotwZigu4iYiIiHwfE4tWZLkzlE+PWFjuCuXk4m3AejoUF3ATERER+T4mFq3I8iyLfF9OLKzOsXB+9MUysciu5CF5RERERL6OiYWLmrV422qNRa3v7ohkucbCyBELIiIiovaMiYWLmrd4WzliUW00oaym3lOheVYLd4UCrBMLrrEgIiIi8n1MLFpRh1C9VZnPToeyOiCv5YlFbmUu6s0+mmAREREREQAmFq0qQKdFRJByq9U8Xz3LwnLEwsldoQCgU6gysTAJE/Kr8t0RFRERERGphIlFK7M8JM9nd4ayOseiGnByvUikPhKBFou/eZYFERERkW9jYtHKYi0XcJf7amJhMWIhzIDJ6NRTJUmyXmdRznUWRERERL6MiYWLmrMrFGC9gDvfZ6dCBViXubDOgiMWRERERL6NiYWLmrMrFGB9loXvToUKtC5jYkFERETUbjGxaGXWZ1n4amJhvcOVK2dZZFfwkDwiIiIiX8bEopXFWo1Y+OpUKBdHLEJ5lgURERFRW8LEopVZrbEor4HZ7IOnb2u0gEa5da4rU6EKqgpQZ6pzR2REREREpAImFq3MciqU0SRQXOWjb6gtD8lrzlkWFomFgOB0KCIiIiIfxsSilcWE6CFJyjLfnQ5lefq282ssQv1DEeYfpihjYkFERETku5hYuKi5283qtBpEB7fRsyyaMWIBWI9acJ0FERERke9iYuGi5m43C1hPh8r31Z2hrEYsmvc6Ood2Vlxzy1kiIiIi38XEQgWWC7h9diqU5ZazzUwsEoITFNdMLIiIiIh8FxMLFVgnFj46YmE1Fcr5NRaA9ZazXGNBRERE5LuYWKjA+pA8Hx2xcHEqFE/fJiIiImo7mFiowNZZFj7JcsSiuWssQpRrLM7UnEGVscrVqIiIiIhIBUwsVGA5YpFb6quJhcUai2buCpUQkmBVxlELIiIiIt/ExEIFsaHKEYvCilrUm8wqReMCneWIRfPWWAT4BSA6IFpRxsSCiIiIyDcxsVCB5VQoswCKKn3w9G3Lk7frm79WxHIBNxMLIiIiIt/ExMJFzT0gDwCig/2h1SiP3/bJnaEsE4tm7goFcAE3ERERUVvBxMJFLTkgT6OREBvaBnaGcnFXKMB6AffpciYWRERERL6IiYVK2sRZFi6eYwFwxIKIiIiorWBioZI2sTOU1YhF80ddLHeG4iF5RERERL6JiYVKEiKUn/YfP+OD5zdYLd5u/oiF5VSocmM5SmtLXYmKiIiIiFTAxEIl3WOCFdfHCitVisQFVou3mz/qEh8SD42k7IacDkVERETke5hYqMQyscgqrIQQQqVoWsjFcywAQKfRIS4oTlHGxIKIiIjI9zCxUEm3aGViUVFbj8IKHzvLwg3nWADW6yy4MxQRERGR72FioZKEiED4+yl//MeKfGw6lBumQgHcGYqIiIioLWBioRKtRkLXqCBFWVaBjyUWVrtCNX8qFGDjLAsmFkREREQ+h4mFiqzWWfjciIXlORYtHLEI5YgFERERka9jYqEiq8TC50cs3DMVKrsi2/cWshMRERG1c0wsVGS15azPjVhYJBZmI2A2NbsZy8SixlSDopoiVyIjIiIiolbGxEJF3WxsOWs2+9An9ZaJBQAYm7/OokNgB/hp/BRlnA5FRERE5FuYWLjIYDAgKSkJycnJzX5uD4vEorbejNyylk0nUoXlORZAi7ac1Wq0SAjmlrNEREREvoyJhYtSU1ORmZmJbdu2Nfu5HUL1CPbXKsqyfOkEbj+9dVkLd4bilrNEREREvo2JhYokSbI5HcpnWO4KBXBnKCIiIqJ2ys9xFfKkbjHB2JtdJl/7VGKh1QGSBhDmc2VuGrH4+djP2F2425XovI4QAuVl5Xj/h/chSZLH79c3qi/uGnQXuoR18fi9iIiIiJhYqMxyncUxX0osJOnsqIWxUcwtWGMBWCcWFcYKHCw+6Ep0Xiu3JLdV7nOw+CCOlR3DR1M+apVEhoiIiNo3ToVSWbdoH54KBVivs2jBrlAA0D28uxuCIUt/FvyJU+Wn1A6DiIiI2gEmFirr3kGZWJw4U4V6k9lObS9kuTNUCw/J6xPZB+d3PN8NAZGlnQU71Q6BiIiI2gFOhVJZd4sRi3qzwKniaqtF3V7L8iyLFo5YSJKENya8gfT8dBRVt83D8UwmEzIyMjBkyBBotVrHT2ih5QeWY2f+uWRiR94OXNXzKo/dj4iIiAhgYqG6yGB/RATpUFJllMuyiip9J7GwGrFo2RoLANBpdW161MJoNEJkCkzpNgU6nc5j9ymsLlQkFo2/JyIiIvIUToXyAlbrLAp8aJ2F5RqLFu4KRe4zNHao4vpo6VGU1JSoEwwRERG1G0wsvIDVzlBFvpRYWIxYtPAcC3KfflH9EKBVTlHLKMhQJxgiIiJqN5hYeAGfPiRPZ7HGgiMWqtNpdRjYYaCibEf+DpWiISIiovaCiYUX6O7LiYXl4m0X1liQ+wzpMERxnZGfoUocRERE1H4wsfAClonF6ZJq1NabVIqmmdy0KxS517C4YYrrPYV7UGti0kdERESew8TCC1hOhRICOFFUpVI0zWQ1FYprLLzB4A6DIeHcadtGsxGZRZkqRkRERERtHRMLLxCi90OHUOXuSj4zHcpq8TZHLLxBqH8oekX2UpTtyOM6CyIiIvIcJhZewmfXWVhtN8vpNt7CcttZnmdBREREnsTEopGVK1eiT58+6NWrF959991WvbflCdw+s+Ws1QF5HLHwFsNilessMgoyYBZmlaIhIiKito6JxV/q6+uRlpaGtWvXYufOnXjhhRdQVFTUavfv3kGZWBz1lUPyrBZvc42Ft7AcsSitLUVWaZZK0RAREVFbx8TiL1u3bkX//v3RqVMnhISEYMqUKfjll19a7f6Wp2/77ogFEwtv0TGkI+KD4xVlPM+CiIiIPKXNJBYbNmzAlVdeiYSEBEiShBUrVljVMRgM6NatGwICAjBq1Chs3bpVfiw7OxudOnWSrzt16oTTp0+3RugAgB4WIxZ5ZbWorK1vtfu3mNUaCyYW3sRy1ILnWRAREZGn+KkdgLtUVlZi8ODBmD17Nq699lqrx5cvX460tDQsXrwYo0aNwqJFizB58mQcOHAAsbGxzb5fbW0tamvPLVQuKysDABiNRhiNxma3lxCqgySd3Wq2weG8UiR1DGt2W61JkvwVnchcVwVTC15/e9DQL1rSP1pqUPQg/Jj1o3y9I29Hq96fnKdG/yDfwj5CjrCPkCOe7httJrGYMmUKpkyZYvfxl19+GXfccQdmzZoFAFi8eDG+//57vPfee5g7dy4SEhIUIxSnT5/GyJEj7ba3cOFCLFiwwKp83bp1CAoKatFriPTX4kztubMHvl61EcdiRBPPUF9C8T4kN7quKCnEuh9+UC0eX7Bq1apWu1eFqUJxfariFJavXI5QTWirxUDN05r9g3wT+wg5wj5C9lRVefactDaTWDSlrq4O6enpmDdvnlym0WgwceJEbNq0CQAwcuRI7NmzB6dPn0Z4eDh+/PFHPP7443bbnDdvHtLS0uTrsrIyJCYmYty4cYiOjm5RnMvzt+OPI2fk68gufXD52B4taqu1SAcl4Ngb8nVogA6XX365ihF5L6PRiFWrVmHSpEnQ6XStck+T2YT3v3ofFcZzCUb0oGhM7DKxVe5PzlOjf5BvYR8hR9hHyBFPb0zULhKLwsJCmEwmxMXFKcrj4uKwf/9+AICfnx9eeukljBs3DmazGf/+97+bTBD0ej30er1VuU6na/Efc88OoYrE4nhxtff/w6BXrg2R6mu8P2aVudJHmn0v6DC4w2BszN4ol/1Z9Cem9LQ/ukfqas3+Qb6JfYQcYR8hezzdL9pFYuGsq666CldddZVq9+9mcUjeMV84JI/nWHi9obFDFYkFd4YiIiIiT2gzu0I1JSYmBlqtFnl5eYryvLw8xMfH23mWcwwGA5KSkpCcnOy4sgM9fPH0bZ5j4fUsd4Y6cOYAqoyenWNJRERE7U+7SCz8/f0xfPhwrFmzRi4zm81Ys2YNRo8e7VLbqampyMzMxLZt21wN02rEorjKiJKqOpfb9SjLxMJUq9zailQ3IGYA/KRzg5MmYcKfhX+qGBERERG1RW0msaioqEBGRgYyMjIAAFlZWcjIyMCJEycAAGlpaXjnnXfw/vvvY9++fbj77rtRWVkp7xLlDTpHBsJPIynKvH7UQhdgXcazLLxKkC4I/aL7Kcp25u1UKRoiIiJqq9rMGovt27dj3Lhx8nXDjk0pKSlYtmwZpk2bhoKCAjzxxBPIzc3FkCFD8NNPP1kt6G4ug8EAg8EAk8nkUjsAoNNqkBgVpEgmjhVVYmiXSJfb9hi/QOsyY7X12gtS1ZDYIdhduFu+3pnPxIKIiIjcq82MWIwdOxZCCKuvZcuWyXXmzJmD48ePo7a2Flu2bMGoUaNcvq87p0IBQLdo5RkYWQUcsSDXDYsdprjeVbAL9WYfONmdiIiIfEabSSzaiu4xIYrrrCIvX2RrucYCYGLhhYbEDlFcV9VX4VDxIXWCISIiojapzUyFaiu6x1iMWBRW2KnpJWwlFtwZyuvEBMagS2gXnCg/IZct2bME/aP7qxgVNWYymbC/Zj8KMgug1WrVDsfraSUthsUNw4CYAWqHQkREf2Fi4WUsRyyOFVZBCAFJkuw8Q2WSdDa5aDxKwbMsvNLQ2KGKxOLnYz/j52M/qxgR2fJzBn8nzpIgYdG4RRjfZbzaoRAREZhYuMydi7cBoJvFiEVFbT1e+PkA9H7e+wnmXfBHAM4lFl9sPozs8DDEh+txaVI8IoP9VYyOGgyLG4ZvjnyjdhhEbiMg8NWhr5hYEBF5CSYWLkpNTUVqairKysoQHh7ucnsJ4YHw99Ogrt4sl72x/ojL7XrSTXoNAhoNqHybfhS/mc+OvCz8cT+eu24QJvd37SBCct34xPFYpF+E4tpitUMhcpsTZSccVyIiolbBxMLLaDQSukcH40BeudqhOK1G+AONEosAnDvUr6TKiLs+TMeMUV3w+BVJCPT33pGXti4iIAJvTnoTXxz4AvlV+WqHQxaEEMjPz0dsbKz3Tn30ApXGSuzI3yFfn644DZPZBK2G/7YQEamNiYUXurR/nG8lFlBOdWqcWDT4ZMsJbDlahFduGooBnVwf2aGW6R/dH/0v4IJtb2Q0GvHDDz/g8rGXQ6fTqR2O1yqsLsS4z8+dWWQ0G1FQXYD4YI6KEhGpjYmFF7pvQi+EBeiw82QxzGbH9dWmPxUM1J67HtEpCDmaSGw/rpxyc6SgEte8sRH/ntwXf7+oOzQafipLRM0THRCNQL9AVDfaJOJk+UkmFkREXoCJhYvcvXgbAPy0GtxxSQ+3tedx70UBjaY5p4yMw60jRuPz7Sfx5LeZqDae+9kYTQLP/LAPvx4swM3nd8WwrhGIDbWxZS0RkQ2SJKFTSCccLjksl52uOI1kJKsYFRERAUwsXObuxds+yfIsC2MNJEnCtOQuSO4Whfs+y8Du06WKKr8fLsTvhwsBAJ0jAzG8aySGdYnE8K6R6BIdBK0kQSNJ0GjQ6HuOcBAR0DmksyKxOFV+SsVoiIioARMLcp0uUHndaIpCjw4h+OruC/DSqgN4e8NRCGH99FPF1ThVXI1vMrId3soTa1pbK13x02rQK1SDC8cZEcM59EQt1jm0s+L6VAUTCyIib6BROwBqA/z0yuv6WsWlv58G86b0w8d/H4W4MIu6zSSE+7/MrfRVV2/G3mINlmw85tLPgKi9s0wsTpefVikSIiJqjIkFuc7PYsTCaPvk7QvOi8Ev94/BQ5P74KLzYhCib58DZntOl6kdApFP6xzCEQsiIm/UPt/ZkXvpLNZY1NfYrgcgPEiH1HHnIXXceTCZBQ7mlWPHiWKkHy/GzhMlyCqs9HCw6ssts//zISLHOoV0UlwXVheiur4agZYfchARUatiYuEiT+wK5XOsRiyce+Os1Ujo1zEM/TqGYeaorgCA0mojqurqYTILCAGYzAJmcfbL1MKtdwVsLOxoeMz+Q26z+1Qp/v3Vn/J1blltE7WJyJFOoZ2syk6Xn8Z5keepEA0RETVgYuEi7goFG2ssWv6JfHigDuGBbWths95POeOwvKYeFbX17XYqGJGrAv0CERMYg8LqQrnsdAUTCyIitXGNBbnOalcoTvVpLD7c+pyO3FL+jIhcYTkdiussiIjUx8SCXGd1joXtxdvtVZC/n9UoTB7XWRC5xGrLWZ5lQUSkOiYW5DqOWDjU0WLUIocjFkQusdoZiokFEZHqmFiQ69y4xqKtspwOlVvKUR0iV/CQPCIi78PEglzXwl2h2hOOWBC5l+Uai9MVpyFaY5s3IiKyi4mFiwwGA5KSkpCcnKx2KOqxOseCn8Zbig9TJl9cvE3kmsTQRMV1dX01imqKVIqGiIgAJhYuS01NRWZmJrZt26Z2KOqxWrzNN82WOGJB5F4dAjtAp1FuisB1FkRE6mJiQa6zTCy4xsJKnOUaC+4KReQSrUZrczoUERGph4kFuY67QjlkOWJxprIONcZ2fFo7kRtYnWXBEQsiIlUxsSDX2TrHgosoFWwdkpdfVqtCJERtB3eGIiLyLkwsyHWWiQUEYDKqEoq3CtX7IdhfqyjL4ZazRC6xPMuCU6GIiNTFxIJcZ7krFMCdoSxIkoS4MK6zIHKnTqGcCkVE5E2YWJDrLM+xALgzlA3x4cqDBLkzFJFrLEcscitzYeRoKRGRaphYkOs4YuGUeMsRCyYWRC6xXGMhIJBdma1SNERExMTCRTwgDzbWWACo58JkS5aJBddYELkm1D8U4fpwRdnpcq6zICJSCxMLF/GAPAAaLWBxUBWMfNNsyXIqFEcsiFxnteUsd4YiIlINEwtyD55l4ZDl4m2usSByneU6Cy7gJiJSDxMLcg9bZ1mQQnyYcsSioKIWRpNZpWiI2gaeZUFE5D2YWJB7WCYWXGNhxXKNhRBAQTl/TkSusEosOGJBRKQaJhbkHpY7Q3FXKCuRQTr4ScoTyTkdisg1XGNBROQ9mFiQe1hNheIbZkuSJCHCX1nGBdxErkkMSVRcl9eVo7S2VKVoiIjaNyYW5B5WU6E4YmFLhHKZBbecJXJRfEg8NJLyf2UctSAiUgcTC3IPq6lQXDtgS7i/cioURyyIXKPT6NAxuKOijGdZEBGpg4kFuYefxXaz3BXKJsupUDllTCyIXMV1FkRE3oGJBbmH1YgF3zDbEsERCyK3485QRETegYkFuQfPsXBKOBdvE7md5SF5pys4FYqISA1MLMg9eI6FUyL0yhGLvLIamM3CTm0icobVVCiOWBARqYKJBbmHzmKNBXeFsslyjUW9WaCwkkkYkSssp0JlV2TDZDapFA0RUfvFxMJFBoMBSUlJSE5OVjsUdfEcC6eE6gA/jaQo43QoItdYJhb1oh55VXkqRUNE1H4xsXBRamoqMjMzsW3bNrVDUZfVVCi+WbZFIwGxocrDLHj6NpFrIvWRCPILUpRxnQURUetjYkHuwV2hnBYfrvxZccSCyDWSJKFTKNdZEBGpjYkFuQfPsXBafBhHLIjczXJnqJPlJ1WKhIio/WJiQe7hp3yzzBEL++LDLEcsmIQRucrqLAsekkdE1OqYWJB7WO0KxcTCHqupUDx9m8hlPMuCiEh9TCzIPbgrlNPiLBZvc40Fket4+jYRkfqYWJB7cMTCaZYjFjmlNRCCh+QRucJyxOJMzRlUGatUioaIqH1iYkHuYbnGgou37bJcvF1bb0ZJlVGlaIjahoSQBKsyTociImpdfmoHQG2E5a5Q9TxN2p4OoXpIEtB4kCKntAaRwf72n0RETQrwC0CHwA4oqC6Qy97c9SYSgq0TDl9lNptxtPooDuw4AI2GnwuSNfYRsnTPsHug1+odV3QTJhbkHlbnWHDEwh6dVoMOIXrkl59LvnLLqpGUEKZiVES+r3NoZ0Viser4KhWj8ZyN+zeqHQJ5OfYRavCPwf9o1cSC6Sy5h+WIhbkeMNWrE4sP6GhjnQURuSYxNFHtEIiI2jUmFuQelmssAI5aNIGnbxO536Suk9QOgYioXXN5KlSPHj0QGxuLzZs3O1X/4osvRnZ2No4cOeLqrcmbWO4KBZxdZ6EPbf1YfEDHcOXPi4kFkevGJo7Fq+NexW+nf0OdqU7tcNzOLMw4deoUOnfuDI3EzwXJGvsIWfLTtO6qB5fvduzYMdTUOP+m6NSpUzhx4oSrtyVvY3mOBcCdoZrAQ/KIPGNcl3EY12Wc2mF4hNFoxA8//IDLz78cOp1O7XDIC7GPkNpaPZ2tr6/nTgVtkc0RC75Ztic+jGssiIiIqG1p1Xf41dXVyM/PR2gop8e0ORo/wHLYlSMWdnGNBREREbU1zZ4KdeLECRw7dkxRVldXh99++83u6cFCCJSUlODjjz+G0WjEwIEDWxSsp11zzTVYv349JkyYgC+//FLtcHyLJJ3dGcpYea6MZ1nYZbkrVEVtPcprjAgN4NA1ERER+aZmJxZLly7Ff/7zH0VZcXExxo4d6/C5QghIkoS77rqrubdtFffddx9mz56N999/X+1QfJMuwCKx4IiFPXFh1mtScktrmFgQERGRz2rRVCghhPwlSZLi2tYXAISFheHCCy/EBx98gBkzZrj1RbjL2LFjOU3LFZYLuI2c3mNPgE6LKIuTtrnOgoiIiHxZsxOL+fPnw2w2y19CCMTHxyvKLL9MJhOKi4vx22+/YebMmS0KdMOGDbjyyiuRkJAASZKwYsUKqzoGgwHdunVDQEAARo0aha1bt7boXtRClokFF283yXIBN9dZEBERkS9zebvZW2+9FREREW4IpWmVlZUYPHgwZs+ejWuvvdbq8eXLlyMtLQ2LFy/GqFGjsGjRIkyePBkHDhxAbGwsAGDIkCGor7c+DfqXX35BQkJCs+Kpra1Fbe25NQRlZWUAzm71ZjQam9VWW+HnFwCp0XV9bQVEO/1Z2NLQLxr+Gxfmj8ycc4+fLq5st32HrPsHkSX2EXKEfYQc8XTfkIS9FddeTJIkfP3115g6dapcNmrUKCQnJ+P1118HAJjNZiQmJuKee+7B3LlznW57/fr1eP311x0u3n7yySexYMECq/JPPvkEQUFBTt+vLbn4wAJEVZ07+HBn4myciBmrXkBe7vOjGmzMOzdoeEGsGdN6mlWMiIiIiNqyqqoqzJgxA6WlpQgLC3N7+249js9sNiM9PR3Hjx9HVVUVbr31Vnc2b1ddXR3S09Mxb948uUyj0WDixInYtGmTR+45b948pKWlyddlZWVITEzEuHHjEB0d7ZF7ejtt0WLgxLnEYlC/XhiQfLmKEXkXo9GIVatWYdKkSdDpdDi2/ig25h2WH9dFxOLyy4epGCGpybJ/EFliHyFH2EfIkaKiIo+277bE4rXXXsPTTz+NwsJCuaxxYlFcXIyLL74Y9fX1+PXXXxEXF+euW6OwsBAmk8mqzbi4OOzfv9/pdiZOnIhdu3ahsrISnTt3xhdffIHRo0fbrKvX66HX663KdTpd+/1j9leO1GiFEdr2+rNoQkMfSYhU/rzyymrbb98hWbv+N4Scwj5CjrCPkD2e7hduOSAvNTUV999/PwoKChAaGgpJkqzqREZGYtiwYTh06BC++OILd9zW7VavXo2CggJUVVXh1KlTdpMKsoO7QjVLx3DlaeW5Zfx5ERERke9yObH46aef8OabbyIkJARff/01SkpK0KFDB5t1Z8yYASEEVq9e7eptFWJiYqDVapGXl6coz8vLQ3x8vFvvZclgMCApKQnJyckevY9P0CnfKPMci6ZZnr5dUmVEdZ1JpWiIiIiIXONyYrF48WJIkoT//Oc/uPrqq5us2zACsHv3bldvq+Dv74/hw4djzZo1cpnZbMaaNWs8PuqQmpqKzMxMbNu2zaP38Ql+FlPDOGLRJMvEAuCoBREREfkul9dYbNmyBQAwe/Zsh3XDw8MRFhaG3NzcZt+noqIChw+fW+ialZWFjIwMREVFoUuXLkhLS0NKSgpGjBiBkSNHYtGiRaisrMSsWbOafS9qIT/LEQu+SW5KiN4PoQF+KK85twXytmNnUFvv2VELCRK6xQRB76f16H2IiIiofXE5sThz5gzCw8OdPrFao9HAbG7+lprbt2/HuHHj5OuGHZlSUlKwbNkyTJs2DQUFBXjiiSeQm5uLIUOG4KeffnLrInFyQMcD8pqrY3gAymsq5Ot/f/lnq9w3UKfF7Iu64e6x5yFE79bN4YiIiKidcvkdRVhYGIqLi2E0Gh2uND9z5gxKS0ubfRgdAIwdOxaOjtyYM2cO5syZ0+y2XWEwGGAwGGAycW681YiFkWssHIkPD8TBvArHFd2s2miCYd0RfL79FB68tDeuH54IrcZ60wUiIiIiZ7m8xmLgwIEQQshTopry6aefQgiBESNGuHpbr8E1Fo1YrrHgiIVDgzqFq3r/gvJaPPzVbvzttd/xx+FCx08gIiIissPlxOL666+HEAJPPvlkk1Ocdu3ahcceewySJGH69Omu3pa8kdWuUEwsHLnj4h6Y2C8W/n4aaCS0ypct+3LKMOPdLbj9/W1Ysy8Pm48WIeNkCQ7kluNEURXyy2pQVVdv+8lEREREcMNUqDvuuANvvPEG1q1bh0mTJuGBBx6QpwUdOnQIx44dw3fffYclS5aguroao0ePxg033OBy4OSFeI5Fs4UH6fBuSutuVXw4vwLP/rAPa/fnWz22el8+Vu+zLgcASQKSu0XhwUv7YGT3KE+HSURERD7G5cRCp9Ph+++/x2WXXYZ169Zh/fr18mN9+/aVvxdCYODAgfjqq69sHqDnq7jGohHLxILnWHil82JD8N5tyfjtUAGeXrkPB/LKnXqeEMDWrDO48a1NmJQUh4cv64vzYkM8HC0RERH5CrecvN21a1ekp6djwYIF6NKlC4QQiq+EhAQ8+eST+OOPPzx+YF1r4xqLRqx2hapVJw5yysW9OuD7ey/Cs9cMREyIf7OeuyozD5MXbcAjX+9GfjlHpoiIiMgNIxYNgoKC8Pjjj+Pxxx9HdnY2srOzYTKZEB8fj65du7rrNuTNuCuUz/HTajBjVBdcObgj3vktC6sy81BSVYcaownVRhNqjPbXTZnMAp9sOYEVO0/jjot7YNaF3RAR1LwEhYiIiNoOlxOL8ePHQ5IkvP322+jZsycAICEhoUVbypKP4zkWPis0QIe0Sb2RNqm3olwIgdp6M6rqTPhuVzZeWXMIZyrrFHWq6kx4Zc0hvL7uMEZ0jcTEfnGY0C8WPTpwmhQREVF74nJi8fvvv0On08lJBbVjXLzd5kiShACdFgE6LVIu6IZrh3XCW78exbu/H7UazTCZBbZkncGWrDN45od96BETjAn9YjEpKR7J3SLb1NoqIiIisubyGou4uDj4+7ff6Q8GgwFJSUlITm7dnX28ktXibSYWbU1ogA4PTu6D9Q+Ow7QRiXa3rwWAo4WVeOe3LNz41ib8/f3tqKzldrVERERtmcuJxSWXXIKysjIcOnTIHfH4HC7ebsTyHAtTLdDE2Sbku+LDA/Dc9YPw432X4PKB8dD7Nf1Pydr9+bj1va0orTa2UoRERETU2lxOLB588EH4+fnhX//6F4QQ7oiJfJXliAXAUYs2rk98KN6YORw7n5iEd24dgZuSE9EhVG+zbvrxYsx8d7PVGg0iIiJqG1xOLIYOHYpPP/0U69evx4UXXoivv/4aeXl5TDLaIyYW7VaQvx8mJcXhv9cNwpZ5E/DtnAtx74ReiAzSKertOV2GaW9tQn4Z+wUREVFb4/Liba1WK3+/ZcsWXH/99Q6fI0kS6us537rNsdwVCmBi0Q5pNBIGdY7AoM4R+Nugjpj57hYUlJ870+RQfgVueGsTPr59FDpHBqkYKREREbmTyyMWlofhOftFbZDlORYAz7Jo53rHheKLu0ajU4SybxwvqsKNizchq7BSpciIiIjI3VwesVi3bp074vBZBoMBBoMBJpNJ7VDU52djbj1HLNq9bjHB+Pwfo3Hzu1sUiUR2aQ1uWHx25KJPfKiKERIREZE7uJxYjBkzxh1x+KzU1FSkpqairKwM4eHhaoejLkk6u86icTLBsywIQKeIQCy/63zc8u5WHMgrl8sLK2ox453N+PTO89E7jskFERGRL3N5KhSRAs+yIDtiQwPw2Z3nY2AnZQJeVFmHGe9sxqFGCQcRERH5HiYW5F6WZ1nUc40FnRMZ7I+P7xiFEV0jFeWFFXWY/s4WHM6vUCkyIiIicpXLU6E2bNjQrPoBAQGIiIhAz549FTtKURthuc6CU6HIQliADu/PHomU97Zi+/FiubywohbT39mMz+48Hz07hKgYIREREbWEy4nF2LFjIUlSs58XEBCACRMm4N///jcuuugiV8Mgb2G5MxSnQpENwXo/LJs9Ercu2YIdJ0rk8oLyWkx/ezOW3zUa3WOC1QuQiIiIms0tU6Fast1sdXU1Vq5cibFjx+KVV15xRxjkDSzPsmBiQXaE6P3w/uyRGJIYoSjP/yu5OMataImIiHyKy4mF2WzGt99+i8jISPTt2xdLlizBkSNHUFNTg5qaGhw5cgRLlixBv379EBUVhZUrV+LMmTP4+eefMX78eJjNZvzrX//Cjh073PF6Wp3BYEBSUhKSk5PVDsU7WI5Y8BwLakJogA4f/H0kBlskF7llNZj+zmacPFOlTmBERETUbC4nFjt37sQNN9yAYcOGYefOnZg1axa6d+8Of39/+Pv7o3v37pg1axZ27tyJoUOH4vrrr8fJkycxadIkrF69GpdffjnMZjMMBoM7Xk+rS01NRWZmJrZt26Z2KN7Bco0FRyzIgbAAHT6YPRKDOit3i8oprcEDyzN4oCYREZGPcDmxWLhwIerq6mAwGKDX2zgg7S/+/v54/fXXUVNTg4ULF8rlCxYsAND8ReDkpax2hWJiQY6FB+rw4exRGNApTFG+/Xgxfj9cqFJURERE1BwuJxa///47wsLC0Lt3b4d1+/Tpg/DwcKxfv14uGz58OAICApCdne1qKOQNLM+x4K5Q5KTwIB0++vsodIpQJqevrD7EUQsiIiIf4HJiUVxcjNraWqf+x282m1FTU4Pi4mJFeWBgYIt2liIvxBELckFEkD/mjD9PUbb9eDE2HS1SKSIiIiJylsuJRUJCAmpra/Hdd985rLty5UrU1tYiISFBLmtINDp06OBqKOQNrM6x4OJtap7rhnW2GrV4dc0hlaIhIiIiZ7mcWFx11VUQQuCOO+7AH3/8Ybfepk2bcOedd0KSJFx11VVy+d69ewEAPXr0cDUU8gZW51jUqhMH+Sx/Pw3uHttTUbb56Bls4agFERGRV3P5gLzHHnsMn3/+OXJycnDJJZfgkksuwZgxY5CQkABJkpCdnY3169djw4YNMJvN6NixIx577DH5+R999BEAYMKECa6GQt7A6hwLjlhQ890wojNeX3sYuWXnptK9uvYQPu4RrWJURERE1BSXE4vo6GisW7cO119/Pfbs2YP169fj119/VdRpWH/Rv39/fPnll4iOPvfm4Oqrr8bYsWNx/vnnuxoKeQMu3iY30PtpcffYnpj/7V65bOPhImw/dgYjukWpGBkRERHZ45aTt3v37o0dO3bgww8/xFVXXYVOnTrJ51h06tQJV111FT744APs2LEDffr0UTx37NixuPrqqxEXF+eOUEhtlokFRyyohaYlJyI2VLlm59W1h1WKhoiIiBxxecRCbsjPDzNnzsTMmTPd1aRPMBgMMBgMMJlMaofiHax2heIaC2qZAJ0Wd43piadWZsplGw4WYOeJYgztEqliZERERGSLW0Ys2jOevG3BaioURyyo5WaM7IKYEOWoxWsctSAiIvJKbk8sCgoKsH37dp6k3V5ZTYXiGgtquUB/Le66RLlj3Nr9+fjzVIk6AREREZFdbkssvv32WwwbNgzx8fEYNWoUxo8fr3i8uLgYl112GS677DKUlpa667bkbSx3heKIBblo5vldEBXsryh7dQ1HLYiIiLyNWxKL//73v7jmmmuQkZEBIYT81VhkZCQCAwOxatUqfPnll+64LXkjnmNBbhbk74c7LlaOWqzel4c9p/kBBRERkTdxObHYvHkzHn30Ufj5+eH//u//UFhYaHeHp5tvvhlCCKxatcrV25K34jkW5AG3ju6KyCCdouzN9UdUioaIiIhscTmxeOWVVwAA8+bNw3333YeoKPt7zI8ZMwYAsHPnTldvS96K51iQBwTr/XC7xajFT3tzkV3CxJWIiMhbuJxYbNy4EQAwZ84ch3VjYmIQHByM7OxsV29L3srWORYW0+KIWuLm87siyF8rX5vMAh9uPq5iRERERNSYy4lFfn4+QkNDERMT41R9vV6Puro6V29L3sryHAsAMPH3Ta4LD9ThumGdFWWfbj2BGiPPkCEiIvIGLicWwcHBqKqqcuqAuIqKCpSUlDQ5XYp8nJ/euow7Q5GbpFzQTXFdUmXEip2n1QmGiIiIFFxOLPr06QOTyYQ///zTYd0VK1bAbDZjyJAhrt6WvJXlrlAAz7IgtzkvNgSX9O6gKFv2xzGrXeiIiIio9bmcWFx11VUQQmDhwoVN1jt16hTmzp0LSZJw3XXXuXpb8laWu0IBTCzIrWZZjFrszy3HpqNF6gRDREREMpcTizlz5qBTp0746quvcOutt2LPnj3yY0ajEYcOHcLLL7+M4cOHIzs7G71790ZKSoqrtyVvZbl4G+DOUORWY3p3QPeYYEXZso3H1AmGiIiIZH6uNhASEoLvvvsOkydPxkcffYSPP/5Yfiwg4NybTCEEEhISsGLFCuh0OltN+SSDwQCDweDUGpN2QaMFNDrAbDxXtuJuQB+iXkxeQisELigsgvbjdwBJUjscn6UB8LF/DbJ0lecKDwM170YiQOeWMz89S+MHdL8EGD0H0LadfwuJiIhcTiwAYMiQIdi1axceffRRfPrpp6ipUX5C7e/vjxkzZuDZZ59FfHy8O27pNVJTU5GamoqysjKEh4erHY530AUCtY0Si+wd6sXiRTQAOgBAhcqBtAEJABK0FoWn1IikhY6sBQ6vAW78AAjiZhZERNQ2uCWxAID4+HgsWbIEb7zxBtLT05GdnQ2TyYT4+HgkJycjKCgIwNnpUW+99ZZT516QjwqKBmrL1I6CyLsd+w14eyww/VMgrr/a0RAREbnMbYlFA71ejwsuuMCq3GQyYcmSJXjmmWdw+vRpJhZt2fDbgNXz1Y6CyPuVHAfenQRc8ybQ63K1oyEiInKJS4lFVVUVDh06BJPJhO7duyMyMtKqjhAC77//Pp566ikcO3Z2W0iJ88vbtgvvAzonA3l7AXAb0AYmkwl7M/eif1J/aLWW83ioJT7echwH887NLYsJ8UfquPOg8dZ/Y8z1wB+vAeU558qMlcDnt0Jz0YOAGKBebERERC5qUWJRWlqKe++9F59//rl8irYkSbjqqqtgMBjQsWNHAMD69etxzz33IDMzU04orr76ajz66KPuewXkfSQJ6Hbh2S+SmY1GZBX8gH7Jl0PbhjYwUFPXqEI8umTLuYJSYHDUSKuzLrzKgOuA5TcDp7YpirW/v4iR4cOBvG6Azl+d2Mg76MOAiES1oyAiarZmJxb19fWYNGkS0tPTFYdSCSHwzTff4ODBg9ixYwdee+01PPzwwzCbzdBqtZg2bRrmzZuH/v05l5iI3OPC86LRKzYEh/LPjVos3Zjl3YlFaDxw2/fAyjQg4yPFQx1L04F3x6oTF3mXHmOB6Z+d3QyDiMhHNHtvxvfffx/bt2+HEALjx4/H888/j+eeew7jx4+HEAL79u3DXXfdhYceeghCCNx66604cOAAPvroIyYVRORWkiThtgu7KcrWHShAVmGl7Sd4Cz89cPXrwGXPARKnxZENR9cDm15XOwoiomZpdmLxxRdfQJIk3HnnnVi9ejUefPBBPPTQQ1i9ejVuv/12CCHwwQcfIDIyEmvXrsWyZcvQo0cPT8RORIRrhnZCWIBy8PXtDUdUiqYZJAk4/x/ALf8DAq3XpxHhj9eBmlK1oyAiclqzE4vdu3cDAB577DGrxx5//HH5+//+978YM2aMC6ERETkW5O+H6SO7KMq+2H4KJ89UqRRRM/UYC9yxDuauF8IMLQQkgF/t+KuRmhJgy9sgIvIVzV5jUVRUhKCgIHTu3NnqscTERAQFBaG6uhpXXXWVWwIkInLk7xd1x7I/jqG23gwAqDcLvLH+MBZeO0jlyJwU1R2mm7/BDz/8gMsvvxw6Lu5vv5bfDOz77tz1pteAUXcCATyAlYi8X7NHLOrq6hAaGmr38YbH4uLiWh4VEVEzxIYFYOaorooynxq1IGow5mHldU0psOUtdWIhImqmZicWRETe6B9jekDvd+6ftHqzwOtrD6sYEVELxA8E+l2pLNv0OlBdoko4RETNwcSCiNqE2LAA3Hy+ctTiqx2ncKKIoxbkY8bMVV5z1IKIfESLEou8vDxotVqbX/n5+QBg93GtVgs/P5cO/CYisumuMT0QoLMYtVh3SMWIiFogfgDQz2Kd4iYDd4giIq/XosRCCOHyFxGRu8WGBuDmUZajFqc5akG+Z6zFqEVtKTRbOWpBRN6t2UMH8+fP90QcRERucdeYnvhoy3HUGM/uEGUyC7y29hBeuGGwypERNUNcfyDpaiDzG7lIs3Ux/Ho/p2JQRERNY2Lxl5MnT+KWW25Bfn4+/Pz88Pjjj+OGG25QOywiaqYOoXrcOrob3t5wVC77387TSB13HrrFBKsYGVEzjZmrSCyk2jL0LPgZAP/fRETeiYu3/+Ln54dFixYhMzMTv/zyC+6//35UVlaqHRYRtcCdl/RAoE4rX5vMAq+v4w5R5GPikoCkqYqingW/cK0FEXktrqL+S8eOHdGxY0cAQHx8PGJiYnDmzBkEB/MTTiJfExOix62ju+KtRqMWX+88jTkctSBfM+bhv0Ytzq5N1JmqYF5x19mkwx0kDdBp+NktbiXJcX0ioib4TGKxYcMGvPDCC0hPT0dOTg6+/vprTJ06VVHHYDDghRdeQG5uLgYPHozXXnsNI0eObPa90tPTYTKZkJiY6Kboiai13XlJD3yw6TiqjSYAZ0ctXl17CC/fOETdwIiaIy4J6D8V2Pu1XKQ5sho4stq997n0GeCCOe5tk4jaHZ+ZClVZWYnBgwfDYDDYfHz58uVIS0vD/PnzsWPHDgwePBiTJ0+Wt78FgCFDhmDAgAFWX9nZ2XKdM2fO4NZbb8Xbb7/t8ddERJ4THaLHrRcod4hasfM0jhdxiiP5mDEPA/DwaMKODzzbPhG1Cz4zYjFlyhRMmTLF7uMvv/wy7rjjDsyaNQsAsHjxYnz//fd47733MHfu2W37MjIymrxHbW0tpk6dirlz5+KCCy5wWLe2tla+LisrAwAYjUYYjUZnXhK1Mw39gv2j9cwe3QUfbjqOqrqzoxZmAfy8JwezLBIOb8D+QXZFngftkJuhyfjQY7cQhQdRX1kM+Id47B7kefx3hBzxdN/wmcSiKXV1dUhPT8e8efPkMo1Gg4kTJ2LTpk1OtSGEwG233Ybx48fjlltucVh/4cKFWLBggVX5unXrEBQU5Hzw1O6sWrVK7RDalQHhGmwtODc4u2b7PsSV7FUxoqaxf5AtkhiH7p0EwquPoWG9has6n9kEDc5uyyxBYPOKd3AmpI9b2iZ18d8RsqeqyrPnOrWJxKKwsBAmkwlxcXGK8ri4OOzfv9+pNjZu3Ijly5dj0KBBWLFiBQDgww8/xMCBA23WnzdvHtLS0uTrsrIyJCYmYty4cYiOjm7ZC6E2zWg0YtWqVZg0aRJ0Op3a4bQbeX8cx9YfD8jX1f4RuPzy81WMyDb2D3LEaJzi1j4ivTMGyD+XZF/QLRDmkZe73C6ph/+OkCNFRUUebb9NJBbucNFFF8FsNjtdX6/XQ6/XW5XrdDr+MVOT2EdaV1JChOL6UH4ltFo/aDTeuQMO+wc54rY+0mmoIrHQ5v4JLftem8B/R8geT/cLn1m83ZSYmBhotVrk5eUpyvPy8hAfH+/RexsMBiQlJSE5Odmj9yGilukTH6q4rjaacLLYs0PBRD6h4xDldU6GGlEQURvSJhILf39/DB8+HGvWrJHLzGYz1qxZg9GjR3v03qmpqcjMzMS2bds8eh8iapmYEH9EBfsryvbnlqsUDZEXSRimvC48BNTyb4OIWs5nEouKigpkZGTIOztlZWUhIyMDJ06cAACkpaXhnXfewfvvv499+/bh7rvvRmVlpbxLFBG1T5IkoU+cctTiIBMLIiCuP6BpPCNaADl/qhYOEfk+n1ljsX37dowbN06+blg4nZKSgmXLlmHatGkoKCjAE088gdzcXAwZMgQ//fST1YJuImp/+sSHYtPRcwvW9ucxsSCCLgCI7Qfk7j5Xlr0T6HahejERkU/zmcRi7NixEKLpLfbmzJmDOXNa9+RQg8EAg8EAk8nUqvclIuf15ogFkW0dhygTC66zICIX+MxUKG/FNRZE3s9yAXdWYSVq6/lhABEShiqvs3eqEwcRtQlMLIiozesdpzxNuN4scLSgUqVoiLxIwhDlddFhoKZMlVCIyPcxsSCiNi80QIdOEYGKsoNcZ0EExA0ANBb72ufsUicWIvJ5TCxcxHMsiHyD5XQobjlLBMBPf3YBd2NcZ0FELcTEwkVcY0HkGywTCy7gJvoL11kQkZswsSCidsHyLIsDnApFdJblOovsDDWiIKI2gIkFEbULllvOniquRkVtvUrREHkRyxGLM0eAmlJ1YiEin8bEgojahZ6xwdBqJEUZF3ATAYhN4gJuInILJhYu4uJtIt+g99Oie0ywouwA11kQnV3AHddfWcZ1FkTUAkwsXMTF20S+w3IBNxMLor9wnQURuQETCyJqNywXcHMqFNFfuDMUEbkBEwsiajcsF3BzxILoL5aJRXEWUF2sTixE5LOYWBBRu9HXYipUUWUdCitqVYqGyIt06Ado/ZVlXMBNRM3ExIKI2o3EqCAE6JT/7HHUggiAnz8QN0BZxulQRNRMTCxcxF2hiHyHViNxOhSRPVzATUQuYmLhIu4KReRbLBMLLuAm+gsXcBORi5hYEFG7YrnOYj9HLIjO6jhEeV1yHKg6o0ooROSbmFgQUbtiOWJxKK8cZrNQKRoiLxLbD9DqlWU5GaqEQkS+iYkFEbUrlofkVdaZcLqkWqVoiLyIVgfEWy7gzlAlFCLyTUwsiKhdiQ3VIyJIpyjjAm6iv3CdBRG5gIkFEbUrkmRjZygu4CY6y3KdBadCEVEzMLFwEbebJfI9lgu4OWJB9BfLEYuSE1zATURO81M7AF+XmpqK1NRUlJWVITw8XO1wiMgJ3HKWyI4OfQG/AKC+5lzZDw8BofHqxUTWQjsCA6/n74W8DhMLImp3LBdwHymogNFkhk7LQVxq57R+QPxA4FSjs5n2fKlePGTfjveBO9YB+hC1IyGS8f+iRNTuWI5YGE0CWYWVKkVD5GUsp0ORdyo8COz6VO0oiBSYWBBRuxMeqEPH8ABFGQ/KI/rLgOsASGpHQc7Y+jYgeA4PeQ9OhSKidqlPfChySs/NIz+YWw4MVjEgIm/R5Xzglq+B/SsBY43j+tR66sqBzG/OXRceBI6uA3qOVy8mokaYWBBRu9QnLhTrDxTI19xylqiRnuPOfpF3EQJ443ygYP+5si1vMbEgr8GpUETULlmdZcGpUETk7SQJGHmnsuzgz0DREXXiIbLAxIKI2iXLnaFOnKlCVV29StEQETlp8E2AvvH29gLY9q5q4RA1xsSCiNql82JDoLFYn3owr0KdYIiInOUfDAy7RVm28yOglv9+kfqYWLiIJ28T+aYAnRbdooMVZUfy+T9mIvIBybdDsXNXbRm3niWvwMTCRampqcjMzMS2bdscVyYir9KjgzKxOFrIxIKIfEBUd6DPFGXZ1rcBYVYnHqK/MLEgonarRwflibVHC3hIHhH5iFF3Ka8LD0LK+lWdWIj+wsSCiNqtnhYjFkcKOGJBRD6i+xigQ19FkWbb2yoFQ3QWEwsiarcsRyyOFVXBZOYptkTkA2xsPSsdXo3g2jyVAiJiYkFE7ViPGOWIRV29GaeLq1WKhoiomSy2npUg0L1gtYoBUXvHxIKI2q2oYH+EB+oUZZwORUQ+w8bWs12KNgC1PPCT1OGndgBERGqRJAk9OwRjx4kSuexIQQXG9Y1VLygiouYYeQewyQDg7DROnbka5v/dDkR2UTcuX+AXAMQlAQlDz65X0eocP4eaxMSCiNq1Hh1CFInF0ULuDEVEPiSy29mtZw/8IBdpjq5RLx5fpdUD8QOAjkOAhCFAdC9Ao1U7KtclDAO0rfd2n4kFEbVrVmdZcCoUEfmaUXcpEgtqAVMtcDr97FdbMvckoA1rtdtxjQURtWs9YpQ7Qx3hWRZE5Gu6jzn7RaQyjlgQUbt2XqxyxKKgvBblNUaEBnCuLRH5CEkCpn0I045PcHzHanTt1g1aDT87dqgiD8jOAEqOqx1Jm8HEgojatS5RwdBqJMX5FUcLKjE4MUK9oIiImisgHObk27G7IAGJky+HVscPR5xWdQbI2QXkZADZO89+X1mkdlQ+iYmFiwwGAwwGA0wmk9qhEFEL+PtpkBgZiGNFVXLZ0cIKJhZERO1FUBTQc9zZL3IJx8lclJqaiszMTGzbtk3tUIiohSxP4D6Sz3UWREREzcXEgojavZ6WO0MVcmcoIiKi5mJiQUTtnuWIxVHuDEVERNRsTCyIqN3rEWM5YlGpWMxNREREjjGxIKJ2z3LEoq7ejOySapWiISIi8k1MLIio3YsJ8UdYgHKTvCM8gZuIiKhZmFgQUbsnSRLXWRAREbmIiQUREYAeFjtDccSCiIioeZhYEBEB6MkRCyIiIpcwsSAiAs+yICIichUTCyIiWO8MlVdWi4raepWiISIi8j1MLIiIAHSNDoJGUpYd5ToLIiIipzGxICICoPfTonNkkKKM6yyIiIicx8SCiOgvVussOGJBRETkNCYWRER/sVxncYQjFkRERE5jYkFE9BeeZUFERNRyTCz+UlJSghEjRmDIkCEYMGAA3nnnHbVDIqJW1iNGOWJxrKgSZrNQKRoiIiLf4qd2AN4iNDQUGzZsQFBQECorKzFgwABce+21iI6OVjs0ImolPWOVIxY1RjOyS6utFnUTERGRNY5Y/EWr1SIo6Oybh9raWgghIAQ/qSRqTzqE6BGqV37ewnUWREREzvGZxGLDhg248sorkZCQAEmSsGLFCqs6BoMB3bp1Q0BAAEaNGoWtW7c26x4lJSUYPHgwOnfujIceeggxMTFuip6IfIEkSVbrLLgzFBERkXN8JrGorKzE4MGDYTAYbD6+fPlypKWlYf78+dixYwcGDx6MyZMnIz8/X67TsH7C8is7OxsAEBERgV27diErKwuffPIJ8vLyWuW1EZH3sNwZimdZEBEROcdn1lhMmTIFU6ZMsfv4yy+/jDvuuAOzZs0CACxevBjff/893nvvPcydOxcAkJGR4dS94uLiMHjwYPz222+4/vrrbdapra1FbW2tfF1WVgYAMBqNMBqNTt2H2peGfsH+4d26RQUqro/kl7fK74z9gxxhHyFH2EfIEU/3DZ9JLJpSV1eH9PR0zJs3Ty7TaDSYOHEiNm3a5FQbeXl5CAoKQmhoKEpLS7FhwwbcfffddusvXLgQCxYssCpft26dvFaDyJZVq1apHQI1oaRIAqCVr/eeKsIPP/zQavdn/yBH2EfIEfYRsqeqqsqj7beJxKKwsBAmkwlxcXGK8ri4OOzfv9+pNo4fP44777xTXrR9zz33YODAgXbrz5s3D2lpafJ1WVkZEhMTMW7cOO4kRTYZjUasWrUKkyZNgk6nUzscsqNnbjmWHjz3gURpnYQxEy5FsN6z/1yyf5Aj7CPkCPsIOVJUVOTR9ttEYuEOI0eOdHqqFADo9Xro9Xqrcp1Oxz9mahL7iHc7Lz4ckgQ03hTuVGkdBnQKtP8kN2L/IEfYR8gR9hGyx9P9wmcWbzclJiYGWq3WarF1Xl4e4uPjPXpvg8GApKQkJCcne/Q+RNQ6AnRadI60WGfBnaGIiIgcahOJhb+/P4YPH441a9bIZWazGWvWrMHo0aM9eu/U1FRkZmZi27ZtHr0PEbUeyxO4eZYFERGRYz4zFaqiogKHDx+Wr7OyspCRkYGoqCh06dIFaWlpSElJwYgRIzBy5EgsWrQIlZWV8i5RRETO6tEhGL8eLJCveZYFERGRYz6TWGzfvh3jxo2TrxsWTqekpGDZsmWYNm0aCgoK8MQTTyA3NxdDhgzBTz/9ZLWgm4jIEcuzLHaeKMHiX49Y1RuSGIGR3aKg0UitFRoREZHX8pnEYuzYsRCNV1PaMGfOHMyZM6eVIjrLYDDAYDDAZDK16n2JyHN6Wpy+fbqkGv/90fYOcxf0jMYrNw1Fh1DrzRyIiIjakzaxxkJNXGNB1Pb0tBixaMofR4rwt9d+w7ZjZzwYERERkfdjYkFEZCE2VI9BncOdrp9XVoub3t6Md3876nBklYiIqK3ymalQREStRZIkvHvrCLy+7jBOnrF9Sune7DLkl9fK1yazwNPf70P68WI8f/0ghAZwD3kiImpfmFi4iGssiNqm2LAA/OfqAXYfL6qoxX2fZeD3w4WK8h/35GJ/bjnevHkY+saHeTpMIiIir8GpUC7iGgui9ik6RI/3Z4/EvePPs3osq7ASUw0bue6CiIjaFSYWREQtpNVISLu0D5bOSkZEkHLqU43RjNfXHrbzTCIioraHiQURkYvG9YnFynsuwmCLBd9ZhTyxm4iI2g8mFkREbtA5MghPXNlfUZZXVsNdooiIqN1gYuEig8GApKQkJCcnqx0KEaksLkx5SF5tvRll1fUqRUNERNS6mFi4iIu3iaiBrdO388prVIiEiIio9TGxICJyE72fFlHB/oqyvDImFkRE1D4wsSAicqNYi1GL3FImFkRE1D4wsSAicqO4sADFdePTuYmIiNoyJhZERG5kuYCbU6GIiKi9YGLhIu4KRUSNWY5YMLEgIqL2gomFi7grFBE1FmuVWHAqFBERtQ9MLIiI3Cjeco0FRyyIiKidYGJBRORGlmss8strYTbz9G0iImr7mFgQEbmR5RqLerPAmao6laIhIiJqPUwsiIjcKDrYHxpJWcYF3ERE1B4wsSAiciM/rQYxIRbTobiAm4iI2gEmFkREbsYtZ4mIqD1iYuEinmNBRJasD8njiAUREbV9TCxcxHMsiMiS1VkW5RyxICKito+JBRGRm8WF8iwLIiJqf5hYEBG5GadCERFRe8TEgojIzbh4m4iI2iMmFkREbhZrMWJRWFGLepNZpWiIiIhaBxMLIiI3sxyxMAugsIKnbxMRUdvGxIKIyM2igvzhZ3H8NqdDERFRW8fEgojIzTQaCbGhlgu4mVgQEVHbxsTCRTwgj4hsiQu3PMuCO0MREVHbxsTCRTwgj4hs4VkWRETU3jCxICLyAOuzLJhYEBFR28bEgojIA2KtzrLgVCgiImrbmFgQEXkAD8kjIqL2hokFEZEHWE6FyufibSIiauOYWBAReYDliMWZyjrU1ptUioaIiMjzmFgQEXmA5a5QAFDAUQsiImrDmFgQEXlAWKAf9H7Kf2K5gJuIiNoyJhZERB4gSZLVdCieZUFERG0ZEwsiIg/hWRZERNSeMLEgIvIQq7MsuMaCiIjaMCYWREQeYrmAmyMWRETUljGxcJHBYEBSUhKSk5PVDoWIvIzVWRZcvE1ERG0YEwsXpaamIjMzE9u2bVM7FCLyMpaLt3M5YkFERG0YEwsiIg+xTCw4FYqIiNoyJhZERB5iORWqvKYeVXX1KkVDRETkWUwsiIg8xHJXKIDrLIiIqO1iYkFE5CEhej+E6P0UZZwORUREbRUTCyIiD4q1PCSPZ1kQEVEbxcSCiMiDLM+yyOeIBRERtVFMLIiIPMhyATenQhERUVvFxIKIyIOst5zlVCgiImqbmFgQEXmQ5c5QHLEgIqK2iokFEZEHWU6FyufibSIiaqOYWBAReZCt07eFECpFQ0RE5DlMLIiIPMhyV6iqOhMqann6NhERtT1MLIiIPMjyHAuAC7iJiKhtYmJBRORBATotwgN1ijKeZUFERG0REwsiIg+zOsuinIkFERG1PUwsiIg8jGdZEBFRe8DEwkJVVRW6du2KBx98UO1QiKiNsEwscks5YkFERG0PEwsLzzzzDM4//3y1wyCiNsT6LAsmFkRE1PYwsWjk0KFD2L9/P6ZMmaJ2KETUhnAqFBERtQc+k1hs2LABV155JRISEiBJElasWGFVx2AwoFu3bggICMCoUaOwdevWZt3jwQcfxMKFC90UMRHRWbGh1ofkERERtTV+agfgrMrKSgwePBizZ8/Gtddea/X48uXLkZaWhsWLF2PUqFFYtGgRJk+ejAMHDiA2NhYAMGTIENTXWx9M9csvv2Dbtm3o3bs3evfujT/++MNhPLW1taitPfepY1lZGQDAaDTCaDS29GVSG9bQL9g/2p/oIK3iOq+sBnV1dZAkSS5j/yBH2EfIEfYRcsTTfUMSQgiP3sEDJEnC119/jalTp8plo0aNQnJyMl5//XUAgNlsRmJiIu655x7MnTvXYZvz5s3DRx99BK1Wi4qKChiNRvzrX//CE088YbP+k08+iQULFliVf/LJJwgKCmrZCyOiNqm4Fnhyh/JznGdH1CNYZ+cJREREHlBVVYUZM2agtLQUYWFhbm+/TSQWdXV1CAoKwpdffqlINlJSUlBSUoJvvvmmWe0vW7YMe/bswYsvvmi3jq0Ri8TEROTk5CA6OrpZ96P2wWg0YtWqVZg0aRJ0Or6jbE+MJjOSnlytKFuZOhp94kPP1WH/IAfYR8gR9hFypKioCB07dvRYYuEzU6GaUlhYCJPJhLi4OEV5XFwc9u/f75F76vV66PV6q3KdTsc/ZmoS+0j7o9MBMSH+KKyok8uKqk02+wH7BznCPkKOsI+QPZ7uF20isXC32267zem6BoMBBoMBJpPJcwERkc+LDQ1QJBbZJdUwmszytdFkhtnnxo+JiIjOaROJRUxMDLRaLfLy8hTleXl5iI+P9+i9U1NTkZqairKyMoSHh3v0XkTku+LC9MjMOXc973+7Me9/uxV1dBotNtfvxbPXDoZWI4GIiMiX+Mx2s03x9/fH8OHDsWbNGrnMbDZjzZo1GD16tIqRERGdZXmWhS1Gs4Tl209j6casVoiIiIjIvXxmxKKiogKHDx+Wr7OyspCRkYGoqCh06dIFaWlpSElJwYgRIzBy5EgsWrQIlZWVmDVrlopRExGd1Tsu1HGlvxjWHca05ESEBnCONBER+Q6fGbHYvn07hg4diqFDhwIA0tLSMHToUHk72GnTpuHFF1/EE088gSFDhiAjIwM//fST1YJudzMYDEhKSkJycrJH70NEvu26YZ0xtEuEU3WLq4x49zeOWhARkW/xye1mvVHDGovCwkJuN0s2GY1G/PDDD7j88su5W0c7JYRATmkNaozWmz08tXIv1h0olK+D/bXY8O9xiA6x3n2O2if+G0KOsI+QI0VFRYiJifHYdrM+M2JBROTrJElCQkQgenQIsfp6aFJvSDj3OU9lnQmGdUdUjJaIiKh5mFgQEXmBXnEhGNFBOYD80ebjOF1SrVJEREREzcPEgojIS0zpbIZOe26b2TqTGa+sPqhiRERERM5jYuEiLt4mIneJDgBuGtFZUfZl+ikczq9QKSIiIiLnMbFwUWpqKjIzM7Ft2za1QyGiNuCfY3sgUKeVr80CeHnVARUjIiIicg4TCyIiLxITosfsi7opyn7YnYvdp0rVCYiIiMhJTCyIiLzMnZf0RHigcqvI53/er1I0REREzmFiQUTkZcIDdfjHmJ6Kst8OFeLXgwUorzFafdXVm1WKlIiI6Bw/tQPwdQaDAQaDASaT9YFXREQtddsF3bB0Yxbyy2vlspT3ttqsK0lAXGgAEqMCkRgZhM5RQegcefb7iCAdJMnm08jH1BvrkV0JHMgth5+O//sma+wjZKlXbCi0mtb7nwBP3nYTnrxNjvBEVGqKrf7x4ebjeHzFHpUjIyIiX7X7yUsRGnDuPQdP3iYiaqduSk5E1+ggtcMgIiJyChMLIiIvpdNq8Pr0YYgN1asdChERkUOcgEdE5MUGdg7H5nkTkFdeA1sTVwWA0iojThZX4eSZKpwqrpb/e6q4CtVGrv9qS4QQkLhohprAPkJqYmJBROTlNBoJHcMD7T7eKSIQSQnunytL3oXrtMgR9hFSG6dCuchgMCApKQnJyclqh0JEREREpBomFi5KTU1FZmYmtm3bpnYoRERERESqYWJBREREREQuY2JBREREREQuY2JBREREREQuY2JBREREREQuY2JBREREREQuY2LhIm43S0RERETExMJl3G6WiIiIiIiJBRERERERuQETCyIiIiIichkTCyIiIiIichkTCyIiIiIichkTCyIiIiIichkTCyIiIiIichkTCyIiIiIichkTCxfxgDwiIiIiIiYWLuMBeUREREREgJ/aAbQVQggAQHl5OXQ6ncrRkDcyGo2oqqpCWVkZ+whZYf8gR9hHyBH2EXKkvLwcwLn3re7GxMJNioqKAADdu3dXORIiIiIiIvuKiooQHh7u9naZWLhJVFQUAODEiRMe+UWR7ysrK0NiYiJOnjyJsLAwtcMhL8P+QY6wj5Aj7CPkSGlpKbp06SK/b3U3JhZuotGcXa4SHh7OP2ZqUlhYGPsI2cX+QY6wj5Aj7CPkSMP7Vre365FWiYiIiIioXWFiQURERERELmNi4SZ6vR7z58+HXq9XOxTyUuwj1BT2D3KEfYQcYR8hRzzdRyThqf2miIiIiIio3eCIBRERERERuYyJBRERERERuYyJBRERERERuYyJBRERERERuYyJhRsYDAZ069YNAQEBGDVqFLZu3ap2SKSShQsXIjk5GaGhoYiNjcXUqVNx4MABRZ2amhqkpqYiOjoaISEhuO6665CXl6dSxKSm//73v5AkCffff79cxv5Bp0+fxs0334zo6GgEBgZi4MCB2L59u/y4EAJPPPEEOnbsiMDAQEycOBGHDh1SMWJqTSaTCY8//ji6d++OwMBA9OzZE0899RQa78XDPtK+bNiwAVdeeSUSEhIgSRJWrFiheNyZ/nDmzBnMnDkTYWFhiIiIwN///ndUVFQ0OxYmFi5avnw50tLSMH/+fOzYsQODBw/G5MmTkZ+fr3ZopIJff/0Vqamp2Lx5M1atWgWj0YhLL70UlZWVcp0HHngA3333Hb744gv8+uuvyM7OxrXXXqti1KSGbdu24a233sKgQYMU5ewf7VtxcTEuvPBC6HQ6/Pjjj8jMzMRLL72EyMhIuc7zzz+PV199FYsXL8aWLVsQHByMyZMno6amRsXIqbU899xzePPNN/H6669j3759eO655/D888/jtddek+uwj7QvlZWVGDx4MAwGg83HnekPM2fOxN69e7Fq1SqsXLkSGzZswJ133tn8YAS5ZOTIkSI1NVW+NplMIiEhQSxcuFDFqMhb5OfnCwDi119/FUIIUVJSInQ6nfjiiy/kOvv27RMAxKZNm9QKk1pZeXm56NWrl1i1apUYM2aMuO+++4QQ7B8kxMMPPywuuugiu4+bzWYRHx8vXnjhBbmspKRE6PV68emnn7ZGiKSyK664QsyePVtRdu2114qZM2cKIdhH2jsA4uuvv5avnekPmZmZAoDYtm2bXOfHH38UkiSJ06dPN+v+HLFwQV1dHdLT0zFx4kS5TKPRYOLEidi0aZOKkZG3KC0tBQBERUUBANLT02E0GhV9pm/fvujSpQv7TDuSmpqKK664QtEPAPYPAr799luMGDECN9xwA2JjYzF06FC888478uNZWVnIzc1V9JHw8HCMGjWKfaSduOCCC7BmzRocPHgQALBr1y78/vvvmDJlCgD2EVJypj9s2rQJERERGDFihFxn4sSJ0Gg02LJlS7Pu5+eesNunwsJCmEwmxMXFKcrj4uKwf/9+laIib2E2m3H//ffjwgsvxIABAwAAubm58Pf3R0REhKJuXFwccnNzVYiSWttnn32GHTt2YNu2bVaPsX/Q0aNH8eabbyItLQ2PPPIItm3bhnvvvRf+/v5ISUmR+4Gt/++wj7QPc+fORVlZGfr27QutVguTyYRnnnkGM2fOBAD2EVJwpj/k5uYiNjZW8bifnx+ioqKa3WeYWBB5SGpqKvbs2YPff/9d7VDIS5w8eRL33XcfVq1ahYCAALXDIS9kNpsxYsQIPPvsswCAoUOHYs+ePVi8eDFSUlJUjo68weeff46PP/4Yn3zyCfr374+MjAzcf//9SEhIYB8h1XEqlAtiYmKg1WqtdmzJy8tDfHy8SlGRN5gzZw5WrlyJdevWoXPnznJ5fHw86urqUFJSoqjPPtM+pKenIz8/H8OGDYOfnx/8/Pzw66+/4tVXX4Wfnx/i4uLYP9q5jh07IikpSVHWr18/nDhxAgDkfsD/77RfDz30EObOnYubbroJAwcOxC233IIHHngACxcuBMA+QkrO9If4+HirTYfq6+tx5syZZvcZJhYu8Pf3x/Dhw7FmzRq5zGw2Y82aNRg9erSKkZFahBCYM2cOvv76a6xduxbdu3dXPD58+HDodDpFnzlw4ABOnDjBPtMOTJgwAbt370ZGRob8NWLECMycOVP+nv2jfbvwwguttqg+ePAgunbtCgDo3r074uPjFX2krKwMW7ZsYR9pJ6qqqqDRKN++abVamM1mAOwjpORMfxg9ejRKSkqQnp4u11m7di3MZjNGjRrVvBu6tPScxGeffSb0er1YtmyZyMzMFHfeeaeIiIgQubm5aodGKrj77rtFeHi4WL9+vcjJyZG/qqqq5Dr/+Mc/RJcuXcTatWvF9u3bxejRo8Xo0aNVjJrU1HhXKCHYP9q7rVu3Cj8/P/HMM8+IQ4cOiY8//lgEBQWJjz76SK7z3//+V0RERIhvvvlG/Pnnn+Lqq68W3bt3F9XV1SpGTq0lJSVFdOrUSaxcuVJkZWWJ//3vfyImJkb8+9//luuwj7Qv5eXlYufOnWLnzp0CgHj55ZfFzp07xfHjx4UQzvWHyy67TAwdOlRs2bJF/P7776JXr15i+vTpzY6FiYUbvPbaa6JLly7C399fjBw5UmzevFntkEglAGx+LV26VK5TXV0t/vnPf4rIyEgRFBQkrrnmGpGTk6Ne0KQqy8SC/YO+++47MWDAAKHX60Xfvn3F22+/rXjcbDaLxx9/XMTFxQm9Xi8mTJggDhw4oFK01NrKysrEfffdJ7p06SICAgJEjx49xKOPPipqa2vlOuwj7cu6detsvvdISUkRQjjXH4qKisT06dNFSEiICAsLE7NmzRLl5eXNjkUSotFRjURERERERC3ANRZEREREROQyJhZEREREROQyJhZEREREROQyJhZEREREROQyJhZEREREROQyJhZEREREROQyJhZEREREROQyJhZEREREROQyJhZERB4wduxYSJKEJ598Uu1QVFVVVYXHH38c/fr1Q2BgICRJgiRJyMjIUDs0j3nyySchSRLGjh2rdigtctttt0GSJNx2221qh0JEPoaJBRG1moY3XJIkISgoCNnZ2XbrHjt2TK67fv361guS3GratGl4+umnsX//fkiShLi4OMTFxUGn06kdWruzfv16PPnkk1i2bJnaoRBRG8XEgohUUV1djQULFqgdBnnQ/v37sXLlSgDA8uXLUVVVhdzcXOTm5qJ///4qR9f+rF+/HgsWLHCYWHTs2BF9+vRBx44dWycwImozmFgQkWree+89HDx4UO0wyEN2794NAIiOjsaNN96ocjTkrIULF2L//v1YuHCh2qEQkY9hYkFErS4xMRGDBg1CfX09HnnkEbXDIQ+pqqoCAISEhKgcCRERtQYmFkTU6jQajfxp6FdffYWtW7c26/mN118cO3bMbr1u3bpBkiSrqR+Wzz9+/DjuuOMOdOnSBQEBAejZsycee+wxVFZWys/Zs2cPbr75ZiQmJiIgIAC9evXC008/DaPR6DDeuro6/Pe//8WgQYMQHByMyMhITJo0CT/++KPD5+7Zswd33nknevXqhaCgIISEhGDQoEF49NFHUVhYaPM5louHv/rqK1x66aWIjY2FRqNp9oLympoaLFq0CBdccAEiIyMREBCArl274tZbb7W5CLvh/g2Lf48fPy7/vFu6KHjjxo24+eab0bVrVwQEBCA8PBwjR47Ec889h4qKCkVdo9GImJgYSJKEV199tcl233vvPUiShLCwMDkRAoDc3Fy89tpruPrqq9GvXz+Eh4cjMDAQ5513Hm6//Xbs3bu32a8BcG5Rf1OLv4uLi7FkyRLceOONGDhwIKKiouTfx4wZM7B582ar5zT094aph7/++qvi92H5N+LM4u3169fjhhtuQKdOnaDX6xETE4MJEyZg6dKlMJlMTr2uNWvW4IorrkCHDh0QEBCAfv36YcGCBaipqbF7359//hnXXnstOnfuDH9/f4SFhaFHjx649NJL8eKLL+LMmTN2n0tErUAQEbWS+fPnCwCia9euQgghxowZIwCIcePGWdXNysoSAAQAsW7dOruPZWVl2b1f165dBQCxdOlSu8//6quvREREhAAgwsLChFarlR+7+OKLRV1dnVi5cqUICgoSAER4eLiQJEmuM23aNJv3bnht8+bNExdffLEAIPz8/OR7NXzNnz/fbvzPPfec0Gg0ct2goCDh7+8vX3fs2FHs2LHD7s95zJgxIi0tTQAQkiSJyMhIodVqm7ynpVOnTokBAwbI99TpdCI8PFy+1mg04tVXX1U854UXXhBxcXEiLCxMrhMXFyd/3XvvvU7f32QyiXvvvVfxMwsJCVH8nvr06SOOHTumeF5qaqoAIEaMGNFk+2PHjhUAxG233aYoT0lJkdv38/MTUVFRws/PTy7T6/Xiyy+/tNlm45+/pYZ+0dTvoKnnNzwGQGi1WhEZGSn0er1cJkmSeOWVVxTPOXHihIiLixPBwcHy77Dx7yMuLk589tlnVq89JSXFZnwPPPCA4n4RERGK38f48eNFWVlZk6/r+eefF5Ikyc9v/Dc1btw4UV9fb/X8BQsWKPpBUFCQCAkJUZRZ/ltBRK2LiQURtRrLxGLTpk3yG4Iff/xRUbe1EouIiAgxYcIEsXfvXiGEEFVVVeLVV1+V3yg99thjIjw8XEybNk1+81peXi4effRRuY1Vq1ZZ3bvhDWR4eLjQ6/Vi8eLForq6Wghx9o3e9ddfLz//m2++sXr+u+++K7+JfuaZZ0ROTo4QQoj6+nqxfft2MX78eAFAdO7cWZSXl9v8OTe86Xr44YdFfn6+EEKImpoaqzfh9tTX14tRo0bJr+Ojjz4StbW1Qgghjhw5Iv72t7/Jby5/+OEHq+cvXbpU8ftuiccee0wAELGxscJgMIiioiIhhBB1dXVi3bp1YujQoQKAGDZsmDCZTPLztmzZIv989+3bZ7Pt48ePy29o165dq3jsqaeeEi+88ILYvXu3MBqNQoizSc6ePXvEzJkzBQARHBwsTp8+bdWuJxOLt956S8yfP19s375d/l2YzWZx9OhRcd999wlJkoRWq3WYcDalqcTitddek3+ud955p9wvKyoqxP/93//JyZethLvh/hEREUKj0Yh58+aJgoICIYQQpaWl4oknnpDbXrJkieK5x44dk5PstLQ0xc+9pKRE/Pbbb+Kf//yn2L59e5OvjYg8i4kFEbUay8RCCCGuueYaAUAMGTJEmM1muby1Eov+/fuLmpoaq+fecsstcp1JkyYpYmvQMBLx97//3eqxhjeQtt4kCXH2Teoll1wix9BYWVmZPLLx008/2XxtRqNRDB8+XAAQ//d//6d4rPGn2mlpaTaf74zPPvtMbufnn3+2GUND4jFgwACrx11NLLKysoRWqxWBgYEiIyPDZp2ysjLRuXNnAUB8/fXXisf69OkjjxrZ8uyzzwoAokuXLjZ/v0254oorBADx1FNPWT3mycTCkYaRGlt90tXEoqqqSkRFRQkAYvr06Taf++qrr8p9xvJNfuN+ae/1X3vttQKAmDhxoqJ8+fLlAoDo3bt3k7ETkbq4xoKIVPXss89Cq9UiIyMDn376aavf/4EHHoBer7cqnzx5svz93LlzIUmS3Tp//vmn3fYTExMxa9Ysq3KNRoPHHnsMALB37155ByXg7JqIkpISDB06VBFHY35+fpg+fTqAs/PObdFoNHj44YftxubI8uXLAQCjR4/GpZdeajOG+fPnAzi7FqTxa3CHZcuWwWQy4bLLLsPgwYNt1gkNDcXUqVMBWP8cbrnlFgDAxx9/DCGE1XM//PBDAMDMmTNt/n6bcsUVVwAAfv/992Y9z9M8GdeqVavkNQz21oj885//lLep/eSTT2zW0ev1ePDBB20+dvXVVwOw/puKiIgAAJSXlyvWPhGRd2FiQUSq6tu3r/zG+/HHH3dqMbQ7jRw50mZ5XFyc/H1ycnKTdYqLi+2237BY15aLL74Yfn5+AIDt27fL5Rs3bgQA7Nu3D/Hx8Xa//vOf/wA4uzjalvPOOw+xsbF2Y3OkIaaJEyfarTNu3DhotVqr1+AODT+HX375pcmfw9KlSwFY/xxuueUWSJKEEydO4Ndff1U8lp6ejn379gEAbr31Vpv337VrF/75z39i0KBBCAsLg0ajkRc7//Of/wQAnDp1yq2v2RlHjx7Fgw8+iOHDhyMiIgJarVaO6/LLL/dYXA2/38TERPTu3dtmHa1Wi/HjxyvqW+rfv7/dncISEhIAwGoR9siRIxETE4OcnByMGjUKr7/+Ovbv328zYSQi9fipHQAR0ZNPPomPP/4YR48exeLFi3HPPfe02r1DQ0Ntlje84XemTlPJUKdOnew+FhAQgOjoaOTl5SE/P18ubziRvKampskdcho03s2oMVeSCgByTI5eQ0xMjNVrcIeGn0NlZaVTn1Jb/hy6dOmCMWPGYP369fjwww8Vuyw1jFYkJyejb9++Vm29/vrruO+++2A2mwEAkiQhPDxcHt2qrq5GWVlZq396/vXXX2P69Omora2Vy8LCwhAQEABJklBXV4fi4mKPxOVMfwCAzp07K+pbsvf3BJz7m6qvr1eUR0RE4NNPP8WMGTOwd+9e+d+I8PBwXHLJJbjxxhsxbdo0nuhOpDKOWBCR6jp16iS/UXj66aettg9tbxq265w2bRrE2bVwTX7Z23K3YSTBVzX8HB5++GGnfg7r16+3aqNhNOLLL79EdXU1gLNvWhum3TVMl2ps3759uP/++2E2m3HDDTdg69atqKmpQXFxsXxy+MsvvwwArfqJeVFREW677TbU1tZi/PjxWL9+PaqqqlBaWoq8vDzk5ubiiy++aLV4WtvEiRORlZWFDz74ACkpKejVqxdKS0vx3Xff4ZZbbsHQoUNx+vRptcMkateYWBCRV5g7dy4iIyORn5+Pl156qcm6jUcTmvpEv7S01G3xtVRTb3Rqa2tRVFQEQDm6EB8fD8D+FKfW0hBTU9NqampqbL4Gd3DHz+H6669HYGAgysrK8M033wA4O7UqPz8fOp1OXqfS2JdffgmTyYR+/frhs88+Q3JyMvz9/RV1cnNzWxRPQ99tSb/94YcfUFZWhsjISHz33XcYM2YMAgMD3RKXM5zpD40fd3d/AIDg4GDccsstWLZsGQ4ePIhTp07hueeeQ0BAgGIkg4jUwcSCiLxCZGQk5s6dCwB46aWXUFBQ0GTdBidPnrRZ5+DBgygpKXFrjC3x66+/2v1U+7fffpOnfIwYMUIuv/DCCwGcXQeQk5Pj+SDtaIhpzZo1duusX79efg321qK0VMPPYfXq1U5NCbOl8eLuhulPDf+dMmUKYmJirJ7T0KcGDx4Mjcb2/yZXr17donga+q69fgsAW7ZssVne8Jw+ffogKCio2XE1vJaWjrI09IdTp07h4MGDNuuYTCasW7cOgPv7gy2dOnXCv//9b/zrX/8CcHaBORGph4kFEXmNe+65B507d0Z5eTmeeuopu/WCg4PRs2dPAGd3ULLlmWee8UiMzXXixAm8//77VuVmsxnPPvssACApKQkDBw6UH7vhhhsQEREBo9GItLS0Jt8Ims1mjyVQN910EwBg06ZN+OWXX6wer6+vlxeQDxgwAAMGDHDr/WfPng0/Pz8UFhbKu0/ZU1dXZ3cKXcN0qF9++QWHDh2SRy7sLdoODw8HAOzevdvmz/7HH3+0Oe3KGQ27W/38888210GsXbsWmzZtajKugwcP2ky0MjIy7O7EBJxdiwGgxf1l0qRJiI6OBmB/V6i33npLXhtjazSopRqvKbGlYeTGXiJIRK2Df4FE5DUCAwPlNyzfffddk3Ub3rS89957eOONN+T58ydPnsTtt9+O5cuX2/1UtzWFh4fj7rvvxjvvvCO/GTx58iSmT58uf7L79NNPK54TERGBRYsWAQA+++wzXHHFFdiyZYu8kNhsNmPfvn146aWX0L9/f6xcudIjsV933XUYNWoUAODGG2/EJ598Ii9Uz8rKwnXXXSe/CX7++efdfv+ePXvi8ccfl9u/9dZbsWfPHvnx+vp6ZGRk4D//+Q/OO+88ZGRk2Gxn0qRJiI+PR319PWbMmIHq6mpERkbib3/7m836l112GYCz2wCnpqbKOxRVVlbirbfewvXXXy+/wW6uG2+8ERqNBkVFRZg+fbo8bai6uhrvv/8+rrnmGkRFRdl87qWXXgqNRoMzZ85g5syZ8jS7uro6fP7557j00kubXBjdkPjt3bsXf/zxR7Njb/z3+emnn+If//gH8vLyAJxdOP/qq6/i/vvvB3B2fdDw4cObfQ97nnvuOUyZMgUffvihYipWbW0tPv/8c7zwwgsAzm23S0QqabUTM4io3bN1QJ6l+vp60bdvX/kgLdg4IE+Is6dfJyUlyXU0Go18qJxOpxOffvqpUwfk2Ttgb926dXIde5o6AK7hILR58+aJiy66SI4rMjJS8doee+wxu+2/+eabwt/fX66r1+tFdHS00Ol0ijY++ugjxfNcOWDN0qlTp0T//v3le/n7+8s/54af+yuvvGLzue44edtsNovHH39cPiEbgAgMDBTR0dHy6egNX7///rvddtLS0hR177rrribve9NNNynqR0REyPcbPny4fAK1rdfm6Off+IRp/HWqecOJ1VOnTpVPG7f1/IcfftjquQ39oXv37uLjjz+222+NRqN8aCAAERkZKbp27Sq6du0qvvjiC7leUydvCyHEAw88ILchSZKIjIyU4wcgxo0bJ8rKypr9cxHC/t9d48P1GvpAVFSUol/069dPPgmciNTBEQsi8iparVaeItSUkJAQ/P7770hLS0P37t3h5+cHnU4nf4reMI1Hbf7+/lizZg2effZZ9OnTB7W1tQgPD8eECRPw/fffNznl6x//+AcOHDiABx98EIMHD4Zer0dJSQlCQkIwYsQI3HPPPVi1apVbp5xY6tSpE7Zv346XX34Z559/PgIDA1FVVYXExETccsstSE9Px7333uux+0uShP/85z/4888/8c9//n97dx4d0/n/Afw9S5aZJCSpLEWksRSlSFQsURG+HFvVkWpsR6zVRVCkDtHlqzmlqOVYjloGcVRiqy2hJSQVYzud4ChaRW0hEpEQEzHL8/vDb6YiE8v3RiaTvF/nzDk193nu/cx0Zm7e997nuZ+iadOmUCgUKCgogJeXFzp06IDY2FhotVrrmAxbnr7sqazLoCw2bNiAhQsXokWLFnBxcYHJZMLbb7+NWbNm4fDhw2Xeh+FF/Pe//8X69evRrl07uLm5wWQyoVWrVli+fDm2bdv2zNm8Zs+ejYSEBISGhkKlUsFgMKBhw4aYPn06MjMzrfeBsEWpVCI1NRWjR49GUFAQHjx4gCtXruDKlSsvNRPb/PnzceDAAURGRsLPzw+FhYXw8PBAREQENBoN9u3b98wzJ/+Ljz76CCtWrMCgQYPQvHlzqNVq60D2d999FwsXLoROp7MO+Cci+5AJwbvLEBERERGRNDxjQUREREREkjFYEBERERGRZAwWREREREQkGYMFERERERFJxmBBRERERESSMVgQEREREZFkDBZERERERCQZgwUREREREUnGYEFERERERJIxWBARERERkWQMFkREREREJBmDBRERERERScZgQUREREREkjFYEBERERGRZAwWREREREQkGYMFERERERFJprR3AUQvSwgBg8EAs9ls71KIiIheCblcDicnJ8hkMnuXQvTCGCzIYZhMJuTm5uL+/fswGAz2LoeIiOiVcnJygoeHB2rVqgWFQmHvcoieSyaEEPYuguh5TCYTrl27huLiYtSsWRPu7u5QKBQ8kkNERFWOEAImkwmFhYUoKCiAi4sLAgICGC6o0mOwIIeQnZ2N/Px81KtXDyqVyt7lEBERVYiioiJcvXoVnp6e8PPzs3c5RM/EwdtU6QkhcP/+fdSsWZOhgoiIqhWVSoUaNWrg/v374LFgquwYLKjSMxgMMBgMcHd3t3cpREREFc7Dw8O6LySqzBgsqNKzzP7Ea0uJiKg6suz/OBsiVXYMFuQwOFCbiIiqI+7/yFEwWBARERERkWQMFkREREREJBmDBRERERERScZgQVRFvPHGG5DJZKUe7u7uaNmyJaZNm4Y7d+48dz3jx4+39t21a1e51/nNN99AJpOhc+fOz2yXlpZmrcMWnU6HkSNHomHDhlCpVFCr1QgMDERYWBimTJmCffv2lXvtVLHK+kw//Vi7dm2pPk8+R47rwoULGDduHN566y24ubnB1dUVdevWRZs2bTBu3Dhs3bpV8jYsvzXP+00qL2vXroVMJsPw4cMrZHtEFUlp7wKIqHyFhYWhYcOGAB7PIJKVlQWtVovZs2cjISEBhw4dQv369W32LS4uxoYNG6z/1mg0eO+99yqk7pexePFiTJw4EWazGXXq1EFERAS8vLyQk5MDnU4HrVaLtLQ0dOvWzd6lUjl48jNty7OWkePatm0bBg8ejOLiYrz22msICwuDj48P7t69i5MnT2Lp0qVITExEZGSkvUslov/HYEFUxYwePbrUkbBbt24hPDwcf/31F7744gts2bLFZt+ff/4ZeXl5qF27Nm7evIndu3cjOzu7Ut3t9fTp09ZQsWDBAsTExJSYithsNiMjIwMZGRl2rJLKk63PNFVt2dnZiI6ORnFxMSZPnoz4+Hi4urqWaPP777+X+VtGRPbBS6GIqgF/f3/ExsYCAFJTU8tst3r1agDAhAkTEB4eDqPRiISEhAqp8UVt3rwZZrMZ7du3x8SJE0vd30Qul6NTp06YPn26nSokIql2796NwsJC1K5dG/PmzSsVKgCgdevWmDVrlh2qI6Ky8IwFOTSzWeCu/pG9y5DMS+0MufzVzlPu7+8PADAajTaX//PPP0hNTYVSqcSwYcNQu3ZtpKWlQaPRWEPJky5duoSQkBDcu3cPycnJ6NmzZ4nlWVlZaNWqFXJycpCYmIioqKhyeR3Z2dkAAF9f33JZX6VjNgNFefauQhqVNyDncauXZRZm5Bfn27sMSTxdPCGXSf9/b/me+/j4vHTfvLw8zJs3Dzt27MDly5ehUCjw5ptvIioqCjExMVCpVGX21ev1iI+Px6ZNm3D9+nV4e3ujZ8+emDlzJurUqWOzz/nz5/H999/jwIEDuHXrFtzc3BAcHIyxY8fiww8/fOn6iRwZgwU5tLv6R2gdv9/eZUj2+4z/4DV3l1e6jePHjwMAmjVrZnO5RqOBEAK9evWCv78/IiMjMW7cOJw/fx5arRYdOnQo0b5+/frQaDSIjIzEsGHDkJmZibp16wIATCYTBg4ciJycHHz66aflFioAoF69egAen3k5c+YMmjdvXm7rrhSK8oC5DexdhTSxFwG3WvauwuHkF+cjPCnc3mVIkh6VDm9Xb8nrsXzPz5w5g9TUVHTt2vWF+l26dAldunTBlStX4OPjg169esFgMODgwYOYOnUqkpKSsH//fnh5eZXq++jRI3Tt2hWnT59G586dERISgoyMDGg0GqSkpOC3335Do0aNSvRJTk7GBx98gIcPH6Jx48bo378/bt++jfT0dBw4cAC//PKL9UwwUXXAQ0pEVZjZbMaNGzewZMkSzJkzBwqFAjNmzLDZzjKLzsiRIwEAKpUKAwcOBIAyd4z9+/fHhAkTkJubi4EDB1rPhsTFxeHQoUMICQnB/Pnzy/U1RUdHw8PDA4WFhQgODkbv3r0xZ84c7N+/HwUFBeW6LSKyj379+qFOnTowmUzo1q0bIiIiEB8fj5SUFOTk5JTZb/Dgwbhy5Qr69u2Ly5cvY8uWLdixYwcuXryIkJAQ6HQ6jBs3zmbfI0eOIDc3F+fOnUNycjI2bdqES5cuITIyErdu3cKwYcNKtM/OzsaQIUPw8OFDxMfH49y5c9i4cSNSU1Nx9OhReHl5QaPRYOXKleX63hBVZgwWRFXMiBEjrNNwKhQK1K1bFzExMWjRogXS09PRp0+fUn1+/fVXXLt2DX5+fujdu7f1+VGjRgEANm3ahMLCQpvbmzt3Ltq2bYvDhw8jLi4OKSkpmDNnDmrWrInNmzfDxaV8z8QEBATg119/RZMmTWA0GpGSkoKpU6eiW7du8Pb2RlhYGJKSksp1m2RfT36mbT3y8/PtXSKVM3d3d6SmpqJt27YQQiAtLQ1ffvklevfuDV9fXwQHB2P58uUwmUzWPhkZGTh27BjUajVWrFgBNzc36zIfHx+sWLECAJCYmIjr16/b3O68efOsZ0sAwNXVFcuWLYNarcbRo0eh1Wqty1auXImCggK0bt0acXFxJabGfueddxAXFwfg8W8kUXXBS6GIqpinp+bMzc3F6dOnceLECXz++efYsGFDqdP5q1atAgAMGzYMSuW/Pwtt2rRB8+bNcebMGSQlJVmDxpOcnJyQlJSEkJAQzJ07F8uXL4cQAqtXry5zWlup2rVrhz/++APp6enYu3cvTpw4AZ1Oh4KCAmi1Wmi1WuzZs4f3MqginjfdrLOzcwVWQxWlcePGOHr0KI4fP47k5GQcO3YMOp0OOTk5OHnyJD755BNs3boVycnJcHZ2RlpaGgCgR48eNmeya926NVq2bIlTp04hPT0dQ4YMKbHc09MTffv2LdXP19cXPXr0wLZt25CWlma9LNSyvejoaJv1jxo1ClOmTMGFCxeQlZWF2rVrS3g3iBwDgwU5NC+1M36f8R97lyGZl7r8/jCyNTWn0WjEV199hVmzZiE8PBx//vknPDw8AAA5OTnYuXMngH8vg3rSyJEjMWnSJGg0GpvBAgACAwOxePFiDBkyBPfu3cMnn3xS5tzylqN6Qohnvo7nLZfL5YiIiEBERASAx+M6jhw5gpkzZ2Lfvn1Yt24devfujQEDBjxzPZWOyvvxGAVHppJ+jf2Tqst0s54unkiPSrd3GZJ4uniW+zpDQ0MRGhoK4PHvQmZmJubOnYvExETs378fixYtQmxsLG7cuAEACAoKKnNdDRo0wKlTp6xtn2S5uaItlnU+eabjedvz9PSEt7c38vLycP36dQYLqhYYLMihyeWyVz7ouSpQKpWIj4/HypUrcfPmTSQkJOCzzz4DAKxfvx4GgwFKpRKjR48u1ddyCZRWq8X58+fRpEmTUm2EECVurKfT6WAwGODk5FSqreXyhAcPHjyzZst23d3dX+g1KhQKdOzYEXv27EFoaCh0Oh22b9/ueMFCLufA52pKLpOXy8DnqkwmkyEkJAQbN26EXq/Hzp07sX37dpsz170KzzvgQVTdcYwFUTUhl8vxxhtvAADOnTtnfd4yMNtoNOLw4cOlHqdOnSrV9mnff/89UlJS0LRpU7Rv3x7Hjh3D1KlTbba1XL988eLFZ+6kL1y4UKL9i1IoFOjSpQuAx5eBEVHV1L17dwD/fs8t08FeunSpzD6WZbamjv3nn3/K7GdZZpn57kW2V1BQgLy8vDK3R1QVMVgQVRNms9m6c7ScBThy5AjOnj0LFxcX3L17F0IIm4+UlBQAj89uPH0fjEOHDmHGjBlQq9XYvHkzkpKS4O3tjQULFmDHjh2l6ujUqROUSiXy8/Nx4MCBMuu13FHXEhIsXuSI4dWrVwGU/COAiBzH//I979y5MwBg79691vtgPCkzMxMnT5603kTzafn5+di1a1ep53NycrB3794S23jyv9etW2ezPo1GAwBo1KgRgwVVGwwWRNWA0WjEjBkzrEf2LAMULWcg3n//fXh6epbZv3v37vD390d2djZ2795tfT4nJweDBg2CyWTC0qVL0axZMwQEBGDdunWQyWQYMWJEqaOA/v7+1sGOH3/8Mf76669StX799dc4cuQIXF1dMWHChBLL4+LiEBMTg9OnT9t8nT/++KM1lFimyyUix7Js2TJER0eXmIXJQgiBbdu2YcmSJQD+/Z537NgRbdu2RVFREcaOHQu9Xm/tk5ubi7Fjx1rbBwQE2Nzu5MmTS4yjKC4uxmeffYYHDx4gNDQUYWFh1mVjxoxBjRo1oNPp8N1335UIQ5mZmYiPjweACrtMi6gy4BgLoipm1apV1tlKAODOnTs4deoUrl27BuDxH+YdOnRAYWGhdVrWsmY1sVAoFBg8eDDmz5+P1atXo1+/fjCbzRg6dChu3LiB6OjoEoNr+/Tpg0mTJuGHH35AVFQUMjIySoy3WLRoES5evIi0tDQ0a9YMbdu2RWBgIPR6PY4fP46srCyoVCokJCSUmg1Ir9djyZIlWLJkCerUqYOWLVvC09PT+jpv3boFAJg2bRq6desm5a2kSuLpz/TTunfvjsGDB1dcQfTKGQwGJCQkICEhAT4+PggODkatWrWQn5+Ps2fPWg9YDB06tMSkEj/99BO6dOmCHTt2ICgoCJ06dbLeIO/evXsICQmxBpKntW/fHmazGY0bN0aXLl2gVquRkZGBrKws+Pr6IiEhoUR7Pz8/bNiwAQMGDEBcXBzWr1+P4OBg6w3yjEYjRowYgTFjxryy94mo0hFElVxRUZE4e/asKCoqsncplVpgYKAAUOrh7OwsAgMDRVRUlDh48KC1/erVqwUA4e/vL4xG43PXf/LkSQFAKBQKcePGDfHtt98KAOKtt94SDx48KNX+0aNHol27dgKAmDhxYqnlRqNRrFu3TvTo0UP4+voKpVIp3N3dRbNmzcT48ePF33//bbOO3NxckZiYKMaMGSNCQkLE66+/LpRKpXBzcxNNmjQRI0eOFFqt9sXfOKq0yvpMP/2YMGFCqT5r1qyxW90k3b1798T27dtFTEyMCA0NFXXr1hVOTk5CpVKJBg0aiEGDBok9e/bY7Hvnzh0xbdo00bRpU+Hq6irUarUIDg4Ws2fPFnq9vlT7gwcPCgAiPDxcFBYWitjYWBEUFCScnZ2Fn5+fGD58uLh69WqZtZ49e1ZER0dba/T09BQREREiMTHRZvs1a9YIACI6OvqF3w/uB8lRyITgFAdUuT18+BCXL19GUFAQXF1d7V0OERFRheJ+kBwFx1gQEREREZFkDBZERERERCQZgwUREREREUnGYEFERERERJIxWBARERERkWQMFkREREREJBmDBRERERERScZgQQ6Dt1whIqLqiPs/chQMFlTpKZVKAEBxcbGdKyEiIqp4lv2fZX9IVFkxWFClp1Qq4ebmhry8PJhMJnuXQ0REVGFMJhPy8vLg5ubGYEGVnkzw/Bo5AL1ej2vXrkGhUKBmzZpQqVRQKBSQyWT2Lo2IiKhcCSFgMplQVFSEgoICmM1mBAQEQKVS2bs0omdisCCH8ejRI9y+fRt6vZ5nLoiIqMpTKBRQq9Xw9fWFs7Ozvcshei4GC3I4QggYDAaYzWZ7l0JERPRKyOVyODk58cw8ORQGCyIiIiIikoyDt4mIiIiISDIGCyIiIiIikozBgoiIiIiIJGOwICIiIiIiyRgsiIiIiIhIMgYLIiIiIiKSjMGCiIiIiIgk+z8Rqb2+17xpQAAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 800x600 with 1 Axes>"
       ]
@@ -1002,7 +1530,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The tutorial would otherwise time out in CI runs. The main change here is to change the evaluation_budget to a smaller number if `SMOKE_TEST=True`. Other than that this also makes some typing and formatting changes.