### PR TITLE
Implement MultiTaskDataset.__eq__

### DIFF
--- a/botorch/utils/datasets.py
+++ b/botorch/utils/datasets.py
@@ -492,6 +492,14 @@ class MultiTaskDataset(SupervisedDataset):
             outcome_names=[outcome_name],
         )
 
+    def __eq__(self, other: Any) -> bool:
+        return (
+            type(other) is type(self)
+            and self.datasets == other.datasets
+            and self.target_outcome_name == other.target_outcome_name
+            and self.task_feature_index == other.task_feature_index
+        )
+
 
 class ContextualDataset(SupervisedDataset):
     """This is a contextual dataset that is constructed from either a single
@@ -548,7 +556,7 @@ class ContextualDataset(SupervisedDataset):
             return torch.cat(Ys, dim=-1)
 
     @property
-    def Yvar(self) -> Tensor:
+    def Yvar(self) -> Tensor | None:
         """Concatenates the Yvars from the child datasets to create the Y expected
         by LCEM model if there are multiple datasets; Or return the Yvar expected
         by LCEA model if there is only one dataset.

--- a/test/utils/test_datasets.py
+++ b/test/utils/test_datasets.py
@@ -354,6 +354,17 @@ class TestDatasets(BotorchTestCase):
         ):
             mt_dataset.X
 
+        # Test equality.
+        self.assertEqual(mt_dataset, mt_dataset)
+        self.assertNotEqual(mt_dataset, dataset_5)
+        self.assertNotEqual(
+            mt_dataset, MultiTaskDataset(datasets=[dataset_1], target_outcome_name="y")
+        )
+        self.assertNotEqual(
+            mt_dataset,
+            MultiTaskDataset(datasets=[dataset_1, dataset_5], target_outcome_name="z"),
+        )
+
     def test_contextual_datasets(self):
         num_contexts = 3
         feature_names = [f"x_c{i}" for i in range(num_contexts)]


### PR DESCRIPTION
Summary:
Previously, this would fallback to `SupervisedDataset.__eq__`, which uses `self.X` for comparison. If the underlying datasets have heterogeneous feature sets, `self.X` errors out.

The new `MultiTaskDataset.__eq__` resolves this issue by comparing the underlying datasets one by one.

Differential Revision: D64911436


