### PR TITLE
Silence input data warnings in tests

### DIFF
--- a/botorch/models/utils/assorted.py
+++ b/botorch/models/utils/assorted.py
@@ -166,8 +166,10 @@ def check_min_max_scaling(
         if torch.any(Xmin < -atol) or torch.any(Xmax > 1 + atol):
             msg = "contained"
         if msg is not None:
+            # NOTE: If you update this message, update the warning filters as well.
+            # See https://github.com/pytorch/botorch/pull/2508.
             msg = (
-                f"Data (input features) not {msg} to the unit cube. "
+                f"Data (input features) is not {msg} to the unit cube. "
                 "Please consider min-max scaling the input data."
             )
             if raise_on_fail:
@@ -196,9 +198,11 @@ def check_standardization(
         mean_not_zero = torch.abs(Ymean).max() > atol_mean
         if Y.shape[-2] <= 1:
             if mean_not_zero:
+                # NOTE: If you update this message, update the warning filters as well.
+                # See https://github.com/pytorch/botorch/pull/2508.
                 msg = (
-                    f"Data (outcome observations) not standardized (mean = {Ymean}). "
-                    "Please consider scaling the input to zero mean and unit variance."
+                    f"Data (outcome observations) is not standardized (mean = {Ymean})."
+                    " Please consider scaling the input to zero mean and unit variance."
                 )
                 if raise_on_fail:
                     raise InputDataError(msg)
@@ -207,8 +211,10 @@ def check_standardization(
             Ystd = torch.std(Y, dim=-2)
             std_not_one = torch.abs(Ystd - 1).max() > atol_std
             if mean_not_zero or std_not_one:
+                # NOTE: If you update this message, update the warning filters as well.
+                # See https://github.com/pytorch/botorch/pull/2508.
                 msg = (
-                    "Data (outcome observations) not standardized "
+                    "Data (outcome observations) is not standardized "
                     f"(std = {Ystd}, mean = {Ymean})."
                     "Please consider scaling the input to zero mean and unit variance."
                 )

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -62,12 +62,12 @@ class BotorchTestCase(TestCase):
             )
             warnings.filterwarnings(
                 "ignore",
-                message="Data is not standardized.",
+                message=r"Data \(outcome observations\) is not standardized ",
                 category=InputDataWarning,
             )
             warnings.filterwarnings(
                 "ignore",
-                message="Input data is not contained to the unit cube.",
+                message=r"Data \(input features\) is not",
                 category=InputDataWarning,
             )
 

--- a/test/models/utils/test_assorted.py
+++ b/test/models/utils/test_assorted.py
@@ -158,14 +158,14 @@ class TestInputDataChecks(BotorchTestCase):
         check_standardization(Y=y, raise_on_fail=True)
 
         # check nonzero mean for case where >= 2 observations per batch
-        msg_more_than_1_obs = r"Data \(outcome observations\) not standardized \(std ="
+        msg_more_than_1_obs = r"Data \(outcome observations\) is not standardized \(std"
         with self.assertWarnsRegex(InputDataWarning, msg_more_than_1_obs):
             check_standardization(Y=Yst + 1)
         with self.assertRaisesRegex(InputDataError, msg_more_than_1_obs):
             check_standardization(Y=Yst + 1, raise_on_fail=True)
 
         # check nonzero mean for case where < 2 observations per batch
-        msg_one_obs = r"Data \(outcome observations\) not standardized \(mean ="
+        msg_one_obs = r"Data \(outcome observations\) is not standardized \(mean ="
         y = torch.ones((3, 1, 2), dtype=torch.float32)
         with self.assertWarnsRegex(InputDataWarning, msg_one_obs):
             check_standardization(Y=y)


### PR DESCRIPTION
Summary: This logic broke since D61797434 updated the warning messages, leading to too many of these warnings in test outputs again.

Differential Revision: D62200731
