### PR TITLE
Fix hard-coded `double` precision in test_functions to default dtype

### DIFF
--- a/botorch/test_functions/base.py
+++ b/botorch/test_functions/base.py
@@ -170,6 +170,7 @@ class MultiObjectiveTestProblem(BaseTestProblem, ABC):
         self,
         noise_std: None | float | list[float] = None,
         negate: bool = False,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""Base constructor for multi-objective test functions.
 
@@ -184,8 +185,8 @@ class MultiObjectiveTestProblem(BaseTestProblem, ABC):
                 f"If specified as a list, length of noise_std ({len(noise_std)}) "
                 f"must match the number of objectives ({len(self._ref_point)})"
             )
-        super().__init__(noise_std=noise_std, negate=negate)
-        ref_point = torch.tensor(self._ref_point, dtype=torch.get_default_dtype())
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
+        ref_point = torch.tensor(self._ref_point, dtype=self.dtype)
         if negate:
             ref_point *= -1
         self.register_buffer("ref_point", ref_point)

--- a/botorch/test_functions/base.py
+++ b/botorch/test_functions/base.py
@@ -47,7 +47,10 @@ class BaseTestProblem(Module, ABC):
                 f"Got {self.dim=} and {len(self._bounds)=}."
             )
         self.register_buffer(
-            "bounds", torch.tensor(self._bounds, dtype=torch.double).transpose(-1, -2)
+            "bounds",
+            torch.tensor(self._bounds, dtype=torch.get_default_dtype()).transpose(
+                -1, -2
+            ),
         )
 
     def forward(self, X: Tensor, noise: bool = True) -> Tensor:

--- a/botorch/test_functions/base.py
+++ b/botorch/test_functions/base.py
@@ -43,7 +43,6 @@ class BaseTestProblem(Module, ABC):
         super().__init__()
         self.noise_std = noise_std
         self.negate = negate
-        self.dtype = dtype
         if len(self._bounds) != self.dim:
             raise InputDataError(
                 "Expected the bounds to match the dimensionality of the domain. "
@@ -51,7 +50,7 @@ class BaseTestProblem(Module, ABC):
             )
         self.register_buffer(
             "bounds",
-            torch.tensor(self._bounds, dtype=self.dtype).transpose(-1, -2),
+            torch.tensor(self._bounds, dtype=dtype).transpose(-1, -2),
         )
 
     def forward(self, X: Tensor, noise: bool = True) -> Tensor:
@@ -186,7 +185,7 @@ class MultiObjectiveTestProblem(BaseTestProblem, ABC):
                 f"must match the number of objectives ({len(self._ref_point)})"
             )
         super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
-        ref_point = torch.tensor(self._ref_point, dtype=self.dtype)
+        ref_point = torch.tensor(self._ref_point, dtype=dtype)
         if negate:
             ref_point *= -1
         self.register_buffer("ref_point", ref_point)

--- a/botorch/test_functions/base.py
+++ b/botorch/test_functions/base.py
@@ -29,6 +29,7 @@ class BaseTestProblem(Module, ABC):
         self,
         noise_std: None | float | list[float] = None,
         negate: bool = False,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""Base constructor for test functions.
 
@@ -37,10 +38,12 @@ class BaseTestProblem(Module, ABC):
                 provided, specifies separate noise standard deviations for each
                 objective in a multiobjective problem.
             negate: If True, negate the function.
