### PR TITLE
Use Standardize outcome transform by default in more models

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -35,6 +35,7 @@ import warnings
 from typing import Optional, TypeVar, Union
 
 import torch
+from botorch.exceptions.warnings import UserInputWarning
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
@@ -70,6 +71,14 @@ from torch.nn import Module
 
 
 TApproxModel = TypeVar("TApproxModel", bound="ApproximateGPyTorchModel")
+TRANSFORM_WARNING = (
+    "Using an {ttype} transform with `SingleTaskVariationalGP`. If this "
+    "model is trained in minibatches, a {ttype} transform with learnable "
+    "parameters would update its parameters for each minibatch, which is "
+    "undesirable. If you do intend to train in minibatches, we recommend "
+    "you not use a {ttype} transform and instead pre-transform your whole "
+    "data set before fitting the model."
+)
 
 
 class ApproximateGPyTorchModel(GPyTorchModel):
@@ -325,9 +334,9 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
         variational_distribution: Optional[_VariationalDistribution] = None,
         variational_strategy: type[_VariationalStrategy] = VariationalStrategy,
         inducing_points: Optional[Union[Tensor, int]] = None,
-        outcome_transform: Optional[OutcomeTransform] = None,
-        input_transform: Optional[InputTransform] = None,
         inducing_point_allocator: Optional[InducingPointAllocator] = None,
+        outcome_transform: OutcomeTransform | None = None,
+        input_transform: InputTransform | None = None,
     ) -> None:
         r"""
         Args:
@@ -338,6 +347,8 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
                 either a `GaussianLikelihood` (if `num_outputs=1`) or a
                 `MultitaskGaussianLikelihood`(if `num_outputs>1`).
             num_outputs: Number of output responses per input (default: 1).
+            learn_inducing_points: If True, the inducing point locations are learned
+                jointly with the other model parameters.
             covar_module: Kernel function. If omitted, uses an `RBFKernel`.
             mean_module: Mean of GP model. If omitted, uses a `ConstantMean`.
             variational_distribution: Type of variational distribution to use
@@ -351,6 +362,20 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
             inducing_point_allocator: The `InducingPointAllocator` used to
                 initialize the inducing point locations. If omitted,
                 uses `GreedyVarianceReduction`.
+            outcome_transform: An outcome transform that is applied to the training
+                data during instantiation and to the posterior during inference.
+                NOTE: If this model is trained in minibatches, an outcome transform
+                with learnable parameters (such as `Standardize`) would update its
+                parameters for each minibatch, which is undesirable. If you do intend
+                to train in minibatches, we recommend you not use an outcome transform
+                and instead pre-transform your whole data set before fitting the model.
+            input_transform: An input transform that is applied in the model's
+                forward pass.
+                NOTE: If this model is trained in minibatches, an input transform
+                with learnable parameters (such as `Normalize`) would update its
+                parameters for each minibatch, which is undesirable. If you do intend
+                to train in minibatches, we recommend you not use an input transform
+                and instead pre-transform your whole data set before fitting the model.
         """
         with torch.no_grad():
             transformed_X = self.transform_inputs(
@@ -358,6 +383,11 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
             )
         if train_Y is not None:
             if outcome_transform is not None:
+                warnings.warn(
+                    TRANSFORM_WARNING.format(ttype="outcome"),
+                    UserInputWarning,
+                    stacklevel=3,
+                )
                 train_Y, _ = outcome_transform(train_Y)
             self._validate_tensor_args(X=transformed_X, Y=train_Y)
             validate_input_scaling(train_X=transformed_X, train_Y=train_Y)
@@ -388,6 +418,7 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
                 "being further optimized during the model fit. If so "
                 "then set `learn_inducing_points` to False.",
                 UserWarning,
+                stacklevel=3,
             )
 
         if inducing_point_allocator is None:
@@ -412,6 +443,11 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
         if outcome_transform is not None:
             self.outcome_transform = outcome_transform
         if input_transform is not None:
+            warnings.warn(
+                TRANSFORM_WARNING.format(ttype="input"),
+                UserInputWarning,
+                stacklevel=3,
+            )
             self.input_transform = input_transform
 
         # for model fitting utilities

--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -25,8 +25,7 @@ without having to do too many expensive high-fidelity evaluations.
 
 from __future__ import annotations
 
-import warnings
-from typing import Any, Optional, Union
+from typing import Any, Sequence
 
 import torch
 from botorch.exceptions.errors import UnsupportedError
@@ -40,6 +39,7 @@ from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
 from botorch.models.utils.gpytorch_modules import get_covar_module_with_dim_scaled_prior
 from botorch.utils.datasets import SupervisedDataset
+from botorch.utils.types import _DefaultType, DEFAULT
 from gpytorch.kernels.kernel import ProductKernel
 from gpytorch.kernels.scale_kernel import ScaleKernel
 from gpytorch.likelihoods.likelihood import Likelihood
@@ -66,15 +66,14 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         self,
         train_X: Tensor,
         train_Y: Tensor,
-        train_Yvar: Optional[Tensor] = None,
-        iteration_fidelity: Optional[int] = None,
-        data_fidelities: Optional[Union[list[int], tuple[int]]] = None,
-        data_fidelity: Optional[int] = None,
+        train_Yvar: Tensor | None = None,
+        iteration_fidelity: int | None = None,
+        data_fidelities: Sequence[int] | None = None,
         linear_truncated: bool = True,
         nu: float = 2.5,
