### PR TITLE
Affine input transforms should error with data of incorrect dimension, even in eval mode

### DIFF
--- a/botorch/models/converter.py
+++ b/botorch/models/converter.py
@@ -388,8 +388,8 @@ def batched_multi_output_to_single_output(
     Example:
         >>> train_X = torch.rand(5, 2)
         >>> train_Y = torch.rand(5, 2)
-        >>> batch_mo_gp = SingleTaskGP(train_X, train_Y)
-        >>> batch_so_gp = batched_multioutput_to_single_output(batch_gp)
+        >>> batch_mo_gp = SingleTaskGP(train_X, train_Y, outcome_transform=None)
+        >>> batch_so_gp = batched_multi_output_to_single_output(batch_mo_gp)
     """
     warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
     was_training = batch_mo_model.training

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -412,8 +412,8 @@ class AffineInputTransform(ReversibleInputTransform, Module):
         Returns:
             A `batch_shape x n x d`-dim tensor of transformed inputs.
         """
+        self._check_shape(X)
         if self.learn_coefficients and self.training:
-            self._check_shape(X)
             self._update_coefficients(X)
         self._to(X)
         return (X - self.offset) / self.coefficient

--- a/test/acquisition/test_proximal.py
+++ b/test/acquisition/test_proximal.py
@@ -78,7 +78,7 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                     proximal_test_X = test_X.clone()
                     if transformed_weighting:
                         if input_transform is not None:
-                            last_X = input_transform(train_X[-1])
+                            last_X = input_transform(train_X[-1].unsqueeze(0))
                             proximal_test_X = input_transform(test_X)
 
                     mv_normal = MultivariateNormal(last_X, torch.diag(proximal_weights))
@@ -105,7 +105,7 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                     proximal_test_X = test_X.clone()
                     if transformed_weighting:
                         if input_transform is not None:
-                            last_X = input_transform(train_X[-1])
+                            last_X = input_transform(train_X[-1].unsqueeze(0))
                             proximal_test_X = input_transform(test_X)
 
                     mv_normal = MultivariateNormal(last_X, torch.diag(proximal_weights))
@@ -122,7 +122,7 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                     proximal_test_X = test_X.clone()
                     if transformed_weighting:
                         if input_transform is not None:
-                            last_X = input_transform(train_X[-1])
+                            last_X = input_transform(train_X[-1].unsqueeze(0))
                             proximal_test_X = input_transform(test_X)
 
                     ei = EI(test_X)
@@ -143,7 +143,7 @@ class TestProximalAcquisitionFunction(BotorchTestCase):
                     proximal_test_X = test_X.clone()
                     if transformed_weighting:
                         if input_transform is not None:
-                            last_X = input_transform(train_X[-1])
+                            last_X = input_transform(train_X[-1].unsqueeze(0))
                             proximal_test_X = input_transform(test_X)
 
                     qEI_prox = ProximalAcquisitionFunction(

--- a/test/models/test_approximate_gp.py
+++ b/test/models/test_approximate_gp.py
@@ -327,5 +327,5 @@ class TestSingleTaskVariationalGP(BotorchTestCase):
                     model.likelihood, model.model, num_data=train_X.shape[-2]
                 )
                 fit_gpytorch_mll(mll)
-                post = model.posterior(torch.tensor([train_X.mean()]))
+                post = model.posterior(torch.tensor([[train_X.mean()]]))
                 self.assertAllClose(post.mean[0][0], y.mean(), atol=1e-3, rtol=1e-3)

--- a/test/models/test_converter.py
+++ b/test/models/test_converter.py
@@ -278,13 +278,21 @@ class TestConverters(BotorchTestCase):
                 batch_shape=torch.Size([3]),
             )
             gp1_ = SingleTaskGP(
-                train_X, train_Y1, input_transform=input_tf2, outcome_transform=None
+                train_X=train_X.unsqueeze(0),
+                train_Y=train_Y1.unsqueeze(0),
+                input_transform=input_tf2,
+                outcome_transform=None,
             )
             gp2_ = SingleTaskGP(
-                train_X, train_Y2, input_transform=input_tf2, outcome_transform=None
+                train_X=train_X.unsqueeze(0),
+                train_Y=train_Y2.unsqueeze(0),
+                input_transform=input_tf2,
+                outcome_transform=None,
             )
             list_gp = ModelListGP(gp1_, gp2_)
-            with self.assertRaises(UnsupportedError):
+            with self.assertRaisesRegex(
+                UnsupportedError, "Batched input_transforms are not supported."
+            ):
                 model_list_to_batched(list_gp)
 
             # test outcome transform
@@ -457,7 +465,6 @@ class TestConverters(BotorchTestCase):
                 bounds=torch.tensor(
                     [[-1.0, -1.0], [1.0, 1.0]], device=self.device, dtype=dtype
                 ),
-                batch_shape=torch.Size([2]),
             )
             batched_mo_model = SingleTaskGP(
                 train_X, train_Y, input_transform=input_tf, outcome_transform=None

--- a/test_community/models/test_gp_regression_multisource.py
+++ b/test_community/models/test_gp_regression_multisource.py
@@ -76,7 +76,9 @@ class TestAugmentedSingleTaskGP(BotorchTestCase):
                 None if train_Yvar else get_gaussian_likelihood_with_gamma_prior()
             ),
         }
-        model = SingleTaskAugmentedGP(**model_kwargs, **extra_model_kwargs)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=OptimizationWarning)
+            model = SingleTaskAugmentedGP(**model_kwargs, **extra_model_kwargs)
         return model, model_kwargs
 
     def test_data_init(self):
@@ -139,8 +141,8 @@ class TestAugmentedSingleTaskGP(BotorchTestCase):
         self.assertListEqual(res.tolist(), true_res.tolist())
 
     def test_gp(self):
-        bounds = torch.tensor([[-1.0], [1.0]])
         d = 5
+        bounds = torch.stack((torch.full((d - 1,), -1), torch.ones(d - 1)))
         for batch_shape, dtype, use_octf, use_intf, train_Yvar in itertools.product(
             (torch.Size(), torch.Size([2])),
             (torch.float, torch.double),
@@ -151,7 +153,7 @@ class TestAugmentedSingleTaskGP(BotorchTestCase):
             tkwargs = {"device": self.device, "dtype": dtype}
             octf = Standardize(m=1, batch_shape=torch.Size()) if use_octf else None
             intf = (
-                Normalize(d=1, bounds=bounds.to(**tkwargs), transform_on_train=True)
+                Normalize(d=d - 1, bounds=bounds.to(**tkwargs), transform_on_train=True)
                 if use_intf
                 else None
             )


### PR DESCRIPTION
Summary:
Context: https://github.com/pytorch/botorch/issues/2509 gives a clear overview

This PR:
* Checks the shape of the `X` provided to an `AffineInputTransform` when it transforms the data, regardless of whether it is updating the coefficients.

Makes some unrelated changes:
* Fixes the example in the docstring for `batched_multi_output_to_single_output`
* fixes an incorrect shape in `test_approximate_gp`
* Makes data and transform batch shapes match in `TestConverters`, since those usages will now (appropriately) error

Differential Revision: D62318530
