### PR TITLE
[Website] Use mathjax svg renderer

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -74,7 +74,7 @@ const siteConfig = {
     'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
     // Mathjax for rendering math content
     `${baseUrl}js/mathjax.js`,
-    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_SVG',
+    'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS_SVG',
   ],
 
   // CSS sources to load

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -74,7 +74,7 @@ const siteConfig = {
     'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
     // Mathjax for rendering math content
     `${baseUrl}js/mathjax.js`,
-    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML',
+    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_SVG',
   ],
 
   // CSS sources to load


### PR DESCRIPTION
We identified an issue where mathjax would fail to render certain math symbols. This happens on MacOS versions Ventura and later (13+) because of a change in the OS-supplied STIX fonts. We fix this here by changing the renderer from HTML+CSS (which tries to use local STIX fonts) to SVG.

More details on the issue can be found here: https://meta.stackexchange.com/a/389308

| **Before**    | <img width="933" alt="image" src="https://github.com/user-attachments/assets/85a381bf-fb43-46b6-a90b-84a2567b7e30"> |
| -------- | ------- |
| **After**  | <img width="933" alt="image" src="https://github.com/user-attachments/assets/0121a602-a8ad-4f44-b68b-fded891bf04a">    |

### Considerations

The [official docs](https://docs.mathjax.org/en/stable/output.html#mathjax-output-formats) outline a couple considerations for using the SVG renderer, the biggest being lack of IE8 support. If IE8 support is crucial then we should consider alternate approaches.

An alternative fix could be to upgrade our mathjax version as later versions may not be as reliant on local STIX fonts but the 3.0 update was a complete rewrite and appears to [not be a straightforward upgrade](https://docs.mathjax.org/en/latest/upgrading/v2.html).