### PR TITLE
Update the remaining models to use new default covar & likelihood modules

### DIFF
--- a/botorch/models/contextual_multioutput.py
+++ b/botorch/models/contextual_multioutput.py
@@ -64,7 +64,7 @@ class LCEMGP(MultiTaskGP):
                 is common across all tasks.
             mean_module: The mean function to be used. Defaults to `ConstantMean`.
             covar_module: The module for computing the covariance matrix between
-                the non-task features. Defaults to `MaternKernel`.
+                the non-task features. Defaults to `RBFKernel`.
             likelihood: A likelihood. The default is selected based on `train_Yvar`.
                 If `train_Yvar` is None, a standard `GaussianLikelihood` with inferred
                 noise level is used. Otherwise, a FixedNoiseGaussianLikelihood is used.

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -149,7 +149,7 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                 is None, and a `FixedNoiseGaussianLikelihood` with the given
                 noise observations if `train_Yvar` is not None.
             covar_module: The module computing the covariance (Kernel) matrix.
-                If omitted, use a `MaternKernel`.
+                If omitted, uses an `RBFKernel`.
             mean_module: The mean function to be used. If omitted, use a
                 `ConstantMean`.
             outcome_transform: An outcome transform that is applied to the
@@ -207,6 +207,7 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                 ard_num_dims=transformed_X.shape[-1],
                 batch_shape=self._aug_batch_shape,
             )