+            dtype: The dtype that is used for the bounds of the function.
         """
         super().__init__()
         self.noise_std = noise_std
         self.negate = negate
+        self.dtype = dtype
         if len(self._bounds) != self.dim:
             raise InputDataError(
                 "Expected the bounds to match the dimensionality of the domain. "
@@ -48,9 +51,7 @@ class BaseTestProblem(Module, ABC):
             )
         self.register_buffer(
             "bounds",
-            torch.tensor(self._bounds, dtype=torch.get_default_dtype()).transpose(
-                -1, -2
-            ),
+            torch.tensor(self._bounds, dtype=self.dtype).transpose(-1, -2),
         )
 
     def forward(self, X: Tensor, noise: bool = True) -> Tensor:

--- a/botorch/test_functions/multi_fidelity.py
+++ b/botorch/test_functions/multi_fidelity.py
@@ -74,13 +74,18 @@ class AugmentedHartmann(SyntheticTestFunction):
     _optimizers = [(0.20169, 0.150011, 0.476874, 0.275332, 0.311652, 0.6573, 1.0)]
     _check_grad_at_opt = False
 
-    def __init__(self, noise_std: float | None = None, negate: bool = False) -> None:
+    def __init__(
+        self,
+        noise_std: float | None = None,
+        negate: bool = False,
+        dtype: torch.dtype = torch.double,
+    ) -> None:
         r"""
         Args:
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
         """
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
         self.register_buffer("ALPHA", torch.tensor([1.0, 1.2, 3.0, 3.2]))
         A = [
             [10, 3, 17, 3.5, 1.7, 8],
@@ -126,7 +131,11 @@ class AugmentedRosenbrock(SyntheticTestFunction):
     _optimal_value = 0.0
 
     def __init__(
-        self, dim=3, noise_std: float | None = None, negate: bool = False
+        self,
+        dim=3,
+        noise_std: float | None = None,
+        negate: bool = False,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -141,7 +150,7 @@ class AugmentedRosenbrock(SyntheticTestFunction):
         self.dim = dim
         self._bounds = [(-5.0, 10.0) for _ in range(self.dim)]
         self._optimizers = [tuple(1.0 for _ in range(self.dim))]
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
 
     def evaluate_true(self, X: Tensor) -> Tensor:
         X_curr = X[..., :-3]

--- a/botorch/test_functions/multi_fidelity.py
+++ b/botorch/test_functions/multi_fidelity.py
@@ -84,6 +84,7 @@ class AugmentedHartmann(SyntheticTestFunction):
         Args:
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
+            dtype: The dtype that is used for the bounds of the function.
         """
         super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
         self.register_buffer("ALPHA", torch.tensor([1.0, 1.2, 3.0, 3.2]))
@@ -142,6 +143,7 @@ class AugmentedRosenbrock(SyntheticTestFunction):
             dim: The (input) dimension. Must be at least 3.
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
+            dtype: The dtype that is used for the bounds of the function.
         """
         if dim < 3:
             raise ValueError(

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -119,13 +119,15 @@ class BraninCurrin(MultiObjectiveTestProblem):
         self,
         noise_std: None | float | list[float] = None,
         negate: bool = False,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the objectives.
+            dtype: The dtype that is used for the bounds of the function.
         """
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
         self._branin = Branin()
 
     def _rescaled_branin(self, X: Tensor) -> Tensor:
