### PR TITLE
Update `closed_loop_botorch_only` tutorial to use LogEI

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ For more details see our [Documentation](https://botorch.org/docs/introduction) 
   ```python
   from botorch.acquisition import LogExpectedImprovement
 
-  logNEI = LogExpectedImprovement(model=gp, best_f=Y.max())
+  logEI = LogExpectedImprovement(model=gp, best_f=Y.max())
   ```
 
 3. Optimize the acquisition function
@@ -183,7 +183,7 @@ For more details see our [Documentation](https://botorch.org/docs/introduction) 
 
   bounds = torch.stack([torch.zeros(2), torch.ones(2)]).to(torch.double)
   candidate, acq_value = optimize_acqf(
-      logNEI, bounds=bounds, q=1, num_restarts=5, raw_samples=20,
+      logEI, bounds=bounds, q=1, num_restarts=5, raw_samples=20,
   )
   ```
 

--- a/tutorials/closed_loop_botorch_only.ipynb
+++ b/tutorials/closed_loop_botorch_only.ipynb
@@ -7,7 +7,7 @@
         "showInput": false
       },
       "source": [
-        "## Closed-loop batch, constrained BO in BoTorch with qEI and qNEI\n",
+        "## Closed-loop batch, constrained BO in BoTorch with qLogEI and qLogNEI\n",
         "\n",
         "In this tutorial, we illustrate how to implement a simple Bayesian Optimization (BO) closed loop in BoTorch.\n",
         "\n",
@@ -16,7 +16,7 @@
         "However, you may want to do things that are not easily supported in Ax at this time (like running high-dimensional BO using a VAE+GP model that you jointly train on high-dimensional input data). If you find yourself in such a situation, you will need to write your own optimization loop, as we do in this tutorial.\n",
         "\n",
         "\n",
-        "We use the batch Expected Improvement (qEI) and batch Noisy Expected Improvement (qNEI) acquisition functions to optimize a constrained version of the synthetic Hartmann6 test function. The standard problem is\n",
+        "We use the batch Log Expected Improvement (`qLogEI`) and batch Noisy Expected Improvement (`qLogNEI`) acquisition functions to optimize a constrained version of the synthetic Hartmann6 test function. The standard problem is\n",
         "\n",
         "$$f(x) = -\\sum_{i=1}^4 \\alpha_i \\exp \\left( -\\sum_{j=1}^6 A_{ij} (x_j - P_{ij})^2  \\right)$$\n",
         "\n",
@@ -29,7 +29,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": 14,
       "metadata": {
         "collapsed": false,
         "customOutput": null,
@@ -38,22 +38,7 @@
         "originalKey": "2c0bfbc7-7e42-4601-83ed-4a77270803a8",
         "requestMsgId": "18ccce84-9f39-4c3d-89b1-1e9ed2540859"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "I0214 132746.769 _utils_internal.py:247] NCCL_DEBUG env var is set to None\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "I0214 132746.770 _utils_internal.py:265] NCCL_DEBUG is forced to WARN from None\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "import os\n",
         "from typing import Optional\n",
@@ -79,13 +64,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 15,
       "metadata": {
         "collapsed": false,
         "customOutput": null,
         "executionStartTime": 1668649988205,
         "executionStopTime": 1668649988602,
         "originalKey": "b1c9de4d-a7ba-4782-ab68-2def8b562f7b",
+        "output": {
+          "id": 364616190032149,
+          "loadingStatus": "loaded"
+        },
         "requestMsgId": "96673081-cc25-4ca0-a40d-48756fde8647"
       },
       "outputs": [],
@@ -122,7 +111,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 16,
       "metadata": {
         "collapsed": false,
         "customOutput": null,
@@ -133,10 +122,11 @@
       },
       "outputs": [],
       "source": [
+        "from botorch.models.transforms.input import Normalize\n",
         "from botorch.models import FixedNoiseGP, ModelListGP\n",
         "from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood\n",
         "\n",
-        "NOISE_SE = 0.5\n",
+        "NOISE_SE = 0.25\n",
         "train_yvar = torch.tensor(NOISE_SE**2, device=device, dtype=dtype)\n",
         "\n",
         "\n",
@@ -153,12 +143,18 @@
         "\n",
         "def initialize_model(train_x, train_obj, train_con, state_dict=None):\n",
         "    # define models for objective and constraint\n",
-        "    model_obj = FixedNoiseGP(train_x, train_obj, train_yvar.expand_as(train_obj)).to(\n",
-        "        train_x\n",
-        "    )\n",
-        "    model_con = FixedNoiseGP(train_x, train_con, train_yvar.expand_as(train_con)).to(\n",
-        "        train_x\n",
-        "    )\n",
+        "    model_obj = FixedNoiseGP(\n",
+        "        train_x,\n",
+        "        train_obj,\n",
+        "        train_yvar.expand_as(train_obj),\n",
+        "        input_transform=Normalize(d=train_x.shape[-1]),\n",
+        "    ).to(train_x)\n",
+        "    model_con = FixedNoiseGP(\n",
+        "        train_x,\n",
+        "        train_con,\n",
+        "        train_yvar.expand_as(train_con),\n",
+        "        input_transform=Normalize(d=train_x.shape[-1]),\n",
+        "    ).to(train_x)\n",
         "    # combine into a multi-output GP model\n",
         "    model = ModelListGP(model_obj, model_con)\n",
         "    mll = SumMarginalLogLikelihood(model.likelihood, model)\n",
@@ -181,7 +177,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 17,
       "metadata": {
         "collapsed": false,
         "customOutput": null,
@@ -192,8 +188,7 @@
       },
       "outputs": [],
       "source": [
-        "from botorch.acquisition.objective import ConstrainedMCObjective\n",
-        "\n",
+        "from botorch.acquisition.objective import GenericMCObjective\n",
         "\n",
         "def obj_callable(Z: torch.Tensor, X: Optional[torch.Tensor] = None):\n",
         "    return Z[..., 0]\n",
@@ -203,11 +198,7 @@
         "    return Z[..., 1]\n",
         "\n",
         "\n",
-        "# define a feasibility-weighted objective for optimization\n",
-        "constrained_obj = ConstrainedMCObjective(\n",
-        "    objective=obj_callable,\n",
-        "    constraints=[constraint_callable],\n",
-        ")"
+        "objective = GenericMCObjective(objective=obj_callable)"
       ]
     },
     {
@@ -223,13 +214,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 18,
       "metadata": {
         "collapsed": false,
         "customOutput": null,
         "executionStartTime": 1668649993442,
         "executionStopTime": 1668649993515,
         "originalKey": "f450c171-6984-4114-bf99-99c3a4e68eb2",
+        "output": {
+          "id": 385726674337920,
+          "loadingStatus": "loaded"
+        },
         "requestMsgId": "57d29886-0a14-410b-aaba-596c8559f5a0"
       },
       "outputs": [],
@@ -281,7 +276,7 @@
         "showInput": false
       },
       "source": [
-        "### Perform Bayesian Optimization loop with qNEI\n",
+        "### Perform Bayesian Optimization loop with qLogNEI\n",
         "The Bayesian optimization \"loop\" for a batch size of $q$ simply iterates the following steps:\n",
         "1. given a surrogate model, choose a batch of points $\\{x_1, x_2, \\ldots x_q\\}$\n",
         "2. observe $f(x)$ for each $x$ in the batch \n",
@@ -295,17 +290,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 19,
       "metadata": {
         "collapsed": false,
         "customOutput": null,
         "executionStartTime": 1668649993811,
         "executionStopTime": 1668650936026,
         "originalKey": "f137bf2a-5d39-4c8c-bb24-84326d4ab5d7",
-        "output": {
-          "id": 3649554978648837,
-          "loadingStatus": "loaded"
-        },
         "requestMsgId": "0b4d1d37-a9cf-4f69-a896-0836506ee521"
       },
       "outputs": [
@@ -314,1048 +305,9 @@
           "output_type": "stream",
           "text": [
             "\n",
-            "Trial  1 of 3 "
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:27:48 assorted:202] Input data is not standardized (mean = tensor([0.2733], dtype=torch.float64), std = tensor([0.4715], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:27:48 assorted:202] Input data is not standardized (mean = tensor([-0.4174], dtype=torch.float64), std = tensor([0.7068], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:27:48 assorted:202] Input data is not standardized (mean = tensor([0.2733], dtype=torch.float64), std = tensor([0.4715], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:28:00 assorted:202] Input data is not standardized (mean = tensor([0.3525], dtype=torch.float64), std = tensor([0.4876], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:00 assorted:202] Input data is not standardized (mean = tensor([-0.1566], dtype=torch.float64), std = tensor([0.8721], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:00 assorted:202] Input data is not standardized (mean = tensor([0.3780], dtype=torch.float64), std = tensor([0.5675], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:00 assorted:202] Input data is not standardized (mean = tensor([-0.1304], dtype=torch.float64), std = tensor([0.8767], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:28:15 assorted:202] Input data is not standardized (mean = tensor([0.3792], dtype=torch.float64), std = tensor([0.4548], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:15 assorted:202] Input data is not standardized (mean = tensor([-0.0395], dtype=torch.float64), std = tensor([0.8258], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:15 assorted:202] Input data is not standardized (mean = tensor([0.4358], dtype=torch.float64), std = tensor([0.5339], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:15 assorted:202] Input data is not standardized (mean = tensor([-0.0392], dtype=torch.float64), std = tensor([0.8183], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:28:30 assorted:202] Input data is not standardized (mean = tensor([0.4175], dtype=torch.float64), std = tensor([0.4603], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:30 assorted:202] Input data is not standardized (mean = tensor([-0.0300], dtype=torch.float64), std = tensor([0.7871], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:30 assorted:202] Input data is not standardized (mean = tensor([0.4556], dtype=torch.float64), std = tensor([0.5301], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:30 assorted:202] Input data is not standardized (mean = tensor([0.0638], dtype=torch.float64), std = tensor([0.8431], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:28:44 assorted:202] Input data is not standardized (mean = tensor([0.3935], dtype=torch.float64), std = tensor([0.4372], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:44 assorted:202] Input data is not standardized (mean = tensor([-0.0959], dtype=torch.float64), std = tensor([0.7738], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:44 assorted:202] Input data is not standardized (mean = tensor([0.5355], dtype=torch.float64), std = tensor([0.5411], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:28:44 assorted:202] Input data is not standardized (mean = tensor([0.0237], dtype=torch.float64), std = tensor([0.8017], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:29:00 assorted:202] Input data is not standardized (mean = tensor([0.4641], dtype=torch.float64), std = tensor([0.4725], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:00 assorted:202] Input data is not standardized (mean = tensor([-0.1337], dtype=torch.float64), std = tensor([0.7963], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:00 assorted:202] Input data is not standardized (mean = tensor([0.5354], dtype=torch.float64), std = tensor([0.5118], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:00 assorted:202] Input data is not standardized (mean = tensor([0.0950], dtype=torch.float64), std = tensor([0.8086], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:29:13 assorted:202] Input data is not standardized (mean = tensor([0.5284], dtype=torch.float64), std = tensor([0.5983], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:13 assorted:202] Input data is not standardized (mean = tensor([-0.1167], dtype=torch.float64), std = tensor([0.8570], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:13 assorted:202] Input data is not standardized (mean = tensor([0.6034], dtype=torch.float64), std = tensor([0.5379], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:13 assorted:202] Input data is not standardized (mean = tensor([0.1994], dtype=torch.float64), std = tensor([0.8243], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:29:28 assorted:202] Input data is not standardized (mean = tensor([0.5898], dtype=torch.float64), std = tensor([0.6401], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:29 assorted:202] Input data is not standardized (mean = tensor([-0.1478], dtype=torch.float64), std = tensor([0.8259], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:29 assorted:202] Input data is not standardized (mean = tensor([0.6057], dtype=torch.float64), std = tensor([0.5178], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:29 assorted:202] Input data is not standardized (mean = tensor([0.1903], dtype=torch.float64), std = tensor([0.7890], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:29:44 assorted:202] Input data is not standardized (mean = tensor([0.5681], dtype=torch.float64), std = tensor([0.7064], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:44 assorted:202] Input data is not standardized (mean = tensor([-0.1913], dtype=torch.float64), std = tensor([0.8203], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:44 assorted:202] Input data is not standardized (mean = tensor([0.6277], dtype=torch.float64), std = tensor([0.4990], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:29:44 assorted:202] Input data is not standardized (mean = tensor([0.1455], dtype=torch.float64), std = tensor([0.7886], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:30:02 assorted:202] Input data is not standardized (mean = tensor([0.6288], dtype=torch.float64), std = tensor([0.7457], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:02 assorted:202] Input data is not standardized (mean = tensor([-0.2247], dtype=torch.float64), std = tensor([0.7956], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:02 assorted:202] Input data is not standardized (mean = tensor([0.6372], dtype=torch.float64), std = tensor([0.4828], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:02 assorted:202] Input data is not standardized (mean = tensor([0.1403], dtype=torch.float64), std = tensor([0.7933], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:30:13 assorted:202] Input data is not standardized (mean = tensor([0.6321], dtype=torch.float64), std = tensor([0.7295], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:13 assorted:202] Input data is not standardized (mean = tensor([-0.2260], dtype=torch.float64), std = tensor([0.7651], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:13 assorted:202] Input data is not standardized (mean = tensor([0.7375], dtype=torch.float64), std = tensor([0.6084], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:13 assorted:202] Input data is not standardized (mean = tensor([0.1418], dtype=torch.float64), std = tensor([0.7763], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:30:25 assorted:202] Input data is not standardized (mean = tensor([0.6277], dtype=torch.float64), std = tensor([0.7376], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:25 assorted:202] Input data is not standardized (mean = tensor([-0.2584], dtype=torch.float64), std = tensor([0.7726], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:25 assorted:202] Input data is not standardized (mean = tensor([0.7108], dtype=torch.float64), std = tensor([0.6077], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:25 assorted:202] Input data is not standardized (mean = tensor([0.0704], dtype=torch.float64), std = tensor([0.7945], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:30:33 assorted:202] Input data is not standardized (mean = tensor([0.6160], dtype=torch.float64), std = tensor([0.7854], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:33 assorted:202] Input data is not standardized (mean = tensor([-0.2652], dtype=torch.float64), std = tensor([0.7475], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:33 assorted:202] Input data is not standardized (mean = tensor([0.6736], dtype=torch.float64), std = tensor([0.6210], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:33 assorted:202] Input data is not standardized (mean = tensor([0.0103], dtype=torch.float64), std = tensor([0.8023], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:30:46 assorted:202] Input data is not standardized (mean = tensor([0.6414], dtype=torch.float64), std = tensor([0.7795], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:46 assorted:202] Input data is not standardized (mean = tensor([-0.2269], dtype=torch.float64), std = tensor([0.7911], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:46 assorted:202] Input data is not standardized (mean = tensor([0.7016], dtype=torch.float64), std = tensor([0.6427], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:46 assorted:202] Input data is not standardized (mean = tensor([0.0155], dtype=torch.float64), std = tensor([0.8040], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:30:58 assorted:202] Input data is not standardized (mean = tensor([0.6458], dtype=torch.float64), std = tensor([0.7703], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:58 assorted:202] Input data is not standardized (mean = tensor([-0.2558], dtype=torch.float64), std = tensor([0.7850], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:58 assorted:202] Input data is not standardized (mean = tensor([0.7303], dtype=torch.float64), std = tensor([0.6473], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:30:58 assorted:202] Input data is not standardized (mean = tensor([0.0330], dtype=torch.float64), std = tensor([0.7920], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:31:04 assorted:202] Input data is not standardized (mean = tensor([0.6421], dtype=torch.float64), std = tensor([0.7931], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:04 assorted:202] Input data is not standardized (mean = tensor([-0.2332], dtype=torch.float64), std = tensor([0.7745], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:04 assorted:202] Input data is not standardized (mean = tensor([0.7330], dtype=torch.float64), std = tensor([0.6406], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:04 assorted:202] Input data is not standardized (mean = tensor([0.0029], dtype=torch.float64), std = tensor([0.8178], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:31:16 assorted:202] Input data is not standardized (mean = tensor([0.6627], dtype=torch.float64), std = tensor([0.8222], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:16 assorted:202] Input data is not standardized (mean = tensor([-0.2511], dtype=torch.float64), std = tensor([0.7655], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:16 assorted:202] Input data is not standardized (mean = tensor([0.7176], dtype=torch.float64), std = tensor([0.6282], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:16 assorted:202] Input data is not standardized (mean = tensor([0.0095], dtype=torch.float64), std = tensor([0.8024], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:31:26 assorted:202] Input data is not standardized (mean = tensor([0.6257], dtype=torch.float64), std = tensor([0.8225], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:26 assorted:202] Input data is not standardized (mean = tensor([-0.2089], dtype=torch.float64), std = tensor([0.7925], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:26 assorted:202] Input data is not standardized (mean = tensor([0.7042], dtype=torch.float64), std = tensor([0.6213], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:26 assorted:202] Input data is not standardized (mean = tensor([-0.0026], dtype=torch.float64), std = tensor([0.7856], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:31:36 assorted:202] Input data is not standardized (mean = tensor([0.5965], dtype=torch.float64), std = tensor([0.8144], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:36 assorted:202] Input data is not standardized (mean = tensor([-0.1965], dtype=torch.float64), std = tensor([0.7931], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:36 assorted:202] Input data is not standardized (mean = tensor([0.6865], dtype=torch.float64), std = tensor([0.6127], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:36 assorted:202] Input data is not standardized (mean = tensor([-0.0005], dtype=torch.float64), std = tensor([0.7878], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:31:46 assorted:202] Input data is not standardized (mean = tensor([0.5893], dtype=torch.float64), std = tensor([0.8044], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:46 assorted:202] Input data is not standardized (mean = tensor([-0.2281], dtype=torch.float64), std = tensor([0.8216], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:46 assorted:202] Input data is not standardized (mean = tensor([0.6766], dtype=torch.float64), std = tensor([0.6235], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:46 assorted:202] Input data is not standardized (mean = tensor([0.0016], dtype=torch.float64), std = tensor([0.7704], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:31:57 assorted:202] Input data is not standardized (mean = tensor([0.5766], dtype=torch.float64), std = tensor([0.7922], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:57 assorted:202] Input data is not standardized (mean = tensor([-0.1866], dtype=torch.float64), std = tensor([0.8565], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:57 assorted:202] Input data is not standardized (mean = tensor([0.6880], dtype=torch.float64), std = tensor([0.6248], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:57 assorted:202] Input data is not standardized (mean = tensor([0.0048], dtype=torch.float64), std = tensor([0.7548], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:57 assorted:202] Input data is not standardized (mean = tensor([0.1254], dtype=torch.float64), std = tensor([0.6022], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:31:57 assorted:202] Input data is not standardized (mean = tensor([0.5027], dtype=torch.float64), std = tensor([1.2975], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            ".\n",
-            "Trial  2 of 3 "
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:32:08 assorted:202] Input data is not standardized (mean = tensor([0.0739], dtype=torch.float64), std = tensor([0.5614], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:08 assorted:202] Input data is not standardized (mean = tensor([0.3059], dtype=torch.float64), std = tensor([1.2141], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:08 assorted:202] Input data is not standardized (mean = tensor([0.2051], dtype=torch.float64), std = tensor([0.5907], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:08 assorted:202] Input data is not standardized (mean = tensor([0.4776], dtype=torch.float64), std = tensor([1.1252], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:32:18 assorted:202] Input data is not standardized (mean = tensor([0.2421], dtype=torch.float64), std = tensor([0.7397], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:18 assorted:202] Input data is not standardized (mean = tensor([0.3858], dtype=torch.float64), std = tensor([1.1179], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:18 assorted:202] Input data is not standardized (mean = tensor([0.1629], dtype=torch.float64), std = tensor([0.5363], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:18 assorted:202] Input data is not standardized (mean = tensor([0.2150], dtype=torch.float64), std = tensor([1.2032], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:32:31 assorted:202] Input data is not standardized (mean = tensor([0.4086], dtype=torch.float64), std = tensor([0.7939], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:31 assorted:202] Input data is not standardized (mean = tensor([0.1987], dtype=torch.float64), std = tensor([1.1134], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:31 assorted:202] Input data is not standardized (mean = tensor([0.1204], dtype=torch.float64), std = tensor([0.5100], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:31 assorted:202] Input data is not standardized (mean = tensor([0.2172], dtype=torch.float64), std = tensor([1.1218], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:32:42 assorted:202] Input data is not standardized (mean = tensor([0.5324], dtype=torch.float64), std = tensor([0.9596], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:42 assorted:202] Input data is not standardized (mean = tensor([0.1259], dtype=torch.float64), std = tensor([1.1775], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:42 assorted:202] Input data is not standardized (mean = tensor([0.2220], dtype=torch.float64), std = tensor([0.5402], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:42 assorted:202] Input data is not standardized (mean = tensor([0.0006], dtype=torch.float64), std = tensor([1.2874], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:32:54 assorted:202] Input data is not standardized (mean = tensor([0.6056], dtype=torch.float64), std = tensor([1.0648], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:54 assorted:202] Input data is not standardized (mean = tensor([0.0996], dtype=torch.float64), std = tensor([1.1398], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:54 assorted:202] Input data is not standardized (mean = tensor([0.2459], dtype=torch.float64), std = tensor([0.6041], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:32:54 assorted:202] Input data is not standardized (mean = tensor([-0.0298], dtype=torch.float64), std = tensor([1.2304], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:33:09 assorted:202] Input data is not standardized (mean = tensor([0.6541], dtype=torch.float64), std = tensor([1.0531], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:09 assorted:202] Input data is not standardized (mean = tensor([-0.0220], dtype=torch.float64), std = tensor([1.1516], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:09 assorted:202] Input data is not standardized (mean = tensor([0.3704], dtype=torch.float64), std = tensor([0.7145], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:09 assorted:202] Input data is not standardized (mean = tensor([-0.0785], dtype=torch.float64), std = tensor([1.1710], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:33:17 assorted:202] Input data is not standardized (mean = tensor([0.6305], dtype=torch.float64), std = tensor([1.0355], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:17 assorted:202] Input data is not standardized (mean = tensor([-0.0104], dtype=torch.float64), std = tensor([1.0959], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:17 assorted:202] Input data is not standardized (mean = tensor([0.5133], dtype=torch.float64), std = tensor([0.9123], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:17 assorted:202] Input data is not standardized (mean = tensor([-0.1256], dtype=torch.float64), std = tensor([1.1236], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:33:22 assorted:202] Input data is not standardized (mean = tensor([0.6377], dtype=torch.float64), std = tensor([1.0196], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:22 assorted:202] Input data is not standardized (mean = tensor([-0.0550], dtype=torch.float64), std = tensor([1.0710], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:22 assorted:202] Input data is not standardized (mean = tensor([0.6463], dtype=torch.float64), std = tensor([0.9966], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:22 assorted:202] Input data is not standardized (mean = tensor([-0.1539], dtype=torch.float64), std = tensor([1.0888], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:33:27 assorted:202] Input data is not standardized (mean = tensor([0.5757], dtype=torch.float64), std = tensor([1.0170], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:27 assorted:202] Input data is not standardized (mean = tensor([-0.0256], dtype=torch.float64), std = tensor([1.0642], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:27 assorted:202] Input data is not standardized (mean = tensor([0.6964], dtype=torch.float64), std = tensor([1.0204], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:27 assorted:202] Input data is not standardized (mean = tensor([-0.2024], dtype=torch.float64), std = tensor([1.0637], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:33:33 assorted:202] Input data is not standardized (mean = tensor([0.5354], dtype=torch.float64), std = tensor([0.9934], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:33 assorted:202] Input data is not standardized (mean = tensor([0.0055], dtype=torch.float64), std = tensor([1.0357], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:33 assorted:202] Input data is not standardized (mean = tensor([0.7830], dtype=torch.float64), std = tensor([1.0484], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:33 assorted:202] Input data is not standardized (mean = tensor([-0.2246], dtype=torch.float64), std = tensor([1.0465], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:33:37 assorted:202] Input data is not standardized (mean = tensor([0.5546], dtype=torch.float64), std = tensor([0.9647], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:37 assorted:202] Input data is not standardized (mean = tensor([-0.0322], dtype=torch.float64), std = tensor([1.0190], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:37 assorted:202] Input data is not standardized (mean = tensor([0.8242], dtype=torch.float64), std = tensor([1.0807], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:37 assorted:202] Input data is not standardized (mean = tensor([-0.2051], dtype=torch.float64), std = tensor([1.0388], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:33:40 assorted:202] Input data is not standardized (mean = tensor([0.5227], dtype=torch.float64), std = tensor([0.9521], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:40 assorted:202] Input data is not standardized (mean = tensor([-0.0076], dtype=torch.float64), std = tensor([1.0119], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:40 assorted:202] Input data is not standardized (mean = tensor([0.7937], dtype=torch.float64), std = tensor([1.0924], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:40 assorted:202] Input data is not standardized (mean = tensor([-0.2510], dtype=torch.float64), std = tensor([1.0452], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:33:44 assorted:202] Input data is not standardized (mean = tensor([0.5390], dtype=torch.float64), std = tensor([0.9474], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:44 assorted:202] Input data is not standardized (mean = tensor([-0.0277], dtype=torch.float64), std = tensor([0.9907], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:44 assorted:202] Input data is not standardized (mean = tensor([0.8655], dtype=torch.float64), std = tensor([1.1495], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:44 assorted:202] Input data is not standardized (mean = tensor([-0.2606], dtype=torch.float64), std = tensor([1.0160], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:33:49 assorted:202] Input data is not standardized (mean = tensor([0.5780], dtype=torch.float64), std = tensor([0.9779], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:49 assorted:202] Input data is not standardized (mean = tensor([-0.0618], dtype=torch.float64), std = tensor([0.9771], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:49 assorted:202] Input data is not standardized (mean = tensor([0.8900], dtype=torch.float64), std = tensor([1.1546], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:49 assorted:202] Input data is not standardized (mean = tensor([-0.2629], dtype=torch.float64), std = tensor([1.0080], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:33:57 assorted:202] Input data is not standardized (mean = tensor([0.6193], dtype=torch.float64), std = tensor([0.9771], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:57 assorted:202] Input data is not standardized (mean = tensor([-0.1043], dtype=torch.float64), std = tensor([0.9695], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:57 assorted:202] Input data is not standardized (mean = tensor([0.9010], dtype=torch.float64), std = tensor([1.1830], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:33:57 assorted:202] Input data is not standardized (mean = tensor([-0.2370], dtype=torch.float64), std = tensor([1.0052], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:34:02 assorted:202] Input data is not standardized (mean = tensor([0.5845], dtype=torch.float64), std = tensor([0.9868], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:02 assorted:202] Input data is not standardized (mean = tensor([-0.0820], dtype=torch.float64), std = tensor([0.9546], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:02 assorted:202] Input data is not standardized (mean = tensor([0.9435], dtype=torch.float64), std = tensor([1.1793], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:02 assorted:202] Input data is not standardized (mean = tensor([-0.2761], dtype=torch.float64), std = tensor([1.0077], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:34:10 assorted:202] Input data is not standardized (mean = tensor([0.6265], dtype=torch.float64), std = tensor([0.9853], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:10 assorted:202] Input data is not standardized (mean = tensor([-0.0924], dtype=torch.float64), std = tensor([0.9369], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:10 assorted:202] Input data is not standardized (mean = tensor([0.9787], dtype=torch.float64), std = tensor([1.1862], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:10 assorted:202] Input data is not standardized (mean = tensor([-0.2420], dtype=torch.float64), std = tensor([0.9960], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:34:13 assorted:202] Input data is not standardized (mean = tensor([0.6123], dtype=torch.float64), std = tensor([0.9678], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:13 assorted:202] Input data is not standardized (mean = tensor([-0.0746], dtype=torch.float64), std = tensor([0.9263], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:13 assorted:202] Input data is not standardized (mean = tensor([1.0160], dtype=torch.float64), std = tensor([1.2043], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:13 assorted:202] Input data is not standardized (mean = tensor([-0.2621], dtype=torch.float64), std = tensor([0.9816], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:34:19 assorted:202] Input data is not standardized (mean = tensor([0.5825], dtype=torch.float64), std = tensor([0.9687], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:19 assorted:202] Input data is not standardized (mean = tensor([-0.0862], dtype=torch.float64), std = tensor([0.9230], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:19 assorted:202] Input data is not standardized (mean = tensor([1.0427], dtype=torch.float64), std = tensor([1.2031], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:19 assorted:202] Input data is not standardized (mean = tensor([-0.2598], dtype=torch.float64), std = tensor([0.9646], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:34:22 assorted:202] Input data is not standardized (mean = tensor([0.5553], dtype=torch.float64), std = tensor([0.9707], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:22 assorted:202] Input data is not standardized (mean = tensor([-0.1290], dtype=torch.float64), std = tensor([0.9302], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:22 assorted:202] Input data is not standardized (mean = tensor([1.0351], dtype=torch.float64), std = tensor([1.2100], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:22 assorted:202] Input data is not standardized (mean = tensor([-0.2435], dtype=torch.float64), std = tensor([0.9776], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:22 assorted:202] Input data is not standardized (mean = tensor([0.3545], dtype=torch.float64), std = tensor([0.3441], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:22 assorted:202] Input data is not standardized (mean = tensor([-0.2680], dtype=torch.float64), std = tensor([0.7962], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            ".\n",
-            "Trial  3 of 3 "
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:34:32 assorted:202] Input data is not standardized (mean = tensor([0.4261], dtype=torch.float64), std = tensor([0.5340], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:32 assorted:202] Input data is not standardized (mean = tensor([-0.6275], dtype=torch.float64), std = tensor([0.9777], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:32 assorted:202] Input data is not standardized (mean = tensor([0.3743], dtype=torch.float64), std = tensor([0.3378], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:32 assorted:202] Input data is not standardized (mean = tensor([-0.4575], dtype=torch.float64), std = tensor([0.8915], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:34:43 assorted:202] Input data is not standardized (mean = tensor([0.6648], dtype=torch.float64), std = tensor([0.7171], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:43 assorted:202] Input data is not standardized (mean = tensor([-0.7409], dtype=torch.float64), std = tensor([0.9093], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:43 assorted:202] Input data is not standardized (mean = tensor([0.3962], dtype=torch.float64), std = tensor([0.3885], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:43 assorted:202] Input data is not standardized (mean = tensor([-0.4020], dtype=torch.float64), std = tensor([0.9841], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:34:55 assorted:202] Input data is not standardized (mean = tensor([0.7743], dtype=torch.float64), std = tensor([0.7166], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:55 assorted:202] Input data is not standardized (mean = tensor([-0.7568], dtype=torch.float64), std = tensor([0.8463], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:55 assorted:202] Input data is not standardized (mean = tensor([0.3175], dtype=torch.float64), std = tensor([0.4189], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:34:55 assorted:202] Input data is not standardized (mean = tensor([-0.4621], dtype=torch.float64), std = tensor([0.9163], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:35:04 assorted:202] Input data is not standardized (mean = tensor([0.9228], dtype=torch.float64), std = tensor([0.7735], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:04 assorted:202] Input data is not standardized (mean = tensor([-0.7598], dtype=torch.float64), std = tensor([0.8169], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:04 assorted:202] Input data is not standardized (mean = tensor([0.3610], dtype=torch.float64), std = tensor([0.5045], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:04 assorted:202] Input data is not standardized (mean = tensor([-0.5577], dtype=torch.float64), std = tensor([0.8854], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:35:15 assorted:202] Input data is not standardized (mean = tensor([1.0540], dtype=torch.float64), std = tensor([0.8249], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:15 assorted:202] Input data is not standardized (mean = tensor([-0.8083], dtype=torch.float64), std = tensor([0.7994], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:15 assorted:202] Input data is not standardized (mean = tensor([0.4168], dtype=torch.float64), std = tensor([0.5080], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:15 assorted:202] Input data is not standardized (mean = tensor([-0.6147], dtype=torch.float64), std = tensor([0.8524], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:35:25 assorted:202] Input data is not standardized (mean = tensor([1.0160], dtype=torch.float64), std = tensor([0.8136], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:25 assorted:202] Input data is not standardized (mean = tensor([-0.7390], dtype=torch.float64), std = tensor([0.9137], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:25 assorted:202] Input data is not standardized (mean = tensor([0.5018], dtype=torch.float64), std = tensor([0.5476], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:25 assorted:202] Input data is not standardized (mean = tensor([-0.6296], dtype=torch.float64), std = tensor([0.8479], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:35:36 assorted:202] Input data is not standardized (mean = tensor([1.0463], dtype=torch.float64), std = tensor([0.8390], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:36 assorted:202] Input data is not standardized (mean = tensor([-0.7581], dtype=torch.float64), std = tensor([0.8850], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:36 assorted:202] Input data is not standardized (mean = tensor([0.5743], dtype=torch.float64), std = tensor([0.5818], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:36 assorted:202] Input data is not standardized (mean = tensor([-0.6208], dtype=torch.float64), std = tensor([0.8064], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:35:48 assorted:202] Input data is not standardized (mean = tensor([1.1631], dtype=torch.float64), std = tensor([0.8880], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:48 assorted:202] Input data is not standardized (mean = tensor([-0.7808], dtype=torch.float64), std = tensor([0.8668], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:48 assorted:202] Input data is not standardized (mean = tensor([0.6677], dtype=torch.float64), std = tensor([0.7461], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:48 assorted:202] Input data is not standardized (mean = tensor([-0.6186], dtype=torch.float64), std = tensor([0.8060], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:35:59 assorted:202] Input data is not standardized (mean = tensor([1.2158], dtype=torch.float64), std = tensor([0.9105], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:59 assorted:202] Input data is not standardized (mean = tensor([-0.7430], dtype=torch.float64), std = tensor([0.8541], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:59 assorted:202] Input data is not standardized (mean = tensor([0.7965], dtype=torch.float64), std = tensor([0.8424], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:35:59 assorted:202] Input data is not standardized (mean = tensor([-0.6100], dtype=torch.float64), std = tensor([0.7746], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:36:06 assorted:202] Input data is not standardized (mean = tensor([1.2303], dtype=torch.float64), std = tensor([0.8849], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:06 assorted:202] Input data is not standardized (mean = tensor([-0.7314], dtype=torch.float64), std = tensor([0.8314], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:06 assorted:202] Input data is not standardized (mean = tensor([0.8024], dtype=torch.float64), std = tensor([0.8711], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:06 assorted:202] Input data is not standardized (mean = tensor([-0.5337], dtype=torch.float64), std = tensor([0.7928], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:36:12 assorted:202] Input data is not standardized (mean = tensor([1.1456], dtype=torch.float64), std = tensor([0.9094], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:12 assorted:202] Input data is not standardized (mean = tensor([-0.7164], dtype=torch.float64), std = tensor([0.8053], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:12 assorted:202] Input data is not standardized (mean = tensor([0.8021], dtype=torch.float64), std = tensor([0.8747], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:12 assorted:202] Input data is not standardized (mean = tensor([-0.5722], dtype=torch.float64), std = tensor([0.7890], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:36:18 assorted:202] Input data is not standardized (mean = tensor([1.1029], dtype=torch.float64), std = tensor([0.8993], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:18 assorted:202] Input data is not standardized (mean = tensor([-0.7169], dtype=torch.float64), std = tensor([0.7839], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:18 assorted:202] Input data is not standardized (mean = tensor([0.8495], dtype=torch.float64), std = tensor([0.8904], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:18 assorted:202] Input data is not standardized (mean = tensor([-0.5345], dtype=torch.float64), std = tensor([0.7764], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:36:26 assorted:202] Input data is not standardized (mean = tensor([1.1081], dtype=torch.float64), std = tensor([0.9595], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:26 assorted:202] Input data is not standardized (mean = tensor([-0.6900], dtype=torch.float64), std = tensor([0.8444], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:26 assorted:202] Input data is not standardized (mean = tensor([0.8781], dtype=torch.float64), std = tensor([0.9012], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:26 assorted:202] Input data is not standardized (mean = tensor([-0.5189], dtype=torch.float64), std = tensor([0.7619], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:36:34 assorted:202] Input data is not standardized (mean = tensor([1.0653], dtype=torch.float64), std = tensor([0.9486], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:34 assorted:202] Input data is not standardized (mean = tensor([-0.6231], dtype=torch.float64), std = tensor([0.8772], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:34 assorted:202] Input data is not standardized (mean = tensor([0.8641], dtype=torch.float64), std = tensor([0.8816], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:34 assorted:202] Input data is not standardized (mean = tensor([-0.5111], dtype=torch.float64), std = tensor([0.7444], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:36:41 assorted:202] Input data is not standardized (mean = tensor([1.0327], dtype=torch.float64), std = tensor([0.9331], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:41 assorted:202] Input data is not standardized (mean = tensor([-0.5712], dtype=torch.float64), std = tensor([0.9219], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:41 assorted:202] Input data is not standardized (mean = tensor([0.9016], dtype=torch.float64), std = tensor([0.9030], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:41 assorted:202] Input data is not standardized (mean = tensor([-0.5222], dtype=torch.float64), std = tensor([0.7306], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:36:48 assorted:202] Input data is not standardized (mean = tensor([1.0067], dtype=torch.float64), std = tensor([0.9164], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:48 assorted:202] Input data is not standardized (mean = tensor([-0.5624], dtype=torch.float64), std = tensor([0.9069], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:48 assorted:202] Input data is not standardized (mean = tensor([0.9085], dtype=torch.float64), std = tensor([0.8961], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:48 assorted:202] Input data is not standardized (mean = tensor([-0.4901], dtype=torch.float64), std = tensor([0.7506], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:36:56 assorted:202] Input data is not standardized (mean = tensor([0.9833], dtype=torch.float64), std = tensor([0.9078], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:56 assorted:202] Input data is not standardized (mean = tensor([-0.5367], dtype=torch.float64), std = tensor([0.9050], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:56 assorted:202] Input data is not standardized (mean = tensor([0.8983], dtype=torch.float64), std = tensor([0.8931], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:36:56 assorted:202] Input data is not standardized (mean = tensor([-0.4601], dtype=torch.float64), std = tensor([0.7749], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:37:03 assorted:202] Input data is not standardized (mean = tensor([0.9557], dtype=torch.float64), std = tensor([0.8952], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:37:03 assorted:202] Input data is not standardized (mean = tensor([-0.5011], dtype=torch.float64), std = tensor([0.9009], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:37:03 assorted:202] Input data is not standardized (mean = tensor([0.9365], dtype=torch.float64), std = tensor([0.8924], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:37:03 assorted:202] Input data is not standardized (mean = tensor([-0.4550], dtype=torch.float64), std = tensor([0.7684], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:37:07 assorted:202] Input data is not standardized (mean = tensor([0.9053], dtype=torch.float64), std = tensor([0.9064], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:37:07 assorted:202] Input data is not standardized (mean = tensor([-0.5207], dtype=torch.float64), std = tensor([0.8890], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:37:07 assorted:202] Input data is not standardized (mean = tensor([0.9151], dtype=torch.float64), std = tensor([0.9004], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:37:07 assorted:202] Input data is not standardized (mean = tensor([-0.4307], dtype=torch.float64), std = tensor([0.7606], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "."
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[W 240214 13:37:13 assorted:202] Input data is not standardized (mean = tensor([0.8586], dtype=torch.float64), std = tensor([0.9161], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:37:13 assorted:202] Input data is not standardized (mean = tensor([-0.5021], dtype=torch.float64), std = tensor([0.8843], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:37:13 assorted:202] Input data is not standardized (mean = tensor([0.9372], dtype=torch.float64), std = tensor([0.9005], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n",
-            "[W 240214 13:37:13 assorted:202] Input data is not standardized (mean = tensor([-0.4370], dtype=torch.float64), std = tensor([0.7482], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.\n"
+            "Trial  1 of 3 ....................\n",
+            "Trial  2 of 3 ....................\n",
+            "Trial  3 of 3 ...................."
           ]
         }
       ],
@@ -1364,9 +316,9 @@
         "import warnings\n",
         "\n",
         "from botorch import fit_gpytorch_mll\n",
-        "from botorch.acquisition.monte_carlo import (\n",
-        "    qExpectedImprovement,\n",
-        "    qNoisyExpectedImprovement,\n",
+        "from botorch.acquisition import (\n",
+        "    qLogExpectedImprovement,\n",
+        "    qLogNoisyExpectedImprovement,\n",
         ")\n",
         "from botorch.exceptions import BadInitialCandidatesWarning\n",
         "from botorch.sampling.normal import SobolQMCNormalSampler\n",
@@ -1383,7 +335,6 @@
         "verbose = False\n",
         "\n",
         "best_observed_all_ei, best_observed_all_nei, best_random_all = [], [], []\n",
-        "\n",
         "\n",
         "# average over multiple trials\n",
         "for trial in range(1, N_TRIALS + 1):\n",
@@ -1421,23 +372,25 @@
         "        qmc_sampler = SobolQMCNormalSampler(sample_shape=torch.Size([MC_SAMPLES]))\n",
         "\n",
         "        # for best_f, we use the best observed noisy values as an approximation\n",
-        "        qEI = qExpectedImprovement(\n",
+        "        qLogEI = qLogExpectedImprovement(\n",
         "            model=model_ei,\n",
         "            best_f=(train_obj_ei * (train_con_ei <= 0).to(train_obj_ei)).max(),\n",
         "            sampler=qmc_sampler,\n",
-        "            objective=constrained_obj,\n",
+        "            objective=objective,\n",
+        "            constraints=[constraint_callable],\n",
         "        )\n",
         "\n",
-        "        qNEI = qNoisyExpectedImprovement(\n",
+        "        qLogNEI = qLogNoisyExpectedImprovement(\n",
         "            model=model_nei,\n",
         "            X_baseline=train_x_nei,\n",
         "            sampler=qmc_sampler,\n",
-        "            objective=constrained_obj,\n",
+        "            objective=objective,\n",
+        "            constraints=[constraint_callable],\n",
         "        )\n",
         "\n",
         "        # optimize and get new observation\n",
-        "        new_x_ei, new_obj_ei, new_con_ei = optimize_acqf_and_get_observation(qEI)\n",
-        "        new_x_nei, new_obj_nei, new_con_nei = optimize_acqf_and_get_observation(qNEI)\n",
+        "        new_x_ei, new_obj_ei, new_con_ei = optimize_acqf_and_get_observation(qLogEI)\n",
+        "        new_x_nei, new_obj_nei, new_con_nei = optimize_acqf_and_get_observation(qLogNEI)\n",
         "\n",
         "        # update training points\n",
         "        train_x_ei = torch.cat([train_x_ei, new_x_ei])\n",
@@ -1500,7 +453,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 20,
       "metadata": {
         "collapsed": false,
         "customOutput": null,
@@ -1508,7 +461,7 @@
         "executionStopTime": 1668650937028,
         "originalKey": "8729310f-7438-4d16-a2d5-5c46e5ef1c03",
         "output": {
-          "id": 338045315894746,
+          "id": 804722568408483,
           "loadingStatus": "loaded"
         },
         "requestMsgId": "3e10cd44-d4fa-4efc-941c-07dabdd6689c"
@@ -1517,16 +470,16 @@
         {
           "data": {
             "text/plain": [
-              "<matplotlib.legend.Legend at 0x7fae17b14a00>"
+              "<matplotlib.legend.Legend at 0x7fd6c7bbb910>"
             ]
           },
-          "execution_count": 8,
+          "execution_count": 23,
           "metadata": {},
           "output_type": "execute_result"
         },
         {
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAr8AAAIVCAYAAADYnpdmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAAC9IUlEQVR4nOzddXQbV9oG8EeShZbMzInDzNRgkzKnkDJsYbe4pS/lbmnLzMzdMqSYpm0aTsPMiWNmlC3WzHx/yHbsxiDLIkvP75yeCkZzryaW9Ojqzntl+/btk0BEREREFAbkge4AEREREZG/MPwSERERUdhg+CUiIiKisMHwS0RERERhg+GXiIiIiMIGwy8RERERhQ2GXyIiIiIKGwy/RERERBQ2IgLdgb5g0KBBfmtLFEVUlBQiOT0Lcjm/m/gLj3tg8LgHBo97YPC4BwaPe2AE4rjv37/fre34V0BEREREYYPhl4iIiIjCBsMvEREREYUNhl8iIiIiChsMv0REREQUNhh+iYiIiChsMPwSERERUdhg+CUiIiKisMHwS0RERERhg+GXiIiIiMIGwy8RERERhQ2GXyIiIiIKGwy/RERERBQ2GH6JiIiIKGww/BIRERFR2GD4JSIiIqKwwfBLRERERGGD4ZeIiIiIwgbDLxERERGFDYZfIiIiIgobDL9EREREFDYYfomIiIgobEQEugPU3qRJk1BaUgK5QhHoroQdURB43AOAxz0weNwDg8c9MHjcA0MUBKSlp2Pjxo2B7ko7DL9Bpry8HGXl5YHuBhEREVGvBeOXDobfIJOSksJvqAHC4x4YPO6BweMeGDzugcHjHhiiICAlJSXQ3TgKw2+QWb9+PSpKCpGcngW5nFOy/UUURR73AOBxDwwe98DgcQ8MHvfAaHvcgw3/CoiIiIgobDD8EhEREVHYYPglIiIiorDB8EtEREREYYPhl4iIiIjCBsMvEREREYUNhl8iIiIiChsMv0REREQUNhh+iYiIiChsMPwSERERUdhg+CUiIiKisMHwS0RERERhg+GXiIiIiMIGwy8RERERhQ2GXyIiIiIKGwy/RERERBQ2GH6JiIiIKGww/BIRERFR2GD4JSIiIqKwwfBLRERERGGD4ZeIiIiIwgbDLxERERGFDYZfIiIiIgobDL9EREREFDYYfomIiIgobDD8EhEREVHYYPglIiIiorDB8EtEREREYYPhl4iIiIjCBsMvEREREYUNhl8iIiIiChsMv0REREQUNhh+iYiIiChsMPwSERERUdhg+CUiIiKisMHwS0RERORHDouI9+bl4715+XBYxEB3J+ww/BIRERFR2GD4JSIiIqKwwfBLRERERGGD4ZeIiIiIwgbDLxEREVEI8/cJdg6LiA+OL8TiKxCUJ/RFBLoDnamtq8PvS1dg774DqK2rh1arQWJCPKZPm4wJ48ZALu8+twuCgD9XrMb6DZtRWVUNhUKOjPQ0zJ0zE6NGDPPL8yAiIiKi4BGU4bewqAQvvPIGIAHHTJuM9LRUmEwmrP5rPT74+HPs3XcAl160oNv9vPPBJ9i2fRdGDB+KObOmw+l0YvXadXjj7Q9w/rlnYcYxU/zyfIiIiIgoOARl+P3mux9htdpwy43/woDcfq23T50yEQ8/9gzWbdiME4+fi6TEhE73sXX7TmzbvgsTxo3BFZde0Hr75Inj8OiTz+ObRT9hzKgRMBj0Pn8+REQUuiyCgOnbtgEAVo0eDa1CwfbYXpesotDustLHs1AD3Z46yOJmUM75HTNmJM48/eR2wRcAtBoN+mVnAQDq6uq73Me69ZsAAHPnzGx3u0qlwvRpk2G327Fp63av952IiIiIgldwRfFms2dM6/B2QRBQWlYOhUKBlJTkLveRl18ApVKJjPTUo+7r3y/btU1efqdtERERkf85rSJuWBjnurxIBCJ9OxLr7/Yo8IIy/LZltdpgs9lQWVWNJX8sQ3VNLc6dfzqiowxdPqapyYTEhPgOT4yLjY0BAFRV17jVB1H035mKLW35s03icQ8UHvfA4HH3rrbHURRFiDJZl9v19ri72563BLw9Lx2vzvbj7fZ60id/tRnQ9iQp6N5rgj78PvviaygpLQMApKel4qbrrsbAAf27fIzVZgMAqNXqDu9Xq1y3W61Wt/pQUVLYw173XlVZsd/bJB73QOFxDwwed++wSlLr5cqyYmi6CYe9Pe49ba+3/N2eySoBcLVRVV4Ks8Y77XV23H3VXlf83WYg26upKIO1wffHtCeCPvxedP45aDKZUFtbh3XrN+HFV9/Ciccfi1NOPK4Xe3W9kGVuvoCT07N60VbPiKKIqrJiJKZmuFXOjbyDxz0weNwDg8fduyyCAFTXAQCSUjM6PWHKW8fd3fa8xd/tNZocAFyDXokpaTBEKnu1v+6Ou7fbc4e/2wxke/HJqYjWq3zaXmu7Bw+6tV3Qh9/srIzWy9OnTcbrb3+Anxf/jsyM9E5r9Wo1GqDNCPDftdyuad6uO4H4cJDL5fxQCgAe98DgcQ+MUD3uDouIj09z/WJ38Q9ZUGp9+xzlbUZG3TmmvT3uPW2vt/zeXpv9e7O9zvblq/a664s/2wxoezJZ0L3PBFdvuiGTyTBl0ngAwM5dezrdTq1WITrKgPr6hg7nmdTUNH+DTeq8VBoRERERhZ6gC7/V1TW498HH8PxLb3R4v8PhANw4YWBAbj84nU4UFBYddd+Bg3kAgEHdzB0mIiLqTku1gBsWxsFpDa4Te4joaEEXfuPiYiGXy3Ew7zAOHjrc7j5JkvBXc/3eAbmu4CoIAsorKlFTW9du22lTJwMAfl+6ot3tZrMFq9auQ2SkDmNHj/TxsyEiIurbGO4p1ATdnF+5XI4LF5yN1958D6+88S6mT52E9PQ0WCxWbNq8FYcLCpHbvx8mjh8DAKivb8DDjz2DrMx03HHbTa37GTJoAKZOnoC16zbitTffw9gxo2Cz2bB85RoYjY248vKLoNVqA/hMiYiIiMjfgi78ojm43nPHLfh96XLs2rMPK9esg0wmQ3JSAs449STMmT0dCjfONr1wwdnIyEjHmrXr8dmX30ChUCAnOwsXLJiPgbmc8kBEREQUboIy/AJAUmICLlxwdrfbxcfH4ZXnn+jwPrlcjtkzpnEVNyIiIiICgnHOLxERERGRrzD8EhEREVHYYPglIiIiorARtHN+iYiI6GgtpccAwLlIBCJ9u9wwUajhyC8RERERhQ2GXyIiIiIKGwy/RERERBQ2GH6JiIiIKGww/BIRERFR2GD4JSIiIqKwwfBLRERERGGD4ZeIiIiIwgbDLxERERGFDYZfIiIiIgobDL9EREREFDYYfomIiIgobDD8EhEREVHYYPglIiIiorDB8EtEREREYYPhl4iIiIjCBsMvEREREYUNhl8iIiIiChsMv0REREQUNhh+iYiIiChsMPwSERERUdhg+CUiIiKisMHwS0RERERhg+GXiIiIiMIGwy8RURhxWER8cHwhFl/huuyP9t6bl4/35uX7pT0iou4w/BIRERFR2GD4JSIiIqKwwfBLRERERGGD4ZeIiIiIwgbDLxEFNYsgYPzmzRi/eTMsghDo7hARUR/H8EtEREREYYPhl4ioDX+PNPu7PasodHg5VNoLVJtE1Hcw/BIRERFR2GD4JSIiIqKwwfBLRERERGGD4ZeI3MbKC0RE1Ncx/BIRERFR2GD4JSIiIqKwwfBLRERERGGD4ZeoDzPbJaTe2YjUOxthtku+b88hdXg5lNoMxHMkIiL/Yfgl8iKeEEZERBTcIgLdASKicOa0irhhYZzr8iIRiFQEuktERCGNI79EREREFDYYfomIiIgobDD8EhEREVHYYPglIiIiorDBE96IiNpodwLaVyKgCXSPiIjImzjyS0RERERhg+GXiCiAQn0Rj3BYGIWI+haGXyIiIiIKGwy/RERERBQ2GH6JiIiIKGyw2gMREVEvWEQRf51ghlUroaiiBMqIjseVJEmCxWSCtqgIMpnM4/YcThGHzjQBQJfteUtfb6+74+7v5xeINgPZ3nyftuQZhl8iIqJeeLOqHBvnWgEAO+tt3T/A6sY23ZkG99vzhlBor6vj7u/nF4g2A9ReMGL4JerDLKKAtPMONF8eBR1f0kR+tdNkwnf1NQCAMSs0GHNWFNQqRYfbSpKEJmMD9FHRvRr5tdkF7P60EQAw7AJDp+15S19vr7vj7u/nF4g2A9keBvq0KY/06pOyrLwCO3fvRW1tHebMmo6kxAQAQH19A2Jior3VRyIioqDjkCT8t7AQEoDBm1SY/qMOJ1+ehOQYVYfbi6KICsGO5JQUyOWe/+xcUW/Hz787AQAn/6vz9rylr7fX3XH39/MLRJuBbM98jYRgS4Qeh98vv/key1euab0+buwoJCUmQBAE/PfJ5zBx/Ficd/YZ3uonERFRUPm0shL7LRYY5ApM/1EX6O4QkZs8+uq5dt0GLF+5BgNy+x0VcB0OJwYNyMWKVWuxdt0Gb/WTiIgoaJTabHijrAwAcGV8CrQmFk8i6is8erWu+WsD+vfLwc03/BMTx49pd59Go8bV/7gEA3L7YfXa9d7qJxERUVCQJAmPFxXBKooYp9fjOH1MoLtERD3g0bSH0rJynH7KiV1uM37saPzw06+e9gtmswVLl63Eth27UF1TC5kMSE1JxrQpkzBtysRuTxZYt2EzPvzk807vT01Jxr133upx/4iIKDz9UV+P1UYjImQy3J2VBZnV85PXiMj/PAq/giBAo9F0uY1KpYLd4fCoU/UNRjz9/CtoaDBi8sRxOHb2DFgsFqxasw7/+/xrVFRWYv4Zp3a5D4vFAgCYO2cmcrIzj7pfq+26/0RERH/XKAh4qrgYAHBFcjL6aTSosNoD3S0i6gGPwm9sTAyKiksweeK4TrfZvnMX4mI9+yno+x8Xo66uHufOPx2zZx7TevuUSRPw0GNPY+myVZh37CxEGQyd7sNsdoXfYUMGYcjgIKyzQUREfc4rJSWodjiQpVbjipSUQHeHiDzg0Zzf0SOHY9Waddi1Z1/rbTK4fvaprKrGJ599hW3bd2H0qBEedSo2NhpjRo/AtCkT292u02mR2y8HkiShtKyiy32Ym0d+tVqtR30gIiJqa4fJhK+qqwEAd2VlQd2LcmVEFDgejfyecNwc7Ni9B6+9+R50Ole4/PB/X8BmtcFkNgMAUpKTcPy82R516rSTT+j0vpZQq+sm1LaM/Lb0TxRFiKKIiAguAkBERD3TtqbvqXFxmNTFL49EFNw8SoJarRb/d/MN+GXJH9i4eSsAC2pr64DmKRHjx43GiccdC41G7dXOlpSW4eChw0hKTEBmRlqX27aE5LXrNmDL1h2orqmFKIqIj4/DtCkTcdyxs6BQuLfCiSiKXul/T9ryZ5vkvePe9vGiKELsxSpOHrXn478bb7fnznHv688xuNuTQu75+arN/1VW4oDFgmiFAv9OSzuqDXfa89n7TIj9G/r7fSZU/kaDtz3fv8/0lMfDoBqNGmedfjLOOv1kWCwW2Gx2aDQarwfeFnV19XjznQ8hk8lw4YKzu6320DLyu3HTVkyfNhmpqSkwGhuxfOUa/PDTr8jPL8Q/r7rMrSUmK0oKvfY83FVVVuz3Nqn3x90qSa2XK8uKofFx+K2zH2mvqqwETlXfbK+r4+7v51jdKAHN07iqy8sAU+i2V1tZDrkltJ6fL9qsEAS8UdsAALhCp4GtohRtJ971tL3evs+E09+oN9vr7LiHwt9oMLfnj/eZnvLKHACtVuvTubUFhcV44+33YTKZcfkl52PggP7dPub0U06A1WpFbm4/aNtUppgyaTyeeOYl7Ni1B9t37sbokcO73Vdyelavn4O7RFFEVVkxElMzerX8JfWMt467RRCAatevIEmpGdC6+euCpyKsTqDB1V5iajriNb6d1uPt9tw57v5+jqi3AygHACSkpPp+qdMAtheXlILkON8MWHTUnl+en5fblCQJjx0+DBuAcZGRuLD/gKMHTdxsz2vv72H0N+qN9ro97n38bzTY2/PL+0yzxoMH3drOo0+Rnxf/3u02EiSIgojTTul8/q47Nm7aio8/+woqlRLX/+tKDBqY69bjBuT26/B2hUKB2TOn4ZPPvsaevfvdCr+BCKFyuZzhNwB6e9zlbUZ+/fFv2Hb/fbm9rvYVKs8xONuThdzz83abS+rqsNpohFImw93Z2R1Ol+tpe71+nwmrv1Hfv8/09b/R4G/P9+8zPeVZ+P21+/Dbojfh9/ely/Ht9z8jLTUF/7zqMiTEx3m8r7ZaSqRZrFav7I+IiEJPo9OJp4uKgDY1fYmo7/Mo/F58wbkd3i4ITlRX12LD5q3IzsrA7BnHdLidO1asWotvv/8ZQwcPxFVXXNKjucQ2mx279uyFXC7HmA7KrZVXVgEA4mJjPe4fERGFtpdLS1HjdCJbrcblrOlLFDI8Cr9TJo3v8v6TT5yHF155E9U1NW7Nz/27vMP5+PKb75HbPwf/vPpyKLsoTyYIAqqqa6BUKhEf5wqzEREKfPH1IlitNty98GYkJSa0bm82W7Bs+SrIZDKMGzOyx30jIqLQt72pCV831/S9mzV9qQ8T7BJKV1tar6+9txpKhW9PQHMIkhtbBY5PzhxRKpU47tjZ+Gnxb5g6eaIbj2jvy29+gCiKGDl8KHbs3N3hNqkpyUhNSUZ9fQMefuwZZGWm447bbgKa5/WeO/90vP/RZ3jmhVcxY9oUJCYmoK6uHqvW/IW6+gacfOI8ZGak9/q5EhFRaGlb0/e0uDhMYE1f6oMaih3Y/1MjDixpgq3hSKmxur1cjttnp01HRRlQWVXt0WMLi1zlSL774ZdOtzn5hHk45aTjOr1//NjRiI2Jxh/LVuKvDZvQaGyESq1CdmYGzj/3LIwYPtSjvhERUWj7X0UFDlqtrpq+GRmB7g6R2wS7hILVJuz7qQnlW4+c16SOk8NW6wrA426PRXSkb6vmNJic2Px0nU/b6A2fPfsdu3a3rq7WU688/4Tb28bHx3W6ff9+OejfL8ejPhARUfgpsdnwRlkZAOCWjAzEclVQ6gMaihzY93MjDv7aBJuxeZRXBmRM1GLwqQYoByuweIHr7zplitbnpc4q6u0AQiz8fvS/Lzu9TxAEVFRWoqi4FOPHju5N34iIiPxGkiQ8VlQEmyRhvF6PU+O8U2GIyBecdhGFq8zY92MjyrfbWm/XJSgw6CQ9Bp5ogD7ZFfNcYZRaeBR+123Y1O02mRlpOOuMUzzZPRERkd/9VleHtS01fbOy3FoBlMjf6gvt2P9zEw4uOTLKK5MDGZO0GHSKARmTtJD7+IS2vs6j8Pvv66/p9D6FQo7o6OjWygtERETBrtHpxNPFrvNN/pGSghzW9KUg4rSLKFhpxr6fGlHRdpQ3UYFBJxkw8EQ99EmcouMuj46UJ+XLiIiIgtVLbWv6JicHujtEAID6gjajvI1tRnknazH4FAPSJ3KU1xP8mkBERGGtbU3fe7KyoGJNXwogp63NKO+OI6O8kYkKDDrZNcobmcj41htuHb0bbrnTo53LZDK89OxjHj2WiIjI1xyShEcKCwEAp8fHYzxr+lKA1BfYse+nRhz8zQR7m1HezCmuubzpEzjK6y1uhd/YmBhw3j8REYWajysqcMhqRUxEBP6dzoWPyP9KlpuxcWkNKne1GeVNajPKm8BRXm9z64g+/B/PRn6JiIiCVbHNhrdaavqmpyOGNX3Jx5xWEfVFDpTsObLc8LaX6oGWUd6pOgw+RY+08Rzl9SWfvdL37juADZu24JILz/NVE0TdsggCpm/bBgBYNXo0tApFoLtEREFAkiQ83lzTd6LBgFNY05e8yN4kor7QjvoCBxoKHagvcKC+0IGmCicgtd9Wm6jA0FMNGHiCHjqO8vpFr46yIAhobDJBFIV2tzvsTqzfuBmbt+5g+CUioqCzpLmmr0omw12ZmazpSx6xNgitwba+wI6G5svmaqHTx2hi5NClRaB2t2vhidkvJyElXu3HXpNH4VeSJCz6cTGWr1wDh8PR6XYpyUm96RsREZHXGZ1OPNOmpm82a/pSFyRJgqVGaA64LaO4djQUOmCtFzt9nC5BgZgsJaKzlYjJViEmW4mYLCU00QpU1Nvx8zmlAAAZpzf4nUfhd9mK1fh96XJo1GokpqagtKwcSYkJkMlkqKyqhlajwbixozB7xjTv95iIiKgXWmr65qjVuIw1fakNc6UTxfudbUKuAw0FdthNUqeP0adEICZL6Qq32UpEZykRk6WCSs+SecHKo/C7dt1G9MvJxo3XXgmnU8DCex7EBQvmY2Buf9TXN+Dzr76Dw+FASgrfVIiIKHhsbWrCN6zpG3QcFhG1h+yoOWhHya4jJ4P9dnmZV6akSCIgkxd3fJ90JNguu66yw21kcsCQFuEawW0OutHZSkRnKKHU8m+or/Eo/FZWVePc+adBpVJBECzt7ouJicZVV1yMp557Bb8tXY7jjp3lrb4SERF5zCGKeLS5pu8Z8fEYx5q+AWEzCqg56Aq6tQfsqDloQ0Px0SeCAYCjSUKHd3ik8ykKLWQRQHSGss1Irmu6QlS6EgoVpyeECo/Cr0wmg1KpAgAoms+et9uPzP1VKBSYPHE8Vq5ey/BLRERB4aPKShyyWhHLmr5+Y65xouaAvU3YtaGpouOTwXTxCsQPVEGdqcDBL5sAADNfSEJClLJXfRBFEdUVZUhIToW8g5H+aqMDK/7tGvE94ZNUpPLks5DnUfiNjjKgtKwcAKBSqRARoUBZeQWGDx3cuo1Go0Zdfb33ekpEROShIpsNbzfX9L01PR3RrOnrVZIkoan86KBrqet4tNWQFoH4ASrED1AhboAK8QPV0Ma6BtMq6u2t4VefHoHomN6HX6sciE5Xdhh+rfVHRpZZWzc8ePTqHzpkEP5cvgrRUVGYM+sYZKSnYemfKzB4YC4yM9LRZDJhzV/rEcWflIiIKMAkScLjhYWwSRImGQw4iTV9e0UUJBiLHa6Q2xx2aw/aYW86OujK5EB0lrJd0I0boIJaz5rrFDgehd/j5s7Cth27sHf/AcyZdQzmzJqO9z78FE888xLUKhXsDgckScIJ8+Z4v8dEREQ98GtdHf5qbGRN3x4QBQnWOgGmagHlBdbW29fcXYWmQiec1qPn4cqVQGyOK+TGD2wOuv1ViNDwhDAKLh6F37jYWNy98GaUlVcAAMaPHQ2bzY7fly5HTW0d4mJjMHH8WJx4/LHe7i8REZHbGgUnnilxneV/ZUoKsljTF06bCHO1AFOVE+YawXW52glzlQBztROmGgGWGgFSBzMW6ve7zu+J0MgQl9s+6MZkq6BQ8osFBT+PJz3pIyMxMLd/6/VpUyZi2pSJ3uoXEREAwGkVccNC18/Uzq9EgNmFeuC92grUOp3op9GEfE1fSZJgM4ow1zQH2+rmMFsttLtsb+y+6gGapyxo4xRQxcpRf8AVesfcHIN+o3SISldyfiz1WR6F33seeBSTJ47D5InjkZyU6P1eERER9VJpjgOLGxuB5pq+yhCp6Ss6jkw52PJ8HUSj2BxuBQh298qCRWhk0MUroEuMQGSCov3lBNf/NbEKyBWydquRpU3XISZG5bPnRuQPHoVfk8mEJb8vw5LflyEnOxNTJk3A+LGjoNVqvd9DIiKiHhIUEpbNNwMAzoyPx1i9PtBd6jVRkHBwSRM2f3SkklLZKstR26mj5YhMiIAuQQFdggKRiRHQxStctyW6blNFyjn3mcKWR+H38Ufux7ZtO7Fx81bsO3AI+QVF+OrbHzBqxDBMmTQeQ4cM4ouKiIgCZstMK2pTBETLFbipj9f0FQUJh/80YctH9Wgscba7b8ilUUjOVLWO1uriI7gYA1E3PAq/GrUakyeNx+RJ49FkMmHzlu3YuHkrNm/djs1btyMqyoBJE8ZhysRxXOKYiIKaVRRR7XC0/nfYaMWGE8wQI4CymnLomnz7U7nZJiLvFNcIpb/bK62tQKTZtyWn/P38AKDJJmDDPNeI6DXxqX22pq8kSshfYcaWD+vRUOiac6uOlqPfmXrs/cAIAOh/uh7JnIZA1CO9fkfQR0Zi5vSpmDl9Kurq67Fp8zZs2bYDvy9djj/+XIGXnn3MOz0lInKTJEkwtQm1VW3Cbbv/nE40CR2sNjXX9b8tDdaj7/OFWQFqz2gFjH5sz1/PDwCUQOb+CMzuF+2/Nr1EkiQUrrFgywd1qMtzhV6VQY6R50Zh6FlRqLU5W8MvEfWcV78OG/R6JCcnITMjHTW1dWhqMnlz90QU5iRJQr3T2XmYbQ601Q4HrKJ7Z7QDgFomQ4JSiQSlEgYo0LDEhgiHDP3P0CNS7duRSpNNRN4i12pW/m6v3+mR0Gt8O/Lr7+fX0mbh100YsUYD2Yl9ZwqAJEko2WDBlvfrUb3fDgBQ6mQYfk40hs+PgkrffOxsge0nUV/X6/ArCAJ2792PTVu2YefOPbDabJDJZBg0MBeTJozzTi+JKOw4RBHbTCb8UVuHldca0RQj4vXDdXDCvbPZASBSLm8NtR39lxgRgQSVCnr5kZN/Kurt+HmR68z2k/+R4vOflCvq7fj558C0d+LlyUiN823tOH8/v9Y2l5T6vB1vkSQJZVus2Px+Pap2u5JthEaGYfOjMOKcKKijuBoakTd5FH5FUcTefQewact2bN+5CxaL66estNQUTJowFhPHj0V0dJS3+0pEIUySJBTYbPjLaMRfRiM2NjXB0jJ626/9ttEKxdFBtoNwqw2R0lYUusp3WLHlvTqUb3eFXoVKhiFnGDBqQTQ0MQy9RL7gUfi9675HYDK7TmCIjjJg2pRJmDRhLNLTUr3dPyIKYUanE6tsduwtKsK6xkaU2e3t7o+LiMBoTSQUbzsRU6XAqU+lYEicLmTqtVL4qtpjw+b361C6yTV4JFcCg08xYNQF0dDF980T9Ij6Co9eYQ6nA5MmjMOkieMweGAuy5oRkVuckoRdJhPWGo34q7ERu0wmuMZ2XXNClTIZxur1mGIwYEpUFAZqtahqcODnza6fsJMiVAy+1Kc15AM7X69E8TpX6JUpgEEn6THqwhjokxh6ifzBszq/D98PlUrp/d4QUcgpaZ7KsNZoxPrGRpj+diJapkKO6XHxmBoVhXF6PbQK/tRLoafusB2bP6hD4SoAsEImBwYcp8foi6NhSOXnKZE/eRR+GXyJqDMmQcDGxkb81diItUYjimztT02PVigwyWDA1KgoTNTrIasqR3J6OuQc0aUQ1FDkwJYP63F4mQmQAMiAfrN1GHtZLKIz+FlKFAj8jYWIekWQJOw1m10nqjU2YltTE9pWzlUAGNU8lWFqVBSG6HRQNE+VEkURFQHrOZHvGEsd2PpRPfL+MEFq/rEje4YWGSdYMGBSAr/sEQUQwy8ReWRxXS12Wk1YZzSi4W8LRWSq1a3zdicYDNBzKgOFCUuVE6vfMeLAkiZIzS+LzKlajL0sBrH9lagoKQx0F4nCHsMvEbnN3ma+7rNlxa2XI+VyTGoOu1OiopChVgeoh0SBtfzGSohO1+X0ia7QmzjE9XoQe7DwChH5DsMvEbmlzG7HrfmHWq8P0eowI9oVdodHRkLJqi8U4px2EU1lThhLnDCWOmAsdqKx1IG6YkfrNqITSBmjwbjLY5A8wrcLiBCRZ3odfiVJgslkhlargYI/bRKFpHVGI+46fLjd9IYX+w1AvIbfnym0OG0iGkubw22JE8YSh+t6iQOmKgHdLTA4+YF4DJtu8Fd3icgDHn9yVVXX4PsfF2P3nn2wOxy46fqrMTC3PwDgm0U/4pgpk5GcnOjNvhKRn0mShPcrKvBqaSlEAAM1WhywWgLdLaJecVpFGEvbB9uW0VxzldDlY5U6GaLSlTCkRSAqXYmo9Ag4o4C/7qsBAMSP4JQfomDnUfitqanFU8+9DLPZgpjoKNjarMrU2NSEZSvWYP2GLbj9luuREB/nzf4SkZ80CQIeLCjA0vp6AMAZ8fG4OjEVp+7dGeiuEbmtbK0FFfXmI2G3xAlzTdcBVxXZHHDTlYhqDrmG9AhEpSmhiZEftbBTRb29030RUfDxKPwu/m0pBKeAm667GhnpaVh4z4Ot9xn0etx+83V48dW3seT3P3HhgrO92V8i8oPDFgtuz8tDvs0GpUyGhZmZOCs+HrW2rkMDUaAJDgl7Pmhovb7lmboOt1MZ5IhqDrRR6REwNP8/Kl0JddTRAZeIQodH4XfvvoOYfswUDBqYC4vl6J9AszIzMGPaZGzass0bfSQiP/qjrg4PFBTALIpIUirxZP/+GBkZGehuEXWrodiB5Y9WoWb/kZHYmIFKxGer2oXbqLQIqKN4jgpRuPIo/BqNRqSnpXS5TWpqCowrVnnaLyLyM6ck4dXSUnxQ4Vp2Yrxej8f79UOckqtQUfA7+FsT1r5YA6dFglIvg6PJdWbatMcSkRyj8nn7jREymCLkOFglos7a8S8koiihpkaBOoUIubybM+e6UNMoolzjCu9dtectfb297o67v59fINoMZHvByLPljdUqmM1dn/TS0NAAlcr3bzhE1Ht1Dgfuys/HhsZGAMAlSUm4IT0dEfzpl4Kcwyxi7Ys1OPS7CQCQMkqNodfH4M9/+m/twI83OPHM6FhIMhlefMcBwNHF1jEAvHDS6IgYAHCjPS/p8+11c9z9/fwC0WaA2rvc9y31mEfhNzsrE+s2bMKsGdM6vL+6ugZLl69CdlZmb/tHRD62y2TC/+XlocLhgFYux3+ys3FcbGygu0XUrep9Nix7tAqNJU7I5MCYS2Mw6oJoVDX6KbwAeOFPG57+QwBkMugcIjTRcsjlnXxplCSIouha2rgXXyxFUYKtwbVghrqr9rykz7fXzXH39/MLRJuBbC8YeRR+586ZgVdefxfPvvg6Ro8cBgA4cCAPpaXlyMsvwNZtOyGKIubOment/hKRF31bXY0niorgkCRkq9V4qn9/5Gq1ge4WUZckUcKur43Y9E4dRCcQmaTArLsT/bqohCRJePI3O55f6ppfPLfEjGPLLDjlq7ROp1mIooiKkkIkp2e5gpiHKurt+PmcUgDAyV205y19vb3ujru/n18g2gxke0DX02QDwaPwO3TwIFxw3nx89e33OJxfAAD4+dffW+9XKiNw3tlnYcigAd7rKRF5jU0U8WRREb6rcdUmnR0djQdycmDgQjUU5Cx1AlY+WY2SDa6fsLNn6HDMrfFQG/z3tytJEh762YbXV7pGmG+eo0DSU6x/TdRXeLzIxTFTJ2H0qOHYtn0XysorYLPZoNFokJaaglEjhiEyUufdnhKRV5TZ7ViYl4fdZjPkAK5NS8PlycmQc34vBbmSjRasfKIKljoRCpUMk6+Lw6BT9H4tSyaKEu79wYb31rqC7yOnqXHqcOBnv/WAiHrLo/C7Z99+DBk0EPrISBwzdZL3e0VEPrHeaMRd+fmodzoRrVDg0X79MCUqKtDdIuqS4JCw+f067PzcCACIyVFi9r2JiM3x70nVgihh4Tc2/G+jAzIZ8ORZalw8ScVFLoj6GI/C7yuvv4uY6ChMmjgOkyeM5zLGREFOkiR8WFGBl5uXKR6i1eKp/v2RpuZSrBTcjKUOLP9vFar3uQLmkNMNmPjPWESoPZ8z6wmnIOGmL634dqsTchnwwnkanDOWZQCJ+iKPwu/4caOxc+ceLPl9GZb8vgw52ZmYMmkCxo8dBS1PliEKKqbmZYr/aF6m+PT4eNyRmQlNL064IfKHQ380Ye0LNXCYJagMcky/LR7Z0/2/4IrdKeG6z6z4aacTEXLg1fM1OG3UkeCrlSs6vOwrbK9vtxeINkO9vZ7yKPxecckFsNsd2LFzNzZu3orde/cjv+BbfPXtDxg1YhimTBqPoUMGcXlIogA7bLXi9kOHkG+zIUImw8KMDMxPSOBrk4KawyLir5dqcHCJq3Zv8kg1Zt6VCH2Sx6epeMzqkHD1Jxb8vleASgG8dZEWxw/zfz+IyHs8fgWrVEqMHzca48eNhsViwZZtO7Bx8zZs2bYDm7duR1SUAZMmjMOZp53k3R4TkVuW1tXhP1ymmPqY6gM2LH+kCsbm2r2jL47B6IuiIVf4/wub2S7hio8sWHFAgCYCePdSLeYMYvAl6uu88irWarWYNmUSpk2ZhMbGJmzasg2//v4nfl+6nOGXyM86Wqb4sX79EO+FZYqdVhE3LIxzXf5KBPxXVpVCnCRJ2P21ERvfdtXu1SW6avemjAzMH1mTTcIl71vw12EBOhXw0WVaTMtl8CUKBV57JdtsduzYuRtbtu/Avv2HYLVaoVZzeWMif6pzOHB3fj7WNy9TfHFSEm7kMsUU5Cx1AlY9VY3i9a5auVnTdZh+azzUUYGZK9hgkXDRe2ZsKhRhUAOf/EOHidnBN2+RiDzTq/Brtzuwc/cebNqyDbv37IPD4YRMJsOQQQMwaeI4jB45wns9JaIu7beY8XBxQesyxfdnZeH4uLhAd4uoS6WbLVjxeDUstQIUSmDStXEYfJohYPPSa0wizn/Hgp2lImK0wKdX6jAmg8GXKJR4FH63bd+FTVu2YefuPbDbXYW+M9LTMGnCWEwYPwZRBoO3+0lE3bgl/xAckoQstRpPc5liCnKiU8Lm9+ux4/MGQAJispWYdU8i4voH7hfDqkYR571twd4KEfGRMnxxlRbDUhl8iUKNR+H3rfc+AgDExERj1vQxmDRxHFJTkr3dNyLqhiRJrZcdkoRZ0dF4kMsUU5BrLHPV7q3a66rdO/hUPSb9Kw4RmsCV3ytrEHHu2xYcqhKRbJDhi6u1GJTE1xFRKPIo/E6eOB6TJ47DoIG53u8RhTSLIGD6tm0AgFWjR0PLkNYri+pqWi9fnpiM6zPSuEwxBbW8P5uw5rnm2r16OY65NR45MwNbhaSoVsS5b5tRUCshPUaGL6/SoV8C62AThSqPwu8lF57r/Z4QUY+saWjA6+WlrdcvTExm8KWgtv2VOhT/6TqpLWm4GrPuToQ+ObAVFPKqRZz7lhmlDRJy4mX44iodMmMZfIlCmVvvOi+88iZOOfE4DMjt13rdXf++/hrPe0dEHcqzWHDn4cMQA90R6nMk4chUmQNfNKJca/Fpe01WofVy8Z8WQAaMvigaYy6JCUjt3rb2VQhY8LYFFY0SBiTK8cVVWqRGM/gShTq3wu+Bg3loajK1u05EgVHndOLmQ4dgEkWM0EVip9nkxqMo3DksIg4uacL2Lxtabzv0lX//djRxcsy+OxGpYwJ/MuauUgHnvWNBrUnC0BQ5Pr9Si0QDgy9ROHAr/D543x0w6PXtrhOR/zlEEQvz8lBityNdpcJ/MrJx7v7dge4WBTFzrRN7vmvEvh8aYWts/1tB1gk66DS+nXdvsQkoWGwGAEx/OhGpWYEPvluLBFzwrhn1FmBUuhyf/kOHuEhOGSIKF26F3/i42HbXZTLAoNdD2cWKUeUVlWgymY56LBF5RpIkPFpUhM1NTYiUy/F8bi6iZVxxijpWl2/Hrq+MOPRHE0RXRUoY0iKQeVIkdr/jGv0ddmUUUuN8u4JaRb29NfyqArRoRVvr85246D0LmmzAhCw5Pr5Ch2gtgy9ROPHok/P+h57AVZdfjDGjO1/EYtfuvVixaq3Ho8RmswVLl63Eth27UF1TC5kMSE1Jbl5GeaJbBdAFQcCfK1Zj/YbNqKyqhkIhR0Z6GubOmYlRI4Z51C+iQPmoshLf19RADuDxfv3QX6tFjdUZ6G5REJEkCWVbrNj5lREl64/M5U0arsaIc6OQOVWHqkZHa/gNN6sPOXHpBxaY7cDUfgp8eLkWejWDL1G4cTv8WqxWWCxH3kybTCbU1tV1uK3D7sT+A4dgbF5itafqG4x4+vlX0NBgxOSJ43Ds7BmwWCxYtWYd/vf516iorMT8M07tdj/vfPAJtm3fhRHDh2LOrOlwOp1YvXYd3nj7A5x/7lmYccwUj/pH5G8r6uvxYkkJAODWjAxMi44OdJcoiIhOCYeXmbDzSyNqD7lq58rkQNYxOow4NwpJw3w7utsXLN3nxJUfWWB1ArMGKvDuJVroVAy+ROHI7fC7dNlK/PLrH63XP/vy224fk52V4VGnvv9xMerq6nHu/NMxe+YxrbdPmTQBDz32NJYuW4V5x87qciW5rdt3Ytv2XZgwbgyuuPSC1tsnTxyHR598Ht8s+gljRo2AwaDvdB9EweCA2Yx78vMhATg7IQHnJyYGuksUJGxNAvb/1ITd3xphrnZVVYjQyDDwBD2GnR2FqLTOp6aFk8W7HLjmf1Y4BOD4oQq8caEWGiWDL1G4cjv8zjxmKpKTEpGfX4hlK9cgJTkJen3HhckVcjni4+Nw/Lw5HnUqNjYaY0aPwLQpE9vdrtNpkdsvB1u370RpWUWX4Xfd+k0AgLlzZra7XaVSYfq0yfj2+5+xaet2zJ4xzaM+EvlDjcOBm/PyYBZFTDQY8H+ZmW5N+aHQ1ljuwO5vGrH/l0Y4La7SZdo4BYaeacCQUw1QB8Hc2mDx6x4B9/zghFMETh0ZgVcWaKCK4GuIKJy5HX4NBj0mjBuDCePGYNnKNTj1pOO7nPPbG6edfEKn95mbp17otF2fMZyXXwClUomM9NSj7uvfL9u1TV6+W+FXFP1XTbWlLX+26U9tn5coihB9HOTcbc9bx92bz88mirjt0CGU2+3IUqvxWHY2FJIEsc2Sxke15+O/G2+3585x7+vP0ZvtVe+zYddXjShYaYbUvFlMjhLDzzGg3+xIKJp/xnf/eEpB9fy83ebmeDW++d4JUQLmj1HgubNViJBLEEWp23140h5an6Of32c6ac9b+np73R13fz+/QLQZ+PaCK9N4dMLby8893ul9giBA4aMla0tKy3Dw0GEkJSYgMyOt0+2sVhuamkxITIiHXH503cbY2BgAQFV1TQePPlpFSWEveu2ZqrJiv7fpD9Y2wa2yrBgaH4ffnrbX2+PurecnSRKeaTRhh82OSJkM9+g0sFaUwvq37ersR9qrKiuB08dzGKsbJQCuNqrLywCTd9rr6rj7qs2+0p4kAlXbgMO/AnX7jtwePxzIOQFIGOGATFaL6qraHrdXW1kOuSW0jmdLm+sTNPguRw9IwFnDrLhrqgk15b5pr6npyOWqshJYujndpbfvMz1tr7dCpb3Ojru/n18g2gxkezUVZbAFWTl6j+sk7d1/EN99/xMuvWgB0lJTWm9ft2ETli5bhfPOPgODBuZ6q5+oq6vHm+98CJlMhgsXnN3lT79Wmw0AoFarO7xfrXLdbrX+PUp0LDk9y6M+e0IURVSVFSMxNaPD4N7XWQQBqHadKJmUmgGtj74o9bQ9bx13bz2/d8vLscxWBwWAJ/v3x7hOpvhEWJ1Ag6u9xNR0xGt8XPqs3g7AlSASUlKRHKPq1e7cOu5ebrNbfm5v3z4bXhpmRblWAdlHR97XIkQJY6ttmFZhQaLVNWoiyIDtcWqsTtGgXBcBrITrvx6Sxru+NLVtz5f83R4AiDmu/y8YJ8fT8+Mgl8f7rC2tUQDgOiE1MTUdUZ1MO/HW+4y77XlLX2+vu+Pu7+cXiDYD2V58cipiYvxz/kHjwYNubefRJ+Xh/EK89sa7kAA4ne1LLen1elTX1OCV19/Brf++FtlZmZ400U5BYTHeePt9mExmXH7J+Rg4oH8v99j8RuzmqFwgQqhcLg/J8CtvMzLqj+fY0/Z62ydvPL8/6urwWrkrfN2RmYkpXVR2aLt/vxxPH7XX1b5C5Tn+nSRJ+GSDA/cscsKui2i+DYh0iJhSacWUKisina6/J4tChvWJaqxN0sCoav7Q6s0v983vfZJ3f/0PnvYAyCQJM8utuPO4aERE+PaDXi738/tMD9vrrVBpr7N9+fv5BaLNUG+vpzwKv4uX/IGY2BjcdO1ViI+Pa3ffqBHD8OC9d+D5l9/Az7/+gWuvvrxXHdy4aSs+/uwrqFRKXP+vK90aTdZqXGV9WkaA/67ldo2G5X8ouOwxm3Fffj4A4PzERJzNyg4hyWSTcMd3Vny9xTV4MLjejtMLmjBomgY1ayyti1JoExXIOc2AzLl6nK31zodHldGBP652fbma80YSkmM6/oXMW9q2N/etFCRG+X4EqMrowIory6EVJMhkMT5vj4j6Fo/Cb0FRMU6Yd+xRwbdFdHQUZk6fiiV/LOtV535fuhzffv8z0lJT8M+rLkNCJ+39nVqtQnSUAfX1DRBF8ahvHDU1zT9LJyX0qn9E3lRlt+OWQ4dgkyRMi4rCLRmelQqk4OWwiNi5244nvzTDXCXgBLuISbEiNAdtkAGoWu46oTdhsAojzo1G9gwd5AovTxUQZYhyuEZlEvUyJEf5eETG3+01t6kV/DjMTER9ikfh12q1Qa3ueh5cZKQOFot7c2o7smLVWnz7/c8YOnggrrriEmg0PRudGJDbD5u2bEdBYRH65WS3u+/AwTwAwKBeT58g8g6LKOKWvDxUORzor9Hg0X79EMGSZn2KJEow1wowVTrRVOH6v6nSiabW/wuwN7rm7h7f9oFlRy4mT9Rg3IUxSB6hZkk7IiIf8Sj8JibEY+++/UfV4W1r6/adSEzw7ASDvMP5+PKb75HbPwf/vPpyKCM676YgCKiqroFSqUR8XGzr7dOmTsamLdvx+9IVuPofl7TebjZbsGrtOkRG6jB29EiP+kfkTaIk4T/5+dhjNiNaocBzubkw+PhEQOo5h0VsDrQCmiqOhNqWYGuudkJ0Y7Vpi0IGh0GBAQMiEJeuhGQA9n3sOvV6/B1xvj+hj4gozHkUfidNGItFPy6GVvsNJk8cj8TEeCiVStisNpSWl2PV6nXYvmM3zjjtJI869eU3P0AURYwcPhQ7du7ucJvUlGSkpiSjvr4BDz/2DLIy03HHbTe13j9k0ABMnTwBa9dtxGtvvoexY0bBZrNh+co1MBobceXlF0HbTa1gIn94o6wMf9TXI0ImwzO5ucjopEoJ+YfUpgbspidq4ah1hV5bY/d1KmVyIDJRgcikCEQmRUCfFAGLTo43dwjYZpLBqJbj+uM0uGWuCgq5a2S3ot7eGn6JiMj3PAq/x86egcMFhVi9dj1Wr13f4TajRg7D3NkzPOpUYZGrFt93P/zS6TYnnzAPp5x0XJf7uXDB2cjISMeatevx2ZffQKFQICc7CxcsmI+BuZzyQIH3S20t3m6u7HBPVhbG6rncdqDt+8TYerliQ/upW6pImSvUJke0CbhHwq4uXtFuju6POxy45SsrmkQ54hNkeP98DWYN9HE5OiIi6pJH78IKhQLX/ONSbNuxC5u3bkd5eSVsNhvUajVSU5IxbuwojBoxzONOvfL8E25vGx8f1+n2crkcs2dM4xLGFJR2mEx4qKAAAHBpUhJOj/ddHVJyz/6fG5G36Eg19uFXRyM1Rw19UgQiEyOg0rt3spbdKeGhn214Z42rbMOkHAVev0CD1OjgKvdDRBSOejUEMXrkcIweOdx7vSEKE2V2O247dAh2ScKs6GjckJ4e6C6FvdItFqx5of2qj9knRPZ4Dm5RnYh//s+CLUWuaRLXz1LhjuNVUHq7agMREXmkV+FXFEUUFZegprYOAwf0h4E/2RJ1yywIuPXQIdQ4nRio1eKRnBwoeGZ/QDUUOfDng1WQBCB1uhZlqywe7ee3PU7c9IUF9RYgRgu8cK4Wxw/jNAciomDi8bvy5q3b8fW3P6DB6DpR4983XNMafp989iXMnTMT48eO9l5PiUKAKEm4Nz8f+y0WxEVE4LncXOhY2SGgrA0CfrunAvYmEYnD1Bh1XUyPw69TkPDEEjteXm4HAIzJkOPNC7XIjOM0ByKiYOPRO/PBQ4fx3oefwikIRwXcJpMJTSYz3v/oMxw4lOetfhKFhJdLS7G8oQEqmQzP5uYiVcWyVoEk2CUsfbASjaVO6FMiMPfBJChUPRuFL2sQcc5bltbge+U0JRb9S8fgS0QUpDx6d/5t6XLExcbgvjtvw4Jzzmx3nz4yEnfedhPi42Lxx58rvdVPoj7v+5oafFBRAQC4PzsbIyMjA92lsCZJEtY8X42K7TYodTLMeyQJ2tiejcIvP+DEcS+asS5fgF4NvHmhBo+croEqgtNYiIiClUfhN7+gEMdMnQy9PhIdTVXU6bQ4ZtpkFBYWeaGLRH3flqYm/LewEABwZUoKTopzb6lu8p0dnzbg4BITZHJg9r2JiM1xfxReECU8/ZsNF7xrQY1JwvBUOX69MRKnjVL6tM9ERNR7ni1vbLEiNja6y21io6NhMnt20ghRKCm22XDboUNwShLmxsTgX6mpge5S2MtfYcKmd+sBAJOvj0PGJJ3bj61uEnH9Z1asOCgAAC6apMTDp6mhVXK0l4ioL/Ao/EbqI1FdU9vlNgVFxdDr+bMuhbdGQcAthw6hQRAwVKfDgzk5kLOyQ0BV77NhxRPVAIChZxow9Iwotx/712Enrv3UinKjBK0SeOIsDc4dx9FeIqK+xKNpD4MG5mLlqrVoaDAedZ8kSVi/cTNWrl6LwQMHeKOPRH2SU5Jw9+HDyLNakahU4tn+/aGV8ySoQGqqdOL3+yoh2CSkT9Ji0rXuTT8RRQmvLLfhnLcsKDdKGJgkxy836Bh8iYj6II9Gfk8+YR527tyD/z7xHHL75wAA/ly+CstXrEF+YRHq6xug0Whw4vHHeru/RH3GK6WlWGM0Qi2T4bncXCSxskNAOSwi/rivApZaATE5Ssy+J7HdUsSdqTNL+PcXFvy21zXNYf6YCDx5lgaRao7gExH1RR6F36TEBNx0/TX47MtvsGPXHgDA9h27W+/PzsrA+eeehaTEBO/1lKiP+bLa9dP6Qzk5GKpzf04peZ8oSFj+3yrUHnJAGyvHcf9Nhiqy+1H4HaUi7vzehJJ6CeoI4JHT1bhoohIyTl0hoj4kQiPH3RPiAQALNL7/BbJte+f6ob2e8niRi6zMdCy89UZUVdegtKwcNpsdWo0aaakpiI/nmexEAHBtairmxcYGuhthb+ObdSj6ywKFSoa5DyVDn9z1W58EYG2SBos/dsApAjnxMrx1kRYj0rggCRFRX9frdTcTE+KRmBDvnd4Q9XGr6o7Mg58TFYMrU1J83qatSgNLQRTuP2CHRuH0aVsWu4CibNeJrBt+dkCrEnu1PwkSLKZIaCNtkKHj0dTethm724z0Fa5/l8Mzo/D4LgnYZe10e4tdwPZBBhyKUgEicMqICDx7jgZRGo72EhGFArfC77r1mzBoYC5iY2Nar/eEWqNGeloqQzKFtJ9qavBgYUHr9dvSMvzy83j9hmQITSp8AwGA4PP2kKgBAGzcLgLoXfh10QDoJrR72OaABjsuO+Bagv23NC3+rI8ANjq6f2CUCgpRwm3HR+DmuRpOcyAiCiFuhd+PPv0SV11+cWv4/ejTL3vckEwmw1mnn4xjZ8/oeS+JgpgkSXi3vByvlpW1u13lh8oOVY0ShCYVAAk3HquEXunbNpusAvZ94hpFHXxRFPSa3k0DkCQJTcZ66KNiOg2YnrYpr3ZA934TZAAcI7WYclo0prgRYm02Cbs+rsegBgeuvDfN58FXK1d0eJnt9a02iajvcCv8nnTCXKSkJB25fvxcdPILZYesVhs2b9mG35cuZ/ilkOKUJDxRVIRvmk9uOy8+EV/UVPmt/S2FrlHQiBg7/jlTh3hNr2cydami3o6fn3FNGTh5ahySY3pXwUIURVSUWJGcroK8ky8LnrRprRfwww1VaLJJSBquxolPJEGhcu9Ny2gU8PXTnU+LICKivs2tT8pTTjyu/fWTjut0286kpSbjf59/0+PHEQUrsyDgrsOHscpohAzAwsxMzDXE+jX8bi50TXNQJVgAxPit3WAm2CX88Z9KNJU7YUiNwNwH3Q++REQU+no9TFRXV4+a2jo4HA6oVCokJMQjOspw1Ha5/fvhwgXze9scUVCocThw86FD2G02Qy2T4b/9+mFOTAxqrL494ezvNjeP/KoTuJQ4mqdRrH62GpW7bFBFyjDvkSRoYvizNxERHeFx+F2/cTN+Xvx7h8scp6Yk49STj8fokcNbb0tKTGDdXwoJ+VYrbjp4ECV2O6IVCjyfm4tRer3f+9Fkk7C3XAIAqBL4Mz0AbPukAYd+N0EmB+bcn4SYbC4sQkRE7XkUfteu24hPPvsKMpkMGempSEiIh0qphM1uR1WVq+7vW+9+hCsvvwhjR4/0fq+JAmRbUxNuOXQIDYKADLUaL+XmIkujCUhfNhcKECVAoXNAofPviHMwOrzMhC3v1wMAptwUj7Tx2kB3iYiIgpBH4XfpspUwGPS48dqrkJZ6dB3TwqISvPL6O1jy+58MvxQyltbV4d78fNgkCcN1Ojyfm4s4pTJg/Vmf33a+b3ir2mPDyiddJx0OPzsKQ049euoVERERAHhUF6mquhpzZh7TYfBF8+pvc2ZNR1l5ZW/7RxQUPq2sxMLDh2GTJMyMjsYbAwcGNPgCwPqClvAb2lMeuitb1VThxO/3VUCwS8icqsWEa7iiHhERdc6jkV+1St1a87cz0dEGqFSBDQdEvSVKEl4oKcHHla4vcuckJOD/MjMREeBFDxyChE0tlR4Sw3fk124S8ds9FbDWi4jLVWLW3YmQK1jZgYiIOufRyO+ggbk4lJff5TZ5hwswoH8/T/tFFHA2UcTdhw+3Bt8b0tJwZxAEXwDYVSbCbAeiNEBElD3Q3QkIUZCw7L9VqM93QBuvwNyHk6HU+n5hESIi6ts8+qSYf+YpOHAwD3/8uQJWm63dfXa7A0uXrcTefQcx/8xTvdVPIr9qcDpx/cGD+K2+HhEyGR7OzsYVKSlBs8xty3zfMZlyBEmX/G79a7UoWW+BQi3DvIeSoE/y7QIfREQUGtz6tHj86ReOuk2SJHz7/c9Y9ONixMZEQ61Ww+FwoLa2DoIoIjk5ER98/Dlu+/e1vug3kc+U2Wy48dAhHLZaESmX4+ncXEwyBNcJVC3hd1yWHAcD3ZkA2LPIiD3fNQIAZt6ZgITB6kB3iYiI+gi3wm9xSVmn94miiJrauqNur6jw3ypXRN6yz2zGv/PyUON0IkmpxIsDBmCgNrhKZkmS1C78fmEKdI/8q3i9GetecdUXH39lDHJmRAa6S0RE1Ie4FX5ffu5xj3bucLL2KPUdm+x2PHHwIMyiiAEaDV4cMADJquBbJCG/RkJVkwSVAhieJgcOBLpH/tNQYMfyR6ogicCA4yMx8vzoQHeJCFqlrMPLbI/tBUubOpUMZY/77xdMnUqGkkcjUVFSCJ0q+AYofDpJThnBOXjUN3xfU4P/NjRBBDDRYMBT/fvDoAjOZXFbRn1HZyig9tMbdbBY82g1HGYJyaPUmHZLQtDMwSYior6jV+n0cH4Btu/YjYqqKthtdqg1aqQmJ2Pc2FGd1gAmCiaSJOGt8nK8Ueaa2nNSbCz+k50NpTx4qwa01PednBOc4dyXzFUCDOkROPY/SVCEWfAnIiLv8Cj8SpKEjz/9Cus2bDrqvm3YhcW/LcVxx87CGaed5I0+EvmEQ5LwWGEhFtXUAADO02lwe1YWFEEcfNFm5HdSmIRfSZJaLysjZTjukWRoosPjuRMRkfd5FH5XrFqLdRs2oV9ONqZOnoDUlCSoVCrYbDaUlJZj9dp1+G3pcqSnp2LCuDHe7zVRL5kEAXcePow1RiPkAO7IyMAxNnPQ/4xe3STiYJUIAJiQrYAIwa/td7famrdZGwT89URN6/UpCxMQncnFc4iIyHMehd91GzYjJzsTN99wDRR/mxfZv18Opk2ZiOdefB0rVv3F8EtBp8rhwL8PHsQ+iwUauRyP9euH6QYDKkoKA921bm1snvIwOFmOWJ0MNSG8snHJRgtWPlUNS82RgJ80UhPQPhERUd/n0e+7FRWVGDdm1FHBt4VCocCkieNQWtp5iTSiQDhsseCKffuwz2JBbEQE3hw4EDOj+07FgJb5vqE85cFpF7Hu1VosubMClhoBhgyeOEtERN7jUfh1CgL0en2X2+i0WpY6o6CyrakJ/9i/H2V2O7LUarw3eDCGRwZfCZautMz3nZgdmuG3Ns+OH68vw+5vjACAIacbcOxTyYHuFhERhRCPhlRiY6JxKO8wJk0Y2+k2B/MOIzam74yoUei7JS8PdknCqMhIPJubi9g+VorPbJewvcQ13zfUKj1IooRd3zZg09t1EByAJkaO6bcnIHOKDkajf+c1ExFRaPPo03/E8KFYsWotkpMSMX3aZKjaLARgNpuxcvU6rPlrA2bPnObNvhL1il2SMCc6Go/06wdNkFd06MjWYgEOAUiJkiEzNrhPzOsJax3w20tVKNvsmsCcMVmL6bcnQBsbWgGfiIiCg0fh98TjjsX2nbvxzaKfsOjHxYiPi4VKpURTkwnGxiaIooikxASceNxc7/eYqAc+qqhovXx2fDzuyMqCIsgrOnSmbYmzYK9K4a6CVWasfhZwNFmhUMsw6Z+xGHyaIWSeHxH1nFIrxxW/54RsexR4HoVfvT4Sd9x6I35a/Bu2bt+Jyqrq1vtioqMwbuxonHTCXGg1PDObAufjigq8UV7eev3m9PQ+G3zRNvyGwHxfh0XE+ldrsf+XJgBA3AAlZt2ViJjs4FtOmojI2xi4A8vjSY+RkTqcd/YZOO/sM2CxWGBrXuGNgZeCweeVlXiupKTdbX15NFEQpdYyZ3290kPVXhuWP1aFxhInIAP6nQgcc0MKlOq+/byIiKhv8MoZP1qtFlqt1hu7Iuq1b6qr8WRxMQDg0qQkfFhZGegu9drechGNNkCvBoam9L35ygAgChK2f9qArR/WQxIBXaIC0/8vHvLESi5VTNQDHDUk6p2+dbo7UTe+r6nBfwtdi1VckpSEq1NSQiL8ttT3HZ+lQISi7wXFxnIHVjxWjcpdNgBAv9k6TP13PJSRMlSUdPtwIgoghm0KNQy/FDJ+rqnBQwUFAIDzExPx7/R0WEUx0N3yirYnu/UlkiQh7w8T1r5YA4dZglInw5Qb45E7LxIymQxiiPz7EBFR38HwSyFhSV0d/lNQAAnA2QkJuD0jo0/P8W1LkiSsO+wKv32pvq+tScDaF2px+E8TACBpuBoz70yAIVUZ6K4REVEYY/ilPm9pfT3uPXwYIoAz4uNxZ2ZmyARfACiul1BmlBAhB8Zm9o3wW77NihWPV8FUJUAmB8ZcGoNRF0RD3genbBARUWjxWfh1Op0QRbHdAhhE3raioQF3HT4MAcApcXG4JysL8hAKvmgz5WFkuhw6VXA/N8EhYcsH9djxeQMgAYa0CMy6KxGJQ9WB7hoREREAwKPTxu9/+Ans3rOvy22WLluJJ559ydN+EXVrjdGIhXl5cEoSjo+Nxf3Z2X26jm9n+kp93/pCO366qQw7PnMF34En6XHGG2kMvkREFFQ8Gvmtra2D3eHochujsRF1dfWe9ouoS+sbG3H7oUNwSBKOjYnBQzk5iAjB4Is+cLKbJEnY92Mj1r9eB8EmQW2QY9qt8ciZERnorhERER3F7fD75/JV+HPF6tbrn335Lb5Z9FOH2zocDjQ2NiEuLtY7vSRqY0tTE245dAg2ScLM6Gg8mpMDZYgG33qzhL0VrooIwRh+LXUCVj9bjaK1FgBA2jgNpi9MQGQCTycgIqLg5PYnVL+cbJSVV6Cg0LV4QFOTCYCpw21lMhkSE+Jx7vzTvddTIgDbm5pw08GDsIoipkVF4Yl+/aCU981FH9yxsdA16pubIEOCPrieZ/lmCza9XAtrvQi5EphwZSyGzY+CTB6aX0SIiCg0uB1+c7IzkZOdCQC44ZY7cdXlF2PM6BG+7BtRO7tMJtxw8CDMoohJBgOe6t8fqhAOvgCwrnXKQ/CNpK5+pBoAEJOjxKy7ExHXnye3EhFR8PPoE/Xf11+D1NRk7/eGqBN7zWZcf/AgTKKIcXo9ns3NhSbEgy/6wHzfoWcZMOGqWESoQ//fgoiIQoNH4XfggP6w2x0oKi5FZkZa6+15hwuwdfsOKOQKTJ0yEUmJCd7sK4WpAxYLrjtwAI2CgNGRkXg+NxfaMAi+VoeErUXBFX7N1c7Wy1P+Lx5DTzAEtD9EREQ95VH4rW8w4tkXXkVqSjKuveYKAMDWbTvxzgefQJIkAMDK1X9h4W03MgBTr+RZLLj2wAE0CAKG63R4YcAARCqCIwj62vYSAXYBSNDL0C8+OObRHvypqfVy+lRdQPtCRETkCY+GzxYv+QONTU2YOmVi623f/7QYarUa115zBW667mqo1Cr88edKb/aVwkyB1Yp/HTiAOqcTg7VavDxgAAxhEnzxt/q+wbBina1JwOElTW5sSUREFLw8Gvnds3c/Zk2fhjGjXCe8lZaVo7KqGifMm4PhQwcDAGYcMwXrN2z2bm8pbBTZbPjXgQOocToxQKPBqwMHIioi+E768qVgm++774dGOC1SoLtBRETUKx6liQZjI9LTU1uv7913AAAwcsSw1tsS4uNQ32D0Rh8pzJQ1B99KhwP9NRq8NnAgYsIs+IqihA0FrvA7uYvwq5UrUPrFQNflh3wXkp12Ebu/4euZiIj6Po+mPahVKjidQuv1vfsPQqfVIjsro/U2p9MJRRj9RE3eUWG3458HDqDcbke2Wo1XBw5EnFIZ6G753YEqEfUWQKsEhqcF/uS+Q7+ZYKkToY3na5qIiPo2jz5V4+NjsWfvPgBAVXUN9h84iKFDBrWbl5h3uAAx0VHe6ymFvCqHA/86cAAldjvSVSq8PnAgEsMw+KJNfd/xWQooFYGd7ysKEnZ+0QAAGHg6qzsQEVHf5tFvyZMmjsdX33yPsvLnUFffAKdTwIzpU1rvX7n6L6zbsBlz58z0Zl8phNU6HLj2wAEU2mxIVanwxsCBSFKF76IJG4Jovm/hGjOMJU6o9HLkzIvE9vfqA90lIiIij3kUfmceMwUVFZXYsHELFBEKnHPWaRjQv1/r/UuXrURKchKOnzvLm32lEFXndOLaAwdw2GpFslKJ1wcORKpaHehuBdT6guAIv5IkYcfnrlHfIacboNQGfgoGERFRb3gUfuVyORaccyYWnHNmh/dffskFyEhP5Zxf6laD04nrDxzAQasVCc3BNyPMg29Zg4jCWglymWvaQyBVbLeheq8dCiUw7KwoOALaGyIiot7r9Sn0kiTBZDJDq9W0ht22J7711tp1G/HVt9/DarXhofvuQHx8nFuPW7dhMz785PNO709NSca9d97qtX5SzzUJAm7Ny8M+iwVxERF4fcAAZGk0ge5WwLVUeRieJodeHdj5vtubR30HnGCANlYBh1Ho9jFERETBzOPwW1Vdg+9/XIzde/bBZrfj3zdcg4G5/QEA3yz6EcdMmYzk5ESPO9bY1IRPP/8G23fuhtKDk54sFgsAYO6cmcjJzjzqfq2WISvQbs/Lw26zGdEKBV4bOBD9tNpAdykotF3cIpBq8+woWW+BTA6MOJcnrxIRUWjwKPzW1NTiqedehtlsQUx0FGx2e+t9jU1NWLZiDdZv2ILbb7keCW6O1P7dE8+8BEEQcN01V2DJ78tw4FBejx5vNrvC77AhgzBk8ECP+kC+tdNsRlRz8B3A4NuqpdJDV/V9/aGlwkP2dB2i0sOz6gYREYUez5Y3/m0pBKeAm667GncvvKXdfQa9HrfffB2cgoAlv//pccf652Th7oU3Y1jzinE9ZW4e+dUyVAUVuyi2Xo6Uy/HKgAEYrNMFtE/BpNEqYXeZ6xhNDGD4bapwIm+pCQAwckF0wPpBRETkbR6F3737DmL6MVMwaGAuZB1MSczKzMCMaZNbV37zxD8uuwgGvd7jx7eM/Op0rvAriiKcTqfH+yPv+LWurvXyM/37Y1hkZED7E2w2FQoQJSArToaUqMBVVtj1dQMkEUgdq0HC4PA+AZGIiEKLR9MejEYj0tNSutwmNTUFxhWrPO1Xr7WM/K5dtwFbtu5AdU0tRFFEfHwcpk2ZiOOOneV2NQqxzWilr7W05c82/WllQ0Pr5WFarc+fZ9v9i6IIsaNva1487ke118P9rTvs+oI2MVvh1mNFUfpbe70/Qc5qFLD/pyYAwPBzDUc9J2+2585x93ab7vYpfNrz82vQx88vEG0e3V7X24Xq+3uw4nEPjGA+7h6FX5Va1Tqy2pmGhgaoArhIQUv/Nm7aiunTJrvCuLERy1euwQ8//Yr8/EL886rL2q1K15mKkkI/9Li9qrJiv7fpa1ZJwsbGxtbrlWXF0Lhx/HvbZk/a6+1xr7Mfaa+qrAROVc+e36r9UQCUGBJdj4oSW7fbWxwAEA8AqCwtgtYLU3MPfg84bYAhE1CkVKGi5Mh9TU1HLleVlcDS2OEueqyr4+6rNtkeUFNRBpvJf+354/kFok1nm5dqZVkxIrr5sSQU39/7Ah73wAjG4+5R+M3OysS6DZswa8a0Du+vrq7B0uWrkJ11dJUFfzn9lBNgtVqRm9sP2jbls6ZMGo8nnnkJO3btwfaduzF65PBu95WcnuXj3h4hiiKqyoqRmJoBuTy0FhRY3tAAe/WRaQ9JqRnQ+rgWtEUQgOY2u2rPW8c9wuoEGlztJaamI17j/kvMIUjYWWkGAMwbnYjk5O77YbZLAFyPSUrLhK6HYfvvnDYRfy4tBSBizEXxSMloPy1FaxQAuNJwYmo6oqJ69+/nznH3dpvdCaf24pNTERPj25MZ/f38AtGmwyICcH3AJ6VmdLoYTCi/vwczHvfACMRxbzx40K3tPAq/c+fMwCuvv4tnX3wdo0cOAwAcOJCH0tJy5OUXYOu2nRBFMaDLGw/I7dfh7QqFArNnTsMnn32NPXv3uxV+A/FikcvlIfciXWU0trvuj+cobzPy6057ve1T28f2dF+7SwRYHUCsDhiUrIBc3n2Qlcv//vx6F34PLWmCrUGEPiUC/efoj9rf0e1559+vq335qs3O+8L2+nJ7gWiz7e798T5DnuFxD4xgPO4ehd+hgwfhgvPm46tvv8fh/AIAwM+//t56v1IZgfPOPgtDBg3wXk+9KMpgAABYrNZAdyVsiJLUbr4vHa2lxNnEbPeCr7eJgoRdX7m+oAw/JwpyRWAX2CAiIvIFjxe5OGbqJIweNRzbtu9CWXkFbDYbNBoN0lJTMGrEMERGBq58lc1mx649eyGXyzFm1Iij7i+vrAIAxMXGBqB34Wm32YwapxM6uRzmIJz8HgxaF7cIUImz/BVmNJY5oY6SY+AJnldaISIiCma9Wt5YHxmJY6ZO8l5vPCAIAqqqa6BUKhEf5wqzEREKfPH1IlitNty98GYkJSa0bm82W7Bs+SrIZDKMGzMygD0PLyuaR30nGQxYxhHgo0iS1Cb89nrVcY/ab1nUYuiZUZ3OWSQiIurrevUpeygvH/sPHERNbR0cDidUKiUSE+IxZPAgZGWme7zfmto6FBQWtV5vNLlO3d21Zx/0etcJOPFxccjOykB9fQMefuwZZGWm447bbgKa5/WeO/90vP/RZ3jmhVcxY9oUJCYmoK6uHqvW/IW6+gacfOI8ZGZ43kfqmZbwe0xUFMNvB/KqJdSYJKgjgFHp/g+eZZutqDlgh0Itw9AzDH5vn4iIyF88Cr8WqxVvv/sR9h041OH93//0K0aNHIbLL74AKlXPzyTef+AQPv70y6Nu//yr71ovT544HpdedF6n+xg/djRiY6Lxx7KV+GvDJjQaG6FSq5CdmYHzzz0LI4YP7XG/yDNlNhsOWCyQA5gaFRXo7gSlllHfMRkKqCP8P9d2R/Oo76CT9NBEB3ZZZSIiIl/yKPwu+uEX7DtwCP1ysjBuzGgkJsZDpVTCZrejqqoaGzZtxfYdu/HDz7/i7DNP7fH+p06egKmTJ7i1bXx8HF55/okO7+vfLwf9++X0uH3yrpXNVR5GRUYiJsL/P+n3BevzXYtbBGK+b/UBG0o3WSGTu050IyIiCmUeJZHtO3Zh8MBcXP+vKzssXzFrxjS8+Opb2Lx1u0fhl0LL8vp6AMDM6OhAdyVorS9wjfxODkD43fmF68tJv9mRMKT4tuYrUShSauW44ncOtBD1FR5NLjSZLRg3dlSnddsUCgUmjBsDk8nHSwdR0DMJAjY1L7c0MyYm0N0JSlWNIvKqJchkwPgs/4bfxlIH8pe7XqcjzuOoLxERhT6Pwm9cbAzarB3QIYfDgWjO7wx7fxmNcEgSMtVq5Ki7WfMzTLWM+g5JliNG59/5vju/NkISgfQJGsQP4L8PERGFPo/C75RJE7BuwyYIgtDh/U6nExs2bcWkCeN62z/q45Y3V3aYGR0NmYyLJnQkUPV9rfUCDix2jcqPWMApKUREFB7cmvNbUlrW7vqwoYOQdzgfTz33Co6ZOgmpKclQq9VwOOwoK6/Emr/WI1Knxbixo3zVb+oDBEnC6uaT3Tjft3OBCr97Fhkh2CQkDFIhdYzGr20TEREFilvh97GnXuj0vrblx/7u0Sefx0vPPuZZz8gvLIKA6du2AQBWjR4NrcJ7AWyHyYR6pxMGhQKj9VwxrCNmu4Qdpa4V7/wZfh0WEXu+awSaR305Kk9EROHCrfA7acI49PSzUZJc0x8ofLUsbDEtKgpKhqsObS4UIIhAWrQMGTH+W9ziwOIm2BpFGNIjkD09cEuRExER+Ztb4berxSSIOtMSfmdxykOnWqY8+LPEmeiUsPNL17/NiHOjIVfwiwkREYUP/6+jSmGhyGrFYasViuaRX+rYugL/z/c9vMwEU6UATYwcA46L9Fu7REREwYDhl3yiZdR3nMEAA1d165BTkLDJz+FXkiTs+Nz1bzNsfhQi1HwLICKi8MJUQj6xok2JM+rY7nIRJjsQpQEGJ/snhJZssKDusAMRWhmGnGbwS5tE/hahkePuCfEAgAUafsEjovYYfsnrjE4ntjSv6jaD4bdTLfN9J2QroJD7Z97tjs9dpecGn2KA2uD/pZTpaFqlrMPLbM9zOpUMZY/zyx0RdYzhl7xujdEIAUB/jQaZXNWtUxu8MOXBaRXx6Maa5ss6QNX5vqr22lC+zQqZwjXlgYiIKBzx9yDyupYpDxz17ZwkSUcWt8j2zwhsy1zf3LmR0Cfxey8REYUnhl/yKockYQ1XdetWUZ2EcqMEpQIYk+n78NtQ7EDBKjMAYMR5/HchIqLwxfBLXrW1qQmNgoCYiAiMjGQZrc6sax71HZ0u98s8yJ1fNgASkDlFi9gclc/bIyIiClb87ZO8amXzlIfpUVFQcFW3TrVOefBDiTNzrROHlrhOQByxgKO+4U6pleOyJVmoKCmEUuv78Q+lVo4rfs/xeTtERO7iyC95jSRJWM4SZ245En59//1zz7eNEBxA4jA1kkfwBEQiIgpvDL/kNflWK4ptNihlMkzhqm6dqjVJ2F8pAgAmZPv2JWg3idj7vWsO9sgFUZBxNJ6IiMIcwy95TUuVhwkGAyIVrCHbmY3NJc4GJskRH+nbl+D+nxthN0mIzlIia6rOp20RERH1BQy/5DVc1c096/20pLHgkLDra9eo74hzoyDz00IaREREwYzhl7yizunEdpMJYH3fbq3PdwJ+qO+bt7QJ5moBungFcufqfdoWERFRX8HwS16xuqEBIoBBWi1SVSyl1RmLQ8LWYtd8X1+O/Eqi1LqU8bD5UVCoOOpLREQEhl/yFq7q5p5txQIcApBkkCE7zneBtGidBQ2FDih1Mgw+xeCzdoiIiPoahl/qNbsoYm3zqm6zGH671La+ry8rL+z4zPVlZMhpBqj0fJkTERG14CIX1GubmppgFkXER0RgqI4VBbrSGn59ON+3YqcVlbtskCtdUx4ouHERCCIi/+KQEPXayjZTHuSsI9spUZSwwQ+VHnZ87vr3GDBPD108v98SERG1xU9G6pW2q7pxykPX9lWKMFoBnQoYnuqb7531BXYUrbUAMmDEefz38ESERo67J8QDABZoOD5ARBRq+M5OvXLQYkG53Q61TIaJXNWtSy1THiZkKRCh8M0I+c4vXHOvs47RITpT6ZM2iIiI+jKGX+qVlioPkwwGaOX8c+rKunzfTnmw1Dhx6I8mAMDI8/hFhIiIqCNMK9QrLVMeZsbEBLorQW+9j8PvgR+bIDqB5FFqJA3T+KQNIiKivo7hlzxW7XBgl9kMsL5vt4rrRZTUS1DIgXGZvgm/h5e0jPry34KIiKgzDL/ksVXNo77DdDokKjm/tCsbmkd9R6TJEan2zXxfp0VCTI4SGZO1Ptk/ERFRKGD4JY+1zPedyVHfbvmjvi8AjFwQ7dPFM4iIiPo6ljojj1hFEX81r+rG8HuE0yrihoVxrstfiUDz1Ftfz/cFAG2CAv3nRPps/0RERKGAI7/kkQ2NjbBJEpKVSgzS8mf2rjRYJOypEAEfhN/6w/bWywNPM0AewVFfIiKirjD8kkfaTnngz+xd21goQJKAfvEyJBm895KrzbNj5QNVrdf7Hc9RXyIiou4w/FKPSZLUuqQxpzx0zxdTHmrz7Fj8f+WwN4qtt0Wo+XImIiLqDj8tqcf2Wiyocjiglcsx3mAIdHeCnrfDb91hV/C1NYiIHaDyyj6JiIjCBU94ox5bXl8PAJgaFQU1V3Xrks0pYWtRS/jt/cutLv9I8E0YpMLU+xLxwyUlXugpEQUrQRBQX18Pc3NddeoZSZJgt9lRXFzMaXp+5M3jrtPpEBMTA4XCO4NIDL/UYy3zfbmwRfd2lIiwOoG4SBlyE3r34q8vsGPx7eWw1ouIH6jC8U8kwyZ5ratEFIQEQUBJSQliY2MRFxfH8OYBSZLgcNihVKp4/PzIW8ddkiQ0NTWhpKQE6enpXgnAHLajHqmw27HPYoEMwPSoqEB3J+i1re/bmxd/2+AbN0CFE55Ihtrg25rBRBR49fX1iI2NhcFgYHCjsCSTyWAwGBAbG4v65l+ee4vhl3qkZdR3VGQk4riqW7fWF7jC7+RezPetL3QFX0udiLhcFU58MhnqKAZfonBgNpuh1+sD3Q2igNPr9V6b+sPwSz2yklMe3CZJUq9PdmsocmDx7RXNwVeJExh8icIOR3yJvPs6YPglt5kFARsaGwGWOHNLfq2EOrMEjRIYkdbzl1pDsQO/3F4OS62A2P5KnPBkCjTRDL5ERES9wfBLbvursRF2SUK6SoX+Gk2guxP0thS7zkYbl6mAqocrrzUUO7D4tnJYagTE9lPixKcYfImIiLyB1R7IbSu5qluPbCnybEljY4kDi28vh7lGQEwOg2+ERo67J8QDABZo+H2diIh6h58k5BaBq7r12NbinodfY4kDv9xWDnN1m+AbE77Bl4jIlz78+DMcd/JZge5Gjx138ln48OPPutzmtjvuxY233OHzvvirHW9i+CW37DKZUOd0Qq9QYCxXdeuWUSlDUT0glwETstwLr8ZS1xxfc7WAmGxX8NXGMvgSUWha+ueKPheaeqOmthbHnXwW7Ha7X9r7z7134L8P3ev1/V5+1XXYsHGzz9vxJU57ILe0lDibFhUFJac8dKtA7yoDNyxFDoOm++PVWOqa42uuEhCdpcSJTzP4ElFo2713X5f3O51ORESETkzZvbvr5+ttUT4YqDIajSgpLfN5O74WOn9V5FNc1a1nCvSul5Y7Ux4ay1wjvqbW4JvM4EtEIe22O+7F9h27gOaf8G+/5UakJCfh9jvvw/13L8SHn3yGmtpafPP5R3jy2RexcdMWfPHJe62PLywqxpX/vBG333IjTjjuWABAaVkZ3nrnQ2zdvgM2mx052Vm49KIFmDxpQrf9OXgoDy+8/AYO5R2GwaDHGaedjAsXnNN6f119Pd5+9yOs37ARJpMZaWmpOGf+6Tjx+Hmt22zbsRMffPQpDucXwOlwIiMjHeedcybmzJqBDz/+DB/973MAwClnLsBx8+Zg4a03ddiXgsIivP3eR9ixcxfsNjtSU1Nwxmkn4/RTT2q3nSiJeOe9j7D4tz9gNlswZPBA3HLjtcjISG89xna7Ay899wTQvFrgJ59+id+WLkN1dQ1iY6IxZ9YMXH7phVC2qdu/eMkf+PLr71BWXoG42BjMmzsbl1y4ADt37cHtd94HALj7/oeRnJSIj99/s7WdF599HBdf/k8MHTII9951e7u+vvTqm/jjz+X44pP3oFKpsHnLNnzw8Wc4lJcHhVyBESOG4ZorL0N2Vma3/1bewPBL3Sqx2XDIaoUCwDFc1c0tLSO/3YXfxnLXyW2mSgHRmRE48alk6OL4siSirk2YMAHl5eWB7gYAICUlBRs3buzRY/5z7x2474H/wuFw4JEH7kVkpA579x0AAHz6xVe44tILkdu/n9v7MzY24pb/uwcxMdF46P67ERVlwI8//4r/PPw4Hn/kPxg+bHCXj3/l9bdx6UULkJqSjF9+/R3vffAJ0lNTMWvmMXA4HFh4139gNlvwf7fehLTUFKxYvRbPPP8KFAoFjps7ByaTCfc98F+cePw83HrTdZAr5Fixcg0ee/I5JCcn4dyzz4DFasVX3yzCx++9Ab0+ssN+1NXX47aF9yItLQWPPHAvoqIMWLl6LV5+7S0AaBeAl/y2FDNnHIOnH38YdXX1ePq5l/DAI0/grdde6PCk9JdefRO//bEM117zD4wdMwoHDhzCi6+8gQajEbffciMA4NffluL5l17DNVdehsmTJqCgoBBPPPMirFYbrrz8Ytx/z0I89N8ncdfCWzFu7Kh2+5fJZJgzezoW/fALbDYbVCoVAEAURaxcvRYzp0+DSqXCzl27cdd9D2HmjGm4+YZ/we6w4613P8Ttd9yLt19/CdHRvs8Z/JSlbrWM+o7R6xEdQj9B+YpNDpTqXKF3Yhfht6nCicW3V6CpQkBURgROfDoFungeXyLqXnl5OUpKSgLdDY9FGQyIiIiAKEqIi4ttd9/oUSMxberkHu1v8a+/o66uHk899hCyMjMAANf980ps37kLX3z9HR4c1vXc4vlnnIaJE8YBAK6+8jKsXL0Wfyxbjlkzj8Gav9Yjv6AQjz3yH0wYNwYAcOGCc7B33358+sXXOG7uHBQVl8BisWLOrBmtI6/nn3c2xoweibS0VGi1WmibS4TGxsa0BsO/+3XJH2hsasJdC29FakoyAOCi88/Fjp278fW337cLv5GRkfjX1VcAALKzMnHZJRfiyWdewKG8wxiQ27/dfmtr6/DLr7/jvHPOwqknnwAASE9LRU1tLd585wNcfulFSIiPw+dffYMZx0zF/DNPa93mn1ddhvyCIiiVytYpDgZ9JGI6+CV47uxZ+PzLb7F+w2ZMP2YKAGDbjl2oq6vHcXPnAAA+/eIbJMTH447b/t06reXuhbfi4suvwS9Lfsf5587v5l+79/hJS93iqm49UxSphCSTITUKSIvu+JzSpgonfrmtHE3lTkSlR+CkPhJ8WXaMKDikpKQEugutvN2XQQNze/yYPXv3Iy4utjX4onkkcuyokfjl19+7ffyI4UPbXe/fPwcFBUWt+5bJZBg1cni7bcaOHoW1f22AsbEROdnZSE9LxUP/fRKnnHQ8xo0bjcEDB2DI4EE9eh579x9AYkJ8a/BtMXzoEGzavBUmsxmROl2Hfc7tnwMAKCwqOSr87jtwEKIoYsyoEe2fw5hREEURe/buw/ixY1BUVIITj5vbbpuTTzze7f7365eNnOwsrFi9pjX8Ll+xCikpya393bN3HyaOH9duPndcXCyys7Owa/det9vqjeD/tKWAahQEbGpqAgDMYvh1S77B9bIam9lJ8K08EnwN6RE48ZkU6BL4UiQi9/V0mkFfoo/seEpAV0xmM+rq6nHa/Ava3S44nXA4nbDabFAqOx5tBQCDQd/uukathtVqc+3bZIYkSTh7waXt9y24lq+vq6tHdlYmXnjmcXz1zSL88edyfPDxp4iKMuDc+Wdgwbnz3a6NbzZbYOjgBLKWaRIWs6U1/P69z2q1GgBgtVqPerzJZAIA/OfhxyCTtflskqTW52Ayu7ZRNe/HU3PnzMT/Pv8Kdrsdoihg9Zp1OO3UE1uPgclkxopVa7Dmr/XtHme326FQ+GdQhZ+41KW1RiOckoRstRpZXNXNLS0nu43NOPpFbKpyYnFL8E1zjfhGMvgSEXVKhqOD49/Lhen1kUhJTsKjD99/1LaSJEHV5oSujjSZTO1+xm9sMkGrc33mGQyRUKlUeP3lZzt8bFJiAgAgOjoKV15xCa684hKUV1Ri8a+/490PPkFcXCyOn3esW881UqdD6d+qKaB5TjMAREbqjvS5ydT+OTQPVOm02qMeb9C7gvIdt9+M/v1yjro/JjoKaA6njcZGt/ramWNnz8S7H3yC9Rs3IyJCgQajEfOOnd2uL+PHjcGlF59/1GOV3fw7eQt/t6QucWGLnrE6JBRGul68Y9Lbv2Gbql0jvo1lThhSXXN8IxMZfIkojDWPPHbFoI+ExWyB1Gbbg4fy2m0zdMhgVFXXQKfTIj0ttfU/hUKB2JgYyOVdx53dbX5ulyQJeXn5yMnKcu178GDY7XbYbLZ2+1ar1TDoI6FUKlFcUoq16za07iMlOQmXN5+0d+Bg+75KXTznoUMGobKqGuUVle1u37FzN7IyM6BtE2x372lfOq2lnezsoysmDBo4AHK5HNXVNe2eQ1xcLORyOSIjIxGp0yEzMx07du1u99ifflmCu+97qF2/u3oOSUmJGD5sCNat34jVa9Zh2JDBSE9Lbfcci4qL2/UjPS0VgiAg/m/zv32F4Zc65ZQkrG4Ov7NiYgLdnT5h1SERDoUMMTYBuYlHwm9r8C11Qp/iCr76JAZfIgpfBr0epeXl2LN3PyorqzrdbtCggbDabFi6bAUkScKBg4fw629L221zwnHHwmDQ4+FHn8Ku3XtRXlGJ5StX48ab/w8ff/pFp/uW4ApxX36zCJs2b0VRcQneePt9VNfU4Ph5rhO0pkyegJzsLDz25HPYvGUbKioqsX7DJty28B48//LrAICysnI88PDj+PKbRSguKUV5RSV+++NPFBQWYdQI11zhlqkLa/5aj4LCog77c8JxcxETE43HnnwOu/fsRUFhEd774BNs274T55/nOhGsJXg2NBjx1jsfoKCwCFu2bsf/Pv8KAwfkol9O9lH7jY2NwUknzMNHn3yO3/5YhrKycuzdtx8P//dJ3H7Hfa1TPM47+0xs3bYDn3z6JYpLSrFu/Ua88/5HyMhIh0wma30Om7dux/4DhzoNwcfOnokNm7Zgw8YtmDd3drv7Fpx7Fg7l5ePFV97A4cMFKCktw+dffourr/03Nm7a0um/lTfx05c6tb2pCQ2CgGiFAiM9mIMVjhbvcS1pPKrWDrnM9fOUudo11aGxxBV8T3omBfpkvvSIKLyddcap2LNvP+6670FcetH5nZY2mzVjGvbs3YfX33oPz7/0OoYOGYR/Xf0P3HDz/7XOu40yGPDcU//F2+9+hHsfeAQ2mx3JSYk484xTseCcsyCKQof7djoFaNRqXHvNlXjxldeRd7gAUVEGXHvNPzBl8kSg+af4Jx97EG+/+xEee/JZmExmxMXFYuaMabjsYtcc44kTxuH2W27Et4t+wEefuJYdTk1NwQ3XXo0Z06cCAGbPnI4lv/+JZ55/GVMnT8I9d952VH+io6PwzBOP4M13PsBd9z0Mh92OzMwMLLzt3ziuOUQ6nU4AwBmnnYTGxibcfse9MJktGDl8GG7593WdHu8br7sG8XFx+PCTz1BdXQN9pA5jRo/Cs08+Ao3GNc/3xOPnQRQlfPXtInzy6ReIjY3F6aechIsvPA8A0L9fDmZOn4Yff16MlavW4sN3X+v03+zVN95pvnxMu/tGDB+Gxx6+Hx9+8hluvHUhZDI5crIyce+dt7tVk9kbZPv27ev+N4cwN2hQz87W7A1RFFFRUojk9Kxuf6bxBosgYPq2bQCAVaNHQ6s4Uprr+eJifFRZiZPj4vBwztFzhLzdni+42543jnujVcLIR5pgcwI37KrHVR8lwyDI8ctt5TAW+yb4Go0Cvp7vGkE4+5tMREX59nia7RJy73fNKzv0kB46Ve9W+3PnuHu7ze74u71A8Pf7DLl4ctyLioqQmemfwv+hSpIkOBx2KJUqt088CwW3/t89EEQBLzzzeEDa98Vx7+71sH//frf2w+En6tQKzvftkcW7nbA5gQSLgFSLAFudgNUPVcJY7ERkkgInPp3s9RFflh4jIqK27HY7ysorUFRcjJF/K89GLvy0pA4VWK0osNkQIZNhKld1c8t32xwAgNG1NsgArH+gBg1FTkQmKnDSMykwpPjnLFYiIgpfe/bux79uuBU6nQ4LzvH9ghF9EUd+qUMto77j9XrofTw1IRTUmESsOOCaUza6xlVjsbGkTfBNZfAlIiLfGz1qBH75/stAdyOoBX34XbtuI7769ntYrTY8dN8diI+Pc/uxgiDgzxWrsX7DZlRWVUOhkCMjPQ1z58zEqBHDfNrvvo4lznrmp51OOEVgbIyEBLtrGr02XoETn0mBIc13wVenkqHs8aMLoodKe4FoMxDPkYiI/Cdow29jUxM+/fwbbN+52+Oix+988Am2bd+FEcOHYs6s6XA6nVi9dh3eePsDnH/uWZjRvPQetdfgdGJrc7Fshl/3fLfVCZ1DxFnbjhQHn/lQIqJ8GHyJiIio54J2zu8Tz7yEwwWFuO6aK5DdZq1ud23dvhPbtu/ChHFjcO3Vl2Pq5AmYccwU3HrTtUhMiMc3i35CY2OTT/re1602GiEAyNVokNbLZQ7DQVmDiG0HHfjHfiMiqpytt+s51YGIiCjoBG347Z+ThbsX3oxhQwd79Ph16zcBzWtMt6VSqTB92mTY7XZs2rrdK30NNS1THmZx1Ncti9bbcfk+I9IsAtTRQfuSIiIiomCe9vCPyy7q1ePz8gugVCqRkZ561H39+7lWP8nLy8fsGdO63Zcoir3qS0+0tOWvNtu2I4oibG1WdZseFeX1fvy9PdHHNRftZiduWOiaJ27/1gl1ZMfteXrc7SYRTW9WI8MsQNLJMf2BBPxxS2XrvkQxfGpKesLff+/kwuMeGJ4cd0mSulxK1lNmu4QB/zEBAA4+GBmS9aw74otjSd3z1nGXJMkr71tBG357w2q1oanJhMSE+A4LicfGupbqraqucWt/FSWFXu9jd6rKiv3SjrXNH2RlWTH2OpwwiSJiZDIk1FWjot69Y+Rpexofh1+n7chlY0UZzN3M4ujJcXdagdVPAvF1gFkhw6R/i7BFHFmPvaqsBJbGLndBzfz1907t8bgHRk+Ou91mh8Nh93ofHA6pzWU7HGGw+IMvjiN1z5vH3W6zeiWThWb4tbkSj7qT+apqlet2q9Xq1v6S07O82LuuiaKIqrJiJKZm+G2FN1TXAQCSUjPwVVkZgEbMjI1Faob3n/ff2/P1Cm8OiwiguLU9pbbjY9rT4+6wiPjj3ipYDttgUciwdV4Mrp1jgNEoACgBACSmpvt8xbW+zt9/7+TC4x4Ynhz34uJiKJUqr/dFKUkAXLXJlUoVlMrQDr8tK42Rf3n7uKvUGiSnd34eWOPBg27tJyTDb/dc33jdXW4vEB8OcrncL+3K24zEymQyrDQaAQAzY2J80n7b9vzxHNvu3p323NnGaRXx5wPVqNhhgz1ChncHRuH/5uiaH+vf5xcqeKwCg8c9MHpy3GUymU+W5G27S1+1ESza/uR+/CnzccmFC3DpxecHtE/hQPpbvvAGmUzmlfeskAy/Wo0GaDMC/Hctt2uatyOXwzYbSux2qGQyTDGwzmlHnHYRf/ynEmVbrJBrZHgnx4CqqAicODwkX0pEREQhJyS/8qvVKkRHGVBf39DhxOiamuaf3ZMSAtC74NVyottEg8Hn0xH6IsEuYekDVSjdZEWERobKM+NQpFfi2MERiNaG7qgJEZGvSZIEQRAC3Q0KEyE7XDUgtx82bdmOgsIi9MvJbnffgYN5AIBBA/oHqHfBaXXLlAeWODuK4JDw58OVKFlvgUItw7xHknDmEgGAhLPGhOzLiIjIZy6+/BpMnTIJVqsNS5etwN0Lb0VCQjze/+h/2H/gIGw2G5KTknDWGafi1JNPaH3c+ZdciZnTpyEzIx1ffPUt6urrkZmRgRuuvRrDhw1p3e6TT7/E9z/9gqYmE/r3y8aN111zVB+qq2vw1rsfYtPmrTCZzUhMiMdx8+bgwgXnQNE8CHT+JVdi3rGzEKmLxLff/wiz2Ywxo0bizv+7BUuXrcBnX3wNk8mMMaNH4v9uvQl6faSfjiB5qs9/aguCgKrqGiiVSsTHxbbePm3qZGzash2/L12Bq/9xSevtZrMFq9auQ2SkDmNHjwxQr4PTLrMZADCD4bcd0Slh2X+rULTWAoVKhnkPJ6E0ToXCWjN0KmDekD7/MiKiPkSSJFgcvduH2S51eNkTWqXnczo3bNyMSRPH481Xn0dcbAwuuPQqDBs6BE8/9jC0Oi3WrF2HF15+HfHxcZg6eSIAIEKhwKbNW2E0GvHwA/dAEAQ8/tRzePzp5/HRu68DABYv+QPvf/Q/XHzheTh29kwUFRXh5dfeate23W7H/911PwDgroW3IDk5CVu2bsdrb74Lq8WKq6+8rLW9NWvXY/y4MXj2iUdw4FAeHn3iWdz34H+RlpqKJx59EIfzC/DIY0/j2+9/xCUXLujV8STfC8pP7ZraOhQUFrVebzS5VmLbtWdf6zeq+Lg4ZGdloL6+AQ8/9gyyMtNxx203tT5myKABmDp5Atau24jX3nwPY8eMgs1mw/KVa2A0NuLKyy+CVqsNwLMLXhKAIVotklU8I7aFKEhY/mgVCleZIVcCcx9MQto4LV77wVUp5IRhEWFTH5OIgoPFAeTe770VSkc+YurV4w89pIfOw48Ns8WCf151ORQKBQRBwJuvvoDISB0idToAwPwzT8OnX3yNDRs3t4ZfADCZzbjt5hugVLpW0jz+uLl48+33Ud/QgJjoaPz62x8YPGgALrv4AkiShOSkBAiChIcefbJ1H6vXrkNxSSmeeeIRjBo5HACQkZ6GQ3mH8f1Pi3HZpRdC1bx/QRBw7TX/gFwuR0ZGOj759Esczi/A44/8B2q1GpkZ6cjOysChQ4d7cyjJT4Iy/O4/cAgff/rlUbd//tV3rZcnTxyPSy86r8v9XLjgbGRkpGPN2vX47MtvoFAokJOdhQsWzMfAXE556AinPBwhChJWPlGN/BVmyCOAYx9IQvpELQRRwvfbXcsYnzWaSxgTEXkqt3+/1ukFCoUChw/n46tvFiG/sAg2mw2SBNhsNjQ2tg/7A3P7twZfADDo9QCAxsYmxERHI7+gEHNmzWj3mLZTIgBg374DkMvlR90+bOhg/PTLEpQUl6Jf86JYA3L7t6syEBVlgFajaVdS1WAwoMnUuy8S5B9BGX6nTp6AqZMnuLVtfHwcXnn+iQ7vk8vlmD1jmluruJHLzJgYn+5fq1Bg07hxPm3DGyRRwupnqpG31ASZAphzfxIyJ7tGItbmCahslBCjBWYN5ImBRORfWqVrtLU3zHapdcR3x729W+FN24sxAH3kkfmxBw/l4T8PP47hw4bgvrv+D3GxMZDJ5bj9jvuOetzfqzW1TLtoKa9lNltaKz+1tvW3ubgmswWROl1r+D6ynb75fnPrbWpN+3UDZDIZVGrVUbdxBbm+ISjDLwVGQkQEhnAqiCv4PleDg0tMkMmB2fckImuarvX+b7e5Rn1PGamEKoJTHojIv2QymcfTDDqiU8mCYvrWylVrIZPJ8MgD97ROSxRFEeY2IdRdGrUalr8tZGVsbL/kZmSkDiazGYIgtAvARmNj6/0UmkKy1Bl55pjo6JAudO4OSZKw9sVaHPilCTI5MPOuROTMPDJaYHdK+Hmn60yTM0fxuyMRkbeYLRaolMp25+OsXL0WZoulxyOqWZkZOJSX3+627Tt2t7s+dMggiKKIXbv3trt9x87d0Ol0yMxI9+h5UPBj+A1zbd9QjomKCmhfAk2SgPWv1mHfj42ADJixMAH957T/mWz5AQH1FiDZIMPU/pzyQETkLUMHD4LZYsE33/2AsvIKLF7yB77/8RcMGzoY+QWFKCuvcHtfc+fOxu49e/G/z79CSUkpNmzcgq+/XYSIiCODFlOnTEJWZgaef+k1bNm6HcXFJfjmux+wdNkKnDP/9HbbUmjhv2yYO9jmZ6Hx+t7NIevLJEnC3s+AgiVNgAyYfns8cucdfTy+3eYa9T1tVAQU8vAeJSci8qbZs6Zj34GD+PTzr/DBR59izOiRuPuOW7Fr9148+8IruOf+h/Humy+7ta8zTj0JtbW1+HbRj/j4f1+gf79s3HT9v3DXfQ/CKbimrqmUSjz52IN48+0P8PBjT8FisSIlOQlXXXEJ5p95mo+fLQWSbN++fZyd3Y1Bgwb5rS1RFFFRUojk9CyvrF/dnReKi/FhZSUAYNXo0SG3spvDIuLj0woBABf/kAWl9uhjKkkSNr5Vi51fuOZ5HXNrPAadfPTyzq4TRJpgtgM/XafDuKyjj5XRKODr+a4yfWd/k4moqNA6nt7m7793cuFxDwxPjntRUREyMzO93hezXWotl+YqVRa6X+YlSYLDYYdSqQr7qX3+5Ivj3t3rYf/+/W7th+96YcwiCPiupibQ3QgoSZKw+b361uA7+cbYDoMvAPy+1wmzHciKk2FsJl86REREfRGnPYSxb2tqYAzztdS3ftSA7f9rAAAMvQgYclrHwRcAvt3q+qnsjFFKjh4QUZ+mU8lQ9njn73dEoYzhN0w5JAkfV7h/8kAo2va/emz9sB4AMOGaGCRMre902waLhKX7mhe2GMOXDRERUV/F327D1K+1tahwOBAXpmez7vi8AZvfdYXd8VfFYvg5XVe6+GWXE3YBGJwsx9AUzuMlIiLqqxh+w5AoSfiwedT3vMTEQHfH73Z93YCNb9UBAMZeHoNR53e/pHNLlYczWNuXiIioT2P4DUOrGhpwyGpFpFyOM+PjA90dv9qzyIj1r7mC75hLojHm4u6Xc65uErHqoGtu9Jmje7GOJxEREQUch7HC0PvNo77nJCZCH2KlzbpyYHET1r1SCwAYeX40xlzaffAFgB92OCFKwJgMOfol8PsiERFRX8ZP8jCzpakJ20wmKGUyXJCUFOju+FVL8B1+bhTGXxnjdsWGlioPHPUlIiLq+xh+w8z75eUAgNPi45GoDP0w9/f14IfNN2DiNbFuB9/iehEbCgTIZMDpnO9LRCHCIggYv3kzxm/eDEuYl7yk8MNP8zBywGLBKqMRMgCXhPior9Mm4vCfJuz+rrH1tkEn6zHp2rge1ej9fptr1HdKjgKp0fyuSERE1Ncx/IaRlgoPc2NikKXRBLo7PtFY6sDeHxpxYHETbI1iu/sm/tP9Ed8WLVUezmRtXyIiopDAT/QwUWaz4dda15zXy1NSAtYPo1HA1/OLAABnf5OJqKjen3AniRKKN1iwd1EjijdYgOaZDvpkBXKO02Pnx64V3KwCoOrBfg9WidhZKiJCDpwywr2XSoRGjrsnuCpoLNBwpJiIyFPbtu/E7Xfe1+U2117zD8w/8zQAwHEnn4UF556Fq6641E89pL6K4TdMfFRZCQHAZIMBQ3W6QHfHK2xGAfsXN2HfD41oLHO23p4+QYMhZ0QhY5IWTSaxNfz21HdbXaO+MwcqEB/JIEtEFAh3LbwVY0aN6PA+XYh8npF/MfyGgTqnE99VVwMALk9ODnR3eq16vw17FzUi708TBLtrmFell2PgCXoMPs2A6Izen8gnSRK+284qD0REgWbQRyIuLjbQ3aAQwvAbBj6vrIRNkjBUp8NEgyHQ3fGIYJdweLkJexcZUbXX3np7XK4KQ88woN+cSCi13hud3Vkq4lCVCE0EcNJwvkyIKHhIkgSrKLqxZefaVnjobbUHjVze4/MpAMBstuClV9/Emr/WQ5JETBw/DieeMA933/cQHn34fqjCoCIRBQY/1UOcWRDwRVUV0Dzq68kbVCA1VTix94dG7P+lEbYG15u9PALImRmJIWcYkDRM7ZPn9F3ziW7zhkZAr+5bx4yIQptVFDF92zav7e+4nTt79fhVo0dD68GCSS+/9iZWrfkLt9x0HQYNzMWWrdvx8qtvAgCUEYwn5Dv86wpx39XUoEEQkKVWY06MeyuaBZokSijdbMWeRUYUr7NAah7g0CUqMORUAwadbIA21ncr04mihO+aS5ydwdq+REReZ7XasGzFapx68gk4dvYMAEBGehoKCouw6Ief2w1qPPDIE5DLj/5lTx8ZiU8/etuv/abQwE/2EOYQRXzcXN7skuRkKIJ81NfWJODgr03Y+0MjjMVHTmBLHavB0DMMyJyqg1zh++ewsVBAaYMEvRqYO4QvESIKLhq5HKtGj+7VPiyC0Dri+9uIER6N3LbtT0+VlJbC4XBg0MDcdrePGDYUi374ud1tN153DUaOGHbUPjoKxETu4Cd7CFtcV4cKhwPxERE4JS4u0N3pVO0hO/YsMiJvqQlOq+sENqVOhgHH6zHkdANisnpSoKz3WkZ9TxoeAa0yuL8wEFH4kclkvQqrf6dVKLy6P3eYzRYAgEGvb3e73qA/atv4uFikp6X6rW8U+hh+Q5QoSa2LWlyUlAR1EH5DLlppQv4SEyp32Vpvi8lRYugZBuTO03v1BDZ3OQUJP+xglQciIl/SaNRA8/SHtozGxk4eQeQ9DL8hamVDA/KsVkTK5ZifmBjo7rRqKU0GAOufcy26IVMA2dN1GHpGFJJH+uYENnetzhNQ3SQhVifDjAH+HQkhIgoX6WlpUCgUOHgoD7NmHtN6+9Zt2wPaLwoPDL8hSJIkvN886ntuYiIMfv45qzOiIGH9szWt1zWxcgw5LQqDT9ZDlxAcf4qLtrtK/pw2MgJKP8wvJiIKRzqdFtOmTML3P/6CAbn9kZvbDxs3b8W27UdXnmhsMqG2tq7D/UQoIxDVR0t4UuAER+Igr9pqMmG7yQSVTIYLkpIC3R2guYLD6mdrULre0nrbSW+kISYueP4E7QLwy66WKQ/B0y8iolB0843/wvMvv46nn38ZMhkwYdxYXPWPS/HQf59st91jTz7b6T6GDxuC559+zA+9pVDCT/gQ9F55OQDgtPh4JHRTJNxpFXHDQtfJcM5FIhDp/VFiSZKw4c06HPy1CTI5WkuXySOCa2R1dYESRiuQGiXD5JzgGC0nIgpVUVFRuP/uhe1uazvyO3rUCPz287du768n21J4C76zoMJYRb0dHxxfiMVXuC574oDZjNVGI+QALnFj1NfskDq87E3bP23Arq+MAIDx1wdv1YnFB1wnYJw+KgJyeXAFcyIib9IqFNg0bhw2jRvn90oPRIHG8BtiPmie6zs3JgaZGk2gu4O9Pxix+d16AMCkf8Uie05koLvUIZNNwsp8V0m1M8ewygMREVGo4rSHEFJqs2FJneukgMtSUgLdHeT9acLaF10VHUZdGI3h50TDaOzdGvK+smSPAKtThpx4GUan8zshEVEg9HSqA5En+CkfQj6urIQAYLLBgKE6XUD7UrzejJVPVAESMPhUA8ZdEdxLK3+3vflEt1ERAS21RkRERL7F8Bsi6hwOfFddDQC4PDk5oH2p2GXF0gerIDqBfnMiMeXGuKAOlHVmCcsPuEakzxjFH0OIiIhCGcNviPisqgo2ScIwnQ4TA1jzsDbPjt/vqYRgk5A+UYsZCxMgD/J6uT/vdMAhAAPjnRiUzJcEERFRKOMnfQgwCwK+qKoCmkd9AzXKaix1YMmdFbA3iUgarsax/0mEQhncwRcAvtvmmvJw4kBbt9sSERFR38bwGwK+ra6GURCQpVZjdkxg5taaa5xYckcFLLUCYvspMe+RJERogv/Pq8IoYnWea8rDCQM9Ky9HRNTXOCwi3puXj/fm5cNhEQPdHSK/4gTHPs4hivikshIAcGlyMhQBGPW1NQr49Y4KNJY5YUiNwPGPJ0Nt6LhuZIRGjrsnxAMAFgRBOP5+uxOSBIzLlCMtih8AREREoS7w6YN65Ze6OlQ4HEhQKnFKnP8XkHBYRPx2TyXq8x3QxitwwhPJ0MX3ne9Ui7Y7AC5nTEREFDb4id+HiZKED5sXtbgoKQkquX+/ywgOCUsfqETVbhtUejmOfywZhrS+s0BEYa2ITYUi5DLgtJEKSMZA94iIiFps274Tt995H9JSU/DW6y9CpVR2eP9H772BlOQklFdU4pIr/tnlPs8641Rc988rAQAXX34Nhg4ZjHvuvM2nz4OCD8NvH7aioQGHrVboFQrMT0jwa9uiIGHF41Uo3WRFhEaG4x5NQlx/lV/74I6upll8t8016ntMrgJJBjkqGH6JiIJOeUUlvvjyW1x84XlubX/VFZfiuLmzW69LkgSH0wFlhBJardaHPaW+guG3j5IkCe83j/qem5AAvR/XZpckCX+9VIP85WbII4BjH0hC0rDAL6XcUy1VHljbl4goeJ1+6kn47MuvMW/ubKQkJ3W7vU6nRVxcbOt1SZLgcNihVKqCuuY8+Q8/9fuoLU1N2GEyQSWT4YKk7t8MvGnze/XY92MTIANm3pmI9Al975v0vgoBe8pFKBXAKSOUAKRAd4mIyC2SJMFp7d17ltMqdnjZExEamUeh0my24KVX38Sav9ZDkkRMHD8OJ54wD3ff9xAeffj+1mkOZ55+CrZu247X3ngHD95/V6/6SgSG376rZdT3tPh4xCv9N89251cN2P6/BgDAtH/Ho9/sSL+17U0to75zBikQo5NBFBl+iej/27vv8Cius+HDv9WuVr33ggAJgQRCCIEKQoheDAZjcMe9dxM7b3Dy2cnr5E1xEicucdwTG0OMjYHQOwbUexdFogkh1HvZlbS73x+rXbRoBQJWSIJzXxeXrZkzM2efmZ159syZM8NDl0LDuqWlJlvfhnvLbmj5h7f7YW517cnvPz75nISkFH726ouMDQwgOyePf/zzcwDMZZfSE6lUyssvPMvP33ybtPRMIiOm3FB9BUEkv8NQcVsbiU1NmAGP3MRXGRfvaSb903oApjzpyLg7B+9NcjdCo9Ho+/sunzR8HtATBEG4VSgUSg4fTeTOxQuZM2sGAL4+3pwrPc/W7bt6tSRPCg1h1sxYPv7sK8LCQns9/NbTJ5//i8+/+uayqRpAwoZvv8TGZng22gimI5LfYUjX6jvPyYkRFhY3ZZvnElpJ/FstABPutWfigw43ZbsDIbdMzdlaDZbmsCBYfAUEQRheZJYSHt7ud0Pr6FKo9S2+D2z0vaGXEsksr73V90J5OZ2dnYwNDDCYHjI+mK3bdxld5rmnHufJ515m44//ZdWD9/a57ofuv4fZ3Qk1um4iXZ3IxANvQjdx5R9mLiiV7K/Xtr4+dpNafcuz2zn8+2o0aghcZEvEs07D+qGBLd2tvguDZdhYDN/PIQjC7UkikVxXN4O+yCzNMLe6uUNltrW1A2Bna2sw3dbOto8lwNXVhYcfvI+16zcwb87MPss5ONjj4+2l/1s88CZcTrzkYphZV1WFCoi2syPI2nrAt1d9XMnBX1eh7gS/WGtifuYyrE8earWGbXna/r7ixRaCIAiDw9JSe9dSoVAaTG9qar7iciuWL8XD3Z1PvvjXgNZPuLWJ5HcYqevsZGtNDQCPeXoO+PYaznWw/1eVdLVr8JpsycxfuWImHb6JL0DKWRUVTRrsLWH2OJH8CoIgDAYfb2+kUiklp04bTM/JzbvicjKZjJdeeIbEpFQyMrMHuJbCrUpc/YeRDdXVKDUaJlhbE2Hb960hU2ip7GLvm5Uom9S4jpMz9x13ZPLh/1tJN8rD4gkyLGTDO5EXBEEYrqytrYiJjmTbjt2MCfAnIGA0GVk55OYVXHXZ8LBQ4mJj2LRlm9H5bW3t1NXV6//u+ZILqUyKo8PwfWZFMA2R/A4TrSoVG6urobuv70B2PWivV7F3TQVt1Soc/MyZ/wcPzK2Hf+LbqdKwI7+7y0OYGOVBEARhMK1+5Xne/8en/PX9fyCRwNTwyTz95KP89vd/vuqyzz/7BGkZWXR2dfWa9+W/1/Llv9caXc7VxYXvvv3SJPUXhi+R/A4TW2pqaFKpGGlhwSxHxwHbTkeLmn2/rKSprAsbdykL3/XA0uHmvT1uICWeUlHfpsHVVsJ0/1vjMwmCIAxX9vb2/PpXvzCY1rPld1JoCPt3bTG6rJurK9s3f2cwzdPD3Wj5vh54W/f15yb4FMJwNPyb824DnWo166uqoHtcX+kAtfqqlBoO/LqSupIOLB3NWPhnT2zcbp3fR9u7W32XTZQhG+Z9lwVBEARBuD63TmZzC9tdX09VZyeu5uYscXYesO1k/72Oqjwl5tYSFvzRAwffW6trwP5j2uT3LjHKgyAItzlzKzOeODBqsKshCINCZAFDnFqj4ZuKCgBWubsjNxu4xvqqDCVSuYR5/+eBS+DNeXnGzdTaAT6OEqb6iS4PgiAIQ9GVujoIgqmIbg9D3JHGRs4qldhKpaxwdTX5+jUajf7/JWYw6203PEMtTb6doWL5JHPMzESXB0EQBEG4XYmW3yFMo9HwdXer732urthKTdNiqe7SUFWo5HxqG2eT2vTTQ192xG/awL84YzCJF1sIgiAIwu1NZAJDWFZLCwVtbcglEh5wd7+hdbXXqyhLa6MstZ3yzHY6WjW9yvjE3dqJr7+rhAle4maHIAjDi0ajGdZv1hQEU+h5p/pGieR3CPu6shKAZS4uuJhf28NnGrWGmpMdlKW2UZbWTs2JDoP5Fg5m+EZYYRciJ+f9+j7XM5A6ujTIBjgX7ei69GVZOtFcXEAEQRhWrK2taWlpwc7ObrCrIgiDqqWlBWtr0zTSieR3iDrdoSCpqQmz7uHN+kPZoqI8U6FPeBUNaoP5LoFyfKOs8I20wnWcBWZSCZUNHQOW/Go0GqqaNRReVFN0UUVRhZqC8kt1Cv5t64Bsty9LJ4rDXRCE4cXR0ZELFy4AYGtrK37AC7cdjUZDS0sL9fX1+Pj4mGSdIhsYojY11gAw38kJXwvjIy9oNBoaznVSltpOWWoblQVKND3yXXNrCd7hVvqE19pl4HZ3R5eGkmr1pUT3ovb/a410rxgso11FlwdBEIYXqVSKj48PDQ0NlJWVDXZ1hiWNRkOHUoHcwlL8eLiJTBl3a2trfHx8kJro2SeR/A5Bjc4q4lubAHj0slbfLoWaizkKbcKb1kZLpcpgvoOfuT7Z9QixRGpu+i96TYuaoovq7gRXm+gWV6vpVPUuayYBf1czxntp/41xNePp9QoAcn5lg5V8YE9E7R0awv5wc1uYBUEQTEkqleLi4oKLi8tgV2VYUqvVVF4oxcPHF7MBHC5UMDSU4y6S3yEoJ06BGphmb0+QtTXNFzs5n9pOWVo7FTkKVB2XWlOl5uAZpm3dHRFphZ236V5M0aXScKpG24J7rEeiW9lsvDXX3hKCPaVM6E50J3hJGethhnWPBLetR93tLCUG8wbCQPcpFgRBEARheBmyya9KpeKno4mkpWdRVV2DVGqGr483c2fHERoy/qrLp6ZnsXb9933O9/L04K03XzdxrW9cm42a45OV+JTIWFBpy+bsCzSWdhqUsXGXMiLKGt8oK7zCLJFZ3niG1y6VkH5OzcWCDoouqiisUHOyUo2yy3j50S4SxntJtS26ntpE19dJIm4pCYIgCIIwpA3Z5Perb9aTm1dIyIRgZs+Mpauri8TkVD778hseuPduZkyPvuLy7e3tAMydHceokSN6zbeyGpovcihzhyf+4IRcKaEWbfcAtQQqHGWUusopdZNTbyMFpQSOquFo21XXeSUqtYbGUCea5WbwXWev+dZyGO9ppk90J3hJCfY0w8ZCJLmCIAiCIAw/QzL5zckrIDevkKnhYTzx6IP66VER4fzhz++zeetOwkJDsLOz7XMdbW3a5Hd80FiCxgXelHrfKLVGg5lchVxpTosFnLC14KSDOcX25ih09+87uv9hwgfJ5Np1ezvARB+ZQbcFPyeJeCOaIAiCIAi3jCGZ/KamZUJ3q21Pcrmc2JgotmzbRWZOHrNmxPS5jrbull8rK6sBrq3pmEkkOJTKyZnYycLHPYlxGvi61zV3kvLLalyValZ874WHo3zAtykIgiAIgjBYhmTye/rsOczNzfH18eo1z3/0SG2Z02evnPx2t/xaW2sTSLVajVqtRia79o+sVqv7UerGqdVq3No1uOXLmOQjxct54FtcKxugrE2l3/5Af1a1WtPj/9Wo1QP7Gfu7Pd3nvtHPf7M/33BnqrgL10bEfXCIuA8OEffBMZTjPuSSX4VCSUtLK26uLkaHxnBycgSguqb2iuvRtfwmp6aTnZNPTW0darUaFxdnYqIjmD9nZr/HiyspKbmuz3I9pv9T+9/WuvOU1N3cbTbXlNJcM/DbO/Kk9r/lpQO/rWvdXvPp0zd1e4KWKeIuXDsR98Eh4j44RNwHx1CM+9BLfpVKACz6eLGDhVw7XaFQXHE9upbfjMwcYmOi8PLypKmpmSPxSWzfuZezZ0t57unHxOgEgiAIgiAIt5Ehl/xenfa28tWS1mVLFqJQKAgIGI2V5aWRHaIjp/Duex+RX3iMvIIiJk2cMOA1FgRBEARBEIaGIfcKAF2iqmsBvpxuuqXllYcqGxMwmpAJwQaJL91vypkVp+0rfOz4SRPVWhAEQRAEQRgOhlzya2Ehx8HejoaGRqOdpGtr6wFwd3e97m3Y29kB0H6VrhOCIAiCIAjCrWXIJb90t9p2dXVxrvR8r3nFJdqO02PH+Pe5vFLZQVZOHjl5BUbnV1RVA+Ds5GSyOguCIAiCIAhD35BMfmOmRQFw4NBRg+ltbe0kJKdiY2PN5EkTofs1yBWVVdTW1evLyWRSfti0la+/3UBVdU2vdRw+koBEIiE8bOJN+TyCIAiCIAjC0CA5ceKECV8VZjrrvttIcmoGIeODmBwWilKp5Eh8ElXVNTz1+Cp98ltbW8evf/cufiN8WPPGq/rlM7Nz+frbDVhbWzEjJho3N1fq6xtISEqhvqGRxYvmsWTR/EH8hIIgCIIgCMLNNmRHe3jo/pX4+vqQlJzGho2bkUqljBrpx4P3ryAwoO8uDzpTJk/CydGBg4fjSUnPpLmpGbmFnJEjfHng3rsJmRB8Uz6HIAiCIAiCMHQM2ZZfQRAEQRAEQTC1Idvye7tRqVT8dDSRtPQsqqprkErN8PXxZu7sOEJDxg929W4ZyakZ/LhlGwqFkt++vQYXF+deZcS+MJ22tnYOHY4nN7+Qmto6JBLw8vQgJjqSmOgIg/G6RdxNp66+ngOHjnL8RDF19Q1YWVni5upCbEwUU8PDDN6eKeI+cI6dOMk/PvkKgI/ff9dgnoi7aaSmZ7F2/fd9zvfy9OCtN1/X/y3iblqnz5xl996DnC09T1eXCjdXF6ZFRTArLmZIn99Fy+8Q8fm/1pKbV0jIhGDCQkPo6uoiMTmV82XlPHDv3cyYHj3YVRzWmlta+O77zeQVFGFubk5HR0efya/YF6bR0NjEX9//mMbGJqIiwgnwH017ezsJSalUVlUzd/YMVtx1p768iLtplJ6/wAcffwYamB4ThY+3F62trSSmpFFRUUVURDiPrrpfX17EfWAoFEr+792/UV/fAEaSXxF30zh8NJGNm7cxd3Yco0aO6DXfysqS4HFj9X+LuJtOTl4BX/57Hd5ensTGRCGTyUjLyKK45DSz4qZz74pl+rJDLe6i5XcIyMkrIDevkKnhYTzx6IP66VER4fzhz++zeetOwkJDsLOzHdR6DmfvvvcRKpWKF599gn0HDlN8yvi7xsW+MJ1tO/ZQX9/AvSuWMStuun56dORUfvvHv3LocALz5szE3s5OxN2ENv93BwqFkp+98jxjAkbrp0+LjuB3f3yP1PQsFi2Yi7ubq4j7ANqybSctLa14uLtR2T28po6Iu+m0tbUDMD5oLEHjAq9YVsTddNra2li/4Ud8vL34+eoXMTc3h+5YvvfBJ5w+cxaFQomlpcWQjPuQHOrsdpOalgnA3NlxBtPlcjmxMVF0dHSQmZM3SLW7NfiP8uNXv1jN+OBxVywn9oXpODk5EDYphJjoCIPp1tZWBIwehUajofxiJYi4m1RY2ESWL1tskPjS/fbM0SP9APStkSLuA+PEyRISk9NYvHCe/qVKPYm4m05buzb5tbKyumpZEXfTSU3Poq2tnTvvmK9PfOl+i+4vXn+ZNW+8iqWlhbbsEIy7SH6HgNNnz2Fubo6vj1evef6jR2rLnD47CDW7dTz52CrsbK/+q1LsC9NZunghzzzxCHK5vNc83QXLuvuCJeJuOrNmxDB/zsxe01UqFeUXK5BKpXh6eoCI+4BQKJWs3/AjI3x9mDcnzmgZEXfT0bX8WltrzyVqtZquri6jZUXcTafo2AnMzMz0re0ajYaOjk6jZYdi3EW3h0GmUChpaWnFzdXF4CEUHScnRwCqa2oHoXa3F7Evbo4L5RcpOXUGdzdXRvh6i7gPIIVCiVKppKq6hn0HD1NTW8e9K5bhYG8n4j5Atm7fTWNjE88/87jRuIq4m5buh3RyajrZOfnU1NahVqtxcXEmJjqC+XNmIpVKRdxN7GJFJU6ODtTVN7Bl606OnSimq6sLO1tbIiMmc+cdC5HLzYds3EXyO8gUSiUAFhYWRudbyLXTFQrFTa3X7Ujsi4FXX9/A51+tRSKR8ND9K5FIJCLuA+hvH37ChfKLAPh4e/Hqi88Q2P1qeBF30ztZfIr4xBSWLJqHt5en0TIi7qala/nNyMwhNiYKLy9PmpqaORKfxPadezl7tpTnnn5MxN3EWlrbsLa24sOPPyds0kSefOwhFAolicmpHPwpngsXLvLyC08P2biL5HfI0w7G0XPIEGGwiH1xI86VlvHZl1/T2trG4488oE/Crk7E/XqteuAeWlpbqaurJzUtkw//+QWLFszp59stRdyvRUdHB+s3/Ii3lycL5s2+gTWJuF+LZUsWolAoCAgYjZWlpX56dOQU3n3vI/ILj5FXUMRIv94jQRgScb8WKpWKxsYmVi6/kzmzZuinR0wJ489/+4jjJ0soLDqOr6/PVdY0OHEXfX4Hme7Lqvt1dDnddMseX2phYIh9MXAyMnP4+0ef0qVS8dLzTxEeFqqfJ+I+cEb6+TIheBwzpkfzxuoXGR88jl17DpBXUCTibmL/3b6buvoGHnnoXqRSaZ/lRNxNa0zAaEImBBskvnQ/eDUrLgaAY8dPiribmEX3sxwRUycbTDczMyM6cioAJ0tODdm4i+R3kFlYyHGwt6OhoRG1Wt1rfm1tPQDu7q6DULvbi9gXA+PAoSP8+9vvcHN14Revv8LYwACD+SLuN4dEIiE6cgoABYXHRNxNqOT0GY4mJDNjejS2tjbUNzTo/+kevtL9LeJ+8+hG2mhXKETcTUw3Rr7USD9ee3tt3BUK5ZCNu0h+h4AxAaPp6uriXOn5XvOKS7Tj0Y7t9y1i4UaIfWFaRxOS2bJtF8HjAnnjtRdxNfJSEUTcTaamppa33vkj73/0mdH5nZ3ap7F1FyERd9M4caIEjUbDkfgk3vrfPxr8O3OuFED/NyLuJqNUdpCVk0dOXoHR+RXd4ys7OzmBiLtJBfiPAqC0rLzXvNo6bULr6OAAQzTuIvkdAmKmRQFw4NBRg+ltbe0kJKdiY2PN5EkTB6l2txexL0zn9JmzbNy8jQD/UTz3zOP6MR+NEXE3DWdnJ8zMzCg5fYaSU2cM5mk0GlK6x9scE6C90Ii4m8bUKWE8/8zjRv/pHnzT/Y2Iu8nIZFJ+2LSVr7/dQFV1jcG8trZ2Dh9JQCKREB6mjaWIu+noXk+/e+8Bgxbdjo5OEpNSAZgYEqwtOwTjLl5vPESs+24jyakZhIwPYnJYKEqlkiPxSVRV1/DU46vEF/IG1NbVG/zi3LlnPxUVVdx/z3JsbW0AcHF2ZqSfL4h9YTLvvvcRpefLWL70DqOvkQbw8vTAq3vMWRF30zh+soRPPv83ZmZmxE6LxMfHm/Z2BZlZOZw5V0qA/2hee+kZfb9UEfeB9f5Hn1F86nSv1xuLuJtGZnYuX3+7AWtrK2bEROPm5kp9fQMJSSnUNzSyeNE8gwc8RdxNZ8eufezed5DAAH+iIsNpb1eQnJpB+cUKZs6I4b6Vd+nLDrW4i+R3iFCr1RxNTCEpOY2q6mqkUimjRvqxaMEcAgPEbZgbkZyawbrvNl6xTFTEFB5ddR+IfWEyL61ec9UyixfOY8kd2guTiLvpVFXXcODQEUpOnaGuvgGJRIKHuyvhYZOYPSsWc9mlgX5E3AdWX8mviLvpnD5zloOH4zlXWkZzUzNyCzkjR/gyK246IROCDcqKuJtWWkY2R+ITKb9YiUajwcvTg9iYKKZPizQoN9TiLpJfQRAEQRAE4bYh+vwKgiAIgiAItw2R/AqCIAiCIAi3DZH8CoIgCIIgCLcNkfwKgiAIgiAItw2R/AqCIAiCIAi3DZH8CoIgCIIgCLcNkfwKgiAIgiAItw2R/AqCIAiCIAi3DZH8CoIgCIIgCLcNkfwKwgB5+50/8fM3fzPY1bhumVm5vPP7v/DaG7/i0y+/Mdl6d+7ez0ur15CbV2iydQ5nyakZvLR6DTt37x/sqlyz8osVvL7mbb5Z9z2Ifcvb7/ypX6/11sUpOTXjurZzsvgUL61ew9r1P1y17PsffcZLq9dQW1t3Xdu60bqaykur1/D2O38alG0nJqfy0uo1xCemDMr2BdOT9aOMIAi3mba2dr79biMSiYS771qCu5vrYFfplnDmbClnzp5jzqwZ+mljAwN46vFVeHl6DGrdrlVbWzuff7UWF2dnHrp/xWBXZ1gJnxyKl5cHI/1GXNfyXl4ePPX4KlycnQ2mxyem4OHuxtjAAP20JXfMp7mlBTs72xuu92B66vFVWMjlN7SOfQcOExw0lhG+3te03PRpUZw9d54fNm3Fx9sT/9GjbqgewuATLb+CIPRSVV1DZ2cnwUGBzIqbzvjgcYNdpVtCcmo6Px1JNJjm4uxEeFjosEt+N2/dQU1tHaseuAdzc/PBrs6w4uXpQXhYKC7OTte1vJ2tLeFhoYz089VPU6vVbN66k+KS0wZlA8f4Ex4WivwGE8fBFh4WyoTxQde9fGNTM1t37KbsQvl1Lb9y+VJsbKxZu/4HOru6rrsewtAgkl9BuAWo1Wq6THhC7ujoAMDSwtJk6xzqOjs70Wg0A7qNs+fOD+j6b5aKyipS07MICw1h1Mjra70UTOtCeYX+eyv0dvZs6Q0tb2lpwaIFc6muqSVBdH8Y9kS3B2FY2rp9N/sOHua1l56lqamZ/YeOUFlVjbW1FYFj/FmxbAkODvb68i+tXoOzkxO/+82bBuupra3j1797l8AAf1a/8hwARcdO8PFn/2LR/DmMDQxg647dlF+swNLCkslhE7nn7qU0NjWx6b87OFl8Co1ag6+vN/fcvRRfn96309ra2tiybRcFRcdpa23DycmR6TFRzJsdh0Qi0ZdTq9UkJKWSnJpORWU1Go0aFxdnwkJDWDB3NhYWl1pu3n7nTyg7lPx89Ut8s24D58vKeeqxVUwKnXDFuCWnppOYnMbFi5V0dXXh4GBPcNA47lgwB0dHB+juI1h8Stt6lJqeSWp6pkF8+pJXUMRPRxI4X1ZOR0cHdrY2BAYGcMf8uXh4uBldJiEplSPxSVRV12AhlxMcNJa7ly3W1wWgtq6e/QcPc/xEMQ2NTZiby3B1cSEqIpyZM2IMYtjW1s6+Az+Rm19IXX0DMqkULy8PYqIjiYmO6LXfwyaFEB05lR83b6O2rp5HHryXtf/5gZkzYrhv5V296puYnMp/vt/MgrmzuGvpHQDkFx7jSHwS5eUXaWltw9LCglGj/Fg0fw7+o0dCdx/NDz7+XL+ensdjcmoG677byOKF81hyx3yDOu7Zf4hjx0/S1NyC3Nwcb28v4qZHM3VKmL5cZ1cXq3/+/wgM8OepJ1axZetOCo+doKOjAzdXV+bNmUnk1MkGnyMtI4uEpFSqqmpoVyiws7VhzBh/Fs2bjWc/WqD3HzyCWq0mLnZan2X6s28BzpWWsffAIU6dPkt7uwJbG2sC/EezcP5s/ffpi399S05eAS+/8BTB48b22tZXX68nKyeP1156Vn/Lv7/HY3xiChs2buHhB+/F0cGenXv2c6G8Agu5nJEjR7DiriV4uBsev0kpaRw6nEB1TS2WlhZMCB7H3cuWXDVuOjt372fX3gM8/OC9TIuaCsBf//4xZ86V8uF7f2D3voOkpWfR2NSMo6MDU8MnsWjBXMxl2ku27niKipjCo6vuY+36H0hNzwRg194D7Np7QH886b7Pv317DS4u2m4SarWaI/FJpGdmU1Nbh0KhxM7WhqBxgSxdvLDXPuqPisoqfvfH95g9M5aIKZPZumM350rPo1Kp8fX2YvGieb3uIDW3tLB3/0/kFx6job4BqUyKp4c7kRFTiJsejZnZpfa5y8/huvP04oXzmBgSzNbtuzl77jxmUjN8vL24e9lifbeSnue0dd9tZN13G/Wxb2lp5cBPR8nLL6ShsREJEpydnQgPm8j8ubOQyS6lSdMip/Lfbbs4fDSR2TNjrzlGwtAhkl9hWJLKpNB9ES8uOc2M6dHY29tRUHiMjMwcqqtr+cXrL1/XunUnu4uVlaSkZzIzNobYmCiSUzM4mpCMhVxOdl4BEycEs3L5Us6Vnic+MYV/fPIVv/vNmwa3gDUaDZ9++Q2ODg4sv/MOmltbSUhM4b/bdtHZ0cniRfP0Zdf+5wfSM7KZFDqB6dOikEjgZMlp9u7/iaJjJ3n9tRf0Fz+d/2zYhI+3F3HTp+Hj43XFz7Vx8zYOH01kpJ8vy+5chLm5OWfPlZKYnEp+QSG/eONVHB3sWXLHfE6WnGLXngMEjvEnLnYadrZX7i946HA8m/67Aw93NxYvnIu1tTUXLpRzNCGZ/PwiXn/tBXy8DeuXmJJGbW0dsTFRWFhYUFh0nIysHM6XXeBXv1iNTCajXaHgvfc/RtnRwey4WNzd3ejo6CA3r4CN3QnryuV3AmjLfvhPamrqmD4tEr8RvigUCjKz81i/4UfKLpT3SmgV7Qq++2EzM2KicHR0JDR0AvIfzcnOzeeeu5caXHwBMrJyAYiKnAJAWkY2a9d/j5urC/PmzMTOzpaamlp+OpLIBx9/zhuvvYjfCB99H82vvl6Pra0N99+z/Ir9F6uqa/jr+x/T0dHBjJhoRozwpaGhkZS0DP797XdUVlXrE2WZVPtd6Ojs5MOPv8BvhC/Lly6mvb2d/YeO8M26DdhYW+lvGR84dIQt23YxbuwYltwxHwsLC6qqqzmakExh0XF++T+v4ezU9+14jUZDYdFxLC0sCPA33vexP/sWoLDoOJ99tRYnJ0fmzY7D3t6e6uoa4pNSyC8s4pUXniHAfxSx06PIySsgOSW9V/KrUCopKDqGm6sLgWP8r/l4lHWfS4pLTnPsxElmxsYQFxvD6TNniU9MoexCOe+89Qt9nROSUvnuh804OjqwZNE8bGysOVl8mg//+QUq1fXffdGd0777YTO1dfXMnzsLMzMzEpJS2bPvEKouFcuXLTa67MwZMVhYyDmakMzksIlX7UazYeMWEpPTCBo7hmVLLp0LEpJSKS45zf9b87rBj+3+0MXnQvlFsrJziYqYQlTEFKqqqjl0JJ5PvviaV198Rr+PWlpb+cvfP6a+voHoyCmMCfCnpaWFrJw8Nm7aSmlpGY+uuu+q26usqiL+sxSmT4skKnIqFysqOXDoCB98/DnvvLUGOztbltwxnyMJSWTn5BMXO43AMf6M9BuBWq3mw39+QUVlFbPiYvDx9kalUnHiZAk7du+n7MJFnnnyEf02LSzkBAaMpuj4SSoqq/D0cL+mGAlDh0h+hWFJgra1L7/wGL/51c+xtrYGIGLKZM6XlXOu9Dy1dfXX3acOIC+/iDd//qq+9Wl8cBBv/e8f2H/oCPetvIuZM2IAiI6cQlV1DcdPFHP6zDnGjR2jX4dCqcTH24v771munxYxZTLv/P7PHPjpCPPmzEQuN6eg6DjpGdnMnR3HirsutSBNnxaFm4sLu/cdJCk5Tb9Nuls53dxceOj+lVf9LKXnL3D4aCIjfH14/dUX9BeOmOgIvL292LhpK7v27Oeh+1cSOMZff/vf2UnbH/VKGpua2bp9N44O9vzPz17Cysqqe84Uxo4dw6dffM3mrTt55YWnDZYru1DO22++ri8fEx3Bl1+vIzsnn8zsPKIiwjlxsoTGpmaWL72D+XNn6ZeNjYniP99voq2tDY1Gg0QiYc++Q1RUVPHCM48TMiFYXzYudhoffvwFR+KTiI2JwtvLUz/vRPEpHl11v0HL6KSJIaRnZlNy6ozBg0ONjU0Ul5xm1MgR+otedXUNgWP8uf+e5QYXQmdnZ9au/574xGRWPXCPvo/mV6xHbi6/akw3/3cHra1tPPX4KoOyM2Kj+dNfPmDP/kPEREfg5OSob/k+V3qepYsXsmjBHH15W1tbvlm3gaycPH3ym5aRjaWFBS8//5RBcj8+aCw79xygoqLqislv2YVymltamBgyHml34m2szNX2rUqlYv33m3B0dOCXP38NS0sL/fJTwyfxx798wI9btrPmjVcIGhuIq6sLuflFtLa2YWNjrS+bl19IR0cnMdGRSCSS6zgetfHLzM7l7Tdfx9XVBYDIqZOprq7h+MkSzpwtJXCMP2q1mp179iOTyXj9lef1LanTp0Wxfdde9uw7dMX9eiW6c1pDQyOvvPC0ft+MDx7LW//7R7Jy8vpMfkf6+VJ+sQIALw+PKx5fKpUKhUJByPggnnv6Mf12oiLC6ezsJDk1g9z8AiKnhl9j/bVOFp/i+acfY2LIeP280aP8+OSLr9m19wCvjXkWgF17DlBbW8fdyxYzb85MfdmZM2L44OPPSU3PJDYm8qoPl2Vm5/GzV59njP9o/bSWlhaSUtIpPHaC6MgpBI7x52TxKbLJx2+Erz4+58sucKH8IjOmR7Pirjv1y8dER+Dq6kxFZRVKZYfBD4HgoLEUHT9J0bETIvkdxkSfX2FYi4qYok98ASQSiT5ZbWhovKF1j/IbYdCNwdHBHmsrKyQSicEtdECfUDU2Nfdaz4zp0QZ/O9jbETQ2EKWyg3Ol2j6gGZk5AISFTqCtrd3gX9ikEAAKCo8ZrEej0RAVMaVfnyU7Nx+A6dMiDW7jAcRERSCTSsnLL+rXui6XX1BEl0pF5NTwHomG1sQJwTg5OnDiZAlKpWF/xKnhYb3KR0zRJqEni0ugR6vmmbOlvfo0P3T/Sh556D598peRmY21tRX+o0cZxE+hUDI5bCIABYXHDdYhk8n08/R16E6EM7PzDKZnZuf2ivmSO+bz2kvP4unhjkqlor1du00XF23yWFtX3+846nR0dFB47AQO9na9khgrS0umTglDrVaTf9nxIJFImDVzusE0P9/e3wWpVIqy49Kxp+M/ehSvvPD0VR9urKquAejVFaCn/uzb4pLTNDY2MSF4HGq12mCf2dvb4+fnS+n5Mpqam5FIJMROi6Srq4u0jGyD9aZn5mBmZkZ0lHa/XO/xOHFCsD7x1Rnh6wNAfXf8yi9W0NTUTID/KH3iq9Pzh+mNmBU33eBHiZOjI3a2tvo63CipVMqTj63ihWefwMzMjM6uLv1xqxvV5XqOWx1nJyeDxBdgwvggbKytOXX6LCqVCoCc3HykUimxl50fZTKZvitIf85JfiN8DRJfeuy3q10DdD/ezpddQKFQGsxbunghzzzxSK8WcF2Mqmtqr1o3YegSLb/CsOZ22cUK0Hc70J1kr9flFzcACwsLZDJpr6fbLS0sjG7TzMzMaOuA7iJbW1dPYPdFFeC9Dz7psz519Q2912OkjsZUVFQC4OPt2WueXG6Os7MTVdU1tLW1Y21tZWQNV1+3t5F1A3h6uFPf0EhVdY3BEEM9W2B13HrEBSBoXCCjR/qRm1/Ir3/3LhOCxzEucAxB4wKxtbXRL9fW1k5DYxMA//Or/+2zrnX1hhd1Rwf7Xl1JgscFYm9vR05ePvffc5c+EcnIykEmkzE1fJK+rEKhZPe+g2Tn5hsdR1WtUvdZl75UVtWgVqvxMhIfulv2AKqqqg2m29nZ6o9DnUvfhUv1WDh/Nl99vZ6/ffgpAf6jCBoXSNDYQPxG+PTq5mFMS0urdns94n+5/uxb3TF/NCGZownJfa6rrq4Bezs7oqOmsmPXPpJT05ndneS3tLRy/EQxE0OCsbezgxs4HvtzLqmpqesu23voP3s7O2ysrWlta+vzs/SHsXWbm5ujVl/7sdSX6ppaduzax/ETxbS0tvaafz3HrY6x7lcSiQQXF2dKz5fR0NiElaUljU3NuLu59jpmATy7j/HKy45xY27kGuDt5UlYaAg5eQX8+rd/YnzwOMaNDSBoXCBOjo5Gl9ENGdfc0nLVuglDl0h+hWHt8lZMU+rrlq5U2v9tys3NjSYU8u6Tc2dnJwDK7qe0n33yUaysjI+wYGw4Kcs+yl5Ot35zc+P9+HTDIHV0dFxz8qtbt7wf6+7J2EXv8rjIZDJee+U5EpPTyMjMJiUtk6SUdMzMzAgZH8Q9K5bh4uyEskPbauPs5MQjD93bZ10d7O0N/jYWazMzM6ZOnsShIwmcKC4heNxYqmtqOVdaRnhYqP5Og0aj4ZMv/q3vHrF44TwcHOyQmkmpratj3Xc/XiVyxuk+i7yP4cPM5ebd5QzjKevncRkWGsIvXn+FI/GJFBQdp7jkNNt37sXRwZ5FC+b2ulNxufZ2BfQRO53+7Ftd/WNjopgyeVKv8joe7tpk0M7WlkmhIWRm53Ku9Dwj/UaQlZOHWq1menSkvvz1Ho/9OZdcWrfxsuZyc7ix3FffB3mgNDU389f3P6a1tY1pUVMJDhqLjbU1EomE3PxCDh9N7Mda+taz+0pP5j32v5mZxGDa5eTdx3h/Rq+40WvAU4+vIj0jm9SMLLJz8kjP1N5ZCBzjz70rlvV6VkF3N0H3PRCGJ5H8Cre1rhtsHb6azq4ufZ/UnvQX0e4LsVX3BcPV1bnXydYUdMlIq5FWHgClUptwWfRx4boSi+51G2tB6rnuyy+KHZ29L2yXxwXAXCZj1owYZs2Ioa2tnZPFp0hNzySvoIjqmlp++T+vYWlpqd9Wz3661ysyIpxDRxLIys4jeNxYMrK03VJ0D7oBnD1XSsmpM/h4exn00QQ4c/b6x7211MfTeBalu11vLMHsrxG+3jz84L1oNBoulF+koOg4h48msmHjFn3Xir7okt4rXfz7s291w+jJ5fJ+77MZ06PJzM4lJS2TkX4jyMjKxcnRgeCgSw/BXe/x2B/m3UlvX+O8KhRDPyFKSc2gpaWVuNhpBs8iYKKh+HQ/bi6nS2Qt5PJ+nI+6y17HPrpWZmZmREVOISpyCkplByWnTpOZnUtaRjYfffIlv/7lGwZd69ra2uEqP/6EoU/0+RVuC2ZmZkafxL7eV372l0ql0veR7Km6e5qbq7bbgu428ekz54yuo+0Gb6V6eWlvI17sviXck0KppLauHkcHe6wsr/2E7n2FdWs0Gi5WVGJmZtbrdu7Fiqpe5aurtf3ojN3KBLC2tiJsUgjPPf0Y4WGhXKyopKKyCitLS5ycHGlta6Oysvet0naF4prGQR7h64Onpzt5+UWo1Woys3JxsLdjfI8kq7ZWe/s+wH9Ur9b94pJT/d7W5dzd3JBKpVRVVRu9bavrLtCfIcmuRtdHftH8Oax+SfsgUlZu3hWXuXTb13jiQj/3ra4Lzhkjxzx93FYOHOOPh7sbWTl5VFXXcPrMWaZFRRjE/3qPx/7QdTMy1t+zrr6+V7/Roaim+5ynG3Whp5M3cNzqVBjZ92q1mpqaWszNZTg42GNlZYWjowNNzS1Gf6T0fHjvZrKwkDNhfBCPrrqfebPjaG5uoeT0WYMyLd3H5dVGwBGGNpH8CrcFRwftiVb3q10nKSV9wLd9JD7J4O+GhkZOFJdgbW2F3wjtG5p0t30PH03s1XJyNCGZNW/9jpzcguuuQ3hYKBKJhITk1F5JYEJiCmq1+qojEPQlNGQC5uYy0jOyaW83jG92bj6NTc1MDAnW38rUSc/M7rU/dGOVBo0LBGDHrn38+rd/oqm594OEulY4aXfiM7U7hvsOHjYop9FoWPefjbz51u+oN9Jvui9RU8NpaW0lNT2LixWVREwNN0iyHBy1XSjqLns4qLKymoTkNOgefqwnMzOzPlvGdORycyaGBNPS2trrobv29nbSM7KQyWSEXvZQUX/U1dfzf3/6G1t37Ok1T9Z9C1pqduXb7rqk8Ur9MfuzbwP8R+HoYM+Zc6W93kpWV1/PO//3Fz7/19pe646NiaKlpZX1G7TdSqZFTzWYf73HY3/4eHt1P7h1ptexdCS+737LN4NUqj02r3Z8OTpox/C9/LjNzMqltLSsX+u4korKKo6fLDGYlldQRLtCwbixgfrv0JTJodqxzRNTDcp2dXWRmKydFj75+s5JxpgZiU98Ygr/7ze/1yfbPckuO7/o6BozxCvfhzfR7UG4LYRNCuHQ4XjW/ucH5syMRa1Wk5aRjVqjfbBDg+nf7KVBg42N9gnnL/71LcFBY1EoFBxNSKajo5Olixfq+6tNGB9ExNTJpGdk894Hn+hHZSg5dZrU9Cx8fbyYMP76XzHs4+3FvDkz2X/wMO9/9BnRUVORy80pOXWG5NQM3N1cuWPhvH6sqTdbWxtW3HUn3//4X/76/j+ZMT0aGxtrzpdd4GhCCna2tqzsMYyQLtYebq785e//YFpUBDY21hQUHiOvoIgRvj6EhWpHuAgaF8j+g4f589/+QUxUBK6uLnR1dXH6zFnSMrIJGheobwFduGAO+UXHSEnLQKFQEBoyno7OTjKzc/VjQTs5GX+IxZiIKZPZtnMvW3fshu6hoHoaPdIPV1cXCo+d4MfN2/Dz86X8YiXJKek89vD9fPHvb/VjywaNC8TdzRVXF2eqqmvYuHkb9nZ2zJllfKD8FcuWcOr0Wf7z/SbKyy/i6+NNc0sL8YkpNDQ2cd/Ku/QtsNfC2ckJJ0cH9h34ieqaGoLGBmJhIaehoVHfl/pKL64A8PXxws7OluKSU6hUKoO+8deyb6VSKQ/dv5LPvlrLp198zexZsbi7uVFbW8vRxBS6VCpmzZjea/vRkVPYtnMPJafOMD5obK9h2a71eLwWUqmUhfNns3nrTv724afEzZiGg70dx0+UcL7sAq6uLtTU1Brt6jTQdK3SaZnZ2Nja4OTowNTw3t1XwieHsnvfQfbsO4RGo8HOzo6Txac4frKYhx5YyRf/+pbsvAK8PD2Y1D3SzLUYPdKPL/+9jpjoqXh5elJdU8Ohw/HIpFIWL5yrL3fHgrkUFB5n55791Dc0MiZgFO3tClLTMzlfVs68OTNN2gVMF58j8Ul0dHbi5eGufYnR9t28/4/PmD4tCk8Pd9RqNRculBOfmIK3lydjewxdCVB0/CQA44PEK9+HM5H8CreFpYsXIpVKycrJ4+NPv8LOzpap4WE8eN/drP6ft1B1mb7vb1dXF1KplJeff4pNW3ewfdde2tsVuLo4G4wTrPPoQ/fhP2okKWkZbN66E9Dg7OTEovlzmDd3Zp8Ph/TX8qV34OXhTnxSCpu37kDVpcLJyZHZM2NZOG/2NT/o1lNc7DScnRw5eDieHbv20dHZib29HVER4SxaMMfgyemu7ljPmR1HVVU18Ykp1NbVY2lhQXTkFJYvW6xvHRoTMJrXXn6OQ0fiSUxJo6WlFQu5HBcXJ1bctYTYmEsPZ1lZWvLGqy+y7+BhcvMKKCg6jrm5OR7urjx0/0qmT4s0UvO+OTk56scH9Rvh22sEA5lMxovPPsGPW7aTlpFNcloGfiN8efrJhwkM8Gfp4oXs2nuQbTv24OzkiLubK/esWMaGH7aQlJKGk6MjM+OMD4/l4uLMmtdfYdfeA6Rn5XDwcDwWFhaM9PNl5fI79WP2Xo9nn36Mg4eOkp2bz4mTJXR0dOJgb8foUSN54tEH9Xcj+iKRSJgQHERKWganz54jMODS7fNr2bd0/+h747UX2XvgEPGJKdo3vNnaMMZ/NAvmzdIPWdWTtbU1kyaGkJGVw/RpUUbreC3H47WaOzsOqVTK0YRktu/ci5WlJUFBgbz8wtN8/tU31NTU0tXVdcPf12vlP3oUcbHTSMvI4sDBI0ROnWw0+fX0cOf5Zx5nx6697Np7ELncnKCxgfx89Ys4OToyNTyM3PxCtu3cQ1BQ77fpXY27uxsr776T7bv2kZiUhkqtZoSvL0sXL9C/cY3uB8feeO1F9uw7SF5BEcmp6ZjLZHh7e/HYww/0eivhjZo8aSK5eYUUHjvBwZ+OMnd2nPb4W/0iBw4dITMrh6bmFmRSKU5OjiycP4dZcTEGo8Fo+wSfwd3Ntc+3VgrDg+TEiRMD+zJ7QRAE4ZZSev4C7773IeFhoTz1+Kqbum21Ws0f/vw+CqWS3769pl/DswkDT/fKcN0rl29FR+KT+GHTVh5+8B6mRUX0YwlhqBJnDUEQBOGa+I3wIWLKZLJz83u9LGOgHU1M4WJFJfPnzBSJr3DTKJRK9uw/hIe7W79fLiQMXeLMIQiCIFyze1YsxcHejnXf/XhDD0j1R2NTM+mZ2fywaSubtmxn9Cg/YmOMd3kQhIGwact22tvbefyRB8SPrluA2IOCIAjCNbO1seHZpx6jpraO9d9vGtBt1dbW8Z/vN5GWnkXElMm8+OyTfb6ERhBMLSkljaSUdB68d8VV+8QLw4Po8ysIgiAIgiDcNkTLryAIgiAIgnDbEMmvIAiCIAiCcNsQya8gCIIgCIJw2xDJryAIgiAIgnDbEMmvIAiCIAiCcNsQya8gCIIgCIJw2xDJryAIgiAIgnDbEMmvIAiCIAiCcNv4/8aUkcX84TpoAAAAAElFTkSuQmCC",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAr8AAAIVCAYAAADYnpdmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAAC4/0lEQVR4nOzddXgU1/4G8Hdd4q4ESHB3K1C0UOpKS3vr8qvrrd26u/utU6ell0IpbSleXINDgoS42/rOzO+PTZaE2Gazluz7eR4eNrOzc84MS/Lm7JnvkR08eFACEREREVEQkPu7A0REREREvsLwS0RERERBg+GXiIiIiIIGwy8RERERBQ2GXyIiIiIKGgy/RERERBQ0GH6JiIiIKGgw/BIRERFR0FD6uwOdQZ8+fXzWliiKKMrLQUJKGuRy/m7iK7zu/sHr7h+87v7B6+4fvO7+4Y/rfujQIZf247uAiIiIiIIGwy8RERERBQ2GXyIiIiIKGgy/RERERBQ0GH6JiIiIKGgw/BIRERFR0GD4JSIiIqKgwfBLREREREGD4ZeIiIiIggbDLxEREREFDYZfIiIiIgoaDL9EREREFDQYfomIiIgoaDD8EhEREVHQYPglIiIioqDB8EtEREREQYPhl4iIiIiCBsMvEREREQUNhl8iIiIiChoMv0REREQUNBh+iYiIiChoKP3dAWpszJgxyM/Lg1yh8HdXgo4oCLzufsDr7h+87v7B6+4fvO7+IQoCklNSsHXrVn93pRGG3wBTWFiIgsJCf3eDiIiIqMMC8ZcOht8Ak5iYyN9Q/YTX3T943f2D190/eN39g9fdP0RBQGJior+70QTDb4DZvHkzivJykJCSBrmcU7J9RRRFXnc/4HX3D153/+B19w9ed/9oeN0DDd8FRERERBQ0GH6JiIiIKGgw/BIRERFR0GD4JSIiIqKgwfBLRERE5EM2k4jPZxzD5zOOwWYSu2R7X56Rg2XXwifttRfDLxG5zNffQP3RZjC0F8g/lIh8zR/f18i/GH6JiIiIKGgw/BIRERFR0GD4JSIiohZ19alAFHwYfomIyGs4T7zzt0fU1TD8EhEREVHQYPglIiIioqDB8EtEREREQYPhl4iIiIiCBsMvEREREQUNhl8iIiIiChoMv0REREQUNBh+iYiIiChoMPwSERERUdBg+CUiIiKioMHwS0RERERBg+GXiIiIiIIGwy8RERERBQ2lvztAREREFKwkUYIkSl5vw1/tBSKGXyIiIgpaknQyqFUet0Imk0GwShBskuPvUx+39OfUfZp7TYNt9b4574RPz9fX7QUihl8iIiLqcmwmEaYKAcYyOwqzgIptNTBXOraZygWYKwTH4wrR+Zoltxf6tc/kGwy/RERE1CnYLSfDa31wrQ+yxoq6QFv3nN186kfvFW0eXxMhh1Itg6L+j6rBY1e2u7iPJEpYeE0+AOCSb1Kg1Hr3Fiy7WcSCK/L80l4gYvglIiIKYpIkwW6WYDOIsNb/qRVhNTi2maoE577bPquAQinzan8E+8nQuubFEliqRWegtRnbN5dUqZVBG6WAUm9HeKIOuigldNEK6KLkdX8roNLJ8b8b64Lo16lQ6bxfC8BmOjnarAlXeL1Nm/rkv5mv2wtEDL9ERESdlCRJsFtOBlabQXIGWFujINtwm3Tyca0Iq1GEJLjQGID9v9R4+5QayfnH1GSbQgVncNVGKZyPnX+iT/6t0skhiiKK8nKQkBIHubxp6GsYRCk4MPwSEZFP/HJ9HmQ+GBBqcP+ST9p0tT0JgGAHFMo8dKRLDdv77sITEO0dOFgDMjmgCpFD7fwjgypEDqVWhqMrjQCAAReGQe7lkV/RLmHfQkfIHnVTFELjlY0CripEBpkv3kjUZTH8EhGR12R+V+V8bCh2cXjRg3zdpmvtea5P9cFXJgdU+pOB1RlgQ+WNvlbVhdr6505uc4Tc5kKlzSTi6MocAMCIa6O8/5G5SXSG337nhPlkGgIFF4ZfIiLyip3zK5H57cnwO/u1BCg13g8ydouIZfcV+axNV9uTJBHlxUWIjk+ATOZ+nxq2d8FnyQiJVUKp42gokasYfomIyON2fl2JHV9WNtoW20fj85uJfNGmq+2JogghFIhN0TQ799Sd9kLilBwZJWon/o8hIiKP2vl1JXZ84Qi+w6+O9Hd3iIgaYfglIiKPaRh8R94QhYEXh/u7S0REjTD8EhGRRzQKvtdHYshlEf7uEhFREwy/RETUYU2C7+Wc7kBEgYnhl4iIOoTBl4g6E4ZfIiJy265vGHyJqHNh+CUiIrfs+qYS2z+vC77XMfgSUefA8EtERO3WJPjOY/Alos4hYBe5KK+owPIVa3Dg4GGUV1RCp9MiLjYGEyeMxagRw1wqEC4IAlau+Qebt2xHcUkpFAo5UlOSMX3qZAwZNMAn50FE1NXs+pbBl4g6r4AMvzkn8vDWex8BEnDahLFISU6CwWDAPxs348uvf8CBg4dx1RVz2zzOp19+g12ZezFoYH9MPX0i7HY7/tmwCR998iUuu+QCTDptnE/Oh4KHzSTi63NyAABXLk7jykvU5ez6thLbP3ME3xEMvkTUCQVk+F34vyUwmy24547/Q6+Mns7t48eNxjMvvIZNW7Zj9hnTER8X2+Ixdmbuwa7MvRg1Yhiuvepy5/axo0fg+ZffxMJFv2HYkEEICwv1+vkQEXUFpwbfoQy+RNQJBeSw1LBhg3H+uXMaBV8A0Gm16Nk9DQBQUVHZwqsdNm3eBgCYPnVyo+1qtRoTJ4yF1WrFtp2ZHu87kS/ZTCI+n3EMn884BptJ9Hd3qAvLZPAloi4iIEd+p0ya0Ox2QRCQX1AIhUKBxMSEVo9x5NhxqFQqpKYkNXkuvWd3xz5HjrXYFhEROWR+W4ltDL5E1EUEZPhtyGy2wGKxoLikFH/+vQqlZeW45MJzEREe1upramsNiIuNafbGuKgoxzfuktIyl/ogir4bUatvy5dtkueue8PXi6IIb/8zdvb2XLnunf0cA7o9SWzzPb/7uyps/7wKADD8mggMviy8Xf9PfH1+/mjT1fb4fcY1Rrut0eMwUdWh47V13T3dniusSgHvvlwOALhUmQKFl6+pP9u7WJUMVYBlmoAPv6+//QHy8gsAACnJSbjz1hvRu1d6q68xWywAAI1G0+zzGrVju9lsdqkPRXk57ex1x5UU5Pq8Ter4dbdbTj4uLsiFsvm3oMd0lfZau+5d5RwDsb3SwvxW28teAhz+2fG494VAwulVKMqrcrs9X5yfP9psb3v8PtM6g1kCIAMAlBTmw6iVeeS4LV13syTh3ZcrAABTKiQYKz3TXmvMkuR8XFyQC63Mu236s73SwjzUerm99gr48HvFZRej1mBAeXkFNm3ehrff/y9mnzENZ82e2YGjOv5RZC7+YySkpHWgrfYRRRElBbmIS0p1qZwbeYanrrtj3q3jG2x8UqrXqz109vZcue6d/RwDub3YxGRo9M3/GNj9fRUO/3xyxHfIvIgOt+eL8/NHmzUGGwDHIE14QhLCQpofOfTU9xlX2/MUf7YXl5jc4fbauu4mQQBKHeE3PikVOoWiQ+25wtdt+rO92MQUhCh9EzdrsrJc2i/gw2/3tFTn44kTxuLDT77E0mXL0S01pcVavTqtFmgwAnyq+u3auv3a4o8QKpfLGX79oKPXveFLffFv2FXaa+1YXeUcA7I9WfPtZX5Xie2f1QffSAy70v05vr4+P3+02fD4rrTX8e8z7Wuvo9R6pfMj7Mv03Tptey1dK3mDUUqfvUd93KZf25PJAi7PBFZv2iCTyTBuzEgAwJ69+1vcT6NRIyI8DJWVVc3O8Skrq/vtJ77lUmlERMEo87tKbPvUcXNbR4MvEVEgCriR39LSMrz53seIjY7G3Xfc3OR5m80xMb2tGwZ6ZfTEth2ZOJ5zAj17dG/03OGsIwCAPm3MHSYiCiaZ31d5PPiqdHJcu7yHB3oXuG0qtfKTI5Xabl2uPaKuJuBGfqOjoyCXy5F15Ciyso82ek6SJGysq9/bK8MRXAVBQGFRMcrKKxrtO2H8WADA8hVrGm03Gk1Yt2ETQkL0GD50sJfPhoioc8j8vgrbPnF8H+WILxF1ZQE38iuXyzFv7kX44OPP8d5Hn2Hi+DFISUmGyWTGtu07cfR4DjLSe2L0yGEAgMrKKjzzwmtI65aCB++703mcfn16YfzYUdiwaSs++PhzDB82BBaLBavXrkd1dQ2uv+YK6HQ6P54pEVFgYPAlomAScOEXdcH1Pw/eg+UrVmPv/oNYu34TZDIZEuJjcd7ZZ2LqlIlQuHCn4ry5FyE1NQXrN2zG9wsWQqFQoEf3NFw+90L0zuCUByKi3T8w+BJRcAnI8AsA8XGxmDf3ojb3i4mJxntvvtTsc3K5HFMmTeAqbkREzdi3sAY7v/RMVQcios4i4Ob8EhGRbziD79UMvkQUPAJ25JeIAtval0oh80CddLMR0OpLW3xeEjzfZmuCqT3UB99/MfgSUfBg+CUilwhWCds+PVlV5fg6oweP7tqxPNsm2xt8eTiDLxEFHYZf6tJsJhFfn5MDALhycZpPllbtiiqPW7H6+RKUZ9uc20bfHAW5qmPrtUuShJrKCoRFRrW43Lhok7DlowqPtdmWYGpv8GXhXm2LiCgQMfwSUYskScL+RTXY+nEFBKsETbgclmrHAjN9zw7r8C8ToiiiKK8CCSlhLS5/aTOJzrDmiTbbEkztEREFIw6DEVGzTBUClv+nGJveLYdglZAyWoez303yd7eIiIg6hCO/RNTEiY1GrHu1FOZKEQoVMOqmaPQ/Pwx2s+TvrhG1ySQImLhrFwBg3dCh0LlQF56IggfDLxE52c2Oj8QPLK4BAESlq3D6w3GI6qmu24Phl4iIOjeGXyICAJQdtmD1C6WoynHc1DbwonCMuD4SSjVnRxERUdfB8EsU5CRRwp4F1dj+eQVEO6CLUWDSA7FIGanzd9eIiIg8juGXKIjVFtux9uVSFO40AwDSJupx2j0x0EZwjiQREXVNDL9EQeroagPWv1EGa60IpVaGsbdFo/fs0Bbr7RIREXUFDL9EQcZmFLHx3TJk/WkAAMT2VWPyw3GISFX5u2tERERex/BLFESK95mx5oVS1BTYIZMDgy+LwPCrIiFXcrSXiIiCA8MvURAQBQm7vq7Erm+qIIlAaIICkx6KQ+Jgrb+7RkRE5FMMv0RdXE2+DatfLEXJPgsAIH16CMbfEQN1KEuYERFR8GH4JeqiJElC1l8GbHynDHaTBJVehvF3xSBjeqi/u0ZEROQ3DL9EXZClWsD6N8twbI0RAJAwWIPJD8UhNIH/5YmIKLjxJyFRF1Ow04Q1L5bCWCpApgCGXx2JwXMjIFfwpjYiIiKGX6IuQrBJ2Dm/HHsWVAMSEJ6ixOSH4xDXT+PvrhEREQUMhl+iLmLZ/YWoOGIDAPSZE4oxt0RDpeNNbURERA0x/BJ1EnazCGO5AFOZ4Pi7XEBtkd35fMURGzThcpx2Xwy6nxbi174SEREFKoZfIj+SJAk2gwRjmd0ZaI1ljr9Phlw7jGUCbEap1WMlDddi8oOx0MfyvzUREVFL+FOSyEvMVQJqCux1IdbeaMS2PuAaywUIltZDbUMKjQz6aAV00QroYxTQhMtxcEktAGDak3FQhyi8eEZERESdH8MvkQdJ0skg+9OVeS6/TqWXQR+jgC5a6Qi3MYq6rxv8Ha2EKkQGmexk1QabSXSGX5mc1RyIiIjawvBL5EHlWdZGX2si5I1GanXRygZhti7kRiug1PLGNCIKTpIkodJuR4HVinyrFTlms/O5J44fh1LWsV/sJUmC2WSE1nas0eBBPXuDQQtPtOeKhm0+euwYFDIZREmCBEACGj1u62ux7lhi3bk2t4/QoL0rDxyATCZz7osGx5VOGcRpbnv912hh+6nHCEQMv0QedHSV0fn48oXdoA3nNAQiCm6iJKHMbkeh1Yp8i8UZcgvr/i6wWmEWxWZf+3dlpec6YrG2uYtH23PRqqoqn7Z3zGLxaXuBiOGXyENEQcKxNQbn1woVpyEQUdcnSBJKbDYUWK0oaBBuC+r+FFqtsLowEhinUiFJrUa8SoXldSH0ruRkqOQd+2RMkiTUVFYgLDKq2ZFfmyjirfx8j7XnioZt3pOSAo1cDhkAeV3/5Kc8lgGQyWSOfU59fMrXkMkcr2/w2CqKuOfIEQDA2xkZzvbqX4v6x3X9a26787lmtjuval0/LKKIqw4eBAJ0FJjhl8hD8reZYK5sfvSCiMgTJElCjSA4vz5sMkHr5bDWcFR2aXk5yux25whufbgVWj2CI4jFq9VIUquRrFYjse7v+q8T1Gqo687DJAjO8HtJXBx0io59giaKIoqsJiTExUHezLUyCYIziHqiPVc0bPOi2Fivt2lq8J4ZERrq0/aa+4XD3xh+iTwke7nBhb2IiJoyiyLKbTaU2e0otdlQVv+n4dd2O8pstkajqNceOuTTfj5/4kSz2xUAEuvDrEaDpLrH9eE2Tq2GKgBDEAUnhl8iD7AZRRz/x+jCnkQULARJQkVdYC2z2VBiteK40QRLbi7KBQFlNpsj2NrtqBXaGjttXoxS6fWRNaluzi4AjA4NRWp9uK37O1mtRqxKBQXDLXUSDL9EHnD8HyMEi4SwZCVq8u0uvIKIugJJkrDfePIX3/uOHHEG3gq7Hc1OhDKYmj2WWiZDjEqFGKUSMSoVYusex6pUju0qFWKVSujkckzfvRsAsGjgQJ98hD1x1y4AwBsZGT6ZFkDkTQy/RB6QvdxRa7fnlBBkfuvbO3eJyLckScJeoxHLKyrwd2Ul8q0nqwhsqqlptK8MQHRdmI1WKhFitSAlIhJxarUz5NaH2lCFwqVRXJObo8RE5MDwS9RBxjI7CnY46lL2nKJn+CXqguoD7191gbegQeDVyuXOm8Ie6dYNSWq1M9RGKpXOurGiKKIoLwcJycnN3nhFRL7B8EvUQUdWGiCJQNwADcKSVP7uDhF5iCRJ2NNghLdh4NXJ5ZgUEYEZkZEYERqKGXXTEOZER3NaAFGAY/gl6qD6Kg8Z00P83RUi6qD6wFs/wlvYTOCdGRmJ8RER0DUozUVEnQfDL1EHVByzojzLCpnCMd+XiDqfhoF3eUUFimw253M6uRyT60Z4J0REeL2mLhF5H8Mv+ZTNJOLrc3IAAFcuToNK17l/kBz52zHqmzpGB22EAjYTF7kg6gxEScIegwHLKyubBF59/ZSGqChMCA9n4CXqYhh+idwkiRKy/3ZUeciYEerv7hBRG+oD71+Vlfi7hcA7MyoK4xl4ibo0hl8iNxXttsBQLECll6HbOJ2/u0NEzRAlCbtqa7G8hcA7uW6El4GXKHgw/BK5qb62b4/JIVBq+EOTKFBIDZb/vWj/fpQ0CLwhp4zwahh4iYIOwy+RG+xWEcfW1FV5mMEb3YgChUUU8UxOjvPrEpsNIaeM8DLwEgU3hl8iN+RuNMFqkKCPUyBxiNbf3SEiABU2G+47cgS7DAbnthd79MDkyEgGXiJyYvglckP9lIeMaSGQydtejpSIvOuo2Yy7srKQZ7UiVC5Hbd2KaxMjIhh8iagRfkcgaidzlYDczSaAVR6IAsLmmhpce/Ag8qxWpKjV+LB3b393iYgCGEd+idrp2BoDRDsQnaFGVE+1v7tDFNQWlZbiuZwcCACGhoTgtfR0Vm0golYx/BK1k3M5Y97oRuQ3oiTh3fx8fFlUBACYFRWFJ7p3h0Yu53LDRNQqhl+idqjJt6F4rwWQAelTGX6J/MEkinji2DH8XVkJALgxMRE3JyVBJuP8eyJqG8MvUTtkr3CM+iYP10Ify/8+RL5WarPh3uxs7DUaoZLJ8FhaGs6KifF3t4ioE+FPbyIXSZLkrPKQzhvdyEPMotDosYr3IbfosMmEu7OzUWi1IkKhwGsZGRgeyv+LRNQ+DL9ELio9aEV1rh0KjQw9Jur93R2ioLK+qgoPHT0Kgyiiu0aDtzIy0E3LGttE1H4Mv0Quyv7bMerbfYIeKj1H56hzOnWkWePlHwMmQcDEXbsAAOuGDoVOoWj3MX4sKcErJ05ABDAyNBSvpKcjQskfX0TkHn73IHKBaJdwdKVjvm86qzwQ+YQgSXgzLw/fFhcDAM6OjsajaWlQsZQZEXUAwy+RC/K2mWCuFKGNlCNlpM7f3SHq8oyCgP8cO4Y1VVUAgNuSk3FtQgIrOhBRhzH8ErngSF1t355TQiBX8ocvkTcVWa24JzsbB00maGQyPNmjB86IivJ3t4ioi2D4JWqDzSji+HojwOWMibxuv9GIe7KzUWKzIVqpxOsZGRgcwqlGROQ5DL9EbTi+zgjBIiE8VYnYvsG9nLFKJ8e1y3t06TZ93Z5SK8e7L5cDAC7TdvNpe5dqU7zeXnusqqzEf44dg1kUka7V4q2MDCRrNP7uFhF1MQy/RG2or+2bMSM04OYb+iOMdnWeqE5A7SNJEr4tLsYbeXmQAIwNC8NL6ekI47UnIi9g+CVqhbHUjvwdZgBAxjR+9ErkaXZJwssnTuDn0lIAwEWxsfh3t25QBdgvmkTUdTD8ErXiyEoDIAHxAzUIS1b5uztEXUqNIOChI0ewsaYGMgB3p6Tgivj4gPuEhYi6lg6F34LCIuzZdwDl5RWYevpExMfFAgAqK6sQGRnhqT4S+U12XZWHDNb2JfKofIsFd2dnI9tshlYux3M9emBKZKS/u0VEQcDt8Ltg4a9YvXa98+sRw4cgPi4WgiDguZffwOiRw3HpRed5qp9EPldx1IrybCvkSqDHZIZfIk/ZbTDg3uxslNvtiFOp8EZGBvrruWQ4EfmGW8vkbNi0BavXrkevjJ5NAq7NZkefXhlYs24DNmza4ql+Evlc/Y1uqWN00EbwxhsiT/irogI3HzqEcrsdfXQ6fNm3L4MvEfmUWyO/6zduQXrPHrj79pthMpnw48+LnM9ptRrceN2/8Oa7H+GfDZsxfuxotzpmNJqwYtVa7Nq9F6Vl5ZDJgKTEBEwYNwYTxo1uc07Ypi3b8dU3P7T4fFJiAh596F63+kZdnyRKyF5RP+WBtX2JPGF+URE+KiwEAEwKD8fzPXtCz4oOdAqdQoFtI0Z02fb80aY/2tsybBiK8nICsmKOW+E3v6AQ5541u9V9Rg4fisW//eFWpyqrqvHqm++hqqoaY0ePwLQpk2AymbBu/SZ8+8PPKCouxoXnnd3qMUwmEwBg+tTJ6NG9ae1MnU7rVt8oOBRmmmEsEaAOkSF1nOvLGbP0GHUmeRYLdKLo1TYsguB8XB98L4+Lwz2pqVDwxjYi8gO3wq8gCNBqWw+ParUaVpvNrU79umQZKioqccmF52LK5NOc28eNGYWnX3gVK1atw4xppyM8LKzFYxiNjvA7oF8f9Ovb261+UPDK/tsx6ttjcgiUardmBxEFBKMg4KDJhP1GIw4YjdhrMDifu/zQIZ/2RQ7g39264dK4OJ+2S0TUkFvhNyoyEidy8zB2dMtD6Jl79iI6yr07d6OiIjBs6CBMGNd4yoRer0NGzx7YmbkH+QVFrYffupFfnc71UTsiALBbRRxbzSkP1PkYBAEHjUbsb/DnuMUCqYX9dXI5vD32KgEw1Y0uv9SzJ6ZFRXm5RSKi1rkVfocOHohVa9ejf78+SO+RBgCQ1X0LLS4pxV9/r8KuzL2YOX2KW506Z86sFp+rD7X6NkJt/civXu/YTxRFiKIIpZKljal1JzaYYDNKCIlTIGEwl1alwFRzStA9YDQip4WgG69Sob9ej356PTK0Wjxw9CgA4I+BAxGi8m796oYr5o0PD/dqW0RErnArCc6aORW79+3HBx9/7gyXX337IyxmCwxGIwAgMSEeZ8xwL/y2JC+/AFnZRxEfF4tuqcmt7lsfkjds2oIdO3ejtKwcoigiJiYaE8aNxsxpp0Ph4iRs0ctz4ppry5dt+lLD83L8QhIY7TW87vVVHnpOC4EECZLY0rgZdVQgvt+bvGe8PC/VlfZq7HYcMJkcf4xGHDCZkGOxNHu8eJUK/XU69NPrHYFXp0NMg4BrajAHV5Qkr197X19Pf7Tpanueer9rZDJsGTas2fa9wdfteVogfp8JBoF83d0KvzqdDv+++3b8/uff2Lp9JwATyssrgLopESNHDMXsmdOg1Xpu1KyiohIff/oVZDIZ5s29qM1qD/Ujv1u37cTECWORlJSI6uoarF67Hot/+wPHjuXg5huudmkloaK8HI+dh6tKCnJ93qYv2Bv8vC4uyIXSywOr7W0v71Aucjc7HkcMrkZRXrV3O0hAgL3fzdLJX3aKC3Kh9XJwOrU9uyQhyy4gy25Htl1Als2OghZ+eMTJ5eilVKCXUoleKgUylEpEyuvmqAtWoMYKe00lilpor7QwD7U+Pj9vX09/tNne9gLp/R5MeN39IxCvu9tzALRaDS44dw4uOHcOTCYTLBYrtFqtRwNvveM5ufjoky9gMBhxzb8uQ+9e6W2+5tyzZsFsNiMjoyd0DW7OGzdmJF567R3s3rsfmXv2YejggW0eKyElrcPn4CpRFFFSkIu4pFTI5V3vRiubSQTg+I8Qn5QKlc675+hqe/XXvfZQJCShEtG9VOg1JsmrfaPAfL+bBAEodfwyH5+U6vUyPQ3bu6OqFgUt3CicrFajX92Ibv3fUW5M42rYXmxiCkK8PBXM19fTH2262l4gvt+DAa+7f/jjutdkZbm0n0e+6+l0Oq/dWLZ12058/f1PUKtVuO3/rkef3hkuva5XRs9mtysUCkyZPAHffP8z9h845FL49cd/Frlc3iX/kzY8JV+cY3vbO7rCMW0nY0Zol7z+gSqQ3u/yBqN4vujXN3XlvwA4g2+KWu2ctlA/VzfSQyG10fnJZN7/P+jj6+mPNtvbXiC934MJr7t/BOJ1d+u76dJly9vcR4IEURBxzlkt37zWluUrVuOXX5ciOSkRN99wNWJjot0+VkP1VSJMZrNHjkddg7EYKNlnhUwOpE/hcsbkfT+WlDhr3wLAm+npGBoainDemEtE5DXuhd8/2g6/9dwNv2vWbcAvvy5F/769ccO1/2rXdAqLxYq9+w9ALpdj2JBBTZ4vLC4BAESz5A41kL/B8XfScC30sQwf5F2Ly8rw0okTjbaNCgsLyNWQqHX+WCGMiNzn1k/4Ky+/pNntgmBHaWk5tmzfie5pqZgy6bRm92vLkaPHsGDhr8hI74Gbb7wGqlZGQQRBQElpGVQqFWKiHWFWqVTgx58XwWy24JEH7kZ8XKxzf6PRhFWr10Emk2HEsMFu9Y+6HkmSnOGXtX3J21ZUVODp48cBABfHxuKn0lJ/d4mIKGi4FX7HjRnZ6vNzZs/AW+99jNKyMpduTjvVgoWLIYoiBg/sj9179jW7T1JiApISE1BZWYVnXngNad1S8OB9dwJ183ovufBcfDH/e7z21vuYNGEc4uJiUVFRiXXrN6KisgpzZs9At9SUdveNuqbSg1YYiwClRobuE/X+7g410LBO7LqhQzv9yOj66mo8fOwYRADnxsTgzuRkhl8iIh/yyme7KpUKM6dNwW/L/sL4saNdeEVjOSccd+f/b/HvLe4zZ9YMnHXmzBafHzl8KKIiI/D3qrXYuGUbaqproNao0b1bKi675AIMGti/3f2irutI3XLG3SbovF6BgoLXjtpa3J+dDbskYUZkJB5NS4M1AGtgEhF1ZV6b2BgeHobiEvdGM9578yWX942JiW5x//SePZDes4dbfaDgIdolHFvlqPKQPp03upF37DcacVdWFiyShNPCw/Fsjx5Q+KDmLRERNea18Lt77z7n6m9EgSxvqwnmKhHqcCB5pNaFVxC1zxGTCbcdPgyDKGJEaCheSk+HKsBK/3QlvAGNiFrjVvid/+2CFp8TBAFFxcU4kZuPkcOHdqRvRD6RXTflIWksIFdwJI48K9diwa1ZWagSBAzQ6/FGRgZ0DL5ERH7jVvjdtGVbm/t0S03GBeed5c7hiXzGahCR849jykPyeH/3hrqaYqsVtx4+jBKbDRlaLd7p1QuhnfyGPSKizs6t8HvXbTe1+JxCIUdERISz7BhRIDv+jxGCVUJ4qhLhPez+7g51IRV2O27NykKe1YpUjQbv9e7tsVXaOkKnUGDLsGEoysvxSeUMTkEgokDj1ndid8qXEQWi7L9qgbob3WSyKn93h7qIGkHA7YcP46jZjHiVCh/06oU4lcrf3SIiIgCceEZBy1BqR8FOxxLX6dNY5YE8wySKuDsrCwdMJkQplXi/d28ka1xfoZKIiLzLpZHf2+95yK2Dy2QyvPP6C269lsjbjqwwABKQMEiDsCQljHn+7hF1dlZRxP3Z2dhpMCBUocB7vXqhp5YVRIiIAolL4TcqMhIsR0ldzZG/66Y8cDlj8gC7JOE/x45hY00NtHI53s7IQF89VwskIgo0LoXfZ55wb+SXKFCVH7GiPNsGuRLoOZkBxVVdbalhTxElCU8fP44VlZVQyWR4PT0dQ0P5SxURUSDy2pzfAwcPY/63P3rr8EQdkl036ps6Vg9NOAMcuU+SJLyam4vfysuhAPBiz54YGx7u724REVELOhR+BUFAZVU1yisqGv0pKirB5q3bsW1Hpud6SuQhkijhSN3CFhlczpg66P38fPxQUgIZgCd79MCUyEh/d4mIiFrhVqkzSZKwaMkyrF67HjabrcX9EhPiO9I3Iq8ozDTDWCpAHSpH6jguwU3u+6KwEJ8VFQEAHurWDXOio/3dJSIiaoNb4XfVmn+wfMVqaDUaxCUlIr+gEPFxsZDJZCguKYVOq8WI4UMwZdIEz/eYqIOylztGfXtM1kOpZrU/cs+PJSV4Jz8fAHBXSgoujovzd5eIiMgFboXfDZu2omeP7rjjluthtwt44D9P4fK5F6J3RjoqK6vww0//g81mQ2Jigud7TNQBdouIY2vqpjywygO56beyMrx04gQA4PrERFyVwO91RESdhVvDXsUlpRg3ZgTUanWTEmiRkRG44dorkZdfiL9WrPZQN4k848QGE2xGCSHxCiQM4sID1H4rKivx1PHjAIC5cXG4JSnJ310iIqJ2cCv8ymQyqFRqAICirtSR1Xpy7q9CocDY0SOxYeMWT/WTyCPqqzxkTA+FTM7i1dQ+G6ur8cjRoxAAnBMdjftTUyFjEXQiok7FrWkPEeFhyC8oBACo1WoolQoUFBZhYP++zn20Wg0qKis911OiDjJXCcjdbAIAZMxglQdqn521tbjvyBHYJAnTIyPxaPfukHsg+OoUCmwbMcIjfSQiora5NfLbv18frFy9DitX/wMASE1JxoqVa3Ai17E+bK3BgPUbNyM8LMyzvSXqgOPrjJAEIKa3GpHd1f7uDnUiB4xG3JmVBbMoYkJ4OJ7r0QNKjvgSEXVKbo38zpx+Onbt3osDhw5j6umnYerpE/H5V9/hpdfegUathtVmgyRJmDVjqud7TOSmo6tY25fa76jJhNuysmAQRQwPDcXL6elQyVklhIios3Ir/EZHReGRB+5GQaGjvuXI4UNhsVixfMVqlJVXIDoqEqNHDsfsM6Z5ur9Ebis9YIVMDvScyvBLrsm3WHB7djYq7XYM0OvxZkYGdAy+RESdmlvhFwBCQ0LQOyPd+fWEcaMxYdxoT/WLyCuSR2ihj3H7bU9B5u4jR1BssyFdq8U7vXohVMGlsImIOju3hjD+8+Tz+PW3ZSgqLvF8j4i8iLV9qT3yrVakqNV4v1cvRCr5SxMRUVfg1ndzg8GAP5evwp/LV6FH924YN2YURg4fAp2OS8VS4FJoZEg7Te/vblAAs0sSNlZXO7+OU6nwQe/eiFPzBkkioq7CrfD74rOPY9euPdi6fScOHs7GseMn8NMvizFk0ACMGzMS/fv1Ye1LCjjdxuug0nG+JjWVZTJhSVkZfq+oQKntZM3yN9PTkaLhYihERF2JW+FXq9Fg7JiRGDtmJGoNBmzfkYmt23di+85MbN+ZifDwMIwZNQLjRo/gEsfkV6Jdcj5On8Ib3eikCpsNyyoqsKSsDAdMJuf2CIUCVYIAAOiu1fqxh0RE5A0dnsQWGhKCyRPHY/LE8aiorMS27buwY9duLF+xGn+vXIN3Xn/BMz0lckPRXovzceIwBplgZxNFrK2qwpLycqyrqoJQt10pk2FieDjOjonByJAQTN292889JSIib/HoHRxhoaFISIhHt9QUlJVXoLbW4MnDE7Vb/taTI3pyBafiBCNJkrDPaMSS8nL8UV7uHNUFgAF6Pc6OjsYZ0dGIqruhzdTgeSIi6no6HH4FQcC+A4ewbccu7NmzH2aLBTKZDH16Z2DMKC7ZSf6Vv83kwl7UFRVZrVhaXo7fystx1Gx2bo9TqTAnOhpnRUcjgzfpEhEFHbfCryiKOHDwMLbtyETmnr0wmRw/WJKTEjFm1HCMHjkcERHhnu4rUbvUFtlRdcLu726QD5lEESsrK7GkrAyba2pQP+NbI5NhSmQkzo6JwdiwMCh4Qy4RUdByK/w+/NizMBiNAICI8DBMGDcGY0YNR0pykqf7R+S23M1Gf3eBfECUJOyorcWS8nIsr6iAURSdzw0PDcXZ0dGYERXFBSqIiAhwN/za7DaMGTUCY0aPQN/eGSxrRgEpdzOnPHRlJywW/FZWht/Ky5FvtTq3p6jVOCs6GmfFxCCVZcqIiOgU7tX5feZxqNUqz/eGyEMEq4SCHWYX9qTOpFYQ8HtFBX4rK8NOw8kbakPkcsyIisI5MTEYGhICOX8hJyKiFrgVfhl8KdAV7THDbpagjZLDXCG68AoKVIYG1RfO3bsXVskxk1cOYExYGM6OicGUyEjo5FzAhIiI2sbF6qlLqp/ykDxChyN/s+ReZ2EUBBw0mbDPYMB+oxH7jEYct5ys1WyVJPTUanF2dDTmREcjnssOExFROzH8UpdUH35TRmoZfgOUSRRxwGDAZqMZecePY7/JhKNmM6RWXvPf3r0xPDSU9xkQEZHbGH6py6ktsqMqxwaZHEgczjqugcAiijhkMjlGc+tGdY+YzXBOSDGcrMwRr1Khv16PAXo9+uv16KnR4Jx9+wAA/fV6Bl8iIuoQhl/qcupLnMX110ATynmgvmYVRWSZTNhXN23hgNGILJMJza2bFqNUIl0uw/DoGAwICUF/vR6xqsb3FHDFNSIi8qQOh19JkmAwGKHTaaFgHU0KAPVTHlLHcNTX22yiiGyzGfuMRueobpbZDLvUdPJClFLpHM0dUPcnRqlEUV4OEhITIecNa0RE5ANuh9+S0jL8umQZ9u0/CKvNhjtvuxG9M9IBAAsXLcFp48YiISHOk30lalPDEmcMv95146FDyDabndUXGopQKBwjuTod+oeEYIBejwSVqsmUBVFkJQ4iIvItt8JvWVk5XnnjXRiNJkRGhMPSoMB8TW0tVq1Zj81bduD+e25DbEy0J/tL1Kqi3Y4SZ7poBaJ7qWE3t3b7FHXEfpNjhD1MoXCO6NaP6iap1ZybS0REAcmt8LvsrxUQ7ALuvPVGpKYk44H/POV8Liw0FPfffSvefv8T/Ll8JebNvciT/SVqVe6WuioPo3V14Yvh15PKbDbn44dSUzEuIgKpDLpERNSJuDXJ7sDBLEw8bRz69M5Acz/z0rqlYtKEsThw8LAHukjkOud839Gc8uANf1ZUOB+fHRODbhoNgy8REXUqboXf6upqpCQntrpPUlIiqmtq3O0XUbs1LHGWPFLr7+50OZIk4fcG4ZeIiKgzciv8qjVqGI2mVvepqqqCmqsvkQ81KnEWxsojnnbAZMIRs9nf3SAiIuoQt8Jv97Ru2LRlG6Rm7vIGgNLSMqxYvQ7d07p1tH9ELnNOeRjLKQ/esKSszN9dICIi6jC3bnibPnUS3vvwM7z+9ocYOngAAODw4SPIzy/EkWPHsXPXHoiiiOlTJ3u6v0TNalTijPN9Pc4mivi9vNzf3SAiIuowt8Jv/759cPmlF+KnX37F0WPHAQBL/1jufF6lUuLSiy5Avz69PNdTolacWuKMPGtddTWqBAExSiXK7HZ/d4eIiMhtbi9ycdr4MRg6ZCB2Ze5FQWERLBYLtFotkpMSMWTQAISE6D3bU6JWNC1xRp60uG7Kw6yoKHxbUuLv7hAREbnNrfC7/+Ah9OvTG6EhITht/BjP94qonVjizHsqbDasq6oCAMyOjmb4JSKiTs2t8Pveh58hMiIcY0aPwNhRI7mMMfkVS5x51+8VFRAADNDrka7l9SUios7NrfA7csRQ7NmzH38uX4U/l69Cj+7dMG7MKIwcPgQ6HUfeyLfqS5zFD2CJM2+or/JwdjSXKicios7PrfB77b8uh9Vqw+49+7B1+07sO3AIx47/gp9+WYwhgwZg3JiR6N+vD+dekk/UT3lIGcNfvDztsNGIgyYTlDIZZjH8EhFRF+D2DW9qtQojRwzFyBFDYTKZsGPXbmzdvgs7du3G9p2ZCA8Pw5hRI3D+OWd6tsdEDbDEmXctritvNjkiApFKJUyC4O8uERERdYjb4bchnU6HCePGYMK4MaipqcW2Hbvwx/KVWL5iNcMveRVLnHmPTZKctX3P4agvERF1ER4JvwBgsVixe88+7MjcjYOHsmE2m6HRMIyQd7HEmfdsqK5Gud2OKKUS4yMi/N0dIiIij+hQ+LVabdizbz+27diFffsPwmazQyaToV+fXhgzegSGDh7kuZ4SNYMlzryn/ka3OdHRUPEXCyIi6iLcCr+7Mvdi245d2LNvP6xWGwAgNSUZY0YNx6iRwxAeFubpfhI1wRJn3lNlt2NNXW1fVnkgIqKuxK3w+9/P5wMAIiMjcPrEYRgzegSSEhM83TeiVrHEmff8UVEBmyShr06HPnqu1khERF2HW+F37OiRGDt6BPr0zvB8j4hcxBJn3uOs7RsT4++uEBEReZRb4fdf8y7xfE+I2oElzrzniMmEvUYjFABmR0X5uztEREQe5VL4feu9j3HW7JnoldHT+bWr7rrtJvd7R9QCljjzniV15c0mRkQgWqXyd3eIiIg8yqXwezjrCGprDY2+JvInljjzDkGSsLQu/HLKAxERdUUuhd+nHnsQYaGhjb4m8ieWOPOOTdXVKLHZEKFQYFJ4uL+7Q0RE5HEuhd+Y6Mbz/mQyICw0FKpWPhItLCpGrcHQ5LWuMhpNWLFqLXbt3ovSsnLIZEBSYkLdSnKjXRrtEwQBK9f8g81btqO4pBQKhRypKcmYPnUyhgwa4Fa/yP9qCm0sceYl9VMeZkdHQyWX+7s7REREHufWT7fHn34Je/cdbHWfvfsOYP43P7rVqcqqajz/ypv4Y/lKdE9LxaUXnYezzzwDJpMZ3/7wM3759TeXjvPpl9/gl0W/ISoqEnMvPh/nnzMHFosFH33yJdb+s9GtvpH/5dWN+rLEmWfV2O1YWVkJADiHUx6IiKiLcrnag8lshslkcn5dazCgvKKi2X1tVjsOHc5GdU2NW536dckyVFRU4pILz8WUyac5t48bMwpPv/AqVqxahxnTTm91MY2dmXuwK3MvRo0Yhmuvuty5fezoEXj+5TexcNFvGDZkEMLCQls8BgUm53xfljjzqL8qK2GVJGRotein47UlIqKuyeXwu2LVWvz+x9/Or79f8Eubr+melupWp6KiIjBs6CBMGDe60Xa9XoeMnj2wM3MP8guKWg2/mzZvAwBMnzq50Xa1Wo2JE8bil1+XYtvOTEyZNMGtPpJ/sMSZ9yxuUNuXNxESEVFX5XL4nXzaeCTEx+HYsRysWrseiQnxCA0NaXZfhVyOmJhonDFjqludOmfOrBafM9aNPuvbGJk6cuw4VCoVUlOSmjyX3rO7Y58jxxh+OxmWOPOO42YzMg0GyAGcGeTLGesUCmwbMcLf3SAiIi9xOfyGhYVi1IhhGDViGFatXY+zzzwDw4YO8m7vTpGXX4Cs7KOIj4tFt9TkFvczmy2orTUgLjYG8mZu2omKigQAlJSWudSuKIod6HX71LflyzZ9qeF5iaKI9p7miboljZNHaSFJEiRJ8kh7Xf26t6V+1Hd8eDhiFIoWr0OT69nBEWJXrrun2yS+3/2F190/eN39I5Cvu1srvL37xostPicIAhQKz9+EVFFRiY8//QoymQzz5l7U6seyZosFAKDRaJp9XqN2bDebzS61XZSX41afO6KkINfnbfqC3XLycXFBLpTN/xO16PgGx99hvQwoyjO0tXu72+uq1701giRhcXkVAGCiJLT6fjc3+GWjuCAXWg8F0dauu7fapOB8vwcCXnf/4HX3j0C87m6FXwA4cCgL//v1N1x1xVwkJyU6t2/asg0rVq3DpRedhz69MzzSyeM5ufjoky9gMBhxzb8uQ+9e6R08ouOHqavzGhNS0jrYnutEUURJQS7iklKbHbXu7GwmEYDjP0J8UipUOtfPsbbQDkN+PmRyoP+MVKhD236tq+119evemk01NSgtrUCYQoFzemZA08r5mwQBKHXc6BqflApdB3/RdfW6b0nt3qF2qLFgfr/7E6+7f/C6+4c/rntNVpZL+7kVfo8ey8EHH30GCYDdbm/0XGhoKErLyvDeh5/i3rtuQfe0bu404bR12058/f1PUKtVuO3/rncpUOu0jtqv9SPAp6rfrtW6ViPWH/9Z5HJ5l/xP2vCU2nuO+VsdI/XxAzTQhrv21m1ve131urdmaV3VljOioqBTtn5dQ+Ryr8yHDcbrHgh43f2D190/eN39IxCvu1u9Wfbn34iMisQTj9yPtG6NKzoMGTQATz36IKKjo7C0QXUIdyxfsRqfz/8OcbExeODeO1weSdZo1IgID0NlZVWzc03KyupGruJjO9Q/8i2WOPO8WkHA33Xhl7V9iYgoGLgVfo+fyMWUSachJqb5u8IjIsIxeeJ45Jxwf57HmnUb8MuvS9G/b2/cd9etiG2hrZb0yugJu92O4zknmjx3OOsIAKBPh6dPkK+wxJl3/F1RAYskobtGg0F6vb+7Q0RE5HVuhV+z2QKNpvUyUyEhephMrt1QdqojR49hwcJfkZHeAzffeA202pbvUhIEAYVFxSgrb7zgxoTxYwEAy1esabTdaDRh3YZNCAnRY/jQwW71j3yPJc68Y3HdcsbnsLYvEREFCbfm/MbFxuDAwUNNFqFoaGfmHsTFuvcx6oKFiyGKIgYP7I/de/Y1u09SYgKSEhNQWVmFZ154DWndUvDgfXc6n+/XpxfGjx2FDZu24oOPP8fwYUNgsViweu16VFfX4PprroCOq1h1GvVTHlJH6xjSPCTXYsGO2lrIAMwJ8tq+REQUPNwKv2NGDceiJcug0y3E2NEjERcXA5VKBYvZgvzCQqz7ZxMyd+/Deeec6Van6qdL/G/x7y3uM2fWDJx15sxWjzNv7kVITU3B+g2b8f2ChVAoFOjRPQ2Xz70QvTM45aEzyd3M+b6e9ltdbd+xYWFIUHM0nYiIgoNb4XfalEk4ejwH/2zYjH82bG52nyGDB2D6lEludeq9N19yed+YmOgW95fL5ZgyaQJXcevkagptqMqxQSYHkke6VqGDWidKEpbUTXk4mze6ERFREHEr/CoUCtx03VXYtXsvtu/MRGFhMSwWCzQaDZISEzBi+BAMGTTA872loJRXN+obP0ADTajnF1AJRjtqa5FvtSJELseUyEh/d4eIiMhn3F7kAgCGDh6IoYMHeq43RM1giTPPq1/OeGZUFHQBVn+RiIjImzr0U08URRzPOYHtOzNRU1vruV4R1WGJM88zCgKWV1YCrO1LRERByO2R3+07M/HzL4tRVV0DALjr9psQFhoKAHj59XcwfepkjBw+1HM9paDkLHEWwxJnnrKishImUUQ3jQZDQ0L83R0iIiKfcmvkNyv7KD7/6jvYBaFJwK01GFBrMOKL+d/jcPYRT/WTglR9lYfUUSxx5inOG92io3lNiYgo6LgVfv9asRrRUZF47KH7MPfi8xs9FxoSgofuuxMx0VH4e+VaT/WTghTn+3pWgcWCLTWOT2vOYm1fIiIKQm6F32PHc3Da+LEIDQ1BcwNHer0Op00Yi5xmlhYmchVLnHneb3WjvqPDwpCkaXnlRCIioq7KveWNTWZERUW0uk9URAQMRpO7/SJiiTMPkxrW9uWoLxERBSm3wm9IaAhKy8pb3ef4iVyEhvJmGnIfpzx41i6DAScsFujkckxjbV8iIgpSboXfPr0zsHbdBlRVVTd5TpIkbN66HWv/2YC+vXt5oo8UhBqVOGP49Yj62r4zIiOhV3AknYiIgpNbpc7mzJqBPXv247mX3kBGeg8AwMrV67B6zXocyzmBysoqaLVazD5jmqf7S0GisGGJswyWOOsokyjir4oKgMsZExFRkHMr/MbHxeLO227C9wsWYvfe/QCAzN37nM93T0vFZZdcgPi4WM/1lIJKHkucedSqykoYRBHJajVG1NXjJiIiCkZuL3KR1i0FD9x7B0pKy5BfUAiLxQqdVoPkpETExPBmGuoYzvf1rCV1Ux7Oio6GnL9MEBFREHM7/NaLi41BXCw/RiXPYYkzzyqyWrGpvrYvpzwQEVGQcyn8btq8DX16ZyAqKtL5dXtotBqkJCcxJJNLWOLMs5aWl0MCMDw0FN1Y25eIKOgYrRIyHq8FAGQ/HQq9Org/AXQp/M7/bgFuuOZKZ/id/92Cdjckk8lwwblzMG3KpPb3koJK/ZQHVnnoOEmSnFUezmFtXyIiItfC75mzpiMxMf7k12dMB9rxS4PZbMH2HbuwfMVqhl9qld0qOkuccb5vx+0xGnHcYoFGJsP0qCh/d4eIiMjvXAq/Z82e2fjrM2e2uG9LkpMS8O0PC9v9OgouRbstLHHmQfWjvtOjohDK2r5EREQdv+GtoqISZeUVsNlsUKvViI2NQUR4WJP9MtJ7Yt7cCzvaHHVxLHHmORZRxJ/1tX055YGIiAjoSPjdvHU7li5b3uwyx0mJCTh7zhkYOnigc1t8XCzr/lKbWOLMc1ZXVaFGEJCgUmFUWNNfSImIiIKRW+F3w6at+Ob7nyCTyZCakoTY2BioVSpYrFaUlDjq/v73s/m4/porMHzoYM/3mrokljjzrIa1fRUcRSciIgLcDb8rVq1FWFgo7rjlBiQnJTZ5PudEHt778FP8uXwlwy+5jCXOPKfEZsPG6mqAyxkTERE1InfnRSWlpZg6+bRmgy/qVn+bevpEFBQWd7R/FERyN7PEmaf8Xl4OAcCQkBB013IUnYiIqJ5b4Vej1jhr/rYkIiIMarXK3X5RkLFbRRTsZIkzT5AkyTnl4RyO+hIRETXiVvjt0zsD2UeOtbrPkaPH0Su9p7v9oiDTVUqcmQQBI7dvx8jt22ESBL+0d8BkQrbZDLVMhpmRrf+SSkREFGzcCr8Xnn8WDmcdwd8r18BssTR6zmq1YcWqtThwMAsXnn+2p/pJXRxLnHlOfW3fqZGRCFN2uJohERFRl+LST8YXX32ryTZJkvDLr0uxaMkyREVGQKPRwGazoby8AoIoIiEhDl9+/QPuu+sWb/SbuhiWOPMMmyhiWbmj/CBr+xIRETXlUvjNzSto8TlRFFFWXtFke1FRScd6RkGjpoAlzjxlbXU1qgQBcSoVxoaH+7s7REREAcel8PvuGy+6dXCb3e7W6yi41Fd5iB/IEmcdVX+j2xzW9iUiImqWW3N+XaXifENyQV7dlIfU0Zzy0BEVNhvWVVUBnPJARETUog6l06PHjiNz9z4UlZTAarFCo9UgKSEBI4YPabEGMFFDLHHmOX9VVkIAMFCvR7qO15KIiKg5boVfSZLw9Xc/YdOWbU2e24W9WPbXCsycdjrOO+dMT/SRurCuUuIsEPxef6Mba/sSERG1yK3wu2bdBmzasg09e3TH+LGjkJQYD7VaDYvFgrz8QvyzYRP+WrEaKSlJGDVimOd7TV0GS5x5zmGzGSqZDGdERfm7K0RERAHLrfC7act29OjeDXfffhMUisY3KKX37IEJ40bjjbc/xJp1Gxl+qVUsceZZkyMiEMm59kRERC1y64a3oqJijBg2pEnwradQKDBm9Ajk57dcIo2ottDOEmcexikPFGiMVglJD9Ug6aEaGK1Sl2yT7bG9ztCmLxmtElIeMWDEezEBeX5uhV+7ICA0NLTVffQ6HUudUavytnm/xJlZFJp93BVFKZUYz9q+RERErXLr89GoyAhkHzmKMaOGt7hP1pGjiIqM6EjfqIvL39a1SpwJkoS/KyudX5++a5dP2z8jKgoqzpsmIiJqlVvhd9DA/lizbgMS4uMwccJYqNUn79I3Go1Y+88mrN+4BVMmT/BkX6mLKcy0AF1gvq8gSfizogKfFhbiqNl8cruP+3Eea/sSERG1ya3wO3vmNGTu2YeFi37DoiXLEBMdBbVahdpaA6praiGKIuLjYjF75nTP95i6DMHSuUuc2SUJf5SX49PCQhy3OIJ8qEKBWsERe38ZMABauVfXkYFZFHHBvn0AgDQt500TERG1xa3wGxoaggfvvQO/LfsLOzP3oLik1PlcZEQ4RgwfijNnTYeOP4ypDZ2xxJldkrC0vByfFRbiRF3oDVcocEV8PM6LicHsPXsAAHEqFXQt3BTqKSaha89jJiIi8jS3ayKFhOhx6UXn4dKLzoPJZIKlboU3Bl5qj9SxnWfKg02S8FtZGT4rLESe1QoAiFAocGVCAi6Ni0OoQsEwSkREFOA8UhBUp9NBx+VUqZ1kciBpROD/smQTRSwuL8fnhYXIrwu9UUol/hUfj0vi4qD38uguEREReQ6r4ZPfxPX3XokzT7CKIhaVleHzwkIU2WwAgGilElclJODi2FivT2kgIiIiz2P4Jb8J1IUtLKKI/5WW4ouiIhTXhd4YpRLXJCbigthY6Lx8ExsRERF5D8Mv+ZTQYKWX5JGBNVXGIkn4vqQEXxUXo6Qu9MapVLgmIQHnx8Z6vXIDEREReR/DL/lU8d6TdXCjeqr82pd6JlHEz8XF+KK8EhViBQAgQaXCNYmJOC8mBhqGXiIioi7Da+HXbrdDFMVGC2AQFe62OB/7u8SZSRCwoLQU84uKUF63FHeiSoXrEhNxTkwM1Ay9REREXY5bP90ff+Yl7Nt/sNV9Vqxai5def8fdflEXVbzH4sJe3mUQBHxRWIiz9+7FW3l5KLfbkaxW445QPRb274+L4uIYfImIiLoot0Z+y8srYK2bE9mS6uoaVFRUutsv6oLsZhFlh30bfpVaOd59uRwAcI4qGQsKC/F1URGq6urxpmo0uD4xEbMjI1GWfwIqhl4iIqIuzeXwu3L1Oqxc84/z6+8X/IKFi35rdl+bzYaamlpER0d5ppfUJZQcsEC0+6/9i/fvR01d6E2rD73R0VDKZBBF0X8dIyIiIp9xOfz27NEdBYVFOJ6TCwCorTUAMDS7r0wmQ1xsDC658FzP9ZQ6vcJM3095qLKfTNs1goDuGg1uSErCGVFRUHphzrFOocC2ESM8ftxAaY+IiKizczn89ujeDT26dwMA3H7PQ7jhmisxbOggb/aNupjCTLMLe3nWXxUVzsdPpqVhTkwMFH6+0Y6IiIj8x605v3fddhOSkhI83xvqsgSbhJJ9vh/5/bPy5LzzGVFRDL5ERERBzq3w27tXOqxWG07k5qNbarJz+5Gjx7EzczcUcgXGjxuN+LhYT/aVOrHSgxYIVgmacDks1b6ZX5tjNmOf0eiTtoiIiKhzcCv8VlZV4/W33kdSYgJuuelaAMDOXXvw6ZffQJIcK3it/WcjHrjvDgZgAgAU1U15iB+owYkNJp+0uazBlAciIiIiuFvnd9mff6Omthbjx412bvv1t2XQaDS45aZrceetN0KtUePvlWs92VfqxOrn+yYM0vqkPUmSsLS83CdtERERUefh1sjv/gOHcPrECRg2xHHDW35BIYpLSjFrxlQM7N8XADDptHHYvGW7Z3tLnZIoSCja65jvGz9I45M29xqNOGGxQCuXw8wyZkRERFTHrZHfquoapKQkOb8+cPAwAGDwoAHObbEx0aisqvZEH6mTK8+ywm6SoA6VI7K7yidt1o/6TgoP90l7RERE5FA/BfbUx4HCrfCrUathtwvOrw8cyoJep0P3tFTnNrvdDoVC4ZleUqd2csqDBnKF96st2CQJf9bN9z0jigutEBER+dI3W07W2D9Q1EXCb0xMFPYfOAgAKCktw6HDWejfrw9kDcpIHTl6HJERHHWjBuF3sG/m+26urkaF3Y4opRKjw8J80iYREREBm47Z8czSk6VN+ye6FTW9yq05v2NGj8RPC39FQeEbqKisgt0uYNLEcc7n1/6zEZu2bMf0qZM92VfqhCRRQtEex3+CxKG+Cb+/1015OCMqCtYGyykbbRJ0Xv4wwmiVkPF4LQAg++lQ6NXeHenu6u35o01/nCMRUVdQWC3ipm/MsAf4rTZuxfHJp43DpNPGoaKiEgqFHBdfcA56pfd0Pr9i1VokJsTjjOmne7Kv1AlVHLPBWiNCqZUhppcaZvHkdJmGjz3FKAhYWVUFADgzOtrjxyciIqKmLHYJN35tQnGNhD7xgTfa25BbI79yuRxzLz4fcy8+v9nnr/nX5UhNSeKcX3JOeYgfqIFcKQO8vMjbqqoqmEURqRoNBun1KLd4PmATeZJ/RrYNAGJw+EkJob75QIaIurjHFluwNUdEhBb44HItpr8VuItMuRV+G5IkCQaDETqd1hl2G9741lEbNm3FT7/8CrPZgqcfexAxMa6N5m3ash1fffNDi88nJSbg0Yfu9Vg/qXn1i1skDvHtlIc5UVGN5qATERGRd3yz2Yr5m2yQyYD3LtOhR0wXHPlF3Y1uvy5Zhn37D8JiteKu229C74x0AMDCRUtw2rixSEiIc7tjNbW1+O6Hhcjcsw8qVfvLY5lMjlXEpk+djB7duzV5XqfjcIe3SZJ08mY3H4TfMpsNm6od5fU45YGIiMj7tucIeGSR42Pdf89QY3o/JYzWwKvw0JBb4besrByvvPEujEYTIiPCYbFanc/V1NZi1Zr12LxlB+6/5zbEujhSe6qXXnsHgiDg1puuxZ/LV+Fw9pF2vd5odITfAf36oF/f3m71gTqm6oQN5koRChUQ19f7i1v8WVEBAcBAvR5pWv5yQ0RE5E0lNSJu+NoEqwDMHqDEXVPV/u6SS9xb3vivFRDsAu689UY88sA9jZ4LCw3F/XffCrsg4M/lK93uWHqPNDzywN0YULdiXHsZ60Z+dTqd232gjinKdPwmGNdfA4UP7pivn/LAUV8iIiLvsgkSbvzGjIJqCb3i5Hj7Ui3k8s4x3dCtkd8DB7Mw8bRx6NM7wzm9oKG0bqmYNGEstu3Y5XbHrrv6CrdfiwYjv3q9I/yKoghRFKFUtv+URR8uj1vfli/b9JaCXY5/g4QhmmbPq/7fxBNyLBbsNRqhADAjIsJ5XA1kyP/RMfKveVLWYnueuu6iKDV4LEIUvfuNoLO358p17+znyPZ8254/2nS1PX6f8U97bV13vkfd89QSCzYdExCqAT69QoMQteRsxx/XtD3cCr/V1dVISU5sdZ+kpERUr1nnbr86rH7kd8OmLdixczdKy8ohiiJiYqIxYdxozJx2usvVKIrycrzc26ZKCnJ93qYnSRKQv9PxWJ1UjaI8x1xcg1kC4PhPUFKYD6PWM/8hfjI47iodplLBXlyAorrtJhsAxAAAivNPQNfG9PGOXvf2ttdRXaW91q57VznHQGyvtDAPhi52fv5ok99nOkd7LV13vkfbb8lBNT7d4FhE6ulp1QizlaEor/n2fPF9pr3cCr9qjdo5stqSqqoqqNX+m/tR37+t23Zi4oSxjjBeXYPVa9dj8W9/4NixHNx8w9UuVQRISEnzQY8dRFFESUEu4pJSIZcH9t2SrakpsMNSkQ+ZAugzKRVKreNcagw2AAUAgLjEZISFdPx/hCRJWLt/PwDgvKQkJDSY9uCYdO8IxvHJ3VosI+Wp6+5qe57S2dtz5bp39nMM5PZiE1MQqvVuSUpfn58/2uT3mcBur63rzvdo++zOE/D8KsfN7HdPVWHupKRW2/PF95l6NVlZLu3nVvjtntYNm7Zsw+mTJjT7fGlpGVasXofuaU2rLPjKuWfNgtlsRkZGT+ga3Pw0bsxIvPTaO9i9dz8y9+zD0MED2zyWP0KoXC7v1OG3uG5Vt9i+Gqj1J99mDc/JU+e422BArtUKrVyOqVFRp7QhNXgsb3M+Ukf71N72OqqrtNfade8q5xi47Xn3+4yvz88fbfL7TOdor6Xrzveo68oMIq7/xgKzHZjeV4F/z9Q0eyxff59pL7fC7/Spk/Deh5/h9bc/xNDBAwAAhw8fQX5+IY4cO46du/ZAFEW/Lm/cK6Nns9sVCgWmTJ6Ab77/GfsPHHIp/FL71d/sljjY+1Ue6m90mxoRAT0XViEiIvI4uyDhlu/MyKuU0DNGhvcu03WaG9xO5Vb47d+3Dy6/9EL89MuvOHrsOABg6R/Lnc+rVEpcetEF6Nenl+d66kHhYY55Kiaz2d9d6bLq6/smDvVuyTGbJOGPigqAVR6IiIi85vk/LFibJUCvBj77lw4Rus4ZfNGRRS5OGz8GQ4cMxK7MvSgoLILFYoFWq0VyUiKGDBqAkBC9Z3vaDhaLFXv3H4BcLsewIYOaPF9YXAIAiI6K8kPvuj5DiR01BXbI5ED8QO+G303V1ai02xGlVGJseLhX2yIiIgpGi3bZ8MEaGwDgzYu16JfYuT9l7dDyxqEhITht/BjP9cYNgiCgpLQMKpUKMdGOMKtUKvDjz4tgNlvwyAN3Iz4u1rm/0WjCqtXrIJPJMGLYYD/2vOuqH/WN7qWGOsS783yW1k15mBUVBSWXMyYiIvKofQUC7vnJ8XP99tPVOGdIgJVucEOHwm/2kWM4dDgLZeUVsNnsUKtViIuNQb++fZDWLcXt45aVV+B4zgnn1zWGWgDA3v0HERoaAgCIiY5G97RUVFZW4ZkXXkNatxQ8eN+dQN283ksuPBdfzP8er731PiZNGIe4uFhUVFRi3fqNqKiswpzZM9At1f0+UsuKdtdNeRjs3VFfgyBgVWUlwCkPREREHldhlHDdfBNMNmBybwUemtU5VnBri1vh12Q245PP5uPg4exmn//1tz8wZPAAXHPl5VCr2/8bwqHD2fj6uwVNtv/w0/+cj8eOHomrrri0xWOMHD4UUZER+HvVWmzcsg011TVQa9To3i0Vl11yAQYN7N/ufpFrCutudksY4t3wu6qyEhZJQppGg4F6/02zISIi6moEUcJt35twvFxCtygZPrhMB0UnvcHtVG6F30WLf8fBw9no2SMNI4YNRVxcDNQqFSxWK0pKSrFl205k7t6HxUv/wEXnn93u448fOwrjx45yad+YmGi89+ZLzT6X3rMH0nv2aHf75D5ThYCqHMe8oIRB3q308HuDG91cqddMRERErnnlLytWHhKgVTlucIsO6To/Z90Kv5m796Jv7wzc9n/XN1u77fRJE/D2+//F9p2ZboVf6rzqpzxE9lBBG+G9CfGlNhs2VTtWjTuTNy4SERF5zNI9Nry10goAeO0iLQYld+4b3E7l1t1IBqMJI4YPabFosUKhwKgRw2AwGDraP+pkfFXi7M+KCogABun16Kb1bltERETB4lCxgDt/dPwsv/E0FS4c1vlvcDuVW+E3OioSktT6PjabDREsPRV0fHWzW/3CFnN4oxsREZFHVJslXPeVCQYrMCFdgcfmeH+hKn9wK/yOGzMKm7ZsgyAIzT5vt9uxZdtOjBk1oqP9o07EUiOg/EjdfN8h3vsPc8xsxj6jEQoAMznlgYiIqMNEUcKdP5iRXSohOUKGj+ZpoVJ0nXm+Dbk05zcvv6DR1wP698GRo8fwyhvv4bTxY5CUmACNRgObzYqCwmKs37gZIXodRgwf4q1+UwAq2mMBJCA8VQl9dIeq6LWqftR3XHg4olVd7+MYIiIiX3tzhRV/7LdDowQ+vVKH2FDv1un3J5cSyguvvNXicw3Lj53q+ZffxDuvv+Bez6jTKaqf7+vFEmeSJDnDL2v7EhERddxf++149W/HDW4vnq/FsG4du8FNr5Yh7/kQFOXlQK8O8VAvPcel8Dtm1Ai0t5KUJDmmP1DwKPRB+N1tMCDPaoVOLseUiAivtUNERBQMjpSKuP0HEyQJuGacCpeN6vqfqLoUfltbTII6N5MgYOKuXQCAdUOHQqdw77c9m1FE2WHHb40JXrzZrb6279TISLf7SkRERECtRcK1X5lQbQZGd1fgqbO75g1up+q6EzrIp4r3WiCJQGiiEqEJ3pnva5Mk/NlgYQsiIiJyjyRJuOcnMw4Vi0gIk+G/V2ihVnbNG9xO5b27kqjdiiqtWHpxPgBg9o9WJEV7v35tdY2A2x9wBMnqnwToIt0bTS2sK3GWMLj13xqNNqnR47B2tLGxuhqVdjuilUqMCWvPK4mIiKih91ZbsWS3HSoF8MmVOiSEB894aPCcKXmVL252q7/RbVZUFJRczpiIiMgtqw7Z8cIfjqmKz56rwajuwTWNkOGXOsxuEVFy0AJ4MfwaBAGrKisBTnkgIiJyW065iFu+M0GUgHmjVfjXmK5/g9upGH6pw0r2WyDaAF2MAmHJ3plJs7KyEhZJQneNBgP0eq+0QURE1NXd+r0ZlSZgeDc5nj9PA1kQfpLK8EsdVph5ctTXW/+J6qc8zI6ODsr/qERERJ6wv1BEbKgMn1ypgyZIbnA7FcMvdVhR3c1uiW3c7OauUpsNm2tqAE55ICIi6hClHPh4nhbJEcEbAVntgTpEsEko3lc38jvUO/N9/6yogAhgSEgIummCowYhERFRR1nsEv7cZ8f8zTbntkdmqzE+PbjjX3CfPXVY6SELBIsETYQcEWnemTS/lMsZExERuexgkYBvt9iwYLsdFUap0XNXjQ2+G9xOxfBLHeIscTbYO/N9j5rN2G80QgFgZmSkx49PRETUFdRaJCzaZcN3W23YliM6tyeGy3DhMCXeX+MY/eV9Mwy/1EH1N7sleKnEWf2NbuPDwxGl4m+rRERE9SRJwrYcEd9usWFRpg1GR+leKOXAjH5KXDFGhSm9FbAKcIZfYvilDhAFCcV7vXezmyRJWFYXfudwygMREREAoLRWxE/b7fh2qw2Hi0+O8mbEyjBvtBqXjFAiLuzkDW1WQWrhSMGJ4ZfcVp5lhc0oQR0iQ1S62uPHzzQYkGe1Qi+XYzKnPBARURATRAmrDzvm8v653w6b4NiuVQHnDlZi3hgVxnRXcFqDCxh+yW2FdSXO4gdpIVd4/j9b/ZSHqZGR0MmDtyQLEREFrxPlIr7fZsP3W23Irzo5gjs0VY55o1U4f6gK4VoG3vZg+CW3Fe6qm/Lghfm+NknCnxUVAKs8EBFRkLHYJSzb65jWsDZLgFSXeSN1wEXDVZg3WoUBSQp/d7PTYvglt0iihKI9J1d287QN1dWoEgTEKJUYHRbm8eMTEREFmv2FjmkNP+9oXKJsUi8F5o1WYfYAJbQqjvJ2FMMvuaXimA3WGhFKrQwxvT0/37d+ysOs6GgoOX+JiIi6qBqzhIU7bfh2iw07Tpy8eS0pXIa5o1S4bKQK3WM49c+TGH7JLYV19X3jB2og9/Da4LWCgNWVlQCrPBARtZskSRAlQBABUXL8ker+PrlNOrmtfp8G+wsN9jFaT45A7isQvD7yaLZ5tj1RFFFeokCJTIBc3rTqgafbc0XDNse/YoCprgqZUg7M7K/EFaNVmNJHAYWcgz/ewPBLbqlf3CJhsOenPKysrIRFktBdo0E/nc7jxyci3ymuOTmSNfS5Wp+37+s222pPEqMgkxs81t7AZ2ohnRJ0vemcD0zebcBr7UUCMPuwPdeZbEBGnBzzRqmalCgj72D4pXaTJMk58ps41PPh9/cGtX1ZsoWoc7LaJXzyjw2v/21xbqu1tPoSr/B1m22359lgY+7gugUKOSCXOf7IZCcfK2SAXO5YDUwGoMzgSNXxYY6vvUkCUFzj2fYEQYBC0fwNYt5ory0N2/zheh0m9WKJMl9i+KV2q861w1wpQqECYvt6dr5vic2GLTU1AIDZnPJA1Cn9fdCOJxabkV3aeBhyxd166HzwkbLJJmHam0aftelqe6IoorQoH7EJyZB3oHxjw/bW3KuHXi07GVrl9SH25DZ5XZBt9LXM9WVujVYJGY87RrQ3/DsEerV3r6en2xNFEUV5OUhISWv2uvv6/E5tcxRr8/ocwy+1W32Js7j+GijVnh3F+LO8HCKAoSEhSNV4ftU4IvKeo6Uinlhixl8HHNX340JleOAMNf690DEc2j1a7rNgUc8XbbranigCOrOIhBh5h8Jvw/ZSIn1zTYm6EoZfarf6xS0SvFDibGndlAeO+hJ1HgaLhDdXWvHxWiusguOmnRsnqnDPNA0UcjjDLxFRIGD4pXZpNN/Xw+H3qMmEAyYTFABmRkV59NhE5HmSJOGXXXY8s9SCwmrHaOSUPgo8fbYGveMd8ysbjlISEQUChl9ql9pCO4wlAmQKx7QHT/q9bkW3CeHhiFLyrUkUyHbnCfjPrxZsOe6Y4tA9Woanz9ZiZn/OXySiwMaEQe1SuNvx8WVsHw1UOs/N95UkqVGVByIKTGUGES/9acXXm22QJECnAu6apsbNE9VceYqIOgWGX2qXol31Ux48O+q7y2BAvtUKvVyOSZGRHj02EXWcXZDw1SYbXv7Tgqq6cqkXDFXi0TkaJEewLikRdR4Mv9Qu3rrZrX7Ud1pkJHQduAuaiDxvfbYdjy62YH+hY8GKgUlyPHOOBuPT+SOEiDoffucilxlK7ajJt0MmBxIGei782kQRf9XN9+WUB6LAkVsp4pmlFvyaaQcAROmBB8/Q4MoxKi67SkSdFsMvuax+SePoDDXUoZ4bnV1fXY0qQUCsSoVRYWEeOy4Rucdkk/DBGiveWWWF2eZYEOGqsSr8e6YG0SEMvUTUuTH8kssKMx03uyUM9s6Uh1lRUVDwLnEiv5EkCb/vtePJ3yw4UeEoUTaupwLPnqPBwOTml4YlIupsGH7JZc76vkM9d7NbrSBgTVUVAOBMTnkg8ptDxQIeW2zBmsOO0mVJ4TI8fpYG5w1RBkzpMpPJhPLycoii2Op+ggi8OstxHsUFlVB4+TYCV9uTJAlWixW5ubkduqaBen6B2l5b193X5+ePNv1xjp56vwOAXq9HZGQkFArP/BLO8EsuMVUIqMqxAQASBnlu5HdFZSUskoSeWi366XQeOy4RuabaLOG15RZ8tt4GuwioFcAtk9W4c6o6oJbNFQQBJSUlSEpKgkqlan1fUcIghSMgd0uWe31+sqvtSZIEm80KlUrdwfAbmOcXqO21dd19fX7+aNMf5+ip97skSaitrUVeXh5SUlI8EoAZfsklRXVVHiJ7qKCN8NzHn/VTHs6MigqY0SWiYLFgux2vr7ChtNYxxWHWACWePEuDHjGBV3GlrKwMsbGxbQZfIupaZDIZwuruB6qsrERMTEyHj8nwSy6pL3HmySWNy+w2bKmpAQDM5pQHCjJ2QUJBtYSs4pMf4X+92Qa1l6fWWoWTjx/51QoAyIiT4+mzNZjWN3B/JFgsFsTFxfm7G0TkJ6GhocjNzWX4Jd8pqrvZzZPhd3VtFSQAQ0NCkKLx7KIZRP5mtUsoqJJwokJEbqXj7xMVInIrHI8LqiUIp0xdfWKJxad9DFED98/Q4LoJKqiVgf/JCz8dIgpenvz/z/BLbbLUCCg/4hghShjsuZC6srYSYG1f6qQsdgl5daE2t0LEiYqTQTe3LtxKUuvHUCmApAgZcsodO84eoPDJ3L9l+xzDv3/eoUN6HH8MEFFw4Xc9alPxXgsgAeEpSuhjPPOWKY8XkG01QwFgRlSUR45J5GnZJSJKahuH2vqgW1TTRrIFoFECqZEypEbJ0S1KjtQoGbrVP46UISFMBrMdyHi8FgDw3mU6r99kZrRKzvbiwziSSkTBh+GX2lS4y/PzfQ8Od3y8OzEiApFK770NS2tPfq48/PlatPajXpSiIJcZOtRewzjUVnue0BXaa+u6+/Mcz3jH2Oq+OhXqgq3MGWgdIdexLTZEBnmbI7lth2giIvIchl9qU/3NbgkeCr+STMKh4Y5pFN680c0uSLhrwck5lNXmtl7h2Tvc227Pszpve65fd1+fY4gaSItuGmpT64JuTIiM81Cp0/vq6+8x/9sf8NfSX/zdFad/Vi3Dn4t/hN1qwWcfv4v4uFiftX3fg4/CarXhnTdeAgDMnHMB/jVvLq668jKXX+Pt/gHAay892+I+9f+mv/3vB6jVaq/1xVfteBrDL7XKZhRRdsgRVD018lvQ3Y6aaBE6mRyTIyI8cszmvPSXFRuPnry1/a879dCqmg8qoiiirCgfMQnJkMvdD8Fmm4SZbxvbbM9TOnt7rlx3f57jrv+EIEQTeGW/qOtYsXINfvn1N5+EpkBQVl6Oy668vs2wtHThN+iR0RcP3/t/iIn27dS4Jx590KftecMlF52Hs+fM8nggfePt9xEWFoobrr3Kq+14G8Mvtap4nwWSCIQmKBCa4Jm3y8ERjjB9Wkg4tB0Imq1ZtteGd1dZG21Lj5W3OJ9SFIEwq4iEOHmHwq/RevIj7Nba85TO3p4r192f58hRXfK2fQcOtvq83W6H0otTw3xt377WzxcArDYbLGYT0nr2RmJCvE8WZGgovK6mbGem0+mg88LCUfv2H8TYMSO93o63dZ3/UeQV9Usae2rKg00SkTXEEUqnhUV65JinOloq4q4Fjn5fM06FLzbavNIOEVFH3Pfgo8jcvReo+2j9/nvuQGJCPO5/6DE8/sgD+Oqb71FWXo6FP8zHy6+/ja3bduDHbz53vr64IA+zb7oL999zB2bNnAYAyC8owH8//Qo7M3fDYrGiR/c0XHXFXIwbO7rN/mRlH8Fb736E7CNHERYWivPOmYN5cy92Pl9TXYXXfvwaW7Zsg8FgRHJyEi6+8FzMPmOGc59du/fgy/nf4eix47Db7EhNTcGlF5+PqadPcn5EDgBnnT8XM2dMxQP33tmoD7sy9+D+hx4DAPy1ZAH+WrIA8z//CIkJ8Vi1eh2+X7AQOSdyodVoMHLEMNx8wzWIjT1Z93XFqrX4aeEi5OXlAzIZevZIw7VXXYH+/Xo791m3fiO+++Fn5ObmAQB69EjDxFlz0WfAEOe/y6lTGERJxKefz8eyv/6G0WhCv769cc8dtyA1NaXZaykIAr75bgH+WrEKpaVliIqMwNTTJ+Gaq+a1ulCLwWDAJ5/Px/qNm1FdXYOoyAhMmjgB1151BbTaxtWWVqxcgy+/+R4lxSVITErATddd7fx3bm46ws4t/2DFsl9QUpjX4vXbu+8APv18Pg5lZUGn1WLkiOG4+YZrEBUViZlzLgAAHDuegx8W/IL5n3+EP/9a4Wzn9bfex46dmfhu/ieNBjPWrFuPZ194FW+9/iIG9OvbofeopzD8UquKMj13s5skSfiuogQWvQR9tQyDe4Z4oIeNGa0SbvjahGozMLq7Ag/NUjP8EnVho0aNQmFhYZPttroZTyovLxrSsL3YuERk7tzi8mueePRBPPbkc7DZbHj2yUcREqLHgYOHAQDf/fgTrr1qHjLSe7p8vOqaGtzz7/8gMjICTz/+CMLDw7Bk6R944pkX8dJzT2LY0MGtvv69Dz/BVVfMRVJiAn7/Yzk+//IbpCQlYeLECbDbbfjo9acg2oz49713IjkpEWv+2YDX3nwPCoUCM6dPhcFgwGNPPofZZ8zAvXfeCrlCjjVr1+OFl99AQkI8LrnoPJjMZvy0cBG+/vwjhIY2/RkwoH9ffPnZh7j6uv/D6TPPwc1XnY/oyAisWLUWL7z8Oi48/xw8/MA9qKqqxrsf/BcP/OcJfPjuG1CrVNizdx9eePl1XHbJhXj04fsgCCK+/f4nPP7U8/jwvdeQmJCI3Nw8PPvCq7jmqnk4feIE2Ox2LP5tGT5953k8/Ny7QHJ8s9fmz79WYPKk0/Dqi8+goqISr77xDp589iX894O3mv2E6J33P8Zff6/CLTddh+HDhuDw4Wy8/d5HqKquxv333NHiv8FjTz2PvLwC3HHbTejZozsOHc7C2+99hNLSMjz2yL+d++Xm5uOvFavwyAP3QKlU4r+ffYWnn38FX3zyfrPzo1euXouv//sGJk0/C08+ci9qqptev5wTuXjgkScwfepk3Hn7zTCZzHjznQ/wnyeexXtvvYIfvv4Mc6+8zvlLUUREeKM2pk+djL9XrsaevfsxZPBA5/bVa/5BSnISBvTr2+H3qKcw/FKL7BYRJQcdN4wlDO5Y+JUkCW/l5eH7yhIAwKi/dVAM8+xHWZIk4eH/mbGvUERsqAwfzdNCpeDH1kRdWWFhIfLy8vzdDbeEh4VBqVRCFCVEnzKvdeiQwZgwfmy7jrfsj+WoqKjEKy88jbRuqQCAW2++Hpl79uLHn35pM1hceN45GD1qBADgxuuvxtp/NuDvVasxceIE7N25BYX5OXju6ccxZtRwAMC8uRfjwMFD+O7HnzFz+lScyM2DyWTG1NMnOUdEL7v0IgwbOhjJyUmOj8i1jp8lUVGRzc4TValUiIp0fCqo1mgRHRUFhVyGb79fgAH9++KWm65z7vvAfXfiljvuw/r1mzDl9Ino3SsDX336AeLj46BQKOravxDLV6zCvv2HkJiQiOwjxyAIAmbNmIaoKEc7N91wLVL7T4BO3/KATEhICP7vxmsBAN3TuuHqf83Dy6+9hewjR9ErI73RvuXlFfj9j+W49OILcPacWQCAlOQklJWX4+NPv8Q1V12BqGZKfO47cBC79+zDA/fdiYkTxjlfV1hYjM+/+gbFJaXOYFtVXY0H7r3TeQ733nkrrrjmJqxdtx4XXXBuk2N/98NP6J7eB+fNvRZpyXIo5LIm1++XRUsQFhaKu++4xTlye8etN+G33/9ERUWl8z2q1WqavF8BYMTwoYiMjMCadeud4ddsNmPz1m247JKLAA+8Rz2F4ZdaVLLfAtEG6GIUCE9x/60iSBJeOnECP5eWAgAm/qrHkA2eK5tW75stNvy43Q65DPjwci2SIuSN5m8SUdeTmJjY7HZ/jfx6Sp/eGe1+zf4DhxAdHeUMFaibtz58yGD8/sfyNl8/aGD/Rl+np/fA8eMnAADHjx6GTCbD4AYjegAwfOgQbNi4BdU1NejRvTtSkpPw9HMv46wzz8CIEUPRt3cv9Ovbp93n0pDBaMTxnBO4fO5Fjbb3ykhHWFgo9u4/gCmnT4RarcY/Gzbh75VrUFRUDJvdjvqVZmpqagAAAwf0Q2RkBO578FGcOWsGRgwfiu7du6NHRt92XZuM9B4AgJwTeU3C78HDWRBFEcOGDGq0ffiwIRBFEfsPHMSE8eOatHGwbtR/8KDG13jAgL6QJAnZR446w29ycqIz+AJAfHwcwkJDcSK36S+CBqMROTknMP3MC1u9fgcPHUZGes9GUxYGDezf5NxbolAocPqk07Bu/Ubc9n83AAA2bt4Gq9WGGdOnAB54j3oKwy+1qGh33ZLGgzVu3/hjkyQ8eewYllVUQAbgzthkCOs8X69qZ66A/yxy9PfhWWqclsG3NlEw2Lp1a5NtgihhT76jxvegulEub2rYnqeEhrR/WpjBaERFRSXOufDyRtsFux02ux1ms6XJvNGGwsJCG32t1WhgNju+r5pNRkiShEsvv7rxsQXHbxkVFZXontYNb732In5auAh/r1yNL7/+DuHhYbjkwvMw95IL3f45YjQ6qq/89PMi/LLot0bPWSwWlJdXAAAWLV6Kjz75AuecNRt333ELQkNDUFpWhvsffMy5f2xsDN5942UsWLgIv/z6Gz7+9EvExsZg2pxLMWbidJevjUbjuI5mc9OfZwaDo275E8+8AJmswY28dUG8oqKyhfM0NdtWWGhoo+vg2Nb0pjyNRtNsf+pft+qvX7F2xVI0/O/Q8PoZDEYkJiQ02zdXTZs6GYsWL8XeffsxcEB/rF23AYMG9kdigmM6SUffo57ChEAtKuzgfF+rKOKho0exuqoKCgDP9uiBofJQLEW+R/tZbpBw49cmWAVg1gAlbju9c5VcISJqi6yZ5V1sNkujr0NDQ5CYEI/nn3m82WOo1S3faAUAtQYDIhuUn6ypNUCnd3z/1+lDoFSp8f7brzW7cEv9iGRERDiuv/ZfuP7af6GwqBjL/liOz778BtHRUThjxjQXz7ax+l8ELjj/HMyZPbPJ8/VTKVatWYf+/frgzttuPnlOtbVN9k9IiMftt9yI22+5EcdzTmDh/5bgx68+QExcIgYlN/+xe22t4ZSvHcfVN1PpoD6sPnj/3Ujv2aPJ85GnzJWtFxKiBwDU1NQiRK93bq+udoxaN9xWH7BP7VNzlRfqr9+k6Wdh3KQZ6BMvb/RvWH/9QkL0qK4bIXfXgH59kZSYgNVr16NHj+7YtmMXbr/lhpN96eB71FNYwJKaJdgkFO+rm+/rRvg1CQLuzs7G6qoqqGUyvJqejjO8sKCFKEq4/QcTcisl9IiR4a1LtCxPRUSdi9T29Kyw0BCYjCZIDfbNyznaaJ/+/fqipLQMer0OKclJzj8KhQJRkZFtlnHct+9Agy5JOHLkGHqkpQEAuvfsA7vNCrPF0ujYGo0GYaEhUKlUyM3Lx4ZNJ2/4S0yIxzV1N+0dzjpyyim7PiVNp9OhR/c05OXnN2o7JTkJNpsNkZGOwG40mhBxSu34P/5a0ai9rOyj2L4z0/l897RuuPP2/4M+JBS5OY372Oja7G9coq3+fLp379Zk3z69e0Eul6O0tKxRX6OjoyCXyxHSwqh+/36O6SG79+xttH33nn2Qy+Xo3WAqTF5+ASqrqpxfn8jNg9liQffuaS1ev9LiAsTGJyG5hevXt09vHD6c7RztB4CDhw7j7vsfRm7eyUGrtv7ppk2ZjI2bt2Ljpi2QyYDJEyc0OMeOvUc9heGXmlV22ALBIkETLkdkWvt+E6sRBNyWlYVNNTXQyeV4KyMDkyO9U9bszRVWrDwkQKsEPrlChwgdgy8RdR5hoaHILyzE/gOHUFxc0uJ+ffr0htliwYpVayBJEnKPH8GW9Ssb7TNr5jSEhYXimedfwd59B1BYVIzVa//BHXf/G19/90OLx5bqlthesHARtm3fiRO5efjoky9QWlaGM2ZMBQAMGDoSiclpePnVN7F9xy4UFRVj85ZtuO+B/+DNdz8EABQUFOLJZ17EgoWLkJuXj8KiYvz190oczzmBIXXzWOsrPKzfuBnHc064fJ0un3sx1m/YjPnf/ICcE7k4nnMCH33yBf7v9ntx9NhxoC487ty1G9t37EJubh4+/Xw+RFGEQqHAwUNZqKisxP4DB/HE0y9g2Z9/o6CgEPkFBVj4v8Uwm4zo2atf02tTl/Sqqqrx30+/xPGcE9ixMxPf/vATevfKQM8e3Zu8JioqEmfOmoH53/yAv/5ehYKCQhw4eAjPPPcy7n/wsUbhsqG+fXpj+LAh+OQzR6mzvPwC/Ll8BX5auAgzp09BTN0AkiRJCA8Lwyuvv4NDh7ORfeQo3nn/Y2i1Wkw+bXyzx5576UXYu3ML/lz8I060cP3OP/cs2Ox2vPL62zh69DgOHjqMt9/7GBaLFclJic5/vwMHDyEr+2iT0fB606ZORmFhEX7+ZTHGjRnVKOy7+x71NE57oGYV7jpZ31fWjvlyFXY7bj98GAdMJoQqFHgnIwNDQkNdeGX7rTxkx6t/O2oGv3SBFgOTfXRnCxGRh1xw3tnYf/AQHn7sKVx1xWUtljY7fdIE7D9wEB/+93O8+c6H6NajN8699Bq89fxDznm34WFheOOV5/DJZ/Px6JPPwmKxIiE+DuefdzYuu+TCZo8LAHa7AK1Gg1tuuh5vv/chjhw9jvDwMNxy03UYN3Y0BFGCUqnCzfc+gfXLvsYLL78Og8GI6OgoTJ40AVdf6Zi/OXrUCNx/zx34ZdFizP/mewBAUlIibr/lRkya6AhlUyZPxJ/LV+K1N9/F+LFj8J+H7nPpOk2bMglymQw//PQLvvvxZ6hUKvTulY4Xn33Cec2uuWoeyisq8dSzL0GtUWP61NNx+y03QqfVYsnvf0ClUuG+u2+HxWLBTwsX4b0P/gu5QoG0bqm46ub7kdazd5N27XY7AOC8c85ETU0t7n/wURiMJgweOAD33HVri/2949abEBMdja+++R6lpWUIDdFj2NAheP3lZ6HVaiCIzQ+fPvHog/j08/l4650PUVVdjdiYaJx/7ln41xVznfsIgoBevdIxZfJEPPfiqyguKUVqShKeevzhZqswAMDU0ychrxJYuex/WLnsl2avX/e0bnj5+Sfx6Rdf4/Z7HoBOq8WokcNw4/VXO0dk5112Cb7+5gc8/NhTeOrxh5ttK61bKnr3SsfhrCO48vJLGj3n7nvU02QHDx7k7fBt6NOnY3equqqo0oqlFzs+Wpj9YyKSoj1fEaG1Nuf8lIyESMd82T8fKULeZhPG3BKFgRe5tgRxidWKW7OycMRsRpRSifd69ULfBnOUWmuvvU5UiJj1jgEVRuDKMSq8cmHz18polZDxuGNuVvbToa2s8CaiKC8HCSlpHV7hzZX2PKWzt+fKde/s5xjI7R1+Uo9QrXd/afTU+Z04cQLdujX9iLk5/rzhrbX2JEmCzWaFSqXu0PSsQD2/QG2vrevu6/PzRZtfzP8W33y3AEsX/QiVSuWXc/TU+72htr4PHDp0yKXjcOSXmhAFCcV72nezW77Fgv87fBh5ViviVSq837s3emq9E94tdgk3fWNChREYkiLHM+d4/85QIiKizqCoqBj79h9ERHh4q6vJBTOGX2qiPNsKm1GCOkSGqPS2R2aPms249fBhFNtsSFGr8UHv3kjReC+QPrHEgp25IiJ1jnm+WhXn+RIREQmCgGtvuh06nRY3XHuVv7sTsBh+qYn6JY3jB2khb2OFtINGI27LykKF3Y50rRbv9+qFuGZW7fGUBdtt+HKjDTIZ8O5lOnSL5j2bREREqFtoYumiH/3djYAX8OF3w6at+OmXX2E2W/D0Yw8iJsb1clmCIGDlmn+wect2FJeUQqGQIzUlGdOnTsaQQQO82u/OzNX6vpm1tbgzOxs1goB+Oh3e7d0bUUrvvaX2Fwp44BdH3+6Zpsb0vgH/9iUiIqIAE7Dpoaa2Ft/9sBCZe/a5PWfl0y+/wa7MvRg0sD+mnj4Rdrsd/2zYhI8++RKXXXIBJp3WdHnBYCeJknNlt4TBLU9d2FxTg3uzs2ESRQwNCcFbvXohTOG9G2eqzRJu+NoEsw04vbcC907nQhZERETUfgH7mfFLr72Do8dzcOtN16J7gzWgXbUzcw92Ze7FqBHDcMuN12D82FGYdNo43HvnLYiLjcHCRb+hpqbpyi/BruKYDZYaEUqtDLF9mg+/a6qqcFdWFkyiiLFhYXjPy8FXkiTcvcCMI6USUiJleO8yrU/uVCUiIqKuJ2DDb3qPNDzywN0Y0L+vW6/ftHkbAGD61MmNtqvVakycMBZWqxXbGqzyQg5Fu+vm+w7QQK5sGjD/LC/H/dnZsEoSTo+IwBsZGdB5MfgCwIdrbfh9rx1qheMGt5iQgH3bEhERUYAL2GkP1119RYdef+TYcahUKqSmJDV5Lr2nY0WWI0eOYcqkCc28ujFRFDvUF1c1bEcUJZ+027hNEQV1i1vED9Y0aX9RWRmeO3ECEoDZUVF4Ii0NynZen1Pba+u1G44IeG6ZYxrGU2erMSRF1s72pAaPRYhiy3V+T+2fO1xtz1M6e3uuXPfOfo5szzPtSZLUriVxT31tc4xWCb2ecKxSlfVUiMdqLLvST3fPxdvH6urt+frfxlWd+Zr6sj1J8kw2Ctjw2xFmswW1tQbExcY0Wzg/Ksqx1G5JaZlLxyvKy/F4H5tTWiMBcHzzLS8uhNzk/Y/2G7ZZUlCAgp2Ox+qkKhTlnVw3fJHRjP8ajACA2VoNblUAZfmuL03ZXHulhQWAoeVzLDHIcPMPkRBEOc7qa8EZKWUoymtfeyYbAMQAAIrzT0DXxvTxkoLc9jXQwfY6qqu019p17yrnGIjtlRbmwdBJzs9qscJms7q0r+PnrOPHm91mRUv19W02qcFjK2xuFuJ3tb2GbXVEe9vrqK7SXkvX3dfn5482/XGO9Tr6fm/IajF7JJN1zfBrcYwUalqoNatRO7abzWaXjpeQkubB3rWi0gqgEAAQHZ+IhGgfLN7QoE29FAdrdSnkKqDPxG5QqGWQJAmfFRXhv4ZyAMAVcXG4KznZ/dVaGrQXm5jU4gpvNkHC/31iRplJRP9EGd66PAo6teuVPuoZrRIAR2iPT+7W6gpvJQW5iEtK7fAKb6605ymdvT1XrntnP8dAbi82McUnK7x54vxyc3OhUrl2o6tjsNkxOqRUqdHSLQIqSQJgczxWqaFys2a4q+2hLgi4eh6eaM8TukJ7rV13X5+fP9r0xznCQ+/3htQaLRJSWr4PrCYry6XjdMnw2zbHb/uuBriOhKH2aNiOXC7zSbsN26jY7/ghENdfA5VWAUmS8E5+Pr4qLgYA3JyUhBsTEzu0TGHjc5S3eI4vLDVj83ERYRrgkyv1CNG6dy3kcqnBYznkbfyPb61P3mivo7pKe61d965yjoHbnne/z3jq/GQymevfe075iLWl1zXc3K7ju9lew49+O7Tcq4vttWbmnAvwr3lzcdWVl/mkvXbxcHttXndfn58/2vTDOXrs/d6ATOaZbNQlw6+ublnd+hHgU9Vv13pp+d3Oqny/46OJxMFaiJKEF0+cwM+lpQCAe1NScEVCgk/6sWS3DR+tcwTxNy/RIj2WN7gRERGRZ3TJ8KvRqBERHobKyiqIotjkt4SysgoAQHx8rJ96GJjK9znCb9wQDZ44fhxLy8shA/BIWhoujPXNtcoqEXH3Asd0lFsnqzBnENclJ6LgUX9Dj8LLVXSIglmXDL8A0CujJ7btyMTxnBPo2aN7o+cOZx0BAPTple6n3gUmc6kAmQJ4W1eAFeVVUAB4ukcPzI5u/1xbdxgsEq6fb4LBCozrqcDDs3ww55mIyM+uvOYmjB83BmazBStWrcEjD9yL2NgYfDH/Wxw6nAWLxYKE+HhccN7ZOHvOLOfrnn7gJkybPB5p3VLx40+/oKKyEt1SU3H7LTdi4IB+zv2++W4Bfv3td9TWGtAroyduv+XGJn0oLS3Dfz/7Ctu274TBaERcbAxmzpiKeXMvBmRyZ3uzZ5yO0JAQ/PLrEhiNRgwbMhgP/fserFi1Bt//+DMMBiOGDR2Mf997J0JDQ3x0BYnap9OHX0EQUFJaBpVKhZjoKOf2CePHYtuOTCxfsQY3Xvcv53aj0YR1GzYhJESP4UMH+6nXgasmTcQKcxXUMhle6tkTkyMjfdKuJEn490IzDhWLiA+T4aN5WigVXMiCiFomSVJdNYnGBFGCua6Sg9EqQdHCzCnHzXhNH7dXfXuaDvxE3bJ1O8aMHomP338T0VGRuPyqGzCgfz+8+sIz0Ol1WL9hE95690PExERjzOhRAACFQoHtO3ahpqYGzzz5HwiCgBdfeQMvvvom5n/2IQBg2Z9/44v53+LKeZdi+pTJyC8oxDvvf9yobavVin8//DgA4OEH7kFCQjx27MzEBx9/BrPJjOuuvcrZ3vqNmzFqxDC8/tKzOJx9BM+/9Doee+o5JCcl4aXnn8LRY8fx7Auv4pdfl+Bf8+a6f0GIvCggw29ZeQWO55wso1VjcKzEtnf/QedvkjHR0eielorKyio888JrSOuWggfvu9P5mn59emH82FHYsGkrPvj4cwwfNgQWiwWr165HdXUNrr/mCuh0Oj+cXWASFBIUggwHu1uglcvxRno6xoSH+6z9Lzba8MsuOxRy4KN5WsSHcZ4vEbXOZAMyHvfMSp2DnzV0+Bj/u9n9nylGkwk333ANFAoFBEHAx++/hZAQPUL0egDAheefg+9+/LkuJI9yvs5gMOK+u2+HSuWYInbGzOn4+JMvUFlVhciICPzx19/o26cXrr7ycgBAamoKLFYrnn7uZecx/tmwCbl5+XjtpWcxZPBAx34pycg+chS//rYMV155OQDHNAxBEHDLTddBLpcjNTUF33y3AEePHceLzz4BjUaDbqkp6J6Wiuzso25fCyJvC8jwe+hwNr7+bkGT7T/89D/n47GjR+KqKy5t9Tjz5l6E1NQUrN+wGd8vWAiFQoEe3dNw+dwL0TuDUx7qmfQi7CoJYVUKlPcS8X6vXhgaGuqz9rflCHhiieMmxEfP1GBcz4B8WxIReU1Gek/nPF+FQoGjR4/hp4WLcCznBCwWCyQJsFgsqKlpHPZ7ZaQ7gy8AhNV9766pqUVkRASOHc/B1NMnNXrNoAH9G3198OBhyOXyRlMlAGBA/7747fc/kZeXD6i7OdtreB9NeHgYdFpto9KiYWFhqDV0/JcJIm8JyJQxfuwojB87yoU9gZiYaLz35kvNPieXyzFl0gSXVnELNjZJwnGzGVtra7Dsylpc8HE4JJmER6Z3xyAfBt/SWhE3fWOCTQDOGqTEzRN5gxsRuUanArKfbvr9ShAl7Ctw1DQdkCSHooXyakar5Bzx3f2o+yu81bfXkWkPoSEn58dmZR/BE8+8iIED+uGxh/+N6KhIyORy3P/gY01ep9U2vjeivqRUfZkpo9HkrIDkbOuUubgGowkhen2Tm+xC634WGI1GoK5U66n182UyGdQadZNt/lgljchVARl+yXMkSUKJzYbDJhOyTCbH32YzjprNsNd9c+pd6/jGpeuuxKA43wVfQZRw5/dm5FdJyIiV4Y2Ltb6pr0hEXYJMJoO+mfr5ggho6xas0KtlLYbfhvRqWQfC78n2PGHtug2QyWR49sn/OKfniaLoCKHtpNVoYDplQafqmppGX4eE6GEwGiEIQqMAXF3t2C9Er4dnJpcQBQaG3y7EKAjINpudQbc+7FYLQrP7h8jlSFNp0X+945td4kDf1j3+cJ2ANVkCdCrgkyt1CNMy+BIRGU0mqFWqRvelrP1nA4wmU7tHVNO6pSL7yLFG2zJ37230df9+ffDzLyL27jvgnPMLALv37INer0dqagoOFLt9OkQBh+G3ExIkCScslsajuSYT8qzNr5+tANBdq0UvnQ69dTr00mrRW6dDolqN4ioblh7LBwBED/DcEoRtORChwlfrHaH8lQu16JfImpZERADQv28f/O/X37Dwf4sxftwY7Mrcg7/+XokB/fvi2PEcFBYWAYhz6VjTp0/Bex/8F9/+8BMmT5yAvPwC/LTwVyiVJ3/8jx83BmndUvHmOx/gjltvQlxsDDZv3Y4Vq9Zg3mUX1+0revGMiXyL4TfAlTczZeGIyQRLC7/9x6pUznBbH3Z7aLXQtLAcoKXq5KhwdH/fhN9ytRw/9nRMr7h2vAoXDec8XyKielNOn4iDh7Pw3Q8/4cv532HY0MF45MF7sXffAbz+1nt49Mlncffjb7l0rPPOPhPl5eX4ZdESfP3tj8hI74m7bv8/PPTok7ALdgCAWqXCyy88hY8/+RLPvPAKTCYzEhPiccO1/8KF558DkdN3qYth+A0wu3uLkNQi9ryfC4vCDkHW+LtOGICh0EIuARpRCa2khEZUQFv3WCmdDLnHIeE4jABanicmltsRCqBWKcMnuySEHmx+SWhPqTUL+LVXGMxKOQYny/DkWVzIgoiC29dfNK67K5fLcctN1+GWm65rtH3yxAmYPHECBFHCnnwR/3nhAwxKbjywMWvmNMyaOc35tUwmw3VXX4nrrr6y0X4Lf5jf6OuY6Gg8/MA9zXewbrClufZee+nZJrs3t40okDD8BpgIi4i0w/X/LK7+84gArHV/3LM7So3F/wgAmp8f7FF6JfQ2Ea+cr4VayXm+RERE5DsMvwGmUi+DsbcAXYgKOiihFBWQS94LiHZBRMUJAdVqOeaOkEOv8e7cW6NFQO5SA0aVWpAYzkVGiMh/9GoZCl4M83c3iMjHGH4DzJADjvA5+8d4JEV7v/pCUaUVSy/OR+8aG+acEYWESO/O+y2qtGLpx+0v10NERETkCVxDloiIiIiCBsMvEREREQUNhl8iIiIiChoMv0REREQUNBh+iYiIiChoMPwSEVFQMgkCRm7fjpHbt8Mk+KDGOREFBIZfIiIiIgoaDL9EREREFDS4yAUREVEA25W5B/c/9Bief/oxjB41wmftteaWm67DheefAwCYOecCzL3kAtxw7VVe7xuRJzD8EhERURMPP3Avhg0ZBEGScKBQBAD0S5RDIZNBr9f7u3tEbmP4JSIioibCQkMQHR0FQZQQbnKE3+goORRymb+7Ru2kkMswNFXh724EDIZfIiLqlCRJglkUm2wXRAkWybHdJEhQSM2HtYYVHjpS7aG+PbWbt9EYjSa88/7HWL9xMyRJxOiRIzB71gw88tjTeP6Zx6FWqVw6TmlpGf772VfYtn0nDEYj4mJjMHPGVMybezEUCkfwMRiNeOe9j7Fx8xZIooQJ48fizFkzcN+Dj+LFZ5/AyBHD3DoHos6E4ZeIiLxGr5ah4MUwrxzbLIqYuGtX6zuVuHasmXv2dLg/64YOdWtU9N0PPsa69Rtxz523ok/vDOzYmYl33/8YAKBSNv0x3dwontVqxb8ffhwA8PAD9yAhIR47dmbig48/g9lkxo3XXw0AePvdj7B+wybcefv/YUD/vli7bj3eePt9AICymbZaas+bunp7/mqTTmL4JSIi8hOz2YJVa/7B2XNmYdqUSQCA1JRkHM85gUWLl0Imcy1M/7NhE3Lz8vHaS89iyOCBzuNkHzmKX39bhquvmgdBELBm3XrMmT0TM6dPAQBcdulFyD5yDLl5+U2O+eSzL0EubzqaHRoSgu/mf9LBMyfyH4ZfIiLqlLRyOdYNHer2602C4Bzx/WvQIOgUHRuJ0zYTFNuSl58Pm82GPr0zGm0fNKA/Fi1e6vJxDh48DLlcjoED+jXaPqB/X/z2+5/Iy82HIIqw2+3o17dPo33GjR2FVWvWNTnmHbfehMGDBjTZ3lwgJupMGH6JiKhTkslkHQ6s9XQKhceO1R5GowkAEBYa2mh7aFhoC69onsFoQohe75zb6zxO3XENRiMkSarbFtJon8iIiGaPGRMdhZTkpHb1g6gz4K9vREREfqLVaoC66Q8NVVfXtOs4ISF6GIxGCKfcuFd/nJAQPTQaR1tGo7HRPlXtbIuos2P4JSIi8pOU5GQoFApkZR9ptH3nrsx2Had/vz4QRRF79x1otH33nn3Q6/XolpqC5KREyOVyZGUfbbTPxk1bOnAGRJ0Ppz0QEfmRN6shtNRe3vMhKMrLgV4d4sIryJv0eh0mjBuDX5f8jl4Z6cjI6Imt23diV2bT6hM1tQaUl1c02R4VFYnx48YgrVsq3nznA9xx602Ii43B5q3bsWLVGsy77GIolUqEhioxcsQwLF32F/r17Y0+vTKweu0/OH7iRLN9a6k9AFCqlAgP8937lsiTGH6JiIj86O47/g9vvvshXn3zXchkwKgRw3HDdVfh6edebrTfCy+/3uzrf/ruS0REhOPlF57Cx598iWdeeAUmkxmJCfG44dp/OZchBoD7774db7zzAV55/W2o1WpMmzIZ1111BR598jmo1I3rCbfUHgAMHNAPb776QofPncgfGH6JiIj8KDw8HI8/8kCjbQ1HfocOGYS/lv7S5nFioqPx8AP3tLpPaFgo7r/7dkREhDu3Lf5tGQAgOSmxXe3Va8++RIGA4ZeIiIKSTqHAthEj/N0Nn3rjrfexees23H/PHUjv0R3Hck7g2+9/wmkTxrZY9YGoq2H4JSIiChJ33n4zPvvia7zz3keorKpGTEw0Jp42Dldfebm/u0bkMwy/REREAaa9Uw9cpdNqcdv/3YDb/u8Gjx+bqLNgqTMiIiIiChoMv0REREQUNDjtgbo0f9RQZXudu01/nCMREfkOR36JiIiIKGgw/BIRUVCymUR8PuMYPp9xDDaT6O/uEJGPMPwSERERUdBg+CUiIiKioMHwS0REFMB2Ze7BzDkXYMvW7T5t7+rrb4HVZmvx+cKiYgBAYVExZs65oNU/73/0qfP1V15zE5578TWfnAtRc1jtgYiIiJooLCrGjwt+wZXzLnVp/xuuvQozp09p9jmtVuvh3hG5j+GXiIiImjj37DPx/YKfMWP6FCQmxLe5v16vQ3R0lE/6RtQRDL9ERNQpSZIEu1ly+/V2s9jsY3cptTLIZLJ2v85oNOGd9z/G+o2bIUkiRo8cgdmzZuCRx57G8888DrVK5dJxSkvL8N/PvsK27TthMBoRFxuDmTOmYt7ci6FQKAAABqMR77z3MTZu3gJJlDBh/FicOWsG7nvwUbz47BMYOWKY83jnn3sWdu7KxAcffYqnHn+43edFFKgYfsmndHJFs4+JiNrLbpbw9Tk5HjnW95fkdvgYVy5Og0rX/vD77gcfY936jbjnzlvRp3cGduzMxLvvfwwAUCld+zFttVrx74cfBwA8/MA9SEiIx46dmfjg489gNplx4/VXAwDefvcjrN+wCXfe/n8Y0L8v1q5bjzfefh8AoDylLYVCgdtvuQn3P/QYNm/ZhjGjR7b73IgCEcMvERGRn5jNFqxa8w/OnjML06ZMAgCkpiTjeM4JLFq81OWR5H82bEJuXj5ee+lZDBk80Hmc7CNH8etvy3D1VfMgCALWrFuPObNnOufmXnbpRcg+cgy5efnNHnfokEGYcvpEvPfRpxg2bEiro9AffPwZPv70y2af+37+JwgJCXHpXIi8jeGXiIg6JaVWhisXp7n9ertZdI74XrYgFUptxwogKbXtH/XNy8+HzWZDn94ZjbYPGtAfixYvdfk4Bw8ehlwux8AB/RptH9C/L377/U/k5eZDEEXY7Xb069un0T7jxo7CqjXrWjz2zddfg+tuvh0Lfvofrrj8khb3mzf3YkytC/Cn0ul0Lp8Lkbcx/BIRUackk8ncmmbQHKVWDpXO99U/jUYTACAsNLTR9tCw0BZe0TyD0YQQvd45t9d5nLrjGoxGSJJUt63xCGxkRESrx46NjcGVl1+Kr775HjOmnd7ifhER4UhJTmpXv4n8gXV+iYiI/ESr1QB10x8aqq6uaddxQkL0MBiNEASh2eOEhOih0TjaMhqNjfapcqGtC88/Bwnx8fjgv5+1q19EgYjhl4iIyE9SkpOhUCiQlX2k0faduzLbdZz+/fpAFEXs3Xeg0fbde/ZBr9ejW2oKkpMSIZfLkZV9tNE+GzdtafP4SqUSt91yI/5Zvwlbt+1oV9+IAg2nPRAREfmJXq/DhHFj8OuS39ErIx0ZGT2xdftO7Mrc02TfmloDyssrmmyPiorE+HFjkNbt/9u77/go6vzx469k00mvpBAgIZBACCGkkYTQpQkiqKicvYuFU0+8++ndeX7vPL3TQz3OfiqCoAgevSMhvXdqaKGF9J5N2/z+SHbNkg0EWEgw7+fjwUMz85mZz75ndua9n/nMZzxY/tHHPP/skzg5OpCSlsG+/Qe4/967MDIywtLSiHFBgWzbsRvfET4MH+ZNTGw8p8+c6VFdgwIDiI6KYP1Pm3TOr69v0Fk/AEOF4RW7Vwhxs0jyK4QQQvSipc8/zfJ/f8I/l/8bAwMIDhrL448+yF/++q5WubfffV/n8j+u+QYbG2vefftNPvviG956+x80NCgZ6OLM4488wIL5czVlX1n6HP/66GP+8f6HmJiYMGVSNI8+uJjX//xXjE2uPJ7w008+QkpaBs0tLV3mffHVSr74aqXO5RwdHFjz7Rc9iIYQN54kv0IIIUQvsra25o9/eFVrWueW3zEB/uze9tMV1+Ngb8/vX/3tZctYWlnyytLnsLGx1kzbvHUHAG6uA6+4PSdHRzZvWKM1baCLc4/qp7bq6896XFaIG0GSXyGEEKKf+NcH/yElLZ1Xfvs8XkMGc6rwDN+t/ZHIiDDpliD6DUl+hRBC9EvG5oY8smdIb1fjpnrhuaf479er+GjFp1RWVePgYE9UZDgP/ea+3q6aEDeNJL9CCCFEH9PTrg5Xy9zMjCVPP86Spx/X+7qFuFVI8ituKiMzQ/4Q7ADAout8m5IQQgghxNWS7EMIIYQQQvQbkvwKIYS4JahfzyuE6H/0+f2X5FcIIUSfZ2pqSkNDQ29XQwjRS2pra7GwsNDLuiT5FUII0ec5ODhQWlpKc3Nzb1dFCHETtbW1UVNTQ0VFBba2tnpZpzzwJoQQos9TKBQ4OTlRXFyMSqXq7epck7a2NpoalZiYmmFgYNDb1ek3JO69Q59xt7CwwN3dHYVCoZe6SfIrhBDilmBubo67u3tvV+OaqVQqLp4rxMXdA0NDufF6s0jce0dfjnvfqo0QQgghhBA3UJ9t+W1tbeXnA/GkpGZQXFKKQmGIh7sbUydHE+A/8orLJ6dmsHL1993Odx3owuuvvaTnWgshhBBCiL6szya/X36zmuycfPxH+TF5YhQtLS3EJybz6RffcO/ddzIhMvyyy6ufCp46OZohgwd1mW9ubnbD6i6EEEIIIfqmPpn8ZuXkkZ2TT3BQII88+Mv7xsNCgvjbu8vZsHErgQH+WFlZdruO+vr25Hek73B8R/jclHoLIYQQQoi+rU/2+U1OSYeOVtvOTExMiIoIo6mpifSsnMuuo76j5dfc3PwG1lQIIYQQQtxK+mTL74lTpzE2NsbD3bXLPK+hg9vLnDjFpAkR3a5D3fJrYdGe/KpUKlQqFUZGV/+Rb9awOp23o1K13ZTtam9TdcO3qVK1dfp/FSpV3xh2Rv25b9UhlG5VEvfeIXHvHRL33iFx7x19Oe59LvlVKhupra3DydFB59AYdnbtAxyXlJZddj3qlt/E5FQys3IpLStHpVLh4GBPRHgI06dM7PF4cQUFBdf0Wa5F5H/a/1tXfoaC8pu7zZrSQmpKb/z2Yh5t/+/5whu/ratVc+JEb1ehX5K49w6Je++QuPcOiXvv6Itx73vJb2MjdLzKUhdTk/bpSqXysutRt/ympWcRFRGGq+tAqqtriIlNYPPWnZw6VchTjz8kA14LIYQQQvQjfS75vbL22+ZXSlrnzZmBUqnE23so5ma/jOwQHjqOd977iNz8Q+TkHWTM6FE3vMZCCCGEEKJv6HMPvKkTVXUL8KXU083MLj9U2TDvofiP8tNKfOl4Reak6Pa+wocOH9VTrYUQQgghxK2gzyW/pqYm2FhbUVlZpbOTdFlZBQDOzo7XvA1rKysAGq7QdUIIIYQQQvy69Lnkl45W25aWFk4Xnuky71hBe8fp4cO8ul2+sbGJjKwcsnLydM4vKi4BwN7OTm91FkIIIYQQfV+fTH4jxocBsGffAa3p9fUNxCUmM2CABWPHjIaO1yAXXSymrLxCU87ISMEP6zfy9bdrKS4p7bKO/TFxGBgYEBQ4+qZ8HiGEEEII0TcYHDlypK0H5W66VWvWkZichv9IX8YGBtDY2EhMbALFJaU89vBiTfJbVlbOH996B89B7ix7+QXN8umZ2Xz97VosLMyZEBGOk5MjFRWVxCUkUVFZxeyZ05gzc3ovfkIhhBBCCHGz9dnRHu5ftBAPD3cSElNYu24DCoWCIYM9uW/RAny8u+/yoDZu7BjsbG3Yuz+WpNR0aqprMDE1YfAgD+69+078R/ndlM8hhBBCCCH6jj7b8iuEEEIIIYS+9dmW3/6mtbWVnw/Ek5KaQXFJKQqFIR7ubkydHE2A/8jert6vRmJyGj/+tAmlspG/vLEMBwf7LmVkX+hPfX0D+/bHkp2bT2lZOQYG4DrQhYjwUCLCQ7TG65a46095RQV79h3g8JFjlFdUYm5uhpOjA1ERYQQHBWq9PVPifuMcOnKUf3/8JQArlr+jNU/irh/JqRmsXP19t/NdB7rw+msvaf6WuOvXiZOn2L5zL6cKz9DS0oqTowPjw0KYFB3Rp8/v0vLbR3z235Vk5+TjP8qPwAB/WlpaiE9M5szZ89x7951MiAzv7Sre0mpqa1nz/QZy8g5ibGxMU1NTt8mv7Av9qKyq5p/LV1BVVU1YSBDeXkNpaGggLiGZi8UlTJ08gQV33K4pL3HXj8Iz5/hgxafQBpERYbi7uVJXV0d8UgpFRcWEhQTx4OJFmvIS9xtDqWzk/955n4qKStCR/Erc9WP/gXjWbdjE1MnRDBk8qMt8c3Mz/EYM1/wtcdefrJw8vvhqFW6uA4mKCMPIyIiUtAyOFZxgUnQkdy+Ypynb1+IuLb99QFZOHtk5+QQHBfLIg/dppoeFBPG3d5ezYeNWAgP8sbKy7NV63sreee8jWltbefbJR9i1Zz/Hjut+17jsC/3ZtGUHFRWV3L1gHpOiIzXTw0OD+cvb/2Tf/jimTZmItZWVxF2PNvxvC0plI799/mmGeQ/VTB8fHsJbb79HcmoGM2+birOTo8T9Bvpp01Zqa+twcXbiYsfwmmoSd/2pr28AYKTvcHxH+Fy2rMRdf+rr61m99kfc3Vx5ZemzGBsbQ0cs3/vgY06cPIVS2YiZmWmfjHufHOqsv0lOSQdg6uRorekmJiZERYTR1NREelZOL9Xu18FriCd/eHUpI/1GXLac7Av9sbOzIXCMPxHhIVrTLSzM8R46hLa2Ns5fuAgSd70KDBzN/HmztRJfOt6eOXSwJ4CmNVLifmMcOVpAfGIKs2dM07xUqTOJu/7UN7Qnv+bm5lcsK3HXn+TUDOrrG7h91nRN4kvHW3Rffek5lr38AmZmpu1l+2DcJfntA06cOo2xsTEe7q5d5nkNHdxe5sSpXqjZr8ejDy3GyvLKvyplX+jP3NkzeOKRBzAxMekyT33Bsui4YEnc9WfShAimT5nYZXprayvnLxShUCgYONAFJO43hLKxkdVrf2SQhzvTpkTrLCNx1x91y6+FRfu5RKVS0dLSorOsxF1/Dh46gqGhoaa1va2tjaamZp1l+2LcpdtDL1MqG6mtrcPJ0UHrIRQ1OztbAEpKy3qhdv2L7Iub49z5CxQcP4mzkyODPNwk7jeQUtlIY2MjxSWl7Nq7n9Kycu5eMA8bayuJ+w2ycfN2qqqqefqJh3XGVeKuX+of0onJqWRm5VJaVo5KpcLBwZ6I8BCmT5mIQqGQuOvZhaKL2NnaUF5RyU8bt3LoyDFaWlqwsrQkNGQst8+agYmJcZ+NuyS/vUzZ2AiAqampzvmmJu3TlUrlTa1XfyT74sarqKjksy9XYmBgwP2LFmJgYCBxv4He//Bjzp2/AIC7mysvPPsEPh2vhpe469/RY8eJjU9izsxpuLkO1FlG4q5f6pbftPQsoiLCcHUdSHV1DTGxCWzeupNTpwp56vGHJO56VltXj4WFOR+u+IzAMaN59KH7USobiU9MZu/PsZw7d4Hnnnm8z8Zdkt8+r30wjs5DhojeIvviepwuPMunX3xNXV09Dz9wryYJuzKJ+7VafO9d1NbVUV5eQXJKOh/+53Nm3jalh2+3lLhfjaamJlav/RE314HcNm3ydaxJ4n415s2ZgVKpxNt7KOZmZprp4aHjeOe9j8jNP0RO3kEGe3YdCUKbxP1qtLa2UlVVzcL5tzNl0gTN9JBxgbz7/kccPlpA/sHDeHi4X2FNvRN36fPby9RfVvWvo0upp5t1+lKLG0P2xY2Tlp7Fvz76hJbWVpY8/RhBgQGaeRL3G2ewpwej/EYwITKcl5c+y0i/EWzbsYecvIMSdz373+btlFdU8sD9d6NQKLotJ3HXr2HeQ/Ef5aeV+NLx4NWk6AgADh0+KnHXM9OOZzlCgsdqTTc0NCQ8NBiAowXH+2zcJfntZaamJthYW1FZWYVKpeoyv6ysAgBnZ8deqF3/IvvixtizL4avvl2Dk6MDr770PMN9vLXmS9xvDgMDA8JDxwGQl39I4q5HBSdOciAukQmR4VhaDqCislLzT/3wlfpvifvNox5po0GplLjrmXqMfIWOfrzW1u1xVyob+2zcJfntA4Z5D6WlpYXThWe6zDtW0D4e7fAe3yIW10P2hX4diEvkp03b8Bvhw8svPoujjpeKIHHXm9LSMl5/822Wf/SpzvnNze1PY6svQhJ3/ThypIC2tjZiYhN4/c9va/07eboQQPM3Ene9aWxsIiMrh6ycPJ3zizrGV7a3swOJu155ew0BoPDs+S7zysrbE1pbGxvoo3GX5LcPiBgfBsCefQe0ptfXNxCXmMyAARaMHTO6l2rXv8i+0J8TJ0+xbsMmvL2G8NQTD2vGfNRF4q4f9vZ2GBoaUnDiJAXHT2rNa2trI6ljvM1h3u0XGom7fgSPC+TpJx7W+U/94Jv6byTuemNkpOCH9Rv5+tu1FJeUas2rr29gf0wcBgYGBAW2x1Lirj/q19Nv37lHq0W3qamZ+IRkAEb7+7WX7YNxl9cb9xGr1qwjMTkN/5G+jA0MoLGxkZjYBIpLSnns4cXyhbwOZeUVWr84t+7YTVFRMYvumo+l5QAAHOztGezpAbIv9Oad9z6i8MxZ5s+dpfM10gCuA11w7RhzVuKuH4ePFvDxZ19haGhI1PhQ3N3daGhQkp6RxcnThXh7DeXFJU9o+qVK3G+s5R99yrHjJ7q83ljirh/pmdl8/e1aLCzMmRARjpOTIxUVlcQlJFFRWcXsmdO0HvCUuOvPlm272L5rLz7eXoSFBtHQoCQxOY3zF4qYOCGCexbeoSnb1+IuyW8foVKpOBCfREJiCsUlJSgUCoYM9mTmbVPw8ZbbMNcjMTmNVWvWXbZMWMg4Hlx8D8i+0JslS5ddsczsGdOYM6v9wiRx15/iklL27Iuh4PhJyisqMTAwwMXZkaDAMUyeFIWx0S8D/Ujcb6zukl+Ju/6cOHmKvftjOV14lprqGkxMTRg8yINJ0ZH4j/LTKitx16+UtExiYuM5f+EibW1tuA50ISoijMjxoVrl+lrcJfkVQgghhBD9hvT5FUIIIYQQ/YYkv0IIIYQQot+Q5FcIIYQQQvQbkvwKIYQQQoh+Q5JfIYQQQgjRb0jyK4QQQggh+g1JfoUQQgghRL8hya8QQgghhOg3JPkVQgghhBD9hiS/Qtwgb7z5d1557U+9XY1rlp6RzZt//QcvvvwHPvniG72td+v23SxZuozsnHy9rfNWlpicxpKly9i6fXdvV+Wqnb9QxEvL3uCbVd+D7FveePPvPXqttzpOiclp17Sdo8eOs2TpMlau/uGKZZd/9ClLli6jrKz8mrZ1vXXVlyVLl/HGm3/vlW3HJyazZOkyYuOTemX7Qv+MelBGCNHP1Nc38O2adRgYGHDnHXNwdnLs7Sr9Kpw8VcjJU6eZMmmCZtpwH28ee3gxrgNderVuV6u+voHPvlyJg7099y9a0NvVuaUEjQ3A1dWFwZ6Drml5V1cXHnt4MQ729lrTY+OTcHF2YriPt2banFnTqamtxcrK8rrr3Zsee3gxpiYm17WOXXv24+c7nEEeble1XOT4ME6dPsMP6zfi7jYQr6FDrqseovdJy68QooviklKam5vx8/VhUnQkI/1G9HaVfhUSk1P5OSZea5qDvR1BgQG3XPK7YeMWSsvKWXzvXRgbG/d2dW4prgNdCAoMwMHe7pqWt7K0JCgwgMGeHpppKpWKDRu3cqzghFZZn2FeBAUGYHKdiWNvCwoMYNRI32tevqq6ho1btnP23PlrWn7h/LkMGGDBytU/0NzScs31EH2DJL9C/AqoVCpa9HhCbmpqAsDM1Exv6+zrmpubaWtru6HbOHX6zA1d/81SdLGY5NQMAgP8GTL42lovhX6dO1+k+d6Krk6dKryu5c3MTJl521RKSsuIk+4Ptzzp9iBuSRs3b2fX3v28uORJqqtr2L0vhovFJVhYmOMzzIsF8+ZgY2OtKb9k6TLs7ex460+vaa2nrKycP771Dj7eXix9/ikADh46wopP/8vM6VMY7uPNxi3bOX+hCDNTM8YGjuauO+dSVV3N+v9t4eix47Sp2vDwcOOuO+fi4d71dlp9fT0/bdpG3sHD1NfVY2dnS2REGNMmR2NgYKApp1KpiEtIJjE5laKLJbS1qXBwsCcwwJ/bpk7G1PSXlps33vw7jU2NvLJ0Cd+sWsuZs+d57KHFjAkYddm4JSanEp+YwoULF2lpacHGxho/3xHMum0KtrY20NFH8Njx9taj5NR0klPTteLTnZy8g/wcE8eZs+dpamrCynIAPj7ezJo+FRcXJ53LxCUkExObQHFJKaYmJvj5DufOebM1dQEoK69g9979HD5yjMqqaoyNjXB0cCAsJIiJEyK0Ylhf38CuPT+TnZtPeUUlRgoFrq4uRISHEhEe0mW/B47xJzw0mB83bKKsvIIH7rubld/9wMQJEdyz8I4u9Y1PTOa77zdw29RJ3DF3FgC5+YeIiU3g/PkL1NbVY2ZqypAhnsycPgWvoYOho4/mBys+06yn8/GYmJzGqjXrmD1jGnNmTdeq447d+zh0+CjVNbWYGBvj5uZKdGQ4weMCNeWaW1pY+sr/w8fbi8ceWcxPG7eSf+gITU1NODk6Mm3KREKDx2p9jpS0DOISkikuLqVBqcTKcgDDhnkxc9pkBvagBXr33hhUKhXRUeO7LdOTfQtwuvAsO/fs4/iJUzQ0KLEcYIG311BmTJ+s+T59/t9vycrJ47lnHsNvxPAu2/ry69VkZOXw4pInNbf8e3o8xsYnsXbdT/zmvruxtbFm647dnDtfhKmJCYMHD2LBHXNwcdY+fhOSUti3P46S0jLMzEwZ5TeCO+fNuWLc1LZu3822nXv4zX13Mz4sGIB//msFJ08X8uF7f2P7rr2kpGZQVV2Dra0NwUFjmHnbVIyN2i/Z6uMpLGQcDy6+h5WrfyA5NR2AbTv3sG3nHs3xpP4+/+WNZTg4tHeTUKlUxMQmkJqeSWlZOUplI1aWA/Ad4cPc2TO67KOeKLpYzFtvv8fkiVGEjBvLxi3bOV14htZWFR5ursyeOa3LHaSa2lp27v6Z3PxDVFZUojBSMNDFmdCQcURHhmNo+Ev73KXncPV5evaMaYz292Pj5u2cOn0GQ4Uh7m6u3DlvtqZbSedz2qo161i1Zp0m9rW1dez5+QA5uflUVlVhgAH29nYEBY5m+tRJGBn9kiaNDw3mf5u2sf9APJMnRl11jETfIcmvuCUpjBTQcRE/VnCCCZHhWFtbkZd/iLT0LEpKynj1peeuad3qk92FixdJSk1nYlQEURFhJCancSAuEVMTEzJz8hg9yo+F8+dyuvAMsfFJ/PvjL3nrT69p3QJua2vjky++wdbGhvm3z6Kmro64+CT+t2kbzU3NzJ45TVN25Xc/kJqWyZiAUUSOD8PAAI4WnGDn7p85eOgoL734jObip/bd2vW4u7kSHTked3fXy36udRs2sf9APIM9PZh3+0yMjY05dbqQ+MRkcvPyefXlF7C1sWbOrOkcLTjOth178BnmRXTUeKwsL99fcN/+WNb/bwsuzk7MnjEVCwsLzp07z4G4RHJzD/LSi8/g7qZdv/ikFMrKyomKCMPU1JT8g4dJy8jizNlz/OHVpRgZGdGgVPLe8hU0NjUxOToKZ2cnmpqayM7JY11Hwrpw/u0A7WU//A+lpeVEjg/Fc5AHSqWS9MwcVq/9kbPnzndJaJUNStb8sIEJEWHY2toSEDAKkx+NyczO5a4752pdfAHSMrIBCAsdB0BKWiYrV3+Pk6MD06ZMxMrKktLSMn6OieeDFZ/x8ovP4jnIXdNH88uvV2NpOYBFd82/bP/F4pJS/rl8BU1NTUyICGfQIA8qK6tISknjq2/XcLG4RJMoGynavwtNzc18uOJzPAd5MH/ubBoaGti9L4ZvVq1lgIW55pbxnn0x/LRpGyOGD2POrOmYmppSXFLCgbhE8g8e5ve/exF7u+5vx7e1tZF/8DBmpqZ4e+nu+9iTfQuQf/Awn365Ejs7W6ZNjsba2pqSklJiE5LIzT/I8888gbfXEKIiw8jKySMxKbVL8qtsbCTv4CGcHB3wGeZ11cejUce55FjBCQ4dOcrEqAiioyI4cfIUsfFJnD13njdff1VT57iEZNb8sAFbWxvmzJzGgAEWHD12gg//8zmtrdd+90V9TlvzwwbKyiuYPnUShoaGxCUks2PXPlpbWpk/b7bOZSdOiMDU1IQDcYmMDRx9xW40a9f9RHxiCr7DhzFvzi/ngriEZI4VnOD/LXtJ68d2T6jjc+78BTIyswkLGUdYyDiKi0vYFxPLx59/zQvPPqHZR7V1dfzjXyuoqKgkPHQcw7y9qK2tJSMrh3XrN1JYeJYHF99zxe1dLC4m9tMkIseHEhYazIWii+zZF8MHKz7jzdeXYWVlyZxZ04mJSyAzK5foqPH4DPNisOcgVCoVH/7nc4ouFjMpOgJ3NzdaW1s5crSALdt3c/bcBZ549AHNNk1NTfDxHsrBw0cpuljMQBfnq4qR6Dsk+RW3JAPaW/ty8w/xpz+8goWFBQAh48Zy5ux5Theeoay84pr71AHk5B7ktVde0LQ+jfTz5fU//43d+2K4Z+EdTJwQAUB46DiKS0o5fOQYJ06eZsTwYZp1KBsbcXdzZdFd8zXTQsaN5c2/vsuen2OYNmUiJibG5B08TGpaJlMnR7Pgjl9akCLHh+Hk4MD2XXtJSEzRbJOOVk4nJwfuX7Twip+l8Mw59h+IZ5CHOy+98IzmwhERHoKbmyvr1m9k247d3L9oIT7DvDS3/+3t2vujXk5VdQ0bN2/H1saa3/12Cebm5h1zxjF8+DA++fxrNmzcyvPPPK613Nlz53njtZc05SPCQ/ji61VkZuWSnplDWEgQR44WUFVdw/y5s5g+dZJm2aiIML77fj319fW0tbVhYGDAjl37KCoq5pknHsZ/lJ+mbHTUeD5c8TkxsQlERYTh5jpQM+/IseM8uHiRVsvomNH+pKZnUnD8pNaDQ1VV1RwrOMGQwYM0F72SklJ8hnmx6K75WhdCe3t7Vq7+ntj4RBbfe5emj+aXrMbE2OSKMd3wvy3U1dXz2MOLtcpOiArn7//4gB279xERHoKdna2m5ft04Rnmzp7BzNumaMpbWlryzaq1ZGTlaJLflLRMzExNee7px7SS+5G+w9m6Yw9FRcWXTX7PnjtPTW0to/1HouhIvHWVudK+bW1tZfX367G1teH3r7yImZmpZvngoDG8/Y8P+PGnzSx7+Xl8h/vg6OhAdu5B6urqGTDAQlM2JzefpqZmIsJDMTAwuIbjsT1+6ZnZvPHaSzg6OgAQGjyWkpJSDh8t4OSpQnyGeaFSqdi6YzdGRka89PzTmpbUyPFhbN62kx279l12v16O+pxWWVnF8888rtk3I/2G8/qf3yYjK6fb5HewpwfnLxQB4Orictnjq7W1FaVSif9IX556/CHNdsJCgmhubiYxOY3s3DxCg4Ousv7tjh47ztOPP8Ro/5GaeUOHePLx51+zbeceXhz2JADbduyhrKycO+fNZtqUiZqyEydE8MGKz0hOTScqIvSKD5elZ+bw2xeeZpjXUM202tpaEpJSyT90hPDQcfgM8+LoseNkkovnIA9NfM6cPce58xeYEBnOgjtu1ywfER6Co6M9RReLaWxs0voh4Oc7nIOHj3Lw0BFJfm9h0udX3NLCQsZpEl8AAwMDTbJaWVl1Xese4jlIqxuDrY01FubmGBgYaN1CBzQJVVV1TZf1TIgM1/rbxtoK3+E+NDY2cbqwvQ9oWnoWAIEBo6ivb9D6FzjGH4C8/ENa62lrayMsZFyPPktmdi4AkeNDtW7jAUSEhWCkUJCTe7BH67pUbt5BWlpbCQ0O6pRotBs9yg87WxuOHC2gsVG7P2JwUGCX8iHj2pPQo8cKoFOr5slThV36NN+/aCEP3H+PJvlLS8/EwsIcr6FDtOKnVDYyNnA0AHn5h7XWYWRkpJmnqUNHIpyemaM1PT0zu0vM58yazotLnmSgizOtra00NLRv08GhPXksK6/ocRzVmpqayD90BBtrqy5JjLmZGcHjAlGpVORecjwYGBgwaWKk1jRPj67fBYVCQWPTL8eemtfQITz/zONXfLixuKQUoEtXgM56sm+PFZygqqqaUX4jUKlUWvvM2toaT08PCs+cpbqmBgMDA6LGh9LS0kJKWqbWelPTszA0NCQ8rH2/XOvxOHqUnybxVRvk4Q5ARUf8zl8oorq6Bm+vIZrEV63zD9PrMSk6UutHiZ2tLVaWlpo6XC+FQsGjDy3mmScfwdDQkOaWFs1xqx7V5VqOWzV7OzutxBdg1EhfBlhYcPzEKVpbWwHIys5FoVAQdcn50cjISNMVpCfnJM9BHlqJL53225WuAeofb2fOnkOpbNSaN3f2DJ545IEuLeDqGJWUll2xbqLvkpZfcUtzuuRiBWi6HahPstfq0osbgKmpKUZGii5Pt5uZmurcpqGhoc7WAfVFtqy8Ap+OiyrAex983G19yisqu65HRx11KSq6CIC728Au80xMjLG3t6O4pJT6+gYsLMx1rOHK63bTsW6AgS7OVFRWUVxSqjXEUOcWWDWnTnEB8B3hw9DBnmTn5vPHt95hlN8IRvgMw3eED5aWAzTL1dc3UFlVDcDv/vDnbutaXqF9Ube1se7SlcRvhA/W1lZk5eSy6K47NIlIWkYWRkZGBAeN0ZRVKhvZvmsvmdm5OsdRVbWquq1Ldy4Wl6JSqXDVER86WvYAiotLtKZbWVlqjkO1X74Lv9RjxvTJfPn1at7/8BO8vYbgO8IH3+E+eA5y79LNQ5fa2rr27XWK/6V6sm/Vx/yBuEQOxCV2u67y8kqsrawIDwtmy7ZdJCanMrkjya+trePwkWOM9vfD2soKruN47Mm5pLS0vKNs16H/rK2sGGBhQV19fbefpSd0rdvY2BiV6uqPpe6UlJaxZdsuDh85Rm1dXZf513LcqunqfmVgYICDgz2FZ85SWVWNuZkZVdU1ODs5djlmAQZ2HOMXLznGdbmea4Cb60ACA/zJysnjj3/5OyP9RjBiuDe+I3yws7XVuYx6yLia2tor1k30XZL8ilvapa2Y+tTdLV2FoufbNDE21plQmHScnJubmwFo7HhK+8lHH8TcXPcIC7qGkzLrpuyl1Os3Ntbdj089DFJTU9NVJ7/qdZv0YN2d6broXRoXIyMjXnz+KeITU0hLzyQpJZ2EpFQMDQ3xH+nLXQvm4WBvR2NTe6uNvZ0dD9x/d7d1tbG21vpbV6wNDQ0JHjuGfTFxHDlWgN+I4ZSUlnG68CxBgQGaOw1tbW18/PlXmu4Rs2dMw8bGCoWhgrLyclat+fEKkdNN/VlMuhk+zNjEuKOcdjyNenhcBgb48+pLzxMTG0/ewcMcKzjB5q07sbWxZuZtU7vcqbhUQ4MSuomdWk/2rbr+URFhjBs7pkt5NRfn9mTQytKSMQH+pGdmc7rwDIM9B5GRlYNKpSIyPFRT/lqPx56cS35Zt+6yxibGcH25r6YP8o1SXVPDP5evoK6unvFhwfj5DmeAhQUGBgZk5+az/0B8D9bSvc7dVzoz7rT/DQ0NtKZdyqTjGO/J6BXXew147OHFpKZlkpyWQWZWDqnp7XcWfIZ5cfeCeV2eVVDfTVB/D8StSZJf0a+1XGfr8JU0t7Ro+qR2prmIdlyIzTsuGI6O9l1OtvqgTkbqdLTyADQ2tidcpt1cuC7HtGPdulqQOq/70otiU3PXC9ulcQEwNjJi0oQIJk2IoL6+gaPHjpOcmk5O3kFKSsv4/e9exMzMTLOtzv10r1VoSBD7YuLIyMzBb8Rw0jLau6WoH3QDOHW6kILjJ3F3c9Xqowlw8tS1j3trpomn7ixKfbteV4LZU4M83PjNfXfT1tbGufMXyDt4mP0H4lm77idN14ruqJPey138e7Jv1cPomZiY9HifTYgMJz0zm6SUdAZ7DiItIxs7Wxv8fH95CO5aj8eeMO5Iersb51Wp7PsJUVJyGrW1dURHjdd6FgE9DcWn/nFzKXUia2pi0oPzUUfZa9hHV8vQ0JCw0HGEhY6jsbGJguMnSM/MJiUtk48+/oI//v5lra519fUNcIUff6Lvkz6/ol8wNDTU+ST2tb7ys6daW1s1fSQ7K+mY5uTY3m1BfZv4xMnTOtdRf523Ul1d228jXui4JdyZsrGRsvIKbG2sMTe7+hO622XW3dbWxoWiixgaGna5nXuhqLhL+ZKS9n50um5lAlhYmBM4xp+nHn+IoMAALhRdpOhiMeZmZtjZ2VJXX8/Fi11vlTYolVc1DvIgD3cGDnQmJ/cgKpWK9IxsbKytGNkpySora7997+01pEvr/rGC4z3e1qWcnZxQKBQUF5fovG2r7i7QkyHJrkTdR37m9CksXdL+IFJGds5ll/nltq/uxIUe7lt1F5yTOo55urmt7DPMCxdnJzKyciguKeXEyVOMDwvRiv+1Ho89oe5mpKu/Z3lFRZd+o31Racc5Tz3qQmdHr+O4VSvSse9VKhWlpWUYGxthY2ONubk5trY2VNfU6vyR0vnhvZvJ1NSEUSN9eXDxIqZNjqamppaCE6e0ytR2HJdXGgFH9G2S/Ip+wdam/USr/tWulpCUesO3HROboPV3ZWUVR44VYGFhjueg9jc0qW/77j8Q36Xl5EBcIstef4us7LxrrkNQYAAGBgbEJSZ3SQLj4pNQqVRXHIGgOwH+ozA2NiI1LZOGBu34ZmbnUlVdw2h/P82tTLXU9Mwu+0M9VqnvCB8AtmzbxR//8neqa7o+SKhuhVN0JD7BHTHctXe/Vrm2tjZWfbeO115/iwod/aa7ExYcRG1dHcmpGVwoukhIcJBWkmVj296FovySh4MuXiwhLjEFOoYf68zQ0LDbljE1ExNjRvv7UVtX1+Whu4aGBlLTMjAyMiLgkoeKeqK8ooL/+/v7bNyyo8s8o45b0ArDy992VyeNl+uP2ZN96+01BFsba06eLuzyVrLyigre/L9/8Nl/V3ZZd1REGLW1daxe296tZHx4sNb8az0ee8LdzbXjwa2TXY6lmNju+y3fDApF+7F5pePL1qZ9DN9Lj9v0jGwKC8/2aB2XU3SxmMNHC7Sm5eQdpEGpZMRwH813aNzYgPaxzeOTtcq2tLQQn9g+LWjstZ2TdDHUEZ/Y+CT+35/+qkm2OzO65Pyipm7MkFe+39qk24PoFwLH+LNvfywrv/uBKROjUKlUpKRlomprf7CjDf2/2auNNgYMaH/C+fP/fouf73CUSiUH4hJpampm7uwZmv5qo0b6EhI8ltS0TN774GPNqAwFx0+QnJqBh7sro0Ze+yuG3d1cmTZlIrv37mf5R58SHhaMiYkxBcdPkpichrOTI7NmTOvBmrqytBzAgjtu5/sf/8c/l/+HCZHhDBhgwZmz5zgQl4SVpSULOw0jpI61i5Mj//jXvxkfFsKAARbk5R8iJ+8ggzzcCQxoH+HCd4QPu/fu5933/01EWAiOjg60tLRw4uQpUtIy8R3ho2kBnXHbFHIPHiIpJQ2lUkmA/0iamptJz8zWjAVtZ6f7IRZdQsaNZdPWnWzcsh06hoLqbOhgTxwdHcg/dIQfN2zC09OD8xcukpiUykO/WcTnX32rGVvWd4QPzk6OODrYU1xSyroNm7C2smLKJN0D5S+YN4fjJ07x3ffrOX/+Ah7ubtTU1hIbn0RlVTX3LLxD0wJ7Nezt7LCztWHXnp8pKS3Fd7gPpqYmVFZWafpSX+7FFQAe7q5YWVlyrOA4ra2tWn3jr2bfKhQK7l+0kE+/XMknn3/N5ElRODs5UVZWxoH4JFpaW5k0IbLL9sNDx7Fp6w4Kjp9kpO/wLsOyXe3xeDUUCgUzpk9mw8atvP/hJ0RPGI+NtRWHjxRw5uw5HB0dKC0t09nV6UZTt0qnpGcywHIAdrY2BAd17b4SNDaA7bv2smPXPtra2rCysuLoseMcPnqM++9dyOf//ZbMnDxcB7owpmOkmasxdLAnX3y1iojwYFwHDqSktJR9+2MxUiiYPWOqptys26aSl3+YrTt2U1FZxTDvITQ0KElOTefM2fNMmzJRr13A1PGJiU2gqbkZVxfn9pcYbd7O8n9/SuT4MAa6OKNSqTh37jyx8Um4uQ5keKehKwEOHj4KwEhfeeX7rUySX9EvzJ09A4VCQUZWDis++RIrK0uCgwK57547Wfq712lt0X/f35aWFhQKBc89/RjrN25h87adNDQocXSw1xonWO3B++/Ba8hgklLS2LBxK9CGvZ0dM6dPYdrUid0+HNJT8+fOwtXFmdiEJDZs3EJrSyt2drZMnhjFjGmTr/pBt86io8Zjb2fL3v2xbNm2i6bmZqytrQgLCWLmbVO0npxu6Yj1lMnRFBeXEBufRFl5BWampoSHjmP+vNma1qFh3kN58bmn2BcTS3xSCrW1dZiamODgYMeCO+YQFfHLw1nmZma8/MKz7Nq7n+ycPPIOHsbY2BgXZ0fuX7SQyPGhOmrePTs7W834oJ6DPLqMYGBkZMSzTz7Cjz9tJiUtk8SUNDwHefD4o7/Bx9uLubNnsG3nXjZt2YG9nS3OTo7ctWAea3/4iYSkFOxsbZkYrXt4LAcHe5a99Dzbdu4hNSOLvftjMTU1ZbCnBwvn364Zs/daPPn4Q+zdd4DM7FyOHC2gqakZG2srhg4ZzCMP3qe5G9EdAwMDRvn5kpSSxolTp/Hx/uX2+dXsWzp+9L384rPs3LOP2Pik9je8WQ5gmNdQbps2STNkVWcWFhaMGe1PWkYWkePDdNbxao7HqzV1cjQKhYIDcYls3roTczMzfH19eO6Zx/nsy28oLS2jpaXlur+vV8tr6BCio8aTkpbBnr0xhAaP1Zn8DnRx5uknHmbLtp1s27kXExNjfIf78MrSZ7GztSU4KJDs3Hw2bd2Br2/Xt+ldibOzEwvvvJ3N23YRn5BCq0rFIA8P5s6+TfPGNToeHHv5xWfZsWsvOXkHSUxOxdjICDc3Vx76zb1d3kp4vcaOGU12Tj75h46w9+cDTJ0c3X78LX2WPftiSM/IorqmFiOFAjs7W2ZMn8Kk6Ait0WDa+wSfxNnJsdu3Vopbg8GRI0du7MvshRBC/KoUnjnHO+99SFBgAI89vPimblulUvG3d5ejbGzkL28s69HwbOLGU78yXP3K5V+jmNgEfli/kd/cdxfjw0J6sIToq+SsIYQQ4qp4DnInZNxYMrNzu7ws40Y7EJ/EhaKLTJ8yURJfcdMoGxvZsXsfLs5OPX65kOi75MwhhBDiqt21YC421lasWvPjdT0g1RNV1TWkpmfyw/qNrP9pM0OHeBIVobvLgxA3wvqfNtPQ0MDDD9wrP7p+BWQPCiGEuGqWAwbw5GMPUVpWzurv19/QbZWVlfPd9+tJSc0gZNxYnn3y0W5fQiOEviUkpZCQlMp9dy+4Yp94cWuQPr9CCCGEEKLfkJZfIYQQQgjRb0jyK4QQQggh+g1JfoUQQgghRL8hya8QQgghhOg3JPkVQgghhBD9hiS/QgghhBCi35DkVwghhBBC9BuS/AohhBBCiH7j/wOwSWx2zB07MwAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 800x600 with 1 Axes>"
             ]
@@ -1556,13 +509,13 @@
         "\n",
         "fig, ax = plt.subplots(1, 1, figsize=(8, 6))\n",
         "ax.errorbar(iters, y_rnd.mean(axis=0), yerr=ci(y_rnd), label=\"random\", linewidth=1.5)\n",
-        "ax.errorbar(iters, y_ei.mean(axis=0), yerr=ci(y_ei), label=\"qEI\", linewidth=1.5)\n",
-        "ax.errorbar(iters, y_nei.mean(axis=0), yerr=ci(y_nei), label=\"qNEI\", linewidth=1.5)\n",
+        "ax.errorbar(iters, y_ei.mean(axis=0), yerr=ci(y_ei), label=\"qLogEI\", linewidth=1.5)\n",
+        "ax.errorbar(iters, y_nei.mean(axis=0), yerr=ci(y_nei), label=\"qLogNEI\", linewidth=1.5)\n",
         "plt.plot(\n",
         "    [0, N_BATCH * BATCH_SIZE],\n",
         "    [GLOBAL_MAXIMUM] * 2,\n",
         "    \"k\",\n",
-        "    label=\"true best objective\",\n",
+        "    label=\"true best feasible objective\",\n",
         "    linewidth=2,\n",
         ")\n",
         "ax.set_ylim(bottom=0.5)\n",

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -135,7 +135,7 @@ fit_gpytorch_mll(mll)
     const constrAcqFuncExample = `${pre}python
 from botorch.acquisition import LogExpectedImprovement
 
-logNEI = LogExpectedImprovement(model=gp, best_f=Y.max())
+logEI = LogExpectedImprovement(model=gp, best_f=Y.max())
     `;
     // Example for optimizing candidates
     const optAcqFuncExample = `${pre}python
@@ -143,7 +143,7 @@ from botorch.optim import optimize_acqf
 
 bounds = torch.stack([torch.zeros(2), torch.ones(2)]).to(torch.double)
 candidate, acq_value = optimize_acqf(
-    logNEI, bounds=bounds, q=1, num_restarts=5, raw_samples=20,
+    logEI, bounds=bounds, q=1, num_restarts=5, raw_samples=20,
 )
 candidate  # tensor([[0.2981, 0.2401]], dtype=torch.float64)
     `;


### PR DESCRIPTION
Updating the constrained noisy optimization tutorial to use LogEI, which improves the performance of both versions, and crystalizes the advantage of the qLogNEI in the noisy context:

Before            |  After with LogEI
:-------------------------:|:-------------------------:
<img width="600" alt="Screenshot 2024-08-29 at 6 37 53 PM" src="https://github.com/user-attachments/assets/be48e0c7-c30b-44a8-9283-16853da57c04"> | <img width="600" alt="Screenshot 2024-08-29 at 6 37 25 PM" src="https://github.com/user-attachments/assets/f26caa78-fbac-4537-8e98-a482d1e11057">

Differential Revision: D61997649
