### PR TITLE
Make input transfroms Modules by default

### DIFF
--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
+from abc import ABC
 from copy import deepcopy
 from random import randint
 
@@ -24,12 +25,14 @@ from botorch.models.transforms.input import (
     Log10,
     Normalize,
     OneHotToNumeric,
+    ReversibleInputTransform,
     Round,
     Warp,
 )
 from botorch.models.transforms.utils import expand_and_copy_tensor
 from botorch.models.utils import fantasize
 from botorch.utils.testing import BotorchTestCase
+from gpytorch import Module as GPyTorchModule
 from gpytorch.priors import LogNormalPrior
 from torch import Tensor
 from torch.distributions import Kumaraswamy
@@ -1158,6 +1161,20 @@ class TestInputTransforms(BotorchTestCase):
             self.assertTrue((warp_tf.concentration0 == 2.0).all())
             warp_tf._set_concentration(i=1, value=3.0)
             self.assertTrue((warp_tf.concentration1 == 3.0).all())
+
+    def test_warp_mro(self) -> None:
+        self.assertEqual(
+            Warp.__mro__,
+            (
+                Warp,
+                ReversibleInputTransform,
+                InputTransform,
+                GPyTorchModule,
+                Module,
+                ABC,
+                object,
+            ),
+        )
 
     def test_one_hot_to_numeric(self) -> None:
         dim = 8


### PR DESCRIPTION
Summary:
`InputTransform`s are required to be `torch.nn.Module` subclasses but the base class does not inherit from `torch.nn.Module`. This leads to type checker complaints when calling methods like `.to(...)`, since it doesn't know that they are `Module`s.

This was originally motivated by the inheritance order of `Warp` transform, as we want `GPyTorchModule` methods to take precedence over `torch.nn.Module`. However, this not actually a concern since the `GPyTorchModule` comes first in the MRO of `Warp` regardless of whether `InputTransform` inherits from `Module` (since `GPyTorchModule` itself inherits from `Module` as well).

This diff updates `InputTransform` to inherit from `Module` and removes the redundant `Module` inheritance from subclasses.

Differential Revision: D65338444


