### PR TITLE
OptimizationGradientError

### DIFF
--- a/botorch/exceptions/errors.py
+++ b/botorch/exceptions/errors.py
@@ -74,7 +74,7 @@ class OptimizationTimeoutError(BotorchError):
         self.runtime = runtime
 
 
-class OptimizationGradientError(BotorchError):
+class OptimizationGradientError(BotorchError, RuntimeError):
     r"""Exception raised when gradient array `gradf` containts NaNs."""
 
     def __init__(self, /, *args: Any, current_x: np.ndarray, **kwargs: Any) -> None:

--- a/botorch/exceptions/errors.py
+++ b/botorch/exceptions/errors.py
@@ -72,3 +72,17 @@ class OptimizationTimeoutError(BotorchError):
         super().__init__(*args, **kwargs)
         self.current_x = current_x
         self.runtime = runtime
+
+
+class OptimizationGradientError(BotorchError):
+    r"""Exception raised when gradient array `gradf` containts NaNs."""
+
+    def __init__(self, /, *args: Any, current_x: np.ndarray, **kwargs: Any) -> None:
+        r"""
+        Args:
+            *args: Standard args to `BoTorchError`.
+            current_x: A numpy array representing the current iterate.
+            **kwargs: Standard kwargs to `BoTorchError`.
+        """
+        super().__init__(*args, **kwargs)
+        self.current_x = current_x

--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, NoReturn, Optional, Union
 import numpy as np
 import torch
 from botorch.acquisition import AcquisitionFunction
+from botorch.exceptions.errors import OptimizationGradientError
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.generation.utils import (
     _convert_nonlinear_inequality_constraints,
@@ -215,7 +216,7 @@ def gen_candidates_scipy(
                 )
                 if initial_conditions.dtype != torch.double:
                     msg += " Consider using `dtype=torch.double`."
-                raise RuntimeError(msg)
+                raise OptimizationGradientError(msg, current_x=x)
             fval = loss.item()
             return fval, gradf
 

--- a/test/exceptions/test_errors.py
+++ b/test/exceptions/test_errors.py
@@ -12,6 +12,7 @@ from botorch.exceptions.errors import (
     CandidateGenerationError,
     DeprecationError,
     InputDataError,
+    OptimizationGradientError,
     OptimizationTimeoutError,
     UnsupportedError,
 )
@@ -48,4 +49,10 @@ class TestBotorchExceptions(BotorchTestCase):
         self.assertEqual(error.runtime, 0.123)
         self.assertTrue(np.array_equal(error.current_x, np.array([1.0])))
         with self.assertRaises(OptimizationTimeoutError):
+            raise error
+
+    def test_OptimizationGradientError(self):
+        error = OptimizationGradientError("message", current_x=np.array([1.0]))
+        self.assertTrue(np.array_equal(error.current_x, np.array([1.0])))
+        with self.assertRaises(OptimizationGradientError):
             raise error

--- a/test/exceptions/test_errors.py
+++ b/test/exceptions/test_errors.py
@@ -54,5 +54,5 @@ class TestBotorchExceptions(BotorchTestCase):
     def test_OptimizationGradientError(self):
         error = OptimizationGradientError("message", current_x=np.array([1.0]))
         self.assertTrue(np.array_equal(error.current_x, np.array([1.0])))
-        with self.assertRaises(OptimizationGradientError):
+        with self.assertRaisesRegex(OptimizationGradientError, "message"):
             raise error

--- a/test/generation/test_gen.py
+++ b/test/generation/test_gen.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import torch
 from botorch.acquisition import qExpectedImprovement, qKnowledgeGradient
+from botorch.exceptions.errors import OptimizationGradientError
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.fit import fit_gpytorch_mll
 from botorch.generation.gen import (
@@ -318,7 +319,7 @@ class TestGenCandidates(TestBaseCandidateGeneration):
             test_grad = torch.tensor([0.5, 0.2, float("nan")], **ckwargs)
             # test NaN in grad
             with mock.patch("torch.autograd.grad", return_value=[test_grad]):
-                with self.assertRaisesRegex(RuntimeError, expected_regex):
+                with self.assertRaisesRegex(OptimizationGradientError, expected_regex):
                     gen_candidates_scipy(
                         initial_conditions=test_ics,
                         acquisition_function=mock.Mock(return_value=test_ics),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

I am currently experimenting with some custom kernels, which exhibit some numeric instabilities, which lead in some situations during optimization to `NaN`s in the gradient. To better examine these situations, I thought it could be nice if the error which is thrown in this situation also contains the current x which leads to the `NaN`s in the gradient. For this purpose, I implemented an `OptimizationGradientError` like the `OptimizationTimeoutError` which holds the current x.

Im also thinking about catching the error in `timeout.py` as the `OptimizationTimeoutError`, throwing a warning and returning a result of the optimization. What do you think about this? I think this could be a useful and elegant way of dealing with it.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.


