### PR TITLE
Switch code formatter to ruff

### DIFF
--- a/botorch/acquisition/cached_cholesky.py
+++ b/botorch/acquisition/cached_cholesky.py
@@ -8,6 +8,7 @@ r"""
 Abstract class for acquisition functions leveraging a cached Cholesky
 decomposition of the posterior covariance over f(X_baseline).
 """
+
 from __future__ import annotations
 
 import warnings

--- a/botorch/acquisition/fixed_feature.py
+++ b/botorch/acquisition/fixed_feature.py
@@ -93,7 +93,6 @@ class FixedFeatureAcquisitionFunction(AcquisitionFunction):
         if isinstance(values, Tensor):
             new_values = values.detach().clone()
         else:
-
             dtype = get_dtype_of_sequence(values)
             device = get_device_of_sequence(values)
 

--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -1258,7 +1258,6 @@ def construct_inputs_qKG(
     }
 
     if with_current_value:
-
         X = _get_dataset_field(training_data, "X", first_only=True)
         _bounds = torch.as_tensor(bounds, dtype=X.dtype, device=X.device)
 
@@ -1868,7 +1867,6 @@ def _get_ref_point(
     objective_thresholds: Tensor,
     objective: MCMultiOutputObjective | None = None,
 ) -> Tensor:
-
     if objective is None:
         ref_point = objective_thresholds
     elif isinstance(objective, RiskMeasureMCObjective):

--- a/botorch/acquisition/multi_objective/analytic.py
+++ b/botorch/acquisition/multi_objective/analytic.py
@@ -16,7 +16,6 @@ References
 
 """
 
-
 from __future__ import annotations
 
 from itertools import product

--- a/botorch/acquisition/multi_objective/base.py
+++ b/botorch/acquisition/multi_objective/base.py
@@ -8,7 +8,6 @@ r"""
 Base classes for multi-objective acquisition functions.
 """
 
-
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/botorch/acquisition/multi_objective/joint_entropy_search.py
+++ b/botorch/acquisition/multi_objective/joint_entropy_search.py
@@ -15,6 +15,7 @@ References:
     2022.
 
 """
+
 from __future__ import annotations
 
 from abc import abstractmethod

--- a/botorch/acquisition/multi_objective/logei.py
+++ b/botorch/acquisition/multi_objective/logei.py
@@ -48,7 +48,6 @@ from torch import Tensor
 class qLogExpectedHypervolumeImprovement(
     MultiObjectiveMCAcquisitionFunction, SubsetIndexCachingMixin
 ):