+            # Used for subsetting along the output dimension. See Model.subset_output.
             self._subset_batch_dict = {
                 "mean_module.raw_constant": -1,
                 "covar_module.raw_lengthscale": -3,

--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -543,7 +543,9 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
             subset_batch_dict = self._subset_batch_dict
         except AttributeError:
             raise NotImplementedError(
-                "subset_output requires the model to define a `_subset_dict` attribute"
+                "`subset_output` requires the model to define a `_subset_batch_dict` "
+                "attribute that lists the indices of the output dimensions in each "
+                "model parameter that needs to be subset."
             )
 
         m = len(idcs)

--- a/botorch/models/kernels/contextual_lcea.py
+++ b/botorch/models/kernels/contextual_lcea.py
@@ -7,9 +7,9 @@
 from typing import Any, Optional
 
 import torch
+from botorch.models.utils.gpytorch_modules import get_covar_module_with_dim_scaled_prior
 from gpytorch.constraints import Positive
 from gpytorch.kernels.kernel import Kernel
-from gpytorch.kernels.matern_kernel import MaternKernel
 from gpytorch.priors.torch_priors import GammaPrior
 from linear_operator.operators import DiagLinearOperator
 from linear_operator.operators.dense_linear_operator import DenseLinearOperator
@@ -158,18 +158,14 @@ class LCEAKernel(Kernel):
         if train_embedding:
             self._set_emb_layers()
         # task covariance matrix
-        self.task_covar_module = MaternKernel(
-            nu=2.5,
+        self.task_covar_module = get_covar_module_with_dim_scaled_prior(
             ard_num_dims=self.n_embs,
             batch_shape=batch_shape,
-            lengthscale_prior=GammaPrior(3.0, 6.0),
         )
         # base kernel
-        self.base_kernel = MaternKernel(
-            nu=2.5,
+        self.base_kernel = get_covar_module_with_dim_scaled_prior(
             ard_num_dims=self.num_param,
             batch_shape=batch_shape,
-            lengthscale_prior=GammaPrior(3.0, 6.0),
         )
         # outputscales for each context (note this is like sqrt of outputscale)
         self.context_weight = None

--- a/botorch/models/kernels/contextual_sac.py
+++ b/botorch/models/kernels/contextual_sac.py
@@ -7,8 +7,8 @@
 from typing import Any, Optional
 
 import torch
+from botorch.models.utils.gpytorch_modules import get_covar_module_with_dim_scaled_prior
 from gpytorch.kernels.kernel import Kernel
-from gpytorch.kernels.matern_kernel import MaternKernel
 from gpytorch.kernels.scale_kernel import ScaleKernel
 from gpytorch.priors.torch_priors import GammaPrior
 from linear_operator.operators.sum_linear_operator import SumLinearOperator
@@ -36,7 +36,7 @@ class SACKernel(Kernel):
     where
     * :math: M is the number of partitions of parameter space. Each partition contains
     same number of parameters d. Each kernel `k_i` acts only on d parameters of ith
-    partition i.e. `\mathbf{x}_(i)`. Each kernel `k_i` is a scaled Matern kernel
+    partition i.e. `\mathbf{x}_(i)`. Each kernel `k_i` is a scaled RBF kernel
     with same lengthscales but different outputscales.
     """
 
@@ -72,11 +72,9 @@ class SACKernel(Kernel):
             for context, active_params in self.decomposition.items()
         }
 
-        self.base_kernel = MaternKernel(
-            nu=2.5,
+        self.base_kernel = get_covar_module_with_dim_scaled_prior(
             ard_num_dims=num_param,
             batch_shape=batch_shape,
-            lengthscale_prior=GammaPrior(3.0, 6.0),
         )
 
         self.kernel_dict = {}  # scaled kernel for each parameter space partition

--- a/botorch/models/utils/gpytorch_modules.py
+++ b/botorch/models/utils/gpytorch_modules.py
@@ -18,7 +18,7 @@ References:
 """
 
 from math import log, sqrt
-from typing import Optional, Union
+from typing import Optional, Sequence, Union
 
 import torch
 from gpytorch.constraints.constraints import GreaterThan
@@ -101,7 +101,8 @@ def get_covar_module_with_dim_scaled_prior(
     ard_num_dims: int,
     batch_shape: Optional[torch.Size] = None,
     use_rbf_kernel: bool = True,
-) -> Union[MaternKernel, RBFKernel, ScaleKernel]:
+    active_dims: Optional[Sequence[int]] = None,
+) -> Union[MaternKernel, RBFKernel]:
     """Returns an RBF or Matern kernel with priors
     from  [Hvarfner2024vanilla]_.
 
@@ -109,6 +110,9 @@ def get_covar_module_with_dim_scaled_prior(
         ard_num_dims: Number of feature dimensions for ARD.
         batch_shape: Batch shape for the covariance module.
         use_rbf_kernel: Whether to use an RBF kernel. If False, uses a Matern kernel.
+        active_dims: The set of input dimensions to compute the covariances on.
+            By default, the covariance is computed using the full input tensor.
+            Set this if you'd like to ignore certain dimensions.
 
     Returns:
         A Kernel constructed according to the given arguments. The prior is constrained
@@ -123,5 +127,7 @@ def get_covar_module_with_dim_scaled_prior(
         lengthscale_constraint=GreaterThan(
             2.5e-2, transform=None, initial_value=lengthscale_prior.mode
         ),
+        # pyre-ignore[6] GPyTorch type is unnecessarily restrictive.
+        active_dims=active_dims,
     )
     return base_kernel

--- a/docs/models.md
+++ b/docs/models.md
@@ -121,10 +121,14 @@ instead.
   a fully Bayesian multi-task GP using an ICM kernel. The data kernel uses the
   SAAS prior to model high-dimensional parameter spaces.
 
-All of the above models use Matérn 5/2 kernels with Automatic Relevance
-Discovery (ARD), and have reasonable priors on hyperparameters that make them
-work well in settings where the **input features are normalized to the unit
-cube** and the **observations are standardized** (zero mean, unit variance).
+All of the above models use RBF kernels with Automatic Relevance Discovery
+(ARD), and have reasonable priors on hyperparameters that make them work well in
+settings where the **input features are normalized to the unit cube** and the
+**observations are standardized** (zero mean, unit variance). The lengthscale
+priors scale with the input dimension, which makes them adaptable to both low
+and high dimensional problems. See
+[this discussion](https://github.com/pytorch/botorch/discussions/2451) for
+additional context on the default hyperparameters.
 
 ## Other useful models
 
@@ -182,6 +186,6 @@ model. If you wish to use gradient-based optimization algorithms, the model
 should allow back-propagating gradients through the samples to the model input.
 
 If you happen to implement a model that would be useful for other researchers as
-well (and involves more than just swapping out the Matérn kernel for an RBF
+well (and involves more than just swapping out the RBF kernel for a Matérn
 kernel), please consider [contributing](getting_started#contributing) this model
 to BoTorch.

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -1841,7 +1841,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
     def _test_with_multitask(self, acqf_class: type[AcquisitionFunction]):
         # Verify that _set_sampler works with MTGP, KroneckerMTGP and HOGP.
         torch.manual_seed(1234)
-        tkwargs = {"device": self.device, "dtype": torch.double}
+        tkwargs: dict[str, Any] = {"device": self.device, "dtype": torch.double}
         train_x = torch.rand(6, 2, **tkwargs)
         train_y = torch.randn(6, 2, **tkwargs)
         mtgp_task = torch.cat(

--- a/test/models/kernels/test_contextual.py
+++ b/test/models/kernels/test_contextual.py
@@ -14,7 +14,7 @@ from botorch.models.kernels.contextual_lcea import (
 
 from botorch.models.kernels.contextual_sac import SACKernel
 from botorch.utils.testing import BotorchTestCase
-from gpytorch.kernels.matern_kernel import MaternKernel
+from gpytorch.kernels.rbf_kernel import RBFKernel
 from torch import Tensor
 from torch.nn import ModuleDict
 
@@ -25,7 +25,7 @@ class ContextualKernelTest(BotorchTestCase):
         kernel = SACKernel(decomposition=decomposition, batch_shape=torch.Size([]))
 
         self.assertIsInstance(kernel.kernel_dict, ModuleDict)
-        self.assertIsInstance(kernel.base_kernel, MaternKernel)
+        self.assertIsInstance(kernel.base_kernel, RBFKernel)
         self.assertDictEqual(kernel.decomposition, decomposition)
 
         # test diag works well for lazy tensor
@@ -46,8 +46,8 @@ class ContextualKernelTest(BotorchTestCase):
         # test init
         self.assertListEqual(kernel.context_list, ["1", "2"])
 
-        self.assertIsInstance(kernel.base_kernel, MaternKernel)
-        self.assertIsInstance(kernel.task_covar_module, MaternKernel)
+        self.assertIsInstance(kernel.base_kernel, RBFKernel)
+        self.assertIsInstance(kernel.task_covar_module, RBFKernel)
         self.assertEqual(kernel.permutation, [0, 3, 1, 2])
 
         # test raise of ValueError

--- a/test/models/test_approximate_gp.py
+++ b/test/models/test_approximate_gp.py
@@ -133,7 +133,7 @@ class TestSingleTaskVariationalGP(BotorchTestCase):
 
                 # but that the covariance does have a gradient
                 self.assertIsNotNone(
-                    batched_model.model.covar_module.raw_outputscale.grad
+                    batched_model.model.covar_module.raw_lengthscale.grad
                 )
 
                 # check that we always have three outputs

--- a/test/models/test_gp_regression_mixed.py
+++ b/test/models/test_gp_regression_mixed.py
@@ -20,7 +20,7 @@ from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.test_helpers import get_pvar_expected
 from botorch.utils.testing import _get_random_data, BotorchTestCase
 from gpytorch.kernels.kernel import AdditiveKernel, ProductKernel
-from gpytorch.kernels.matern_kernel import MaternKernel
+from gpytorch.kernels.rbf_kernel import RBFKernel
 from gpytorch.kernels.scale_kernel import ScaleKernel
 from gpytorch.likelihoods import FixedNoiseGaussianLikelihood
 from gpytorch.likelihoods.gaussian_likelihood import GaussianLikelihood
@@ -90,10 +90,10 @@ class TestMixedSingleTaskGP(BotorchTestCase):
                 self.assertIsInstance(prod_kernel.base_kernel, ProductKernel)
                 sum_cont_kernel, sum_cat_kernel = sum_kernel.base_kernel.kernels
                 prod_cont_kernel, prod_cat_kernel = prod_kernel.base_kernel.kernels
-                self.assertIsInstance(sum_cont_kernel, MaternKernel)
+                self.assertIsInstance(sum_cont_kernel, RBFKernel)
                 self.assertIsInstance(sum_cat_kernel, ScaleKernel)
                 self.assertIsInstance(sum_cat_kernel.base_kernel, CategoricalKernel)
-                self.assertIsInstance(prod_cont_kernel, MaternKernel)
+                self.assertIsInstance(prod_cont_kernel, RBFKernel)
                 self.assertIsInstance(prod_cat_kernel, CategoricalKernel)
             else:
                 self.assertIsInstance(model.covar_module, ScaleKernel)

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -414,6 +414,7 @@ class TestBatchedMultiOutputGPyTorchModel(BotorchTestCase):
 
 class TestModelListGPyTorchModel(BotorchTestCase):
     def test_model_list_gpytorch_model(self):
+        torch.manual_seed(12345)
         for dtype in (torch.float, torch.double):
             tkwargs = {"device": self.device, "dtype": dtype}
             train_X1, train_X2 = (
@@ -512,16 +513,15 @@ class TestModelListGPyTorchModel(BotorchTestCase):
                 self.assertEqual(
                     posterior_subset.mean.shape, torch.Size([2, len(output_indices)])
                 )
-                self.assertTrue(
-                    torch.allclose(
-                        posterior_subset.mean, posterior.mean[..., output_indices]
-                    )
+                self.assertAllClose(
+                    posterior_subset.mean,
+                    posterior.mean[..., output_indices],
+                    atol=1e-6,
                 )
-                self.assertTrue(
-                    torch.allclose(
-                        posterior_subset.variance,
-                        posterior.variance[..., output_indices],
-                    )
+                self.assertAllClose(
+                    posterior_subset.variance,
+                    posterior.variance[..., output_indices],
+                    atol=1e-6,
                 )
             # test observation noise
             model = SimpleModelListGPyTorchModel(m1, m2)


### PR DESCRIPTION
Summary:
Updates the default covar & likelihood modules of BoTorch models. See https://github.com/pytorch/botorch/discussions/2451 for details on the new defaults.

For models that utilize a composite kernel, such as multi-fidelity/task/context, this change only affects the base kernel.

Models that do not utilize the new modules:
- Fully-bayesian models.
- Pairwise GP.
- Fidelity kernels for MF models.

Differential Revision: D62196414
