### PR TITLE
Import fix in  custom_botorch_model_in_ax tutorial

### DIFF
--- a/tutorials/custom_botorch_model_in_ax.ipynb
+++ b/tutorials/custom_botorch_model_in_ax.ipynb
@@ -362,7 +362,7 @@
       ],
       "source": [
         "if SMOKE_TEST:\n",
-        "    fast_smoke_test = fast_botorch_optimize_context_manager\n",
+        "    fast_smoke_test = mock_botorch_optimize_context_manager\n",
         "else:\n",
         "    fast_smoke_test = nullcontext\n",
         "\n",

--- a/tutorials/custom_botorch_model_in_ax.ipynb
+++ b/tutorials/custom_botorch_model_in_ax.ipynb
@@ -34,7 +34,7 @@
         "import os\n",
         "from contextlib import contextmanager, nullcontext\n",
         "\n",
-        "from ax.utils.testing.mock import fast_botorch_optimize_context_manager\n",
+        "from ax.utils.testing.mock import mock_botorch_optimize_context_manager\n",
         "import plotly.io as pio\n",
         "\n",
         "# Ax uses Plotly to produce interactive plots. These are great for viewing and analysis,\n",


### PR DESCRIPTION
This optimizer mock was renamed in Ax, leading to an import failure in this tutorial.