### PR TITLE
Fix posterior method in `BatchedMultiOutputGPyTorchModel` for tracing JIT

### DIFF
--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -38,6 +38,7 @@ from gpytorch.kernels import RBFKernel, ScaleKernel
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.means import ConstantMean
 from gpytorch.models import ExactGP, IndependentModelList
+from gpytorch.settings import trace_mode
 from torch import Tensor
 
 
@@ -410,6 +411,32 @@ class TestBatchedMultiOutputGPyTorchModel(BotorchTestCase):
         post_tf = ScalarizedPosteriorTransform(weights=torch.zeros(2, **tkwargs))
         post = model.posterior(torch.rand(3, 2, **tkwargs), posterior_transform=post_tf)
         self.assertTrue(torch.equal(post.mean, torch.zeros(3, 1, **tkwargs)))
+
+    def test_posterior_in_trace_mode(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        train_X = torch.rand(5, 1, **tkwargs)
+        train_Y = torch.cat([torch.sin(train_X), torch.cos(train_X)], dim=-1)
+        model = SimpleBatchedMultiOutputGPyTorchModel(train_X, train_Y)
+
+        class MeanVarModelWrapper(torch.nn.Module):
+            def __init__(self, model):
+                super().__init__()
+                self.model = model
+
+            def forward(self, x):
+                # get the model posterior
+                posterior = self.model.posterior(x, observation_noise=True)
+                mean = posterior.mean.detach()
+                std = posterior.variance.sqrt().detach()
+                return mean, std
+
+        wrapped_model = MeanVarModelWrapper(model)
+        with torch.no_grad(), trace_mode():
+            X_test = torch.rand(3, 1, **tkwargs)
+            wrapped_model(X_test)  # Compute caches
+            traced_model = torch.jit.trace(wrapped_model, X_test)
+            mean, std = traced_model(X_test)
+            self.assertEqual(mean.shape, torch.Size([3, 2]))
 
 
 class TestModelListGPyTorchModel(BotorchTestCase):


### PR DESCRIPTION
## Motivation

Fixes #2591. Generates the MTMVN for the independent task case slightly differently when jit traced.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

A unit test `test_posterior_in_trace_mode` has been added to test_gpytorch.py

## Related PRs

NA
