### PR TITLE
Add PosteriorTransform to get_optimal_samples and optimize_posterior_samples

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -1800,7 +1800,6 @@ def construct_inputs_qJES(
     model: Model,
     bounds: list[tuple[float, float]],
     num_optima: int = 64,
-    maximize: bool = True,
     condition_noiseless: bool = True,
     X_pending: Tensor | None = None,
     estimation_type: str = "LB",
@@ -1811,7 +1810,6 @@ def construct_inputs_qJES(
         model=model,
         bounds=torch.as_tensor(bounds, dtype=dtype).T,
         num_optima=num_optima,
-        maximize=maximize,
     )
 
     inputs = {
@@ -1819,7 +1817,6 @@ def construct_inputs_qJES(
         "optimal_inputs": optimal_inputs,
         "optimal_outputs": optimal_outputs,
         "condition_noiseless": condition_noiseless,
-        "maximize": maximize,
         "X_pending": X_pending,
         "estimation_type": estimation_type,
         "num_samples": num_samples,

--- a/botorch_community/acquisition/input_constructors.py
+++ b/botorch_community/acquisition/input_constructors.py
@@ -72,7 +72,6 @@ def construct_inputs_SCoreBO(
         model=model,
         bounds=torch.as_tensor(bounds, dtype=dtype).T,
         num_optima=num_optima,
-        maximize=maximize,
     )
 
     inputs = {

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -1620,10 +1620,8 @@ class TestKGandESAcquisitionFunctionInputConstructors(InputConstructorBaseTestCa
             training_data=self.blockX_blockY,
             bounds=self.bounds,
             num_optima=17,
-            maximize=False,
         )
 
-        self.assertFalse(kwargs["maximize"])
         self.assertEqual(self.blockX_blockY[0].X.dtype, kwargs["optimal_inputs"].dtype)
         self.assertEqual(len(kwargs["optimal_inputs"]), 17)
         self.assertEqual(len(kwargs["optimal_outputs"]), 17)


### PR DESCRIPTION
Summary: Added `posterior_transform` arg to get_optimal_samples to enable posterior sampling-based (xES, TestSet IG) acquisition functions with minimization problems. Intended use in one-shot settings with TSIG with Target-aware models (e.g. D63135028), which otherwise cannot be used in minimization problems, nor with multi-objective.

Differential Revision: D64266499


