### PR TITLE
Expose all kwargs to optimize_acqf in optimize_acqf_homotopy

### DIFF
--- a/botorch/optim/optimize_homotopy.py
+++ b/botorch/optim/optimize_homotopy.py
@@ -87,7 +87,7 @@ def optimize_acqf_homotopy(
     ]:
         if kwarg_dict.get("return_best_only", None) is not False:
             warnings.warn(
-                f"`return_best_only` is set to True in `{kwarg_dict_name}`, override to False."
+                f"`return_best_only` is not False in `{kwarg_dict_name}`, override to False."
             )
             kwarg_dict["return_best_only"] = False
 
@@ -101,6 +101,7 @@ def optimize_acqf_homotopy(
                 "removing it in favour of `batch_initial_conditions` given to "
                 "`optimize_acqf_homotopy`."
             )
+            # are pops dangerious here given no copy? if repeatedly reusing kwarg_dict it could create issues
             kwarg_dict.pop("batch_initial_conditions")
 
         for arg_name, arg_value in [("acq_function", acq_function), ("bounds", bounds)]:
@@ -133,7 +134,7 @@ def optimize_acqf_homotopy(
             "removing it as we set `batch_initial_conditions` to the candidates "
             "returned by homotopy loop for the final optimization."
         )
-        optimize_acqf_final_kwargs.pop("raw_samples")
+        optimize_acqf_final_kwargs.pop("raw_samples")  # are pops dangerious here given no copy? see above
 
     candidate_list, acq_value_list = [], []
     if q > 1:

--- a/botorch/optim/optimize_homotopy.py
+++ b/botorch/optim/optimize_homotopy.py
@@ -87,12 +87,12 @@ def optimize_acqf_homotopy(
     ]:
         if "return_best_only" in kwarg_dict:
             warnings.warn(
-                f"`return_best_only` is set to True in `{kwarg_dict_name}`, setting to False."
+                f"`return_best_only` is set to True in `{kwarg_dict_name}`, override to False."
             )
             kwarg_dict["return_best_only"] = False
 
         if kwarg_dict.get("q", None) != 1:
-            warnings.warn(f"`q` is set in `{kwarg_dict_name}`, setting to 1.")
+            warnings.warn(f"`q` is not set to 1 in `{kwarg_dict_name}`, override to 1.")
             kwarg_dict["q"] = 1
 
         if "batch_initial_conditions" in kwarg_dict:
@@ -160,10 +160,12 @@ def optimize_acqf_homotopy(
             ).unsqueeze(1)
 
         # Optimize one more time with the final options
+        # NOTE is there any reason we don't want to pass fixed features to final?
         candidates, acq_values = optimize_acqf(
             acq_function=acq_function,
             bounds=bounds,
-            batch_initial_conditions=candidates, **optimize_acqf_final_kwargs
+            batch_initial_conditions=candidates,
+            **optimize_acqf_final_kwargs
         )
 
         best = torch.argmax(acq_values.view(-1), dim=0)

--- a/botorch/optim/optimize_homotopy.py
+++ b/botorch/optim/optimize_homotopy.py
@@ -85,7 +85,7 @@ def optimize_acqf_homotopy(
         ("optimize_acqf_loop_kwargs", optimize_acqf_loop_kwargs),
         ("optimize_acqf_final_kwargs", optimize_acqf_final_kwargs),
     ]:
-        if "return_best_only" in kwarg_dict:
+        if kwarg_dict.get("return_best_only", None) is not False:
             warnings.warn(
                 f"`return_best_only` is set to True in `{kwarg_dict_name}`, override to False."
             )

--- a/test/optim/test_homotopy.py
+++ b/test/optim/test_homotopy.py
@@ -125,7 +125,10 @@ class TestHomotopy(BotorchTestCase):
             bounds=torch.tensor([[-10], [5]]).to(**tkwargs),
             homotopy=Homotopy(homotopy_parameters=[hp]),
             optimize_acqf_loop_kwargs=optimize_acqf_core_kwargs,
-            optimize_acqf_final_kwargs=optimize_acqf_core_kwargs.update({"post_processing_func":lambda x: x.round()}),
+            optimize_acqf_final_kwargs={
+                **optimize_acqf_core_kwargs,
+                "post_processing_func": lambda x: x.round(),
+            },
         )
         self.assertEqual(candidate, torch.zeros(1, **tkwargs))
         self.assertEqual(acqf_val, 5 * torch.ones(1, **tkwargs))
@@ -141,8 +144,11 @@ class TestHomotopy(BotorchTestCase):
             acq_function=acqf,
             bounds=torch.tensor([[-10, -10], [5, 5]]).to(**tkwargs),
             homotopy=Homotopy(homotopy_parameters=[hp]),
-            optimize_acqf_loop_kwargs=optimize_acqf_core_kwargs.update({"fixed_features":fixed_features}),
-            optimize_acqf_final_kwargs=optimize_acqf_core_kwargs
+            optimize_acqf_loop_kwargs={
+                **optimize_acqf_core_kwargs,
+                "fixed_features": fixed_features,
+            },
+            optimize_acqf_final_kwargs=optimize_acqf_core_kwargs,
         )
         self.assertEqual(candidate[0, 0], torch.tensor(1, **tkwargs))
 
@@ -153,8 +159,11 @@ class TestHomotopy(BotorchTestCase):
             acq_function=acqf,
             bounds=torch.tensor([[-10, -10], [5, 5]]).to(**tkwargs),
             homotopy=Homotopy(homotopy_parameters=[hp]),
-            optimize_acqf_loop_kwargs=optimize_acqf_core_kwargs.update({"fixed_features":fixed_features}),
-            optimize_acqf_final_kwargs=optimize_acqf_core_kwargs
+            optimize_acqf_loop_kwargs={
+                **optimize_acqf_core_kwargs,
+                "fixed_features": fixed_features,
+            },
+            optimize_acqf_final_kwargs=optimize_acqf_core_kwargs,
         )
         self.assertEqual(candidate.shape, torch.Size([3, 2]))
         self.assertEqual(acqf_val.shape, torch.Size([3]))
@@ -207,8 +216,8 @@ class TestHomotopy(BotorchTestCase):
         model = GenericDeterministicModel(f=lambda x: 5 - (x - p) ** 2)
         acqf = PosteriorMean(model=model)
         optimize_acqf_core_kwargs = {
-            "num_restarts":2,
-            "raw_samples":16,
+            "num_restarts": 4,
+            "raw_samples": 16,
         }
 
         candidate, acqf_val = optimize_acqf_homotopy(
@@ -217,7 +226,10 @@ class TestHomotopy(BotorchTestCase):
             bounds=torch.tensor([[-10], [5]]).to(**tkwargs),
             homotopy=Homotopy(homotopy_parameters=[hp]),
             optimize_acqf_loop_kwargs=optimize_acqf_core_kwargs,
-            optimize_acqf_final_kwargs=optimize_acqf_core_kwargs.update({"post_processing_func":lambda x: x.round()}),
+            optimize_acqf_final_kwargs={
+                **optimize_acqf_core_kwargs,
+                "post_processing_func": lambda x: x.round(),
+            },
         )
         # First time we expect to call `prune_candidates` with 4 candidates
         self.assertEqual(


### PR DESCRIPTION
## Motivation

This PR seeks to address https://github.com/pytorch/botorch/issues/2579

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added test incorporating a linear inequality constraint

## Related PRs

If this is merged as is with breaking changes then a follow-on PR will be needed in Ax
