### PR TITLE
Bug: batch_shape default in OAK kernel

### DIFF
--- a/botorch/models/kernels/orthogonal_additive_kernel.py
+++ b/botorch/models/kernels/orthogonal_additive_kernel.py
@@ -90,8 +90,8 @@ class OrthogonalAdditiveKernel(Kernel):
             )
             # zero tensor for construction of upper-triangular coefficient matrix
             self._quad_zero = torch.zeros(
-                tuple(1 for _ in range(len(batch_shape) + 1)), **tkwargs
-            ).expand(*batch_shape, 1)
+                tuple(1 for _ in range(len(self.batch_shape) + 1)), **tkwargs
+            ).expand(*self.batch_shape, 1)
         self.coeff_constraint = coeff_constraint
         self.dim = dim
 

--- a/test/models/kernels/test_orthogonal_additive_kernel.py
+++ b/test/models/kernels/test_orthogonal_additive_kernel.py
@@ -8,7 +8,7 @@ import torch
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.kernels.orthogonal_additive_kernel import OrthogonalAdditiveKernel
 from botorch.utils.testing import BotorchTestCase
-from gpytorch.kernels import MaternKernel
+from gpytorch.kernels import MaternKernel, RBFKernel
 from gpytorch.lazy import LazyEvaluatedKernelTensor
 from torch import nn, Tensor
 
@@ -20,6 +20,13 @@ class TestOrthogonalAdditiveKernel(BotorchTestCase):
         batch_shapes = [(), (2,), (7, 2)]
         for dtype in dtypes:
             tkwargs = {"dtype": dtype, "device": self.device}
+
+            # test with default args and batch_shape = None in second_order
+            oak = OrthogonalAdditiveKernel(
+                RBFKernel(), dim=d, batch_shape=None, second_order=True
+            )
+            self.assertEqual(oak.batch_shape, torch.Size([]))
+
             for batch_shape in batch_shapes:
                 X = torch.rand(*batch_shape, n, d, **tkwargs)
                 base_kernel = MaternKernel().to(device=self.device)


### PR DESCRIPTION
Summary: Current setup fails when batch_shape = None (i.e. default), and the kernel is second_order. Added missing self.batch_shape to OAK kernel initialization, which fixes the problem.

Reviewed By: SebastianAment

Differential Revision: D61484600
