### PR TITLE
Use log1p(x) instead of log(1+x)

### DIFF
--- a/botorch/models/transforms/utils.py
+++ b/botorch/models/transforms/utils.py
@@ -32,7 +32,7 @@ def lognorm_to_norm(mu: Tensor, Cov: Tensor) -> tuple[Tensor, Tensor]:
         - The `batch_shape x n` mean vector of the Normal distribution
         - The `batch_shape x n x n` covariance matrix of the Normal distribution
     """
-    Cov_n = torch.log(1 + Cov / (mu.unsqueeze(-1) * mu.unsqueeze(-2)))
+    Cov_n = torch.log1p(Cov / (mu.unsqueeze(-1) * mu.unsqueeze(-2)))
     mu_n = torch.log(mu) - 0.5 * torch.diagonal(Cov_n, dim1=-1, dim2=-2)
     return mu_n, Cov_n
 


### PR DESCRIPTION
This function is more accurate than torch.log() for small values of input - https://pytorch.org/docs/stable/generated/torch.log1p.html

Found with https://github.com/pytorch-labs/torchfix/