### PR TITLE
Add pyre_extensions as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ mpmath>=0.19,<=1.3
 torch>=2.0.1
 pyro-ppl>=1.8.4
 typing_extensions
+pyre_extensions
 gpytorch==1.13
 linear_operator==0.5.3


### PR DESCRIPTION
Pyre extensions offers useful functionality like `none_throws` and `assert_is_instance` that can be used to refine the type-hints during runtime. This is a light-weight dependency that can help us improve type-checker friendliness of BoTorch over time.