### PR TITLE
Make BaseTestFunction.evaluate_true accept 1d inputs

### DIFF
--- a/botorch/test_functions/base.py
+++ b/botorch/test_functions/base.py
@@ -55,26 +55,33 @@ class BaseTestProblem(Module, ABC):
         r"""Evaluate the function on a set of points.
 
         Args:
-            X: A `batch_shape x d`-dim tensor of point(s) at which to evaluate the
-                function.
+            X: A `(batch_shape) x d`-dim tensor of point(s) at which to evaluate
+                the function.
             noise: If `True`, add observation noise as specified by `noise_std`.
 
         Returns:
             A `batch_shape`-dim tensor ouf function evaluations.
         """
-        batch = X.ndimension() > 1
-        X = X if batch else X.unsqueeze(0)
         f = self.evaluate_true(X=X)
         if noise and self.noise_std is not None:
             _noise = torch.tensor(self.noise_std, device=X.device, dtype=X.dtype)
             f += _noise * torch.randn_like(f)
         if self.negate:
             f = -f
-        return f if batch else f.squeeze(0)
+        return f
 
     @abstractmethod
     def evaluate_true(self, X: Tensor) -> Tensor:
-        r"""Evaluate the function (w/o observation noise) on a set of points."""
+        r"""
+        Evaluate the function (w/o observation noise) on a set of points.
+
+        Args:
+            X: A `(batch_shape) x d`-dim tensor of point(s) at which to
+                evaluate.
+
+        Returns:
+            A `batch_shape`-dim tensor.
+        """
         pass  # pragma: no cover
 
 

--- a/botorch/test_functions/multi_fidelity.py
+++ b/botorch/test_functions/multi_fidelity.py
@@ -46,7 +46,7 @@ class AugmentedBranin(SyntheticTestFunction):
     def evaluate_true(self, X: Tensor) -> Tensor:
         t1 = (
             X[..., 1]
-            - (5.1 / (4 * math.pi**2) - 0.1 * (1 - X[:, 2])) * X[:, 0].pow(2)
+            - (5.1 / (4 * math.pi**2) - 0.1 * (1 - X[..., 2])) * X[..., 0].pow(2)
             + 5 / math.pi * X[..., 0]
             - 6
         )


### PR DESCRIPTION
Summary:
Context:

Currently, every test function except for `AugmentedBranin` has an `evaluate_true` method that works with 1d inputs. It is actually surprising that so many work, since `BaseTestFunction` is currently written so that `BaseTestFunction.forward` casts inputs to 2d before passing them to `BaseTestFunction.evaluate_true`. So currently, it's not clear if we should expect `evaluate_true` to work with 1d inputs, but nonetheless this is happening downstream.

This PR:
* Requires `evaluate_true` to work with 1d inputs
* Removes the logic that expands the dimension of unbatched tensors in `forward` before passign to `evaluate_true` and then removes the batch dimension in favor of leaving unbatched tensors unbatched everywhere
* Changes `AugmentedBranin` to work with 1d inputs
* Fixes a couple type errors
* Expands docstrings

Differential Revision: D61916387
