### PR TITLE
Use default solver (libmamba) when building conda package

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -60,8 +60,6 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
-        conda config --set solver classic
         conda install -y setuptools_scm conda-build conda-verify anaconda-client
         conda install -y scipy sphinx pytest flake8 multipledispatch
         conda install -y -c pytorch pytorch cpuonly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     # 2:30 PST
     - cron:  '30 10 * * *'
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,8 +79,6 @@ jobs:
       # Don't need most deps for conda build, but need them for testing
       # We do need setuptools_scm though to properly parse the version
       run: |
-        # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
-        conda config --set solver classic
         conda install -y scipy multipledispatch setuptools_scm conda-build conda-verify
         conda config --set anaconda_upload no
         conda install -y -c pytorch-nightly pytorch cpuonly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # 2:30 PST
     - cron:  '30 10 * * *'
+  pull_rquest:
+    branches: [main]
   workflow_dispatch:
 
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # 2:30 PST
     - cron:  '30 10 * * *'
-  pull_rquest:
+  pull_request:
     branches: [main]
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,6 @@ jobs:
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
-        # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
-        conda config --set solver classic
         conda install pytorch torchvision -c pytorch
         conda install -y pip scipy sphinx pytest flake8
         pip install git+https://github.com/cornellius-gp/linear_operator.git

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -31,8 +31,6 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        # avoid conda bug in >=23.10.0: https://github.com/conda/conda/issues/13412
-        conda config --set solver classic
         conda install -y -c pytorch pytorch cpuonly
         conda install -y pip scipy pytest
         conda install -y -c gpytorch gpytorch


### PR DESCRIPTION
## Motivation

[This issue](https://github.com/conda/conda/issues/13412) should be resolved now that libmamba 2.0.0 is out.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run nightly cron and make sure conda package build succeeds