@@ -179,12 +181,14 @@ class DH(MultiObjectiveTestProblem, ABC):
         dim: int,
         noise_std: None | float | list[float] = None,
         negate: bool = False,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
             dim: The (input) dimension.
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
+            dtype: The dtype that is used for the bounds of the function.
         """
         if dim < self._min_dim:
             raise ValueError(f"dim must be >= {self._min_dim}, but got dim={dim}!")
@@ -194,7 +198,7 @@ class DH(MultiObjectiveTestProblem, ABC):
         ]
         # max_hv is the area of the box minus the area of the curve formed by the PF.
         self._max_hv = self._ref_point[0] * self._ref_point[1] - self._area_under_curve
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
 
     @abstractmethod
     def _h(self, X: Tensor) -> Tensor:
@@ -339,6 +343,7 @@ class DTLZ(MultiObjectiveTestProblem):
         num_objectives: int = 2,
         noise_std: None | float | list[float] = None,
         negate: bool = False,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -346,6 +351,7 @@ class DTLZ(MultiObjectiveTestProblem):
             num_objectives: Must be less than dim.
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
+            dtype: The dtype that is used for the bounds of the function.
         """
         if dim <= num_objectives:
             raise ValueError(
@@ -356,7 +362,7 @@ class DTLZ(MultiObjectiveTestProblem):
         self.k = self.dim - self.num_objectives + 1
         self._bounds = [(0.0, 1.0) for _ in range(self.dim)]
         self._ref_point = [self._ref_val for _ in range(num_objectives)]
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
 
 
 class DTLZ1(DTLZ):
@@ -608,12 +614,14 @@ class GMM(MultiObjectiveTestProblem):
         noise_std: None | float | list[float] = None,
         negate: bool = False,
         num_objectives: int = 2,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the objectives.
             num_objectives: The number of objectives.
+            dtype: The dtype that is used for the bounds of the function.
         """
         if num_objectives not in (2, 3, 4):
             raise UnsupportedError("GMM only currently supports 2 to 4 objectives.")
@@ -623,7 +631,7 @@ class GMM(MultiObjectiveTestProblem):
         if num_objectives > 3:
             self._ref_point.append(-0.1866)
         self.num_objectives = num_objectives
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
         gmm_pos = torch.tensor(
             [
                 [[0.2, 0.2], [0.8, 0.2], [0.5, 0.7]],
@@ -935,6 +943,7 @@ class ZDT(MultiObjectiveTestProblem):
         num_objectives: int = 2,
         noise_std: None | float | list[float] = None,
         negate: bool = False,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -942,6 +951,7 @@ class ZDT(MultiObjectiveTestProblem):
             num_objectives: Number of objectives. Must not be larger than dim.
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
+            dtype: The dtype that is used for the bounds of the function.
         """
         if num_objectives != 2:
             raise NotImplementedError(
@@ -954,7 +964,7 @@ class ZDT(MultiObjectiveTestProblem):
         self.num_objectives = num_objectives
         self.dim = dim
         self._bounds = [(0.0, 1.0) for _ in range(self.dim)]
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
 
     @staticmethod
     def _g(X: Tensor) -> Tensor:
@@ -1246,6 +1256,7 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
         noise_std: None | float | list[float] = None,
         constraint_noise_std: None | float | list[float] = None,
         negate: bool = False,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -1253,8 +1264,9 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
             constraint_noise_std: Standard deviation of the observation noise of the
                 constraint.
             negate: If True, negate the function.
+            dtype: The dtype that is used for the bounds of the function.
         """
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
         con_bounds = torch.tensor(self._con_bounds, dtype=self.bounds.dtype).transpose(
             -1, -2
         )
@@ -1357,6 +1369,7 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
         noise_std: None | float | list[float] = None,
         constraint_noise_std: None | float | list[float] = None,
         negate: bool = False,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -1365,12 +1378,13 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
             constraint_noise_std: Standard deviation of the observation noise of the
                 constraints.
             negate: If True, negate the function.
+            dtype: The dtype that is used for the bounds of the function.
         """
         if dim < 2:
             raise ValueError("dim must be greater than or equal to 2.")
         self.dim = dim
         self._bounds = [(0.0, 1.0) for _ in range(self.dim)]
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtpye=dtype)
         self.constraint_noise_std = constraint_noise_std
 
     def LA2(self, A, B, C, D, theta) -> Tensor:

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -1384,7 +1384,7 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
             raise ValueError("dim must be greater than or equal to 2.")
         self.dim = dim
         self._bounds = [(0.0, 1.0) for _ in range(self.dim)]
-        super().__init__(noise_std=noise_std, negate=negate, dtpye=dtype)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
         self.constraint_noise_std = constraint_noise_std
 
     def LA2(self, A, B, C, D, theta) -> Tensor:

--- a/botorch/test_functions/sensitivity_analysis.py
+++ b/botorch/test_functions/sensitivity_analysis.py
@@ -24,13 +24,18 @@ class Ishigami(SyntheticTestFunction):
     """
 
     def __init__(
-        self, b: float = 0.1, noise_std: float | None = None, negate: bool = False
+        self,
+        b: float = 0.1,
+        noise_std: float | None = None,
+        negate: bool = False,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
             b: the b constant, should be 0.1 or 0.05.
             noise_std: Standard deviation of the observation noise.
             negative: If True, negative the objective.
+            dtype: The dtype that is used for the bounds of the function.
         """
         self._optimizers = None
         if b not in (0.1, 0.05):
@@ -52,7 +57,7 @@ class Ishigami(SyntheticTestFunction):
             self.dgsm_gradient_square = [2.8, 24.5, 11]
         self._bounds = [(-math.pi, math.pi) for _ in range(self.dim)]
         self.b = b
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
 
     @property
     def _optimal_value(self) -> float:
@@ -127,13 +132,15 @@ class Gsobol(SyntheticTestFunction):
         a: list = None,
         noise_std: float | None = None,
         negate: bool = False,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
             dim: Dimensionality of the problem. If 6, 8, or 15, will use standard a.
             a: a parameter, unless dim is 6, 8, or 15.
             noise_std: Standard deviation of observation noise.
-            negate: Return negatie of function.
+            negate: Return negative of function.
+            dtype: The dtype that is used for the bounds of the function.
         """
         self._optimizers = None
         self.dim = dim
@@ -163,7 +170,7 @@ class Gsobol(SyntheticTestFunction):
         else:
             self.a = a
         self.optimal_sobol_indicies()
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
 
     @property
     def _optimal_value(self) -> float:
@@ -207,11 +214,17 @@ class Morris(SyntheticTestFunction):
     Proposed to test sensitivity analysis methods
     """
 
-    def __init__(self, noise_std: float | None = None, negate: bool = False) -> None:
+    def __init__(
+        self,
+        noise_std: float | None = None,
+        negate: bool = False,
+        dtype: torch.dtype = torch.double,
+    ) -> None:
         r"""
         Args:
             noise_std: Standard deviation of observation noise.
             negate: Return negative of function.
+            dtype: The dtype that is used for the bounds of the function.
         """
         self._optimizers = None
         self.dim = 20
@@ -238,7 +251,7 @@ class Morris(SyntheticTestFunction):
             0,
             0,
         ]
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
 
     @property
     def _optimal_value(self) -> float:

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -68,6 +68,7 @@ class SyntheticTestFunction(BaseTestProblem, ABC):
         noise_std: None | float | list[float] = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -76,10 +77,11 @@ class SyntheticTestFunction(BaseTestProblem, ABC):
                 objective in a multiobjective problem.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         if bounds is not None:
             self._bounds = bounds