-
     _log: bool = True
 
     def __init__(
@@ -321,7 +320,6 @@ class qLogNoisyExpectedHypervolumeImprovement(
     NoisyExpectedHypervolumeMixin,
     qLogExpectedHypervolumeImprovement,
 ):
-
     _log: bool = True
 
     def __init__(

--- a/botorch/acquisition/prior_guided.py
+++ b/botorch/acquisition/prior_guided.py
@@ -15,6 +15,7 @@ References
     Augmenting Acquisition Functions with User Beliefs for Bayesian Optimization.
     ICLR 2022.
 """
+
 from __future__ import annotations
 
 from botorch.acquisition.acquisition import AcquisitionFunction

--- a/botorch/exceptions/warnings.py
+++ b/botorch/exceptions/warnings.py
@@ -7,6 +7,7 @@
 r"""
 Botorch Warnings.
 """
+
 import warnings
 
 

--- a/botorch/generation/utils.py
+++ b/botorch/generation/utils.py
@@ -21,7 +21,7 @@ from torch import Tensor
 
 
 def _convert_nonlinear_inequality_constraints(
-    nonlinear_inequality_constraints: list[Callable | tuple[Callable, bool]]
+    nonlinear_inequality_constraints: list[Callable | tuple[Callable, bool]],
 ) -> list[tuple[Callable, bool]]:
     """Convert legacy defintions of nonlinear inequality constraints into the new
     format. Assumes intra-point constraints.

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -30,7 +30,6 @@ References:
     Seventh Conference on Uncertainty in Artificial Intelligence, 2021.
 """
 
-
 import math
 from abc import abstractmethod
 from collections.abc import Mapping

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -4,9 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-r"""Multi-task Gaussian Process Regression models with fully Bayesian inference.
-"""
-
+r"""Multi-task Gaussian Process Regression models with fully Bayesian inference."""
 
 from collections.abc import Mapping
 from typing import Any, NoReturn

--- a/botorch/models/gp_regression_mixed.py
+++ b/botorch/models/gp_regression_mixed.py
@@ -64,9 +64,8 @@ class MixedSingleTaskGP(SingleTaskGP):
         train_Y: Tensor,
         cat_dims: list[int],
         train_Yvar: Tensor | None = None,
-        cont_kernel_factory: None | (
-            Callable[[torch.Size, int, list[int]], Kernel]
-        ) = None,
+        cont_kernel_factory: None
+        | (Callable[[torch.Size, int, list[int]], Kernel]) = None,
         likelihood: Likelihood | None = None,
         outcome_transform: OutcomeTransform | _DefaultType | None = DEFAULT,
         input_transform: InputTransform | None = None,  # TODO

--- a/botorch/models/kernels/contextual_lcea.py
+++ b/botorch/models/kernels/contextual_lcea.py
@@ -291,7 +291,8 @@ class LCEAKernel(Kernel):
         else:
             context_outputscales = self.outputscale_list * self.context_weight
         context_covar = (
-            (context_outputscales.unsqueeze(-2))  # (ns) x 1 x num_contexts
+            (context_outputscales.unsqueeze(-2))
+            # (ns) x 1 x num_contexts
             .mul(context_covar)
             .mul(context_outputscales.unsqueeze(-1))  # (ns) x num_contexts x 1
         )

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -13,6 +13,7 @@ rounding functions, and log transformations. The input transformation
 is typically part of a Model and applied within the model.forward()
 method.
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -12,6 +12,7 @@ References
     surrogates and dynamic coordinate search in high-dimensional
     expensive black-box optimization, Engineering Optimization, 2013.
 """
+
 from __future__ import annotations
 
 import warnings

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -396,7 +396,7 @@ def _generate_unfixed_nonlin_constraints(
     values = torch.tensor(list(fixed_features.values()), dtype=torch.double)
 
     def _wrap_nonlin_constraint(
-        constraint: Callable[[Tensor], Tensor]
+        constraint: Callable[[Tensor], Tensor],
     ) -> Callable[[Tensor], Tensor]:
         def new_nonlin_constraint(X: Tensor) -> Tensor:
             ivalues = values.to(X).expand(*X.shape[:-1], len(fixed_features))

--- a/botorch/optim/utils/timeout.py
+++ b/botorch/optim/utils/timeout.py
@@ -42,7 +42,6 @@ def minimize_with_timeout(
     track of the runtime and the optimization variables at the current iteration.
     """
     if timeout_sec is not None:
-
         start_time = time.monotonic()
         callback_data = {"num_iterations": 0}  # update from withing callback below
 

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -68,7 +68,8 @@ class EnsemblePosterior(Posterior):
         return self.values.var(dim=-3)
 
     def _extended_shape(
-        self, sample_shape: torch.Size = torch.Size()  # noqa: B008
+        self,
+        sample_shape: torch.Size = torch.Size(),  # noqa: B008
     ) -> torch.Size:
         r"""Returns the shape of the samples produced by the posterior with
         the given `sample_shape`.

--- a/botorch/posteriors/gpytorch.py
+++ b/botorch/posteriors/gpytorch.py
@@ -72,7 +72,8 @@ class GPyTorchPosterior(TorchPosterior):
             return (0, -1)
 
     def _extended_shape(
-        self, sample_shape: torch.Size = torch.Size()  # noqa: B008
+        self,
+        sample_shape: torch.Size = torch.Size(),  # noqa: B008
     ) -> torch.Size:
         r"""Returns the shape of the samples produced by the posterior with
         the given `sample_shape`.

--- a/botorch/posteriors/higher_order.py
+++ b/botorch/posteriors/higher_order.py
@@ -87,7 +87,8 @@ class HigherOrderGPPosterior(GPyTorchPosterior):
         return (0, -1)
 
     def _extended_shape(
-        self, sample_shape: torch.Size = torch.Size()  # noqa: B008
+        self,
+        sample_shape: torch.Size = torch.Size(),  # noqa: B008
     ) -> torch.Size:
         r"""Returns the shape of the samples produced by the posterior with
         the given `sample_shape`.

--- a/botorch/posteriors/posterior.py
+++ b/botorch/posteriors/posterior.py
@@ -108,7 +108,8 @@ class Posterior(ABC):
         )  # pragma: no cover
 
     def _extended_shape(
-        self, sample_shape: torch.Size = torch.Size()  # noqa: B008
+        self,
+        sample_shape: torch.Size = torch.Size(),  # noqa: B008
     ) -> torch.Size:
         r"""Returns the shape of the samples produced by the posterior with
         the given `sample_shape`.

--- a/botorch/posteriors/posterior_list.py
+++ b/botorch/posteriors/posterior_list.py
@@ -108,7 +108,8 @@ class PosteriorList(Posterior):
         return next(iter(dtypes))
 
     def _extended_shape(
-        self, sample_shape: torch.Size = torch.Size()  # noqa: B008
+        self,
+        sample_shape: torch.Size = torch.Size(),  # noqa: B008
     ) -> torch.Size:
         r"""Returns the shape of the samples produced by the posterior with
         the given `sample_shape`.

--- a/botorch/posteriors/torch.py
+++ b/botorch/posteriors/torch.py
@@ -113,7 +113,8 @@ class TorchPosterior(Posterior):
         return self.log_prob(value).exp()
 
     def _extended_shape(
-        self, sample_shape: torch.Size = torch.Size()  # noqa: B008
+        self,
+        sample_shape: torch.Size = torch.Size(),  # noqa: B008
     ) -> torch.Size:
         r"""Returns the shape of the samples produced by the distribution with
         the given `sample_shape`.

--- a/botorch/posteriors/transformed.py
+++ b/botorch/posteriors/transformed.py
@@ -70,7 +70,8 @@ class TransformedPosterior(Posterior):
         return self._posterior.dtype
 
     def _extended_shape(
-        self, sample_shape: torch.Size = torch.Size()  # noqa: B008
+        self,
+        sample_shape: torch.Size = torch.Size(),  # noqa: B008
     ) -> torch.Size:
         r"""Returns the shape of the samples produced by the posterior with
         the given `sample_shape`.

--- a/botorch/sampling/pathwise/prior_samplers.py
+++ b/botorch/sampling/pathwise/prior_samplers.py
@@ -62,7 +62,6 @@ def _draw_kernel_feature_paths_fallback(
     output_transform: TOutputTransform | None = None,
     weight_generator: Callable[[Size], Tensor] | None = None,
 ) -> GeneralizedLinearPath:
-
     # Generate a kernel feature map
     feature_map = map_generator(
         kernel=covar_module,

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -1267,7 +1267,6 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
 
 
 class C2DTLZ2(DTLZ2, ConstrainedBaseTestProblem):
-
     num_constraints = 1
     _r = 0.2
     # approximate from nsga-ii, TODO: replace with analytic

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -163,7 +163,6 @@ class Ackley(SyntheticTestFunction):
 
 
 class Beale(SyntheticTestFunction):
-
     dim = 2
     _optimal_value = 0.0
     _bounds = [(-4.5, 4.5), (-4.5, 4.5)]
@@ -207,7 +206,6 @@ class Branin(SyntheticTestFunction):
 
 
 class Bukin(SyntheticTestFunction):
-
     dim = 2
     _bounds = [(-15.0, -5.0), (-3.0, 3.0)]
     _optimal_value = 0.0
@@ -241,7 +239,6 @@ class Cosine8(SyntheticTestFunction):
 
 
 class DropWave(SyntheticTestFunction):
-
     dim = 2
     _bounds = [(-5.12, 5.12), (-5.12, 5.12)]
     _optimal_value = -1.0
@@ -256,7 +253,6 @@ class DropWave(SyntheticTestFunction):
 
 
 class DixonPrice(SyntheticTestFunction):
-
     _optimal_value = 0.0
 
     def __init__(
@@ -639,7 +635,6 @@ class Powell(SyntheticTestFunction):
 
 
 class Rastrigin(SyntheticTestFunction):
-
     _optimal_value = 0.0
 
     def __init__(
@@ -764,7 +759,6 @@ class Shekel(SyntheticTestFunction):
 
 
 class SixHumpCamel(SyntheticTestFunction):
-
     dim = 2
     _bounds = [(-3.0, 3.0), (-2.0, 2.0)]
     _optimal_value = -1.0316
@@ -815,7 +809,6 @@ class StyblinskiTang(SyntheticTestFunction):
 
 
 class ThreeHumpCamel(SyntheticTestFunction):
-
     dim = 2
     _bounds = [(-5.0, 5.0), (-5.0, 5.0)]
     _optimal_value = 0.0

--- a/botorch/test_utils/mock.py
+++ b/botorch/test_utils/mock.py
@@ -8,6 +8,7 @@
 Utilities for speeding up optimization in tests.
 
 """
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/botorch/utils/constraints.py
+++ b/botorch/utils/constraints.py
@@ -19,7 +19,7 @@ from torch import Tensor
 
 
 def get_outcome_constraint_transforms(
-    outcome_constraints: tuple[Tensor, Tensor] | None
+    outcome_constraints: tuple[Tensor, Tensor] | None,
 ) -> list[Callable[[Tensor], Tensor]] | None:
     r"""Create outcome constraint callables from outcome constraint tensors.
 

--- a/botorch/utils/multi_objective/box_decompositions/utils.py
+++ b/botorch/utils/multi_objective/box_decompositions/utils.py
@@ -6,7 +6,6 @@
 
 r"""Utilities for box decomposition algorithms."""
 
-
 import torch
 from botorch.exceptions.errors import BotorchTensorDimensionError, UnsupportedError
 from botorch.utils.multi_objective.pareto import is_non_dominated

--- a/botorch/utils/multi_objective/scalarization.py
+++ b/botorch/utils/multi_objective/scalarization.py
@@ -14,6 +14,7 @@ References
     for expensive multiobjective optimization problems," in IEEE Transactions
     on Evolutionary Computation, vol. 10, no. 1, pp. 50-66, Feb. 2006.
 """
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/botorch/utils/test_helpers.py
+++ b/botorch/utils/test_helpers.py
@@ -40,7 +40,6 @@ from torch.nn.functional import pad
 
 
 def _get_mcmc_samples(num_samples: int, dim: int, infer_noise: bool, **tkwargs):
-
     mcmc_samples = {
         "lengthscale": 1 + torch.rand(num_samples, 1, dim, **tkwargs),
         "outputscale": 1 + torch.rand(num_samples, **tkwargs),

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -277,7 +277,8 @@ class MockPosterior(Posterior):
         raise NotImplementedError  # pragma: no cover
 
     def _extended_shape(
-        self, sample_shape: torch.Size = torch.Size()  # noqa: B008
+        self,
+        sample_shape: torch.Size = torch.Size(),  # noqa: B008
     ) -> torch.Size:
         return sample_shape + self.base_sample_shape
 

--- a/botorch/utils/transforms.py
+++ b/botorch/utils/transforms.py
@@ -269,7 +269,6 @@ def t_batch_mode_transform(
         def decorated(
             acqf: AcquisitionFunction, X: Any, *args: Any, **kwargs: Any
         ) -> Any:
-
             # Allow using acquisition functions for other inputs (e.g. lists of strings)
             if not isinstance(X, Tensor):
                 return method(acqf, X, *args, **kwargs)
@@ -311,7 +310,7 @@ def t_batch_mode_transform(
 
 
 def concatenate_pending_points(
-    method: Callable[[Any, Tensor], Any]
+    method: Callable[[Any, Tensor], Any],
 ) -> Callable[[Any, Tensor], Any]:
     r"""Decorator concatenating X_pending into an acquisition function's argument.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ write_to = "./botorch/version.py"
 
 [tool.usort]
 first_party_detection = false
+
+[tool.ufmt]
+formatter = "ruff-api"

--- a/test/acquisition/multi_objective/test_hypervolume_knowledge_gradient.py
+++ b/test/acquisition/multi_objective/test_hypervolume_knowledge_gradient.py
@@ -370,9 +370,7 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
                         ModelListGP, "fantasize", return_value=mfm
                     ) as patch_f, mock.patch(
                         NO, new_callable=mock.PropertyMock
-                    ) as mock_num_outputs, warnings.catch_warnings(
-                        record=True
-                    ) as ws:
+                    ) as mock_num_outputs, warnings.catch_warnings(record=True) as ws:
                         mock_num_outputs.return_value = 3
                         qHVKG = acqf_class(
                             model=model,

--- a/test/acquisition/test_analytic.py
+++ b/test/acquisition/test_analytic.py
@@ -82,7 +82,6 @@ class TestAnalyticAcquisitionFunction(BotorchTestCase):
 
 
 class TestExpectedImprovement(BotorchTestCase):
-
     def test_expected_improvement(self):
         mean = torch.tensor([[-0.5]], device=self.device)
         variance = torch.ones(1, 1, device=self.device)

--- a/test/acquisition/test_fixed_feature.py
+++ b/test/acquisition/test_fixed_feature.py
@@ -162,7 +162,6 @@ class TestFixedFeatureAcquisitionFunction(BotorchTestCase):
                 self.assertEqual(ff.values.dtype, expected_dtype)
 
     def test_values_devices(self) -> None:
-
         acqf = MockAcquisitionFunction()
         cpu = torch.device("cpu")
         cuda = torch.device("cuda")

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -1267,14 +1267,12 @@ class TestKGandESAcquisitionFunctionInputConstructors(InputConstructorBaseTestCa
         func = get_acqf_input_constructor(qKnowledgeGradient)
 
         with self.subTest("test_with_current_value"):
-
             current_value = torch.tensor(1.23)
 
             with mock.patch(
                 target="botorch.acquisition.input_constructors.optimize_objective",
                 return_value=(None, current_value),
             ):
-
                 kwargs = func(
                     model=mock.Mock(),
                     training_data=self.blockX_blockY,
@@ -1299,7 +1297,6 @@ class TestKGandESAcquisitionFunctionInputConstructors(InputConstructorBaseTestCa
             self.assertNotIn("current_value", kwargs)
 
     def test_construct_inputs_mfhvkg(self) -> None:
-
         get_kwargs = get_acqf_input_constructor(
             qMultiFidelityHypervolumeKnowledgeGradient
         )
@@ -1327,7 +1324,6 @@ class TestKGandESAcquisitionFunctionInputConstructors(InputConstructorBaseTestCa
 
     @mock.patch("botorch.acquisition.input_constructors._get_hv_value_function")
     def test_construct_inputs_hvkg(self, mock_get_hv_value_function) -> None:
-
         current_value = torch.tensor(1.23)
         objective_thresholds = torch.rand(2)
 
@@ -1335,7 +1331,6 @@ class TestKGandESAcquisitionFunctionInputConstructors(InputConstructorBaseTestCa
             qHypervolumeKnowledgeGradient,
             qMultiFidelityHypervolumeKnowledgeGradient,
         ):
-
             get_kwargs = get_acqf_input_constructor(acqf_cls)
 
             model = mock.Mock()
@@ -1353,7 +1348,6 @@ class TestKGandESAcquisitionFunctionInputConstructors(InputConstructorBaseTestCa
                 target="botorch.acquisition.input_constructors.optimize_acqf",
                 return_value=(None, current_value),
             ) as mock_optimize_acqf:
-
                 kwargs = get_kwargs(
                     model=model,
                     training_data=self.blockX_blockY,

--- a/test/acquisition/test_integration.py
+++ b/test/acquisition/test_integration.py
@@ -36,7 +36,6 @@ class TestObjectiveAndConstraintIntegration(BotorchTestCase):
         self.tkwargs = {"device": self.device, "dtype": torch.double}
 
     def _get_acqf_inputs(self, train_batch_shape: torch.Size, m: int) -> dict:
-
         train_x = torch.rand((*train_batch_shape, 5, self.d), **self.tkwargs)
         y = torch.rand((*train_batch_shape, 5, m), **self.tkwargs)
 

--- a/test/acquisition/test_knowledge_gradient.py
+++ b/test/acquisition/test_knowledge_gradient.py
@@ -587,7 +587,6 @@ class TestQMultiFidelityKnowledgeGradient(BotorchTestCase):
                         torch.zeros(2, **tkwargs),
                     ),
                 ):
-
                     candidate, value = optimize_acqf(
                         acq_function=kg,
                         bounds=bounds,

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -473,7 +473,6 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
             self._test_cache_root()
 
     def _test_cache_root(self):
-
         sample_cached_path = (
             "botorch.acquisition.cached_cholesky.sample_cached_cholesky"
         )

--- a/test/acquisition/test_thompson_sampling.py
+++ b/test/acquisition/test_thompson_sampling.py
@@ -15,7 +15,6 @@ from botorch.utils.testing import BotorchTestCase
 
 
 def _get_mcmc_samples(num_samples: int, dim: int, infer_noise: bool, **tkwargs):
-
     mcmc_samples = {
         "lengthscale": torch.rand(num_samples, 1, dim, **tkwargs),
         "outputscale": torch.rand(num_samples, **tkwargs),
@@ -32,7 +31,6 @@ def get_fully_bayesian_model(
     num_models,
     **tkwargs,
 ):
-
     model = SaasFullyBayesianSingleTaskGP(
         train_X=train_X,
         train_Y=train_Y,

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -710,7 +710,7 @@ class TestFullyBayesianSingleTaskGP(BotorchTestCase):
                 num_models=num_models,
                 num_cond=num_cond,
                 infer_noise=infer_noise,
-                **tkwargs
+                **tkwargs,
             )
             model = SaasFullyBayesianSingleTaskGP(
                 train_X=train_X,
@@ -721,7 +721,7 @@ class TestFullyBayesianSingleTaskGP(BotorchTestCase):
                 num_samples=num_models,
                 dim=train_X.shape[-1],
                 infer_noise=infer_noise,
-                **tkwargs
+                **tkwargs,
             )
             model.load_mcmc_samples(mcmc_samples)
 
@@ -757,7 +757,7 @@ class TestFullyBayesianSingleTaskGP(BotorchTestCase):
                 num_samples=num_models,
                 dim=train_X.shape[-1],
                 infer_noise=infer_noise,
-                **tkwargs
+                **tkwargs,
             )
             model.load_mcmc_samples(mcmc_samples)
 

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -72,7 +72,6 @@ EXPECTED_KEYS_NOISE = EXPECTED_KEYS + [
 
 
 class TestFullyBayesianMultiTaskGP(BotorchTestCase):
-
     def _get_data_and_model(
         self,
         task_rank: int | None = None,

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -456,7 +456,6 @@ class TestSingleTaskGP(TestGPRegressionBase):
 
 
 class TestSingleTaskGPFixedNoise(TestSingleTaskGP):
-
     def _get_model_and_data(
         self,
         batch_shape,

--- a/test/models/test_gp_regression_fidelity.py
+++ b/test/models/test_gp_regression_fidelity.py
@@ -40,7 +40,6 @@ def _get_random_data_with_fidelity(
 
 
 class TestSingleTaskMultiFidelityGP(BotorchTestCase):
-
     FIDELITY_TEST_PAIRS = (
         # (iteration_fidelity, data_fidelities)
         (None, [1]),
@@ -430,7 +429,6 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
 
 
 class TestFixedNoiseSingleTaskMultiFidelityGP(TestSingleTaskMultiFidelityGP):
-
     def _get_model_and_data(
         self,
         iteration_fidelity,

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -225,7 +225,6 @@ class TestModelListGP(BotorchTestCase):
         for dtype, outcome_transform in itertools.product(
             (torch.float, torch.double), ("None", "Standardize", "Log", "Chained")
         ):
-
             model = self._base_test_ModelListGP(
                 fixed_noise=False, dtype=dtype, outcome_transform=outcome_transform
             )
@@ -261,7 +260,6 @@ class TestModelListGP(BotorchTestCase):
                 )
 
     def test_ModelListGP_fixed_noise(self) -> None:
-
         for dtype, outcome_transform in itertools.product(
             (torch.float, torch.double), ("None", "Standardize")
         ):

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -290,7 +290,6 @@ class TestOutcomeTransforms(BotorchTestCase):
 
         # test transforming a subset of outcomes
         for batch_shape, dtype in itertools.product(batch_shapes, dtypes):
-
             m = 2
             outputs = [-1]
 
@@ -373,7 +372,6 @@ class TestOutcomeTransforms(BotorchTestCase):
 
         # test transform and untransform
         for m, batch_shape, dtype in itertools.product(ms, batch_shapes, dtypes):
-
             # test init
             tf = Log()
             self.assertTrue(tf.training)
@@ -435,7 +433,6 @@ class TestOutcomeTransforms(BotorchTestCase):
 
         # test transforming a subset of outcomes
         for batch_shape, dtype in itertools.product(batch_shapes, dtypes):
-
             m = 2
             outputs = [-1]
 
@@ -490,7 +487,6 @@ class TestOutcomeTransforms(BotorchTestCase):
 
         # test transform and untransform
         for m, batch_shape, dtype in itertools.product(ms, batch_shapes, dtypes):
-
             # test init
             tf1 = Log()
             tf2 = Standardize(m=m, batch_shape=batch_shape)
@@ -605,7 +601,6 @@ class TestOutcomeTransforms(BotorchTestCase):
 
         # test transform and untransform
         for m, batch_shape, dtype in itertools.product(ms, batch_shapes, dtypes):
-
             # test init
             tf = Power(power=power)
             self.assertTrue(tf.training)

--- a/test/models/transforms/test_utils.py
+++ b/test/models/transforms/test_utils.py
@@ -21,7 +21,6 @@ from botorch.utils.testing import BotorchTestCase
 class TestTransformUtils(BotorchTestCase):
     def test_lognorm_to_norm(self):
         for dtype in (torch.float, torch.double):
-
             # independent case
             mu = torch.tensor([0.25, 0.5, 1.0], device=self.device, dtype=dtype)
             diag = torch.tensor([0.5, 2.0, 1.0], device=self.device, dtype=dtype)
@@ -54,7 +53,6 @@ class TestTransformUtils(BotorchTestCase):
 
     def test_norm_to_lognorm(self):
         for dtype in (torch.float, torch.double):
-
             # Test joint, independent
             expmu = torch.tensor([1.0, 2.0, 3.0], device=self.device, dtype=dtype)
             expdiag = torch.tensor([1.5, 2.0, 3], device=self.device, dtype=dtype)

--- a/test/models/utils/test_inducing_point_allocators.py
+++ b/test/models/utils/test_inducing_point_allocators.py
@@ -138,12 +138,10 @@ class TestGreedyVarianceReduction(BotorchTestCase):
         self.assertEqual(n_tensors_before, n_tensors_after)
 
     def test_inducing_points_shape_and_repeatability(self):
-
         for train_X in [
             torch.rand(15, 1, device=self.device),  # single task
             torch.rand(2, 15, 1, device=self.device),  # batched inputs
         ]:
-
             inducing_points_1 = self.ipa.allocate_inducing_points(
                 inputs=train_X,
                 covar_module=MaternKernel(),
@@ -227,7 +225,6 @@ class TestGreedyImprovementReduction(BotorchTestCase):
             torch.rand(15, 1, device=self.device),  # single task
             torch.rand(2, 15, 1, device=self.device),  # batched inputs
         ]:
-
             inducing_points_1 = self.ipa.allocate_inducing_points(
                 inputs=train_X,
                 covar_module=MaternKernel(),

--- a/test/optim/test_fit.py
+++ b/test/optim/test_fit.py
@@ -151,7 +151,6 @@ class TestFitGPyTorchMLLScipy(BotorchTestCase):
             raise RuntimeError("singular")
 
         for dtype in [torch.float32, torch.float64]:
-
             parameters = {"x": torch.tensor([0.0], dtype=dtype)}
 
             wrapper = NdarrayOptimizationClosure(closure=closure, parameters=parameters)

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -1304,7 +1304,6 @@ class TestSampleAroundBest(BotorchTestCase):
             acqf = qExpectedImprovement(model, best_f=0.0)
 
             with warnings.catch_warnings(record=True) as w, settings.debug(True):
-
                 X_rnd = sample_points_around_best(
                     acq_function=acqf,
                     n_discrete_points=4,

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -132,7 +132,6 @@ class TestOptimizeAcqf(BotorchTestCase):
                 mock_gen_candidates_scipy,
                 mock_gen_candidates_torch,
             ):
-
                 mock_gen_batch_initial_conditions.return_value = torch.zeros(
                     num_restarts, q, 3, device=self.device, dtype=dtype
                 )

--- a/test/optim/utils/test_acquisition_utils.py
+++ b/test/optim/utils/test_acquisition_utils.py
@@ -164,7 +164,6 @@ class TestGetXBaseline(BotorchTestCase):
             acqf = qExpectedImprovement(model, best_f=0.0)
 
             with warnings.catch_warnings(record=True) as w, settings.debug(True):
-
                 X_rnd = get_X_baseline(
                     acq_function=acqf,
                 )

--- a/test/sampling/test_qmc.py
+++ b/test/sampling/test_qmc.py
@@ -163,7 +163,6 @@ class MultivariateNormalQMCTests(BotorchTestCase):
 
     def test_MultivariateNormalQMCEngineSeeded(self):
         for dtype in (torch.float, torch.double):
-
             # test even dimension
             a = torch.randn(2, 2)
             cov = a @ a.transpose(-1, -2) + torch.rand(2).diag()

--- a/test/test_functions/test_base.py
+++ b/test/test_functions/test_base.py
@@ -19,7 +19,6 @@ class DummyTestProblem(BaseTestProblem):
 
 
 class DummyConstrainedTestProblem(DummyTestProblem, ConstrainedBaseTestProblem):
-
     num_constraints = 1
 
     def evaluate_slack_true(self, X: Tensor) -> Tensor:

--- a/test/test_functions/test_multi_fidelity.py
+++ b/test/test_functions/test_multi_fidelity.py
@@ -19,7 +19,6 @@ from botorch.utils.testing import (
 class TestAugmentedBranin(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         AugmentedBranin(),
         AugmentedBranin(negate=True),
@@ -30,7 +29,6 @@ class TestAugmentedBranin(
 class TestAugmentedHartmann(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         AugmentedHartmann(),
         AugmentedHartmann(negate=True),
@@ -41,7 +39,6 @@ class TestAugmentedHartmann(
 class TestAugmentedRosenbrock(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         AugmentedRosenbrock(),
         AugmentedRosenbrock(negate=True),

--- a/test/test_functions/test_synthetic.py
+++ b/test/test_functions/test_synthetic.py
@@ -126,7 +126,6 @@ class DummyConstrainedSyntheticTestFunction(ConstrainedSyntheticTestFunction):
 
 
 class TestConstraintNoise(BotorchTestCase):
-
     functions = [
         DummyConstrainedSyntheticTestFunction(),
         DummyConstrainedSyntheticTestFunction(constraint_noise_std=0.1),
@@ -143,49 +142,42 @@ class TestConstraintNoise(BotorchTestCase):
 class TestAckley(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [Ackley(), Ackley(negate=True), Ackley(noise_std=0.1), Ackley(dim=3)]
 
 
 class TestBeale(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [Beale(), Beale(negate=True), Beale(noise_std=0.1)]
 
 
 class TestBranin(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [Branin(), Branin(negate=True), Branin(noise_std=0.1)]
 
 
 class TestBukin(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [Bukin(), Bukin(negate=True), Bukin(noise_std=0.1)]
 
 
 class TestCosine8(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [Cosine8(), Cosine8(negate=True), Cosine8(noise_std=0.1)]
 
 
 class TestDropWave(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [DropWave(), DropWave(negate=True), DropWave(noise_std=0.1)]
 
 
 class TestDixonPrice(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         DixonPrice(),
         DixonPrice(negate=True),
@@ -197,14 +189,12 @@ class TestDixonPrice(
 class TestEggHolder(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [EggHolder(), EggHolder(negate=True), EggHolder(noise_std=0.1)]
 
 
 class TestGriewank(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         Griewank(),
         Griewank(negate=True),
@@ -216,7 +206,6 @@ class TestGriewank(
 class TestHartmann(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         Hartmann(),
         Hartmann(negate=True),
@@ -237,14 +226,12 @@ class TestHartmann(
 class TestHolderTable(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [HolderTable(), HolderTable(negate=True), HolderTable(noise_std=0.1)]
 
 
 class TestLevy(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         Levy(),
         Levy(negate=True),
@@ -258,7 +245,6 @@ class TestLevy(
 class TestMichalewicz(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         Michalewicz(),
         Michalewicz(negate=True),
@@ -275,14 +261,12 @@ class TestMichalewicz(
 class TestPowell(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [Powell(), Powell(negate=True), Powell(noise_std=0.1)]
 
 
 class TestRastrigin(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         Rastrigin(),
         Rastrigin(negate=True),
@@ -296,7 +280,6 @@ class TestRastrigin(
 class TestRosenbrock(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         Rosenbrock(),
         Rosenbrock(negate=True),
@@ -310,21 +293,18 @@ class TestRosenbrock(
 class TestShekel(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [Shekel(), Shekel(negate=True), Shekel(noise_std=0.1)]
 
 
 class TestSixHumpCamel(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [SixHumpCamel(), SixHumpCamel(negate=True), SixHumpCamel(noise_std=0.1)]
 
 
 class TestStyblinskiTang(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         StyblinskiTang(),
         StyblinskiTang(negate=True),
@@ -338,7 +318,6 @@ class TestStyblinskiTang(
 class TestThreeHumpCamel(
     BotorchTestCase, BaseTestProblemTestCaseMixIn, SyntheticTestFunctionTestCaseMixin
 ):
-
     functions = [
         ThreeHumpCamel(),
         ThreeHumpCamel(negate=True),
@@ -355,7 +334,6 @@ class TestConstrainedGramacy(
     ConstrainedTestProblemTestCaseMixin,
     SyntheticTestFunctionTestCaseMixin,
 ):
-
     functions = [
         ConstrainedGramacy(),
         ConstrainedGramacy(negate=True),
@@ -370,7 +348,6 @@ class TestConstrainedHartmann(
     SyntheticTestFunctionTestCaseMixin,
     ConstrainedTestProblemTestCaseMixin,
 ):
-
     functions = [
         ConstrainedHartmann(dim=6, negate=True),
         ConstrainedHartmann(noise_std=0.1, dim=6, negate=True),
@@ -386,7 +363,6 @@ class TestConstrainedHartmannSmooth(
     SyntheticTestFunctionTestCaseMixin,
     ConstrainedTestProblemTestCaseMixin,
 ):
-
     functions = [
         ConstrainedHartmannSmooth(dim=6, negate=True),
         ConstrainedHartmannSmooth(
@@ -400,7 +376,6 @@ class TestPressureVessel(
     BaseTestProblemTestCaseMixIn,
     ConstrainedTestProblemTestCaseMixin,
 ):
-
     functions = [
         PressureVessel(),
         PressureVessel(noise_std=0.1, constraint_noise_std=0.1, negate=True),
@@ -415,7 +390,6 @@ class TestSpeedReducer(
     BaseTestProblemTestCaseMixIn,
     ConstrainedTestProblemTestCaseMixin,
 ):
-
     functions = [
         SpeedReducer(),
         SpeedReducer(noise_std=0.1, constraint_noise_std=0.1, negate=True),
@@ -428,7 +402,6 @@ class TestTensionCompressionString(
     BaseTestProblemTestCaseMixIn,
     ConstrainedTestProblemTestCaseMixin,
 ):
-
     functions = [
         TensionCompressionString(),
         TensionCompressionString(
@@ -442,7 +415,6 @@ class TestWeldedBeamSO(
     BaseTestProblemTestCaseMixIn,
     ConstrainedTestProblemTestCaseMixin,
 ):
-
     functions = [
         WeldedBeamSO(),
         WeldedBeamSO(noise_std=0.1, constraint_noise_std=[0.2] * 6),

--- a/test/utils/multi_objective/box_decompositions/test_box_decomposition.py
+++ b/test/utils/multi_objective/box_decompositions/test_box_decomposition.py
@@ -77,7 +77,6 @@ class TestBoxDecomposition(BotorchTestCase):
                 DummyBoxDecomposition,
                 "_partition_space_2d" if m == 2 else "_partition_space",
             ) as mock_partition_space:
-
                 ref_point = self.ref_point_raw[:m].to(dtype=dtype)
                 Y = self.Y_raw[:, :m].to(dtype=dtype)
                 pareto_Y = self.pareto_Y_raw[:, :m].to(dtype=dtype)

--- a/test/utils/probability/test_bvn.py
+++ b/test/utils/probability/test_bvn.py
@@ -32,7 +32,6 @@ def run_gaussian_estimator(
     batch_limit: int | None = None,
     seed: int | None = None,
 ) -> Tensor:
-
     if batch_limit is None:
         batch_limit = num_samples
 

--- a/test/utils/probability/test_mvnxpb.py
+++ b/test/utils/probability/test_mvnxpb.py
@@ -30,7 +30,6 @@ def run_gaussian_estimator(
     batch_limit: int | None = None,
     seed: int | None = None,
 ) -> Tensor:
-
     if batch_limit is None:
         batch_limit = num_samples
 

--- a/test/utils/test_feasible_volume.py
+++ b/test/utils/test_feasible_volume.py
@@ -56,7 +56,6 @@ class TestFeasibleVolumeEstimates(BotorchTestCase):
                 torch.zeros(1, 2, 1, device=self.device, dtype=dtype),
                 torch.ones(1, 1, 1, device=self.device, dtype=dtype),
             ):
-
                 mm = MockModel(MockPosterior(samples=samples))
                 bounds = torch.ones((2, 1))
                 outcome_constraints = [lambda y: y[..., 0] - 0.5]

--- a/test/utils/test_low_rank.py
+++ b/test/utils/test_low_rank.py
@@ -85,7 +85,6 @@ class TestSampleCachedCholesky(BotorchTestCase):
                                 torch.Size([4]),
                                 torch.Size([4, 2]),
                             ):
-
                                 if len(train_batch_shape) > 0:
                                     train_X_ex = train_X.unsqueeze(0).expand(
                                         train_batch_shape + train_X.shape

--- a/test/utils/test_multitask.py
+++ b/test/utils/test_multitask.py
@@ -14,7 +14,6 @@ from gpytorch.distributions.multivariate_normal import MultivariateNormal
 
 
 class TestSeparateMTMVN(BotorchTestCase):
-
     def _test_separate_mtmvn(self, interleaved=False):
         for dtype in (torch.float, torch.double):
             tkwargs = {"device": self.device, "dtype": dtype}

--- a/test/utils/test_test_helpers.py
+++ b/test/utils/test_test_helpers.py
@@ -13,7 +13,6 @@ from botorch.utils.testing import BotorchTestCase
 
 
 class TestTestHelpers(BotorchTestCase):
-
     def test_get_pvar_expected(self):
         # The test helper is used throughout, veryfying that an error is raised
         # when it is used with an unsupported model.


### PR DESCRIPTION
Summary:
Use the ruff code formatter. This diff

- Changes the Meta-internal config to use ruff.
- Updates `pyproject.toml` to use ruff as the code formatter.
- Applies the new formatting across the codebase.

This does NOT change the code sorting engine (that is still usort). We can update that in a next step.

Differential Revision: D64517061
