### PR TITLE
Remove unnecessary ufmt install in github actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,6 @@ jobs:
       run: |
         # pin dependencies to match Meta-internal versions
         pip install -r requirements-fmt.txt
-        pip install ufmt
     - name: ufmt
       run: |
         ufmt diff .


### PR DESCRIPTION
Summary: The line `pip install -r requirements-fmt.txt` above already installs `ufmt`, so this is not needed.

Differential Revision: D64517856