-        likelihood: Optional[Likelihood] = None,
-        outcome_transform: Optional[OutcomeTransform] = None,
-        input_transform: Optional[InputTransform] = None,
+        likelihood: Likelihood | None = None,
+        outcome_transform: OutcomeTransform | _DefaultType | None = DEFAULT,
+        input_transform: InputTransform | None = None,
     ) -> None:
         r"""
         Args:
@@ -89,8 +88,6 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
             data_fidelities: The column indices for the downsampling fidelity parameter.
                 If a list/tuple of indices is provided, a kernel will be constructed for
                 each index (optional).
-            data_fidelity: The column index for the downsampling fidelity parameter
-                (optional). Deprecated in favor of `data_fidelities`.
             linear_truncated: If True, use a `LinearTruncatedFidelityKernel` instead
                 of the default kernel.
             nu: The smoothness parameter for the Matern kernel: either 1/2, 3/2, or
@@ -98,24 +95,14 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
             likelihood: A likelihood. If omitted, use a standard GaussianLikelihood
                 with inferred noise level.
             outcome_transform: An outcome transform that is applied to the
-                    training data during instantiation and to the posterior during
-                    inference (that is, the `Posterior` obtained by calling
-                    `.posterior` on the model will be on the original scale).
+                training data during instantiation and to the posterior during
+                inference (that is, the `Posterior` obtained by calling
+                `.posterior` on the model will be on the original scale). We use a
+                `Standardize` transform if no `outcome_transform` is specified.
+                Pass down `None` to use no outcome transform.
             input_transform: An input transform that is applied in the model's
                     forward pass.
         """
-        if data_fidelity is not None:
-            warnings.warn(
-                "The `data_fidelity` argument is deprecated and will be removed in "
-                "a future release. Please use `data_fidelities` instead.",
-                DeprecationWarning,
-            )
-            if data_fidelities is not None:
-                raise ValueError(
-                    "Cannot specify both `data_fidelity` and `data_fidelities`."
-                )
-            data_fidelities = [data_fidelity]
-
         self._init_args = {
             "iteration_fidelity": iteration_fidelity,
             "data_fidelities": data_fidelities,
@@ -179,47 +166,11 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         return inputs
 
 
-class FixedNoiseMultiFidelityGP(SingleTaskMultiFidelityGP):
-    def __init__(
-        self,
-        train_X: Tensor,
-        train_Y: Tensor,
-        train_Yvar: Tensor,
-        iteration_fidelity: Optional[int] = None,
-        data_fidelities: Optional[Union[list[int], tuple[int]]] = None,
-        data_fidelity: Optional[int] = None,
-        linear_truncated: bool = True,
-        nu: float = 2.5,
-        outcome_transform: Optional[OutcomeTransform] = None,
-        input_transform: Optional[InputTransform] = None,
-    ) -> None:
-        r"""DEPRECATED: Use `SingleTaskMultiFidelityGP` instead.
-        Will be removed in a future release (~v0.11).
-        """
-        warnings.warn(
-            "`FixedNoiseMultiFidelityGP` has been deprecated. "
-            "Use `SingleTaskMultiFidelityGP` with `train_Yvar` instead.",
-            DeprecationWarning,
-        )
-        super().__init__(
-            train_X=train_X,
-            train_Y=train_Y,
-            train_Yvar=train_Yvar,
-            iteration_fidelity=iteration_fidelity,
-            data_fidelities=data_fidelities,
-            data_fidelity=data_fidelity,
-            linear_truncated=linear_truncated,
-            nu=nu,
-            outcome_transform=outcome_transform,
-            input_transform=input_transform,
-        )
-
-
 def _setup_multifidelity_covar_module(
     dim: int,
     aug_batch_shape: torch.Size,
-    iteration_fidelity: Optional[int],
-    data_fidelities: Optional[list[int]],
+    iteration_fidelity: int | None,
+    data_fidelities: Sequence[int] | None,
     linear_truncated: bool,
     nu: float,
 ) -> tuple[ScaleKernel, dict]:
@@ -246,6 +197,7 @@ def _setup_multifidelity_covar_module(
     if iteration_fidelity is not None and iteration_fidelity < 0:
         iteration_fidelity = dim + iteration_fidelity
     if data_fidelities is not None:
+        data_fidelities = list(data_fidelities)
         for i in range(len(data_fidelities)):
             if data_fidelities[i] < 0:
                 data_fidelities[i] = dim + data_fidelities[i]

--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 import torch
 from botorch.models.gp_regression import SingleTaskGP
@@ -16,6 +16,7 @@ from botorch.models.transforms.outcome import OutcomeTransform
 from botorch.models.utils.gpytorch_modules import get_covar_module_with_dim_scaled_prior
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.transforms import normalize_indices
+from botorch.utils.types import _DefaultType, DEFAULT
 from gpytorch.constraints import GreaterThan
 from gpytorch.kernels.kernel import Kernel
 from gpytorch.kernels.scale_kernel import ScaleKernel
@@ -65,7 +66,7 @@ class MixedSingleTaskGP(SingleTaskGP):
             Callable[[torch.Size, int, list[int]], Kernel]
         ] = None,
         likelihood: Optional[Likelihood] = None,
-        outcome_transform: Optional[OutcomeTransform] = None,  # TODO
+        outcome_transform: Optional[Union[OutcomeTransform, _DefaultType]] = DEFAULT,
         input_transform: Optional[InputTransform] = None,  # TODO
     ) -> None:
         r"""A single-task exact GP model supporting categorical parameters.
@@ -87,7 +88,9 @@ class MixedSingleTaskGP(SingleTaskGP):
             outcome_transform: An outcome transform that is applied to the
                 training data during instantiation and to the posterior during
                 inference (that is, the `Posterior` obtained by calling
-                `.posterior` on the model will be on the original scale).
+                `.posterior` on the model will be on the original scale). We use a
+                `Standardize` transform if no `outcome_transform` is specified.
+                Pass down `None` to use no outcome transform.
             input_transform: An input transform that is applied in the model's
                 forward pass. Only input transforms are allowed which do not
                 transform the categorical dimensions. If you want to use it

--- a/botorch/utils/test_helpers.py
+++ b/botorch/utils/test_helpers.py
@@ -19,13 +19,13 @@ from botorch.acquisition.objective import PosteriorTransform
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models import SingleTaskGP
 from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
-from botorch.models.gpytorch import GPyTorchModel
+from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel, GPyTorchModel
 from botorch.models.model import FantasizeMixin, Model
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.transforms.outcome import Standardize
 from botorch.models.utils import add_output_dim
 from botorch.models.utils.assorted import fantasize
-from botorch.posteriors.posterior import Posterior
+from botorch.posteriors.torch import TorchPosterior
 from botorch.utils.datasets import MultiTaskDataset, SupervisedDataset
 from gpytorch.distributions.multivariate_normal import MultivariateNormal
 from gpytorch.kernels import RBFKernel, ScaleKernel
@@ -244,21 +244,58 @@ def gen_multi_task_dataset(
     return dataset, (train_X, train_Y, train_Yvar)
 
 
-def get_pvar_expected(posterior: Posterior, model: Model, X: Tensor, m: int) -> Tensor:
+def get_pvar_expected(
+    posterior: TorchPosterior, model: Model, X: Tensor, m: int
+) -> Tensor:
     """Computes the expected variance of a posterior after adding the
     predictive noise from the likelihood.
