### PR TITLE
Use expm1 in Bilog outcome transform

### DIFF
--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -790,7 +790,7 @@ class Bilog(OutcomeTransform):
             - The un-transformed outcome observations.
             - The un-transformed observation noise (if applicable).
         """
-        Y_utf = Y.sign() * (Y.abs().exp() - 1.0)
+        Y_utf = Y.sign() * Y.abs().expm1()
         outputs = normalize_indices(self._outputs, d=Y.size(-1))
         if outputs is not None:
             Y_utf = torch.stack(
@@ -822,5 +822,5 @@ class Bilog(OutcomeTransform):
             )
         return TransformedPosterior(
             posterior=posterior,
-            sample_transform=lambda x: x.sign() * (x.abs().exp() - 1.0),
+            sample_transform=lambda x: x.sign() * x.abs().expm1(),
         )


### PR DESCRIPTION
Summary: Similar to https://github.com/pytorch/botorch/pull/2540, replaces `exp(x) - 1` with the numerically more stable `expm1`.

Differential Revision: D62813775