-        super().__init__(noise_std=noise_std, negate=negate)
+        super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
         if self._optimizers is not None:
             if bounds is not None:
                 # Ensure at least one optimizer lies within the custom bounds
@@ -138,6 +140,7 @@ class Ackley(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -150,7 +153,7 @@ class Ackley(SyntheticTestFunction):
         if bounds is None:
             bounds = [(-32.768, 32.768) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
-        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds)
+        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype)
         self.a = 20
         self.b = 0.2
         self.c = 2 * math.pi
@@ -261,6 +264,7 @@ class DixonPrice(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -277,7 +281,7 @@ class DixonPrice(SyntheticTestFunction):
                 for i in range(1, self.dim + 1)
             )
         ]
-        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds)
+        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype)
 
     def evaluate_true(self, X: Tensor) -> Tensor:
         d = self.dim
@@ -330,6 +334,7 @@ class Griewank(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -337,12 +342,13 @@ class Griewank(SyntheticTestFunction):
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
         if bounds is None:
             bounds = [(-600.0, 600.0) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
-        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds)
+        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype)
 
     def evaluate_true(self, X: Tensor) -> Tensor:
         part1 = torch.sum(X.pow(2) / 4000.0, dim=-1)
@@ -372,6 +378,7 @@ class Hartmann(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -379,6 +386,7 @@ class Hartmann(SyntheticTestFunction):
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         if dim not in (3, 4, 6):
             raise ValueError(f"Hartmann with dim {dim} not defined")
@@ -393,7 +401,7 @@ class Hartmann(SyntheticTestFunction):
         }
         self._optimal_value = optvals.get(self.dim)
         self._optimizers = optimizers.get(self.dim)
-        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds)
+        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype)
         self.register_buffer("ALPHA", torch.tensor([1.0, 1.2, 3.0, 3.2]))
         if dim == 3:
             A = [[3.0, 10, 30], [0.1, 10, 35], [3.0, 10, 30], [0.1, 10, 35]]
@@ -506,6 +514,7 @@ class Levy(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -513,12 +522,13 @@ class Levy(SyntheticTestFunction):
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
         if bounds is None:
             bounds = [(-10.0, 10.0) for _ in range(self.dim)]
         self._optimizers = [tuple(1.0 for _ in range(self.dim))]
-        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds)
+        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype)
 
     def evaluate_true(self, X: Tensor) -> Tensor:
         w = 1.0 + (X - 1.0) / 4.0