+
+    Args:
+        posterior: The posterior to compute the variance of. Must be a
+            `TorchPosterior` object.
+        model: The model that generated the posterior. If `m > 1`, this must be
+            a `BatchedMultiOutputGPyTorchModel`.
+        X: The test inputs.
+        m: The number of outputs.
+
+    Returns:
+        The expected variance of the posterior after adding the observation
+        noise from the likelihood.
     """
     X = model.transform_inputs(X)
     lh_kwargs = {}
+    odim = -1  # this is the output dimension index
+
+    if m > 1:
+        if not isinstance(model, BatchedMultiOutputGPyTorchModel):
+            raise UnsupportedError(
+                "`get_pvar_expected` only supports `BatchedMultiOutputGPyTorchModel`s."
+            )
+        # We need to add a batch dimension to the input to be compatible with the
+        # augmented batch shape of the model. This also changes the output dimension
+        # index.
+        X, odim = add_output_dim(X=X, original_batch_shape=model._input_batch_shape)
+
     if isinstance(model.likelihood, FixedNoiseGaussianLikelihood):
-        lh_kwargs["noise"] = model.likelihood.noise.mean().expand(X.shape[:-1])
+        noise = model.likelihood.noise.mean(dim=-1, keepdim=True)
+        broadcasted_shape = torch.broadcast_shapes(noise.shape, X.shape[:-1])
+        lh_kwargs["noise"] = noise.expand(broadcasted_shape)
+
+    pvar_exp = model.likelihood(model(X), X, **lh_kwargs).variance
     if m == 1:
-        return model.likelihood(
-            posterior.distribution, X, **lh_kwargs
-        ).variance.unsqueeze(-1)
-    X_, odi = add_output_dim(X=X, original_batch_shape=model._input_batch_shape)
-    pvar_exp = model.likelihood(model(X_), X_, **lh_kwargs).variance
-    return torch.stack([pvar_exp.select(dim=odi, index=i) for i in range(m)], dim=-1)
+        pvar_exp = pvar_exp.unsqueeze(-1)
+    pvar_exp = torch.stack(
+        [pvar_exp.select(dim=odim, index=i) for i in range(m)], dim=-1
+    )
+
+    # If the model has an outcome transform, we need to untransform the
+    # variance according to that transform.
+    if hasattr(model, "outcome_transform"):
+        _, pvar_exp = model.outcome_transform.untransform(
+            Y=torch.zeros_like(pvar_exp), Yvar=pvar_exp
+        )
+
+    return pvar_exp
 
 
 class DummyNonScalarizingPosteriorTransform(PosteriorTransform):

--- a/test/models/test_approximate_gp.py
+++ b/test/models/test_approximate_gp.py
@@ -8,6 +8,7 @@ import itertools
 import warnings
 
 import torch
+from botorch.exceptions.warnings import UserInputWarning
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.approximate_gp import (
     _SingleTaskVariationalGP,
@@ -189,6 +190,26 @@ class TestSingleTaskVariationalGP(BotorchTestCase):
                 self.assertIsInstance(posterior, TransformedPosterior)
             else:
                 self.assertFalse(hasattr(model, "outcome_transform"))
+
+        # test user warnings when using transforms
+        with self.assertWarnsRegex(
+            UserInputWarning,
+            "Using an input transform with `SingleTaskVariationalGP`",
+        ):
+            SingleTaskVariationalGP(
+                train_X=train_X,
+                train_Y=train_Y,
+                input_transform=Normalize(d=1),
+            )
+        with self.assertWarnsRegex(
+            UserInputWarning,
+            "Using an outcome transform with `SingleTaskVariationalGP`",
+        ):
+            SingleTaskVariationalGP(
+                train_X=train_X,
+                train_Y=train_Y,
+                outcome_transform=Log(),
+            )
 
         # test default inducing point allocator
         self.assertIsInstance(model._inducing_point_allocator, GreedyVarianceReduction)

--- a/test/models/test_contextual_multioutput.py
+++ b/test/models/test_contextual_multioutput.py
@@ -7,7 +7,7 @@
 
 import torch
 from botorch.fit import fit_gpytorch_mll
-from botorch.models.contextual_multioutput import FixedNoiseLCEMGP, LCEMGP
+from botorch.models.contextual_multioutput import LCEMGP
 from botorch.models.multitask import MultiTaskGP
 from botorch.posteriors import GPyTorchPosterior
 from botorch.utils.test_helpers import gen_multi_task_dataset
@@ -101,26 +101,6 @@ class ContextualMultiOutputTest(BotorchTestCase):
                 right_interp_indices=task_idcs,
             ).to_dense()
             self.assertAllClose(previous_covar, model.task_covar_module(task_idcs))
-
-    def test_FixedNoiseLCEMGP(self):
-        for dtype in (torch.float, torch.double):
-            _, (train_x, train_y, train_yvar) = gen_multi_task_dataset(
-                yvar=0.01, dtype=dtype, device=self.device
-            )
-
-            with self.assertWarnsRegex(DeprecationWarning, "FixedNoiseLCEMGP"):
-                model = FixedNoiseLCEMGP(
-                    train_X=train_x,
-                    train_Y=train_y,
-                    train_Yvar=train_yvar,
-                    task_feature=0,
-                )
-            mll = ExactMarginalLogLikelihood(model.likelihood, model)
-            fit_gpytorch_mll(mll, optimizer_kwargs={"options": {"maxiter": 1}})
-            self.assertIsInstance(model, FixedNoiseLCEMGP)
-
-            test_x = train_x[:5]
-            self.assertIsInstance(model(test_x), MultivariateNormal)
 
     def test_construct_inputs(self) -> None:
         for with_embedding_inputs, yvar, skip_task_features_in_datasets in zip(

--- a/test/models/test_converter.py
+++ b/test/models/test_converter.py
@@ -211,8 +211,18 @@ class TestConverters(BotorchTestCase):
             batch_gp = model_list_to_batched(list_gp)
             self.assertIsInstance(batch_gp.likelihood, FixedNoiseGaussianLikelihood)
             # test SingleTaskMultiFidelityGP
-            gp1_ = SingleTaskMultiFidelityGP(train_X, train_Y1, iteration_fidelity=1)
-            gp2_ = SingleTaskMultiFidelityGP(train_X, train_Y2, iteration_fidelity=1)
+            gp1_ = SingleTaskMultiFidelityGP(
+                train_X,
+                train_Y1,
+                iteration_fidelity=1,
+                outcome_transform=None,
+            )
+            gp2_ = SingleTaskMultiFidelityGP(
+                train_X,
+                train_Y2,
+                iteration_fidelity=1,
+                outcome_transform=None,
+            )
             list_gp = ModelListGP(gp1_, gp2_)
             batch_gp = model_list_to_batched(list_gp)
             gp2_ = SingleTaskMultiFidelityGP(train_X, train_Y2, iteration_fidelity=2)
@@ -372,7 +382,11 @@ class TestConverters(BotorchTestCase):
             # SingleTaskMultiFidelityGP
             for lin_trunc in (False, True):
                 batch_gp = SingleTaskMultiFidelityGP(
-                    train_X, train_Y, iteration_fidelity=1, linear_truncated=lin_trunc
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    iteration_fidelity=1,
+                    linear_truncated=lin_trunc,
+                    outcome_transform=None,
                 )
                 list_gp = batched_to_model_list(batch_gp)
                 batch_gp_recov = model_list_to_batched(list_gp)
@@ -429,7 +443,10 @@ class TestConverters(BotorchTestCase):
             self.assertEqual(batched_so_model.num_outputs, 1)
             # test SingleTaskMultiFidelityGP
             batched_mo_model = SingleTaskMultiFidelityGP(
-                train_X, train_Y, iteration_fidelity=1
+                train_X,
+                train_Y,
+                iteration_fidelity=1,
+                outcome_transform=None,
             )
             batched_so_model = batched_multi_output_to_single_output(batched_mo_model)
             self.assertIsInstance(batched_so_model, SingleTaskMultiFidelityGP)
@@ -478,5 +495,8 @@ class TestConverters(BotorchTestCase):
             batched_mo_model = SingleTaskGP(
                 train_X, train_Y, outcome_transform=Standardize(m=2)
             )
-            with self.assertRaises(NotImplementedError):
+            with self.assertRaisesRegex(
+                NotImplementedError,
+                "Converting batched multi-output models with outcome transforms",
+            ):
                 batched_multi_output_to_single_output(batched_mo_model)

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -11,21 +11,24 @@ from typing import Optional
 import torch
 from botorch import fit_fully_bayesian_model_nuts
 from botorch.acquisition.analytic import (
-    ExpectedImprovement,
+    LogExpectedImprovement,
     PosteriorMean,
     ProbabilityOfImprovement,
     UpperConfidenceBound,
 )
+from botorch.acquisition.logei import (
+    qLogExpectedImprovement,
+    qLogNoisyExpectedImprovement,
+)
 from botorch.acquisition.monte_carlo import (
-    qExpectedImprovement,
-    qNoisyExpectedImprovement,
     qProbabilityOfImprovement,
     qSimpleRegret,
     qUpperConfidenceBound,
 )
-from botorch.acquisition.multi_objective import (
-    qExpectedHypervolumeImprovement,
-    qNoisyExpectedHypervolumeImprovement,
+
+from botorch.acquisition.multi_objective.logei import (
+    qLogExpectedHypervolumeImprovement,
+    qLogNoisyExpectedHypervolumeImprovement,
 )
 from botorch.models import ModelList, ModelListGP
 from botorch.models.deterministic import GenericDeterministicModel
@@ -70,31 +73,38 @@ EXPECTED_KEYS_NOISE = EXPECTED_KEYS + [
 
 
 class TestFullyBayesianMultiTaskGP(BotorchTestCase):
+
     def _get_data_and_model(
         self,
         task_rank: Optional[int] = None,
         output_tasks: Optional[list[int]] = None,
         infer_noise: bool = False,
-        **tkwargs
+        use_outcome_transform: bool = True,
+        **tkwargs,
     ):
         with torch.random.fork_rng():
             torch.manual_seed(0)
             train_X = torch.rand(10, 4, **tkwargs)
-            task_indices = torch.cat(
-                [torch.zeros(5, 1, **tkwargs), torch.ones(5, 1, **tkwargs)], dim=0
-            )
-            self.num_tasks = 2
-            train_X = torch.cat([train_X, task_indices], dim=1)
-            train_Y = torch.sin(train_X[:, :1])
-            train_Yvar = 0.5 * torch.arange(10, **tkwargs).unsqueeze(-1)
-            model = SaasFullyBayesianMultiTaskGP(
-                train_X=train_X,
-                train_Y=train_Y,
-                train_Yvar=None if infer_noise else train_Yvar,
-                task_feature=4,
-                output_tasks=output_tasks,
-                rank=task_rank,
-            )
+        task_indices = torch.cat(
+            [torch.zeros(5, 1, **tkwargs), torch.ones(5, 1, **tkwargs)], dim=0
+        )
+        self.num_tasks = 2
+        train_X = torch.cat([train_X, task_indices], dim=1)
+        train_Y = torch.sin(train_X[:, :1])
+        train_Yvar = 0.5 * torch.arange(10, **tkwargs).unsqueeze(-1)
+        model = SaasFullyBayesianMultiTaskGP(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=None if infer_noise else train_Yvar,
+            task_feature=4,
+            output_tasks=output_tasks,
+            rank=task_rank,
+            outcome_transform=(
+                Standardize(m=1, batch_shape=train_X.shape[:-2])
+                if use_outcome_transform
+                else None
+            ),
+        )
         return train_X, train_Y, train_Yvar, model
 
     def _get_unnormalized_data(self, **tkwargs):
@@ -205,13 +215,24 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
         dtype: torch.dtype = torch.double,
         infer_noise: bool = False,
         task_rank: int = 1,
+        use_outcome_transform: bool = False,
     ):
         tkwargs = {"device": self.device, "dtype": dtype}
         train_X, train_Y, train_Yvar, model = self._get_data_and_model(
-            infer_noise=infer_noise, task_rank=task_rank, **tkwargs
+            infer_noise=infer_noise,
+            task_rank=task_rank,
+            use_outcome_transform=use_outcome_transform,
+            **tkwargs,
         )
         n = train_X.shape[0]
         d = train_X.shape[1] - 1
+
+        # Handle outcome transforms (if used)
+        train_Y_tf, train_Yvar_tf = train_Y, train_Yvar
+        if use_outcome_transform:
+            train_Y_tf, train_Yvar_tf = model.outcome_transform(
+                Y=train_Y, Yvar=train_Yvar
+            )
 
         # Test init
         self.assertIsNone(model.mean_module)
@@ -219,12 +240,12 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
         self.assertIsNone(model.likelihood)
         self.assertIsInstance(model.pyro_model, MultitaskSaasPyroModel)
         self.assertAllClose(train_X, model.pyro_model.train_X)
-        self.assertAllClose(train_Y, model.pyro_model.train_Y)
+        self.assertAllClose(train_Y_tf, model.pyro_model.train_Y)
         if infer_noise:
             self.assertIsNone(model.pyro_model.train_Yvar)
         else:
             self.assertAllClose(
-                train_Yvar.clamp(MIN_INFERRED_NOISE_LEVEL),
+                train_Yvar_tf.clamp(MIN_INFERRED_NOISE_LEVEL),
                 model.pyro_model.train_Yvar,
             )
 
@@ -345,14 +366,32 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
 
         # Check the keys in the state dict
         true_keys = EXPECTED_KEYS_NOISE if infer_noise else EXPECTED_KEYS
+        if use_outcome_transform:
+            true_keys = true_keys + [
+                "outcome_transform.stdvs",
+                "outcome_transform._is_trained",
+                "outcome_transform._stdvs_sq",
+                "outcome_transform.means",
+            ]
         self.assertEqual(set(model.state_dict().keys()), set(true_keys))
 
         # Check that we can load the state dict.
         state_dict = model.state_dict()
         _, _, _, m_new = self._get_data_and_model(
-            infer_noise=infer_noise, task_rank=task_rank, **tkwargs
+            infer_noise=infer_noise,
+            task_rank=task_rank,
+            use_outcome_transform=use_outcome_transform,
+            **tkwargs,
         )
-        self.assertEqual(m_new.state_dict(), {})
+        expected_state_dict = {}
+        if use_outcome_transform:
+            expected_state_dict.update(
+                {
+                    "outcome_transform." + k: v
+                    for k, v in model.outcome_transform.state_dict().items()
+                }
+            )
+        self.assertEqual(m_new.state_dict(), expected_state_dict)
         m_new.load_state_dict(state_dict)
         self.assertEqual(model.state_dict().keys(), m_new.state_dict().keys())
         for k in model.state_dict().keys():
@@ -377,12 +416,15 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
     def test_fit_model_infer_noise(self):
         self.test_fit_model(infer_noise=True, task_rank=2)
 
+    def test_fit_model_with_outcome_transform(self):
+        self.test_fit_model(use_outcome_transform=True)
+
     def test_transforms(self, infer_noise: bool = False):
         tkwargs = {"device": self.device, "dtype": torch.double}
         train_X, train_Y, train_Yvar, test_X = self._get_unnormalized_data(**tkwargs)
         n, d = train_X.shape
         normalize_indices = torch.tensor(
-            list(range(train_X.shape[-1] - 1)), **{"device": self.device}
+            list(range(train_X.shape[-1] - 1)), device=self.device
         )
 
         lb, ub = (
@@ -466,14 +508,14 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                 posterior=mixed_list.posterior(test_X), sample_shape=torch.Size([2])
             )
             acquisition_functions = [
-                ExpectedImprovement(model=model, best_f=train_Y.max()),
+                LogExpectedImprovement(model=model, best_f=train_Y.max()),
                 ProbabilityOfImprovement(model=model, best_f=train_Y.max()),
                 PosteriorMean(model=model),
                 UpperConfidenceBound(model=model, beta=4),
-                qExpectedImprovement(
+                qLogExpectedImprovement(
                     model=model, best_f=train_Y.max(), sampler=simple_sampler
                 ),
-                qNoisyExpectedImprovement(
+                qLogNoisyExpectedImprovement(
                     model=model, X_baseline=test_X, sampler=simple_sampler
                 ),
                 qProbabilityOfImprovement(
@@ -481,13 +523,13 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                 ),
                 qSimpleRegret(model=model, sampler=simple_sampler),
                 qUpperConfidenceBound(model=model, beta=4, sampler=simple_sampler),
-                qNoisyExpectedHypervolumeImprovement(
+                qLogNoisyExpectedHypervolumeImprovement(
                     model=list_gp,
                     X_baseline=test_X,
                     ref_point=torch.zeros(2, **tkwargs),
                     sampler=list_gp_sampler,
                 ),
-                qExpectedHypervolumeImprovement(
+                qLogExpectedHypervolumeImprovement(
                     model=list_gp,
                     ref_point=torch.zeros(2, **tkwargs),
                     sampler=list_gp_sampler,
@@ -496,13 +538,13 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                     ),
                 ),
                 # qEHVI/qNEHVI with mixed models
-                qNoisyExpectedHypervolumeImprovement(
+                qLogNoisyExpectedHypervolumeImprovement(
                     model=mixed_list,
                     X_baseline=test_X,
                     ref_point=torch.zeros(2, **tkwargs),
                     sampler=mixed_list_sampler,
                 ),
-                qExpectedHypervolumeImprovement(
+                qLogExpectedHypervolumeImprovement(
                     model=mixed_list,
                     ref_point=torch.zeros(2, **tkwargs),
                     sampler=mixed_list_sampler,
@@ -522,14 +564,22 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                     self.assertEqual(acqf(test_X).shape, torch.Size(batch_shape))
 
     def test_load_samples(self):
-        for task_rank, dtype in itertools.product([1, 2], [torch.float, torch.double]):
+        for task_rank, dtype, use_outcome_transform in itertools.product(
+            [1, 2], [torch.float, torch.double], (False, True)
+        ):
             tkwargs = {"device": self.device, "dtype": dtype}
             train_X, train_Y, train_Yvar, model = self._get_data_and_model(
-                task_rank=task_rank, **tkwargs
+                task_rank=task_rank,
+                use_outcome_transform=use_outcome_transform,
+                **tkwargs,
             )
+
             d = train_X.shape[1] - 1
             mcmc_samples = self._get_mcmc_samples(
-                num_samples=3, dim=d, task_rank=task_rank, **tkwargs
+                num_samples=3,
+                dim=d,
+                task_rank=task_rank,
+                **tkwargs,
             )
             model.load_mcmc_samples(mcmc_samples)
 
@@ -551,10 +601,24 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                     mcmc_samples["mean"],
                 )
             )
+
+            # Handle outcome transforms (if used)
+            train_Y_tf, train_Yvar_tf = train_Y, train_Yvar
+            if use_outcome_transform:
+                train_Y_tf, train_Yvar_tf = model.outcome_transform(
+                    Y=train_Y, Yvar=train_Yvar
+                )
+
+            self.assertTrue(
+                torch.allclose(
+                    model.pyro_model.train_Y,
+                    train_Y_tf,
+                )
+            )
             self.assertTrue(
                 torch.allclose(
                     model.pyro_model.train_Yvar,
-                    train_Yvar.clamp(MIN_INFERRED_NOISE_LEVEL),
+                    train_Yvar_tf.clamp(MIN_INFERRED_NOISE_LEVEL),
                 )
             )
             self.assertTrue(

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
+import math
 import warnings
 
 import torch
@@ -115,9 +116,7 @@ class TestGPRegressionBase(BotorchTestCase):
             # test param sizes
             params = dict(model.named_parameters())
             for p in params:
-                self.assertEqual(
-                    params[p].numel(), m * torch.tensor(batch_shape).prod().item()
-                )
+                self.assertEqual(params[p].numel(), m * math.prod(batch_shape))
 
             # test posterior
             # test non batch evaluation
@@ -133,18 +132,9 @@ class TestGPRegressionBase(BotorchTestCase):
             self.assertIsInstance(posterior_pred, GPyTorchPosterior)
             self.assertEqual(posterior_pred.mean.shape, expected_shape)
             self.assertEqual(posterior_pred.variance.shape, expected_shape)
-            if use_octf:
-                # ensure un-transformation is applied
-                tmp_tf = model.outcome_transform
-                del model.outcome_transform
-                pp_tf = model.posterior(X, observation_noise=True)
-                model.outcome_transform = tmp_tf
-                expected_var = tmp_tf.untransform_posterior(pp_tf).variance
-                self.assertAllClose(posterior_pred.variance, expected_var)
-            else:
-                pvar = posterior_pred.variance
-                pvar_exp = get_pvar_expected(posterior, model, X, m)
-                self.assertAllClose(pvar, pvar_exp, rtol=1e-4, atol=1e-5)
+            pvar = posterior_pred.variance
+            pvar_exp = get_pvar_expected(posterior=posterior, model=model, X=X, m=m)
+            self.assertAllClose(pvar, pvar_exp, rtol=1e-4, atol=1e-5)
 
             # Tensor valued observation noise.
             obs_noise = torch.rand(X.shape, **tkwargs)
@@ -167,18 +157,9 @@ class TestGPRegressionBase(BotorchTestCase):
             posterior_pred = model.posterior(X, observation_noise=True)
             self.assertIsInstance(posterior_pred, GPyTorchPosterior)
             self.assertEqual(posterior_pred.mean.shape, expected_shape)
-            if use_octf:
-                # ensure un-transformation is applied
-                tmp_tf = model.outcome_transform
-                del model.outcome_transform
-                pp_tf = model.posterior(X, observation_noise=True)
-                model.outcome_transform = tmp_tf
-                expected_var = tmp_tf.untransform_posterior(pp_tf).variance
-                self.assertAllClose(posterior_pred.variance, expected_var)
-            else:
-                pvar = posterior_pred.variance
-                pvar_exp = get_pvar_expected(posterior, model, X, m)
-                self.assertAllClose(pvar, pvar_exp, rtol=1e-4, atol=1e-5)
+            pvar = posterior_pred.variance
+            pvar_exp = get_pvar_expected(posterior=posterior, model=model, X=X, m=m)
+            self.assertAllClose(pvar, pvar_exp, rtol=1e-4, atol=1e-5)
 
             # test batch evaluation with broadcasting
             for input_batch_shape in ([], [3], [1]):
@@ -186,11 +167,10 @@ class TestGPRegressionBase(BotorchTestCase):
 
                 if input_batch_shape == [3] and len(batch_shape) > 0:
                     msg = (
-                        "Shape mismatch: objects cannot be broadcast to a"
-                        " single shape"
+                        "Shape mismatch: objects cannot be broadcast to a single shape"
                         if m == 1
-                        else "The trailing batch dimensions of X must match"
-                        " the trailing batch dimensions of the training inputs."
+                        else "The trailing batch dimensions of X must match "
+                        "the trailing batch dimensions of the training inputs."
                     )
                     with self.assertRaisesRegex(RuntimeError, msg):
                         model.posterior(X, observation_noise=True)

--- a/test/models/test_gp_regression_mixed.py
+++ b/test/models/test_gp_regression_mixed.py
@@ -34,12 +34,16 @@ class TestMixedSingleTaskGP(BotorchTestCase):
     def test_gp(self):
         d = 3
         bounds = torch.tensor([[-1.0] * d, [1.0] * d])
-        for batch_shape, m, ncat, dtype, observed_noise in (
-            (torch.Size(), 1, 0, torch.float, False),
-            (torch.Size(), 2, 1, torch.double, True),
-            (torch.Size([2]), 2, 3, torch.double, False),
+        for batch_shape, m, ncat, dtype, observed_noise, use_octf in (
+            (torch.Size(), 1, 0, torch.float, False, False),
+            (torch.Size(), 2, 1, torch.double, True, True),
+            (torch.Size([2]), 2, 3, torch.double, False, True),
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
+            # The model by default uses a `Standardize` outcome transform, so
+            # to test without that transform we need to explicitly pass in `None`.
+            outcome_transform_kwargs = {} if use_octf else {"outcome_transform": None}
+
             train_X, train_Y = _get_random_data(
                 batch_shape=batch_shape, m=m, d=d, **tkwargs
             )
@@ -70,6 +74,7 @@ class TestMixedSingleTaskGP(BotorchTestCase):
                 train_Y=train_Y,
                 cat_dims=cat_dims,
                 train_Yvar=train_Yvar,
+                **outcome_transform_kwargs,
             )
             self.assertEqual(model._ignore_X_dims_scaling_check, cat_dims)
             mll = ExactMarginalLogLikelihood(model.likelihood, model).to(**tkwargs)
@@ -118,7 +123,7 @@ class TestMixedSingleTaskGP(BotorchTestCase):
             self.assertEqual(posterior_pred.mean.shape, expected_shape)
             self.assertEqual(posterior_pred.variance.shape, expected_shape)
             pvar = posterior_pred.variance
-            pvar_exp = get_pvar_expected(posterior, model, X, m)
+            pvar_exp = get_pvar_expected(posterior=posterior, model=model, X=X, m=m)
             self.assertAllClose(pvar, pvar_exp, rtol=1e-4, atol=1e-5)
 
             # test batch evaluation
@@ -132,7 +137,7 @@ class TestMixedSingleTaskGP(BotorchTestCase):
             self.assertIsInstance(posterior_pred, GPyTorchPosterior)
             self.assertEqual(posterior_pred.mean.shape, expected_shape)
             pvar = posterior_pred.variance
-            pvar_exp = get_pvar_expected(posterior, model, X, m)
+            pvar_exp = get_pvar_expected(posterior=posterior, model=model, X=X, m=m)
             self.assertAllClose(pvar, pvar_exp, rtol=1e-4, atol=1e-5)
 
             # test that model converter throws an exception

--- a/test/utils/test_test_helpers.py
+++ b/test/utils/test_test_helpers.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import mock
+
+from botorch.exceptions import UnsupportedError
+
+from botorch.utils.test_helpers import get_pvar_expected
+from botorch.utils.testing import BotorchTestCase
+
+
+class TestTestHelpers(BotorchTestCase):
+
+    def test_get_pvar_expected(self):
+        # The test helper is used throughout, veryfying that an error is raised
+        # when it is used with an unsupported model.
+        with self.assertRaisesRegex(
+            UnsupportedError,
+            "`get_pvar_expected` only supports `BatchedMultiOutputGPyTorchModel`s.",
+        ):
+            get_pvar_expected(
+                posterior=mock.Mock(), model=mock.Mock(), X=mock.Mock(), m=2
+            )

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -340,7 +340,7 @@ class TestIsFullyBayesian(BotorchTestCase):
             SingleTaskGP(train_X=X, train_Y=Y),
             MultiTaskGP(train_X=X, train_Y=Y, task_feature=-1),
             HigherOrderGP(train_X=X, train_Y=Y),
-            SingleTaskMultiFidelityGP(train_X=X, train_Y=Y, data_fidelity=3),
+            SingleTaskMultiFidelityGP(train_X=X, train_Y=Y, data_fidelities=[3]),
             MixedSingleTaskGP(train_X=X, train_Y=Y, cat_dims=[1]),
             PairwiseGP(datapoints=X, comparisons=None),
         )
@@ -382,7 +382,7 @@ class TestIsEnsemble(BotorchTestCase):
             SingleTaskGP(train_X=X, train_Y=Y),
             MultiTaskGP(train_X=X, train_Y=Y, task_feature=-1),
             HigherOrderGP(train_X=X, train_Y=Y),
-            SingleTaskMultiFidelityGP(train_X=X, train_Y=Y, data_fidelity=3),
+            SingleTaskMultiFidelityGP(train_X=X, train_Y=Y, data_fidelities=[3]),
             MixedSingleTaskGP(train_X=X, train_Y=Y, cat_dims=[1]),
             PairwiseGP(datapoints=X, comparisons=None),
         )


### PR DESCRIPTION
Summary:
Makes models which had their priors updated in https://github.com/pytorch/botorch/pull/2507 use the `Standardize` outcome transform by default, mimicking https://github.com/pytorch/botorch/pull/2458

Also removes some deprecated functionality in the process, namely the `data_fidelity` argument to `SingleTaskMultiFidelityGP` as well as the `FixedNoiseMultiFidelityGP` and `FixedNoiseLCEMGP` models.

TODO: Some unit tests don't actually test things with (even the now default) outcome transform - those will need to be updated.

Differential Revision: D62552307
