### PR TITLE
Multi-objective qBayesianActiveLearningByDisagreement

### DIFF
--- a/botorch/utils/test_helpers.py
+++ b/botorch/utils/test_helpers.py
@@ -123,6 +123,25 @@ def get_fully_bayesian_model(
     return model
 
 
+def get_fully_bayesian_model_list(
+    train_X: Tensor,
+    train_Y: Tensor,
+    num_models: int,
+    standardize_model: bool,
+    infer_noise: bool,
+    **tkwargs: Any,
+) -> ModelListGP:
+    model = ModelListGP(
+        *[
+            get_fully_bayesian_model(
+                train_X, train_Y, num_models, standardize_model, infer_noise, **tkwargs
+            )
+            for _ in range(2)
+        ]
+    )
+    return model
+
+
 def get_sample_moments(samples: Tensor, sample_shape: Size) -> tuple[Tensor, Tensor]:
     """Computes the mean and covariance of a set of samples.
 

--- a/test/acquisition/test_bayesian_active_learning.py
+++ b/test/acquisition/test_bayesian_active_learning.py
@@ -3,15 +3,25 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
 from itertools import product
 
 import torch
 from botorch.acquisition.bayesian_active_learning import (
+    check_negative_info_gain,
+    FULLY_BAYESIAN_ERROR_MSG,
     FullyBayesianAcquisitionFunction,
+    NEGATIVE_INFOGAIN_WARNING,
     qBayesianActiveLearningByDisagreement,
 )
+from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
+from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.sampling.normal import IIDNormalSampler
-from botorch.utils.test_helpers import get_fully_bayesian_model, get_model
+from botorch.utils.test_helpers import (
+    get_fully_bayesian_model,
+    get_fully_bayesian_model_list,
+    get_model,
+)
 from botorch.utils.testing import BotorchTestCase
 
 
@@ -20,12 +30,63 @@ class TestFullyBayesianActuisitionFunction(BotorchTestCase):
         with self.assertRaises(TypeError):
             FullyBayesianAcquisitionFunction()
 
+    def test_fully_bayesian_model_can_init(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        train_X = torch.rand(4, 2, **tkwargs)
+        train_Y = torch.rand(4, 1, **tkwargs)
+
+        acq = qBayesianActiveLearningByDisagreement(
+            model=get_fully_bayesian_model(
+                train_X=train_X,
+                train_Y=train_Y,
+                num_models=3,
+                standardize_model=True,
+                infer_noise=True,
+                **tkwargs,
+            ),
+        )
+        acq_with_model_list = qBayesianActiveLearningByDisagreement(
+            get_fully_bayesian_model_list(
+                train_X=train_X,
+                train_Y=train_Y,
+                num_models=3,
+                standardize_model=True,
+                infer_noise=True,
+                **tkwargs,
+            ),
+        )
+        self.assertIsInstance(acq.model, SaasFullyBayesianSingleTaskGP)
+        self.assertIsInstance(acq_with_model_list.model, ModelListGP)
+
+        # Support with non-fully bayesian models is not possible. Thus, we
+        # throw an error.
+
+    def test_non_fully_bayesian_model_raises(self):
+        train_X = torch.rand(4, 2)
+        train_Y = torch.rand(4, 1)
+        non_fully_bayesian_model = get_model(train_X=train_X, train_Y=train_Y)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            FULLY_BAYESIAN_ERROR_MSG,
+        ):
+            qBayesianActiveLearningByDisagreement(model=non_fully_bayesian_model)
+
 
 class TestQBayesianActiveLearningByDisagreement(BotorchTestCase):
-    def test_q_bayesian_active_learning_by_disagreement(self):
+    def test_check_negative_info_gain(self):
+        negative_ig_tensor = torch.tensor([0.0, 1.2, -3.0])
+        with self.assertWarnsRegex(RuntimeWarning, NEGATIVE_INFOGAIN_WARNING):
+            check_negative_info_gain(negative_ig_tensor)
+
+        # test that it doesn't raise a warning if the tensor is all positive
+        positive_ig_tensor = torch.tensor([0.01, 1.2, 3.0])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            check_negative_info_gain(positive_ig_tensor)
+
+    def _test_q_bayesian_active_learning_by_disagreement_base(self, model_getter):
         torch.manual_seed(1)
         tkwargs = {"device": self.device}
-        num_objectives = 1
         num_models = 3
         input_dim = 2
 
@@ -44,14 +105,14 @@ class TestQBayesianActiveLearningByDisagreement(BotorchTestCase):
             X_pending = X_pending.to(**tkwargs) if X_pending is not None else None
             tkwargs["dtype"] = dtype
             train_X = torch.rand(4, input_dim, **tkwargs)
-            train_Y = torch.rand(4, num_objectives, **tkwargs)
+            train_Y = torch.rand(4, 1, **tkwargs)
 
-            model = get_fully_bayesian_model(
-                train_X,
-                train_Y,
-                num_models,
-                standardize_model,
-                infer_noise,
+            model = model_getter(
+                train_X=train_X,
+                train_Y=train_Y,
+                num_models=num_models,
+                standardize_model=standardize_model,
+                infer_noise=infer_noise,
                 **tkwargs,
             )
 
@@ -77,19 +138,21 @@ class TestQBayesianActiveLearningByDisagreement(BotorchTestCase):
             for j in range(len(test_Xs)):
                 acq_X = acq.forward(test_Xs[j])
                 acq_X = acq(test_Xs[j])
+
                 # assess shape
                 self.assertTrue(acq_X.shape == test_Xs[j].shape[:-2])
 
+                # for a model with sensible lengthscales (such as the ones sampled)
+                # this test should always pass since the EIG is always postitive
+                # in theory.
                 self.assertTrue(torch.all(acq_X > 0))
 
-        # Support with non-fully bayesian models is not possible. Thus, we
-        # throw an error.
-        non_fully_bayesian_model = get_model(train_X, train_Y, False)
-        with self.assertRaisesRegex(
-            ValueError,
-            "Fully Bayesian acquisition functions require a "
-            "SaasFullyBayesianSingleTaskGP to run.",
-        ):
-            acq = qBayesianActiveLearningByDisagreement(
-                model=non_fully_bayesian_model,
-            )
+    def test_q_bayesian_active_learning_by_disagreement_multi_objective(self):
+        self._test_q_bayesian_active_learning_by_disagreement_base(
+            model_getter=get_fully_bayesian_model_list
+        )
+
+    def test_q_bayesian_active_learning_by_disagreement_single_objective(self):
+        self._test_q_bayesian_active_learning_by_disagreement_base(
+            model_getter=get_fully_bayesian_model
+        )

--- a/test_community/acquisition/test_bayesian_active_learning.py
+++ b/test_community/acquisition/test_bayesian_active_learning.py
@@ -7,22 +7,13 @@
 from itertools import product
 
 import torch
-from botorch.acquisition.bayesian_active_learning import (
-    FullyBayesianAcquisitionFunction,
-)
-from botorch.utils.test_helpers import get_fully_bayesian_model, get_model
+from botorch.utils.test_helpers import get_fully_bayesian_model
 from botorch.utils.testing import BotorchTestCase
 from botorch_community.acquisition.bayesian_active_learning import (
     qBayesianQueryByComittee,
     qBayesianVarianceReduction,
     qStatisticalDistanceActiveLearning,
 )
-
-
-class TestFullyBayesianActuisitionFunction(BotorchTestCase):
-    def test_abstract_raises(self):
-        with self.assertRaises(TypeError):
-            FullyBayesianAcquisitionFunction()
 
 
 class TestQStatisticalDistanceActiveLearning(BotorchTestCase):
@@ -88,16 +79,6 @@ class TestQStatisticalDistanceActiveLearning(BotorchTestCase):
                 X_pending=X_pending,
             )
 
-        # Support with non-fully bayesian models is not possible. Thus, we
-        # throw an error.
-        non_fully_bayesian_model = get_model(
-            train_X=train_X, train_Y=train_Y, standardize_model=False
-        )
-        with self.assertRaises(ValueError):
-            acq = qStatisticalDistanceActiveLearning(
-                model=non_fully_bayesian_model,
-            )
-
 
 class TestQBayesianQueryByComittee(BotorchTestCase):
     def test_q_bayesian_query_by_comittee(self):
@@ -151,16 +132,6 @@ class TestQBayesianQueryByComittee(BotorchTestCase):
                     # assess shape
                     self.assertTrue(acq_X.shape == test_Xs[j].shape[:-2])
 
-        # Support with non-fully bayesian models is not possible. Thus, we
-        # throw an error.
-        non_fully_bayesian_model = get_model(
-            train_X=train_X, train_Y=train_Y, standardize_model=False
-        )
-        with self.assertRaises(ValueError):
-            acq = qBayesianQueryByComittee(
-                model=non_fully_bayesian_model,
-            )
-
 
 class TestQBayesianVarianceReduction(BotorchTestCase):
     def test_q_bayesian_variance_reduction(self):
@@ -213,13 +184,3 @@ class TestQBayesianVarianceReduction(BotorchTestCase):
                     acq_X = acq(test_Xs[j])
                     # assess shape
                     self.assertTrue(acq_X.shape == test_Xs[j].shape[:-2])
-
-        # Support with non-fully bayesian models is not possible. Thus, we
-        # throw an error.
-        non_fully_bayesian_model = get_model(
-            train_X=train_X, train_Y=train_Y, standardize_model=False
-        )
-        with self.assertRaises(ValueError):
-            acq = qBayesianVarianceReduction(
-                model=non_fully_bayesian_model,
-            )

--- a/test_community/acquisition/test_scorebo.py
+++ b/test_community/acquisition/test_scorebo.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from botorch.utils.test_helpers import get_fully_bayesian_model, get_model
+from botorch.utils.test_helpers import get_fully_bayesian_model
 from botorch.utils.testing import BotorchTestCase
 from botorch_community.acquisition.scorebo import qSelfCorrectingBayesianOptimization
 
@@ -89,16 +89,4 @@ class TestQSelfCorrectingBayesianOptimization(BotorchTestCase):
                 distance_metric="NOT_A_DISTANCE",
                 X_pending=X_pending,
                 maximize=maximize,
-            )
-
-        # Support with non-fully bayesian models is not possible. Thus, we
-        # throw an error.
-        non_fully_bayesian_model = get_model(
-            train_X=train_X, train_Y=train_Y, standardize_model=False
-        )
-        with self.assertRaises(ValueError):
-            acq = qSelfCorrectingBayesianOptimization(
-                model=non_fully_bayesian_model,
-                optimal_inputs=optimal_inputs,
-                optimal_outputs=optimal_outputs,
             )


### PR DESCRIPTION
Summary: Multi-objective extension of BayesianActiveLearningByDisagreement. The acquisition seamlessly extends to multiple independent objectives by summing the information gains over multiple objectives.

Differential Revision: D61347694
