### PR TITLE
Replace tutorials widget with nightly cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Lint](https://github.com/pytorch/botorch/workflows/Lint/badge.svg)](https://github.com/pytorch/botorch/actions?query=workflow%3ALint)
 [![Test](https://github.com/pytorch/botorch/workflows/Test/badge.svg)](https://github.com/pytorch/botorch/actions?query=workflow%3ATest)
 [![Docs](https://github.com/pytorch/botorch/workflows/Docs/badge.svg)](https://github.com/pytorch/botorch/actions?query=workflow%3ADocs)
-[![Nightly](https://github.com/pytorch/botorch/workflows/Nightly%20Cron/badge.svg)](https://github.com/pytorch/botorch/actions?query=workflow%3ANightly)
+[![Nightly](https://github.com/pytorch/botorch/actions/workflows/nightly.yml/badge.svg)](https://github.com/pytorch/botorch/actions?query=workflow%3ANightly)
 [![Codecov](https://img.shields.io/codecov/c/github/pytorch/botorch.svg)](https://codecov.io/github/pytorch/botorch)
 
 [![Conda](https://img.shields.io/conda/v/pytorch/botorch.svg)](https://anaconda.org/pytorch/botorch)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Lint](https://github.com/pytorch/botorch/workflows/Lint/badge.svg)](https://github.com/pytorch/botorch/actions?query=workflow%3ALint)
 [![Test](https://github.com/pytorch/botorch/workflows/Test/badge.svg)](https://github.com/pytorch/botorch/actions?query=workflow%3ATest)
 [![Docs](https://github.com/pytorch/botorch/workflows/Docs/badge.svg)](https://github.com/pytorch/botorch/actions?query=workflow%3ADocs)
-[![Tutorials](https://github.com/pytorch/botorch/workflows/Tutorials/badge.svg)](https://github.com/pytorch/botorch/actions?query=workflow%3ATutorials)
+[![Nightly](https://github.com/pytorch/botorch/workflows/Nightly%20Cron/badge.svg)](https://github.com/pytorch/botorch/actions?query=workflow%3ANightly)
 [![Codecov](https://img.shields.io/codecov/c/github/pytorch/botorch.svg)](https://codecov.io/github/pytorch/botorch)
 
 [![Conda](https://img.shields.io/conda/v/pytorch/botorch.svg)](https://anaconda.org/pytorch/botorch)


### PR DESCRIPTION
The tutorials widget in README.md did not show a status for a long time, since the workflow was renamed to tutorials with smoke test. I looked into using the widget with the new workflow name, but because the name is long, it looks ugly (https://github.com/pytorch/botorch/workflows/Tutorials%20with%20smoke%20test/badge.svg). Since the Nightly Cron includes the non-smoke test tutorials (and has a nicer displaying name), it seemed like a better widget here.

Test plan:

Before:
<img width="870" alt="Screenshot 2024-08-22 at 10 09 25 AM" src="https://github.com/user-attachments/assets/98718a93-3139-4f45-8bb1-3487362d8f45">

After:
<img width="1048" alt="Screenshot 2024-08-22 at 10 18 20 AM" src="https://github.com/user-attachments/assets/49817558-2d18-425e-b5b0-a7fe7282870b">

