### PR TITLE
fix json in hentropy_search.ipynb community notebook

### DIFF
--- a/notebooks_community/hentropy_search.ipynb
+++ b/notebooks_community/hentropy_search.ipynb
@@ -454,7 +454,6 @@
    "language": "python",
    "name": "python3"
   }
-  }
  },
  "nbformat": 4,
  "nbformat_minor": 4


### PR DESCRIPTION
There appears to be invalid json in notebook (from #1794 merged yesterday) due to an extra bracket towards end of the file. This PR aims to fix the json.

## Motivation

The hentropy_search.ipynb community notebook appears to have invalid json. This fixes the issue by removing an extra bracket.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

No additional tests. I did verify that the notebook renders now, both locally and in github.

## Related PRs

This relates to PR #1794 — thanks for the work on that one @sangttruong @saitcakmak @martinakaduc and all. 