@@ -548,6 +558,7 @@ class Michalewicz(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -563,7 +574,7 @@ class Michalewicz(SyntheticTestFunction):
         optimizers = {2: [(2.20290552, 1.57079633)]}
         self._optimal_value = optvals.get(self.dim)
         self._optimizers = optimizers.get(self.dim)
-        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds)
+        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype)
         self.register_buffer(
             "i", torch.tensor(tuple(range(1, self.dim + 1)), dtype=self.bounds.dtype)
         )
@@ -608,6 +619,7 @@ class Powell(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -615,12 +627,13 @@ class Powell(SyntheticTestFunction):
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
         if bounds is None:
             bounds = [(-4.0, 5.0) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
-        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds)
+        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype)
 
     def evaluate_true(self, X: Tensor) -> Tensor:
         result = torch.zeros_like(X[..., 0])
@@ -643,6 +656,7 @@ class Rastrigin(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -650,12 +664,13 @@ class Rastrigin(SyntheticTestFunction):
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
         if bounds is None:
             bounds = [(-5.12, 5.12) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
-        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds)
+        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype)
 
     def evaluate_true(self, X: Tensor) -> Tensor:
         return 10.0 * self.dim + torch.sum(
@@ -682,6 +697,7 @@ class Rosenbrock(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.dtype,
     ) -> None:
         r"""
         Args:
@@ -689,12 +705,13 @@ class Rosenbrock(SyntheticTestFunction):
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
         if bounds is None:
             bounds = [(-5.0, 10.0) for _ in range(self.dim)]
         self._optimizers = [tuple(1.0 for _ in range(self.dim))]
-        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds)
+        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype)
 
     def evaluate_true(self, X: Tensor) -> Tensor:
         return torch.sum(
@@ -724,6 +741,7 @@ class Shekel(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -731,11 +749,12 @@ class Shekel(SyntheticTestFunction):
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         self.m = m
         optvals = {5: -10.1532, 7: -10.4029, 10: -10.536443}
         self._optimal_value = optvals[self.m]
-        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds)
+        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype)
 
         self.register_buffer("beta", torch.tensor([1, 2, 2, 4, 4, 6, 3, 7, 5, 5.0]))
         C_t = torch.tensor(
@@ -789,6 +808,7 @@ class StyblinskiTang(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -796,13 +816,14 @@ class StyblinskiTang(SyntheticTestFunction):
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
         if bounds is None:
             bounds = [(-5.0, 5.0) for _ in range(self.dim)]
         self._optimal_value = -39.166166 * self.dim
         self._optimizers = [tuple(-2.903534 for _ in range(self.dim))]
-        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds)
+        super().__init__(noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype)
 
     def evaluate_true(self, X: Tensor) -> Tensor:
         return 0.5 * (X.pow(4) - 16 * X.pow(2) + 5 * X).sum(dim=-1)
@@ -835,6 +856,7 @@ class ConstrainedSyntheticTestFunction(
         constraint_noise_std: None | float | list[float] = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -846,9 +868,10 @@ class ConstrainedSyntheticTestFunction(
                 deviations for each constraint.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         SyntheticTestFunction.__init__(
-            self, noise_std=noise_std, negate=negate, bounds=bounds
+            self, noise_std=noise_std, negate=negate, bounds=bounds, dtype=dtype
         )
         self.constraint_noise_std = self._validate_constraint_noise(
             constraint_noise_std
@@ -927,6 +950,7 @@ class ConstrainedHartmann(Hartmann, ConstrainedSyntheticTestFunction):
         constraint_noise_std: None | float | list[float] = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -937,9 +961,15 @@ class ConstrainedHartmann(Hartmann, ConstrainedSyntheticTestFunction):
                 deviations for each constraint.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         Hartmann.__init__(
-            self, dim=dim, noise_std=noise_std, negate=negate, bounds=bounds
+            self,
+            dim=dim,
+            noise_std=noise_std,
+            negate=negate,
+            bounds=bounds,
+            dtype=dtype,
         )
         self.constraint_noise_std = self._validate_constraint_noise(
             constraint_noise_std
@@ -965,6 +995,7 @@ class ConstrainedHartmannSmooth(Hartmann, ConstrainedSyntheticTestFunction):
         constraint_noise_std: None | float | list[float] = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:
@@ -975,9 +1006,15 @@ class ConstrainedHartmannSmooth(Hartmann, ConstrainedSyntheticTestFunction):
                 deviations for each constraint.
             negate: If True, negate the function.
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
+            dtype: The dtype that is used for the bounds of the function.
         """
         Hartmann.__init__(
-            self, dim=dim, noise_std=noise_std, negate=negate, bounds=bounds
+            self,
+            dim=dim,
+            noise_std=noise_std,
+            negate=negate,
+            bounds=bounds,
+            dtype=dtype,
         )
         self.constraint_noise_std = self._validate_constraint_noise(
             constraint_noise_std

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -697,7 +697,7 @@ class Rosenbrock(SyntheticTestFunction):
         noise_std: float | None = None,
         negate: bool = False,
         bounds: list[tuple[float, float]] | None = None,
-        dtype: torch.dtype = torch.dtype,
+        dtype: torch.dtype = torch.double,
     ) -> None:
         r"""
         Args:

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -271,6 +271,7 @@ class DixonPrice(SyntheticTestFunction):
             dim: The (input) dimension.
             noise_std: Standard deviation of the observation noise.
             negate: If True, negate the function.
+            dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
         if bounds is None:

--- a/test/test_functions/test_synthetic.py
+++ b/test/test_functions/test_synthetic.py
@@ -101,13 +101,13 @@ class TestCustomBounds(BotorchTestCase):
         self.assertEqual(dummy._bounds[1], (-3, 3))
         self.assertAllClose(
             dummy.bounds,
-            torch.tensor([[-2, -3], [2, 3]], dtype=torch.torch.get_default_dtype()),
+            torch.tensor([[-2, -3], [2, 3]], dtype=torch.double),
         )
 
         # Test each function with custom bounds.
         for func_class, dim in self.functions_with_custom_bounds:
             bounds = [(-1e5, 1e5) for _ in range(dim)]
-            bounds_tensor = torch.tensor(bounds, dtype=torch.get_default_dtype()).T
+            bounds_tensor = torch.tensor(bounds, dtype=torch.double).T
             func = func_class(bounds=bounds)
             self.assertEqual(func._bounds, bounds)
             self.assertAllClose(func.bounds, bounds_tensor)

--- a/test/test_functions/test_synthetic.py
+++ b/test/test_functions/test_synthetic.py
@@ -100,13 +100,14 @@ class TestCustomBounds(BotorchTestCase):
         self.assertEqual(dummy._bounds[0], (-2, 2))
         self.assertEqual(dummy._bounds[1], (-3, 3))
         self.assertAllClose(
-            dummy.bounds, torch.tensor([[-2, -3], [2, 3]], dtype=torch.double)
+            dummy.bounds,
+            torch.tensor([[-2, -3], [2, 3]], dtype=torch.torch.get_default_dtype()),
         )
 
         # Test each function with custom bounds.
         for func_class, dim in self.functions_with_custom_bounds:
             bounds = [(-1e5, 1e5) for _ in range(dim)]
-            bounds_tensor = torch.tensor(bounds, dtype=torch.double).T
+            bounds_tensor = torch.tensor(bounds, dtype=torch.get_default_dtype()).T
             func = func_class(bounds=bounds)
             self.assertEqual(func._bounds, bounds)
             self.assertAllClose(func.bounds, bounds_tensor)


### PR DESCRIPTION
## Motivation

This PR replaces the hard-coded double precision that was used in the initialization of `test_functions/base.py` to use `torch.get_default_dtype()` instead.

See #2596 for more details.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes, I have read it.

## Test Plan

I ran code formatting via `ufmt` and checked the code via `pytest -ra`. All tests related to the changes here were adjusted in the second commit of the branch.
Locally, two tests failed for me, but it seems to me that these are not related to the fix implemented here. If it turns out they are, I'd be more than happy to further adjust.

## Related PRs

None, but #2596 is related.
