### PR TITLE
Added posterior_transform to posterior method in ApproximateGPyTorchModel

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import copy
 import warnings
-
 from typing import Optional, TypeVar, Union
 
 import torch
@@ -139,10 +138,14 @@ class ApproximateGPyTorchModel(GPyTorchModel):
     def posterior(
         self,
         X,
-        output_indices=None,
-        observation_noise=False,
-        posterior_transform=None,
+        output_indices: Optional[list[int]] = None,
+        observation_noise: bool = False,
+        posterior_transform: Optional[PosteriorTransform] = None,
     ) -> GPyTorchPosterior:
+        if output_indices is not None:
+            raise NotImplementedError(  # pragma: no cover
+                f"{self.__class__.__name__}.posterior does not support output indices."
+            )
         self.eval()  # make sure model is in eval mode
 
         # input transforms are applied at `posterior` in `eval` mode, and at

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -142,8 +142,6 @@ class ApproximateGPyTorchModel(GPyTorchModel):
         output_indices=None,
         observation_noise=False,
         posterior_transform=None,
-        *args,
-        **kwargs,
     ) -> GPyTorchPosterior:
         self.eval()  # make sure model is in eval mode
 
@@ -158,7 +156,7 @@ class ApproximateGPyTorchModel(GPyTorchModel):
             X = X.unsqueeze(-3).repeat(*[1] * (X_ndim - 2), self.num_outputs, 1, 1)
         dist = self.model(X)
         if observation_noise:
-            dist = self.likelihood(dist, *args, **kwargs)
+            dist = self.likelihood(dist)
 
         posterior = GPyTorchPosterior(distribution=dist)
         if hasattr(self, "outcome_transform"):

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -137,7 +137,13 @@ class ApproximateGPyTorchModel(GPyTorchModel):
         return Module.train(self, mode=mode)
 
     def posterior(
-        self, X, output_indices=None, observation_noise=False, *args, **kwargs
+        self,
+        X,
+        output_indices=None,
+        observation_noise=False,
+        posterior_transform=None,
+        *args,
+        **kwargs,
     ) -> GPyTorchPosterior:
         self.eval()  # make sure model is in eval mode
 
@@ -157,6 +163,8 @@ class ApproximateGPyTorchModel(GPyTorchModel):
         posterior = GPyTorchPosterior(distribution=dist)
         if hasattr(self, "outcome_transform"):
             posterior = self.outcome_transform.untransform_posterior(posterior)
+        if posterior_transform is not None:
+            posterior = posterior_transform(posterior)
         return posterior
 
     def forward(self, X) -> MultivariateNormal:

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import copy
 import warnings
-from typing import Optional, TypeVar, Union
+from typing import Optional, Union
 
 import torch
 from botorch.acquisition.objective import PosteriorTransform

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -34,6 +34,7 @@ import warnings
 from typing import Optional, TypeVar, Union
 
 import torch
+from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform

--- a/test/models/test_approximate_gp.py
+++ b/test/models/test_approximate_gp.py
@@ -103,7 +103,7 @@ class TestSingleTaskVariationalGP(BotorchTestCase):
                 # test batch_shape property
                 self.assertEqual(model.batch_shape, tx.shape[:-2])
 
-        # Test that checks if posterior_transfomr is correctly applied
+        # Test that checks if posterior_transform is correctly applied
         [tx1, ty1, test1] = all_tests["non_batched_mo"]
         model1 = SingleTaskVariationalGP(tx1, ty1, inducing_points=tx1)
         posterior_transform = ScalarizedPosteriorTransform(

--- a/test/models/test_approximate_gp.py
+++ b/test/models/test_approximate_gp.py
@@ -105,7 +105,7 @@ class TestSingleTaskVariationalGP(BotorchTestCase):
 
         # Test that checks if posterior_transfomr is correctly applied
         [tx1, ty1, test1] = all_tests["non_batched_mo"]
-        model1 = SingleTaskVariationalGP(tx1, ty1, inducing_points=tx)
+        model1 = SingleTaskVariationalGP(tx1, ty1, inducing_points=tx1)
         posterior_transform = ScalarizedPosteriorTransform(
             weights=torch.tensor([1.0, 1.0])
         )

--- a/test/models/test_approximate_gp.py
+++ b/test/models/test_approximate_gp.py
@@ -108,7 +108,7 @@ class TestSingleTaskVariationalGP(BotorchTestCase):
         [tx1, ty1, test1] = all_tests["non_batched_mo"]
         model1 = SingleTaskVariationalGP(tx1, ty1, inducing_points=tx1)
         posterior_transform = ScalarizedPosteriorTransform(
-            weights=torch.tensor([1.0, 1.0])
+            weights=torch.tensor([1.0, 1.0], device=self.device)
         )
         posterior1 = model1.posterior(test1, posterior_transform=posterior_transform)
         self.assertIsInstance(posterior1, GPyTorchPosterior)

--- a/test/models/test_approximate_gp.py
+++ b/test/models/test_approximate_gp.py
@@ -8,6 +8,7 @@ import itertools
 import warnings
 
 import torch
+from botorch.acquisition.objective import ScalarizedPosteriorTransform
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.approximate_gp import (
     _SingleTaskVariationalGP,
@@ -20,7 +21,6 @@ from botorch.models.utils.inducing_point_allocators import (
     GreedyImprovementReduction,
     GreedyVarianceReduction,
 )
-from botorch.acquisition.objective import ScalarizedPosteriorTransform
 from botorch.posteriors import GPyTorchPosterior, TransformedPosterior
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.likelihoods import GaussianLikelihood, MultitaskGaussianLikelihood


### PR DESCRIPTION
## Motivation

This PR fixes #2530. Adds a new posterior_transform parameter to the posterior method of ApproximateGPyTorchModel.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I was able to generate candidate points with ExpectedImprovement acquisition function with a SingleTaskVariationalGP that was trained on 2 output columns.

## Related PRs

NA
