### PR TITLE
Clean up settings.debug

### DIFF
--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -30,7 +30,6 @@ from botorch.optim.utils import (
     get_parameters,
     sample_all_priors,
 )
-from botorch.settings import debug
 from botorch.utils.context_managers import (
     module_rollback_ctx,
     parameter_rollback_ctx,
@@ -200,7 +199,7 @@ def _fit_fallback(
 
             try:
                 # Fit the model
-                with catch_warnings(record=True) as warning_list, debug(True):
+                with catch_warnings(record=True) as warning_list:
                     simplefilter("always", category=OptimizationWarning)
                     result = optimizer(mll, closure=closure, **optimizer_kwargs)
 
@@ -250,11 +249,7 @@ def _fit_fallback(
         mll.load_state_dict(best_state_dict)
         return mll.eval()
 
-    msg = "All attempts to fit the model have failed."
-    if debug.off():
-        msg = msg + " For more information, try enabling botorch.settings.debug mode."
-
-    raise ModelFittingError(msg)
+    raise ModelFittingError("All attempts to fit the model have failed.")
 
 
 @FitGPyTorchMLL.register(SumMarginalLogLikelihood, object, ModelListGP)

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -21,7 +21,6 @@ from math import ceil
 from typing import Optional, Union
 
 import torch
-from botorch import settings
 from botorch.acquisition import analytic, monte_carlo, multi_objective
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
@@ -341,7 +340,7 @@ def gen_batch_initial_conditions(
     q = 1 if q is None else q
     # the dimension the samples are drawn from
     effective_dim = bounds.shape[-1] * q
-    if effective_dim > SobolEngine.MAXDIM and settings.debug.on():
+    if effective_dim > SobolEngine.MAXDIM:
         warnings.warn(
             f"Sample dimension q*d={effective_dim} exceeding Sobol max dimension "
             f"({SobolEngine.MAXDIM}). Using iid samples instead.",

--- a/botorch/settings.py
+++ b/botorch/settings.py
@@ -51,21 +51,6 @@ class propagate_grads(_Flag):
     _state: bool = False
 
 
-class debug(_Flag):
-    r"""Flag for printing verbose warnings.
-
-    To make sure a warning is only raised in debug mode:
-        >>> if debug.on():
-        >>>     warnings.warn(<some warning>)
-    """
-
-    _state: bool = False
-
-    @classmethod
-    def _set_state(cls, state: bool) -> None:
-        cls._state = state
-
-
 class validate_input_scaling(_Flag):
     r"""Flag for validating input normalization/standardization.
 

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -16,7 +16,6 @@ from typing import Any
 from unittest import mock, TestCase
 
 import torch
-from botorch import settings
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.exceptions.warnings import BotorchTensorDimensionWarning, InputDataWarning
 from botorch.models.model import FantasizeMixin, Model
@@ -47,7 +46,6 @@ class BotorchTestCase(TestCase):
 
     def setUp(self, suppress_input_warnings: bool = True) -> None:
         warnings.resetwarnings()
-        settings.debug._set_state(False)
         warnings.simplefilter("always", append=True)
         if suppress_input_warnings:
             warnings.filterwarnings(

--- a/test/acquisition/multi_objective/test_multi_fidelity.py
+++ b/test/acquisition/multi_objective/test_multi_fidelity.py
@@ -8,7 +8,6 @@ import warnings
 from unittest import mock
 
 import torch
-from botorch import settings
 from botorch.acquisition.multi_objective.multi_fidelity import MOMF
 from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
 from botorch.exceptions.errors import BotorchError
@@ -149,11 +148,11 @@ class TestMOMF(BotorchTestCase):
             acqf.model._posterior._samples = torch.zeros(1, 2, 2, **tkwargs)
             res = acqf(X)
             X2 = torch.zeros(1, 1, 1, requires_grad=True, **tkwargs)
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            with warnings.catch_warnings(record=True) as ws:
                 acqf.set_X_pending(X2)
-                self.assertEqual(acqf.X_pending, X2)
-                self.assertEqual(len(ws), 1)
-                self.assertTrue(issubclass(ws[-1].category, BotorchWarning))
+            self.assertEqual(acqf.X_pending, X2)
+            self.assertEqual(len(ws), 1)
+            self.assertTrue(issubclass(ws[-1].category, BotorchWarning))
 
             # test objective
             acqf = MOMF(

--- a/test/acquisition/multi_objective/test_multi_output_risk_measures.py
+++ b/test/acquisition/multi_objective/test_multi_output_risk_measures.py
@@ -7,7 +7,6 @@
 import warnings
 
 import torch
-from botorch import settings
 from botorch.acquisition.multi_objective.multi_output_risk_measures import (
     IndependentCVaR,
     IndependentVaR,
@@ -512,7 +511,7 @@ class TestMARS(BotorchTestCase):
         # With Y_samples.
         mars._baseline_Y = None
         Y_samples = model.posterior(X_baseline).mean
-        with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+        with warnings.catch_warnings(record=True) as ws:
             mars.set_baseline_Y(model=model, X_baseline=X_baseline, Y_samples=Y_samples)
         self.assertTrue(torch.equal(mars.baseline_Y, torch.tensor([[1.5, 1.5]])))
         self.assertTrue(any(w.category == BotorchWarning for w in ws))

--- a/test/acquisition/test_cost_aware.py
+++ b/test/acquisition/test_cost_aware.py
@@ -8,7 +8,6 @@
 import warnings
 
 import torch
-from botorch import settings
 from botorch.acquisition.cost_aware import (
     CostAwareUtility,
     GenericCostAwareUtility,
@@ -63,11 +62,11 @@ class TestCostAwareUtilities(BotorchTestCase):
                 # check warning for negative cost
                 mm = MockModel(MockPosterior(mean=mean.clamp_max(-1e-6)))
                 icwu = InverseCostWeightedUtility(mm)
-                with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+                with warnings.catch_warnings(record=True) as ws:
                     icwu(X, deltas)
-                    self.assertTrue(
-                        any(issubclass(w.category, CostAwareWarning) for w in ws)
-                    )
+                self.assertTrue(
+                    any(issubclass(w.category, CostAwareWarning) for w in ws)
+                )
 
                 # basic test for both positive and negative delta values
                 mm = MockModel(MockPosterior(mean=mean))

--- a/test/acquisition/test_decoupled.py
+++ b/test/acquisition/test_decoupled.py
@@ -7,7 +7,6 @@
 import warnings
 
 import torch
-from botorch import settings
 from botorch.acquisition.decoupled import DecoupledAcquisitionFunction
 from botorch.exceptions import BotorchTensorDimensionError, BotorchWarning
 from botorch.logging import shape_to_str
@@ -74,10 +73,10 @@ class TestDecoupledAcquisitionFunction(BotorchTestCase):
             af.set_X_pending(X_pending=X_pending)
         af.X_evaluation_mask = None
         X_pending = X_pending.requires_grad_(True)
-        with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+        with warnings.catch_warnings(record=True) as ws:
             af.set_X_pending(X_pending)
-            self.assertEqual(af.X_pending, X_pending)
-            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
+        self.assertEqual(af.X_pending, X_pending)
+        self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
         self.assertIsNone(af.X_evaluation_mask)
 
         # test setting X_pending with X_pending_evaluation_mask

--- a/test/acquisition/test_logei.py
+++ b/test/acquisition/test_logei.py
@@ -11,7 +11,6 @@ from math import pi
 from unittest import mock
 
 import torch
-from botorch import settings
 from botorch.acquisition import (
     AcquisitionFunction,
     LogImprovementMCAcquisitionFunction,
@@ -204,12 +203,10 @@ class TestQLogExpectedImprovement(BotorchTestCase):
             mm._posterior._samples = torch.zeros(1, 2, 1, **tkwargs)
             res = acqf(X)
             X2 = torch.zeros(1, 1, 1, **tkwargs, requires_grad=True)
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            with warnings.catch_warnings(record=True) as ws:
                 acqf.set_X_pending(X2)
-                self.assertEqual(acqf.X_pending, X2)
-                self.assertEqual(
-                    sum(issubclass(w.category, BotorchWarning) for w in ws), 1
-                )
+            self.assertEqual(acqf.X_pending, X2)
+            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
             # testing with illegal taus
             with self.assertRaisesRegex(ValueError, "tau_max is not a scalar:"):
@@ -419,12 +416,10 @@ class TestQLogNoisyExpectedImprovement(BotorchTestCase):
             X2 = torch.zeros(
                 1, 1, 1, device=self.device, dtype=dtype, requires_grad=True
             )
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            with warnings.catch_warnings(record=True) as ws:
                 log_acqf.set_X_pending(X2)
-                self.assertEqual(log_acqf.X_pending, X2)
-                self.assertEqual(
-                    sum(issubclass(w.category, BotorchWarning) for w in ws), 1
-                )
+            self.assertEqual(log_acqf.X_pending, X2)
+            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
     def test_q_noisy_expected_improvement_batch(self):
         for dtype in (torch.float, torch.double):
@@ -670,9 +665,8 @@ class TestQLogNoisyExpectedImprovement(BotorchTestCase):
             # test we fall back to standard sampling for
             # ill-conditioned covariances
             acqf._baseline_L = torch.zeros_like(acqf._baseline_L)
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
-                with torch.no_grad():
-                    acqf(test_X)
+            with warnings.catch_warnings(record=True) as ws, torch.no_grad():
+                acqf(test_X)
             self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
         # test w/ posterior transform

--- a/test/acquisition/test_monte_carlo.py
+++ b/test/acquisition/test_monte_carlo.py
@@ -10,11 +10,11 @@ from copy import deepcopy
 from functools import partial
 from itertools import product
 from math import pi
+from typing import Any
 from unittest import mock
 from warnings import catch_warnings, simplefilter
 
 import torch
-from botorch import settings
 from botorch.acquisition.monte_carlo import (
     MCAcquisitionFunction,
     qExpectedImprovement,
@@ -109,7 +109,7 @@ class TestQExpectedImprovement(BotorchTestCase):
                     self._test_q_expected_improvement(dtype)
 
     def _test_q_expected_improvement(self, dtype: torch.dtype) -> None:
-        tkwargs = {"device": self.device, "dtype": dtype}
+        tkwargs: dict[str, Any] = {"device": self.device, "dtype": dtype}
         # the event shape is `b x q x t` = 1 x 1 x 1
         samples = torch.zeros(1, 1, 1, **tkwargs)
         mm = MockModel(MockPosterior(samples=samples))
@@ -161,10 +161,10 @@ class TestQExpectedImprovement(BotorchTestCase):
         mm._posterior._samples = torch.zeros(1, 2, 1, **tkwargs)
         res = acqf(X)
         X2 = torch.zeros(1, 1, 1, **tkwargs, requires_grad=True)
-        with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+        with warnings.catch_warnings(record=True) as ws:
             acqf.set_X_pending(X2)
-            self.assertEqual(acqf.X_pending, X2)
-            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
+        self.assertEqual(acqf.X_pending, X2)
+        self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
     def test_q_expected_improvement_batch(self):
         for dtype in (torch.float, torch.double):
@@ -330,10 +330,10 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
         self.assertEqual(acqf.X_pending, X)
         res = acqf(X)
         X2 = torch.zeros(1, 1, 1, device=self.device, dtype=dtype, requires_grad=True)
-        with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+        with warnings.catch_warnings(record=True) as ws:
             acqf.set_X_pending(X2)
-            self.assertEqual(acqf.X_pending, X2)
-            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
+        self.assertEqual(acqf.X_pending, X2)
+        self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
     def test_q_noisy_expected_improvement_batch(self):
         for dtype in (torch.float, torch.double):
@@ -586,9 +586,8 @@ class TestQNoisyExpectedImprovement(BotorchTestCase):
             # test we fall back to standard sampling for
             # ill-conditioned covariances
             acqf._baseline_L = torch.zeros_like(acqf._baseline_L)
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
-                with torch.no_grad():
-                    acqf(test_X)
+            with warnings.catch_warnings(record=True) as ws, torch.no_grad():
+                acqf(test_X)
             self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
         # test w/ posterior transform
@@ -693,12 +692,10 @@ class TestQProbabilityOfImprovement(BotorchTestCase):
             X2 = torch.zeros(
                 1, 1, 1, device=self.device, dtype=dtype, requires_grad=True
             )
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            with warnings.catch_warnings(record=True) as ws:
                 acqf.set_X_pending(X2)
-                self.assertEqual(acqf.X_pending, X2)
-                self.assertEqual(
-                    sum(issubclass(w.category, BotorchWarning) for w in ws), 1
-                )
+            self.assertEqual(acqf.X_pending, X2)
+            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
     def test_q_probability_of_improvement_batch(self):
         # the event shape is `b x q x t` = 2 x 2 x 1
@@ -806,12 +803,10 @@ class TestQSimpleRegret(BotorchTestCase):
             X2 = torch.zeros(
                 1, 1, 1, device=self.device, dtype=dtype, requires_grad=True
             )
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            with warnings.catch_warnings(record=True) as ws:
                 acqf.set_X_pending(X2)
-                self.assertEqual(acqf.X_pending, X2)
-                self.assertEqual(
-                    sum(issubclass(w.category, BotorchWarning) for w in ws), 1
-                )
+            self.assertEqual(acqf.X_pending, X2)
+            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
     def test_q_simple_regret_batch(self):
         # the event shape is `b x q x t` = 2 x 2 x 1
@@ -920,12 +915,10 @@ class TestQUpperConfidenceBound(BotorchTestCase):
             X2 = torch.zeros(
                 1, 1, 1, device=self.device, dtype=dtype, requires_grad=True
             )
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            with warnings.catch_warnings(record=True) as ws:
                 acqf.set_X_pending(X2)
-                self.assertEqual(acqf.X_pending, X2)
-                self.assertEqual(
-                    sum(issubclass(w.category, BotorchWarning) for w in ws), 1
-                )
+            self.assertEqual(acqf.X_pending, X2)
+            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
     def test_q_confidence_bound_batch(self):
         # TODO: T41739913 Implement tests for all MCAcquisitionFunctions
@@ -987,12 +980,10 @@ class TestQUpperConfidenceBound(BotorchTestCase):
             X2 = torch.zeros(
                 1, 1, 1, device=self.device, dtype=dtype, requires_grad=True
             )
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            with warnings.catch_warnings(record=True) as ws:
                 acqf.set_X_pending(X2)
-                self.assertEqual(acqf.X_pending, X2)
-                self.assertEqual(
-                    sum(issubclass(w.category, BotorchWarning) for w in ws), 1
-                )
+            self.assertEqual(acqf.X_pending, X2)
+            self.assertEqual(sum(issubclass(w.category, BotorchWarning) for w in ws), 1)
 
     def test_beta_prime(self, negate: bool = False) -> None:
         acqf = self.acqf_class(

--- a/test/exceptions/test_warnings.py
+++ b/test/exceptions/test_warnings.py
@@ -6,7 +6,6 @@
 
 import warnings
 
-from botorch import settings
 from botorch.exceptions.warnings import (
     BadInitialCandidatesWarning,
     BotorchTensorDimensionWarning,
@@ -42,8 +41,8 @@ class TestBotorchWarnings(BotorchTestCase):
             SamplingWarning,
             UserInputWarning,
         ):
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            with warnings.catch_warnings(record=True) as ws:
                 warnings.warn("message", WarningClass, stacklevel=1)
-                self.assertEqual(len(ws), 1)
-                self.assertTrue(issubclass(ws[-1].category, WarningClass))
-                self.assertTrue("message" in str(ws[-1].message))
+            self.assertEqual(len(ws), 1)
+            self.assertTrue(issubclass(ws[-1].category, WarningClass))
+            self.assertTrue("message" in str(ws[-1].message))

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -8,7 +8,6 @@ import itertools
 import warnings
 
 import torch
-from botorch import settings
 from botorch.acquisition.objective import ScalarizedPosteriorTransform
 from botorch.exceptions import (
     BotorchTensorDimensionError,
@@ -232,7 +231,7 @@ class TestGPyTorchModel(BotorchTestCase):
                     BotorchTensorDimensionError, expected_message
                 ):
                     GPyTorchModel._validate_tensor_args(X, Y[0])
-                with settings.debug(True), self.assertWarnsRegex(
+                with self.assertWarnsRegex(
                     BotorchTensorDimensionWarning,
                     (
                         "Non-strict enforcement of botorch tensor conventions. "

--- a/test/models/utils/test_assorted.py
+++ b/test/models/utils/test_assorted.py
@@ -83,60 +83,47 @@ class TestInputDataChecks(BotorchTestCase):
             check_no_nans(torch.tensor([1.0, float("nan")]))
 
     def test_check_min_max_scaling(self):
-        with settings.debug(True):
-            # check unscaled input in unit cube
-            X = 0.1 + 0.8 * torch.rand(4, 2, 3)
-            with warnings.catch_warnings(record=True) as ws:
-                check_min_max_scaling(X=X)
-                self.assertFalse(
-                    any(issubclass(w.category, InputDataWarning) for w in ws)
-                )
+        # check unscaled input in unit cube
+        X = 0.1 + 0.8 * torch.rand(4, 2, 3)
+        with warnings.catch_warnings(record=True) as ws:
+            check_min_max_scaling(X=X)
+            self.assertFalse(any(issubclass(w.category, InputDataWarning) for w in ws))
+        check_min_max_scaling(X=X, raise_on_fail=True)
+        with self.assertWarnsRegex(
+            expected_warning=InputDataWarning, expected_regex="not scaled"
+        ):
+            check_min_max_scaling(X=X, strict=True)
+        with self.assertRaises(InputDataError):
+            check_min_max_scaling(X=X, strict=True, raise_on_fail=True)
+        # check proper input
+        Xmin, Xmax = X.min(dim=-1, keepdim=True)[0], X.max(dim=-1, keepdim=True)[0]
+        Xstd = (X - Xmin) / (Xmax - Xmin)
+        with warnings.catch_warnings(record=True) as ws:
+            check_min_max_scaling(X=Xstd)
+            self.assertFalse(any(issubclass(w.category, InputDataWarning) for w in ws))
+        check_min_max_scaling(X=Xstd, raise_on_fail=True)
+        with warnings.catch_warnings(record=True) as ws:
+            check_min_max_scaling(X=Xstd, strict=True)
+            self.assertFalse(any(issubclass(w.category, InputDataWarning) for w in ws))
+        check_min_max_scaling(X=Xstd, strict=True, raise_on_fail=True)
+        # check violation
+        X[0, 0, 0] = 2
+        with warnings.catch_warnings(record=True) as ws:
+            check_min_max_scaling(X=X)
+            self.assertTrue(any(issubclass(w.category, InputDataWarning) for w in ws))
+            self.assertTrue(any("not contained" in str(w.message) for w in ws))
+        with self.assertRaises(InputDataError):
             check_min_max_scaling(X=X, raise_on_fail=True)
-            with self.assertWarnsRegex(
-                expected_warning=InputDataWarning, expected_regex="not scaled"
-            ):
-                check_min_max_scaling(X=X, strict=True)
-            with self.assertRaises(InputDataError):
-                check_min_max_scaling(X=X, strict=True, raise_on_fail=True)
-            # check proper input
-            Xmin, Xmax = X.min(dim=-1, keepdim=True)[0], X.max(dim=-1, keepdim=True)[0]
-            Xstd = (X - Xmin) / (Xmax - Xmin)
-            with warnings.catch_warnings(record=True) as ws:
-                check_min_max_scaling(X=Xstd)
-                self.assertFalse(
-                    any(issubclass(w.category, InputDataWarning) for w in ws)
-                )
-            check_min_max_scaling(X=Xstd, raise_on_fail=True)
-            with warnings.catch_warnings(record=True) as ws:
-                check_min_max_scaling(X=Xstd, strict=True)
-                self.assertFalse(
-                    any(issubclass(w.category, InputDataWarning) for w in ws)
-                )
-            check_min_max_scaling(X=Xstd, strict=True, raise_on_fail=True)
-            # check violation
-            X[0, 0, 0] = 2
-            with warnings.catch_warnings(record=True) as ws:
-                check_min_max_scaling(X=X)
-                self.assertTrue(
-                    any(issubclass(w.category, InputDataWarning) for w in ws)
-                )
-                self.assertTrue(any("not contained" in str(w.message) for w in ws))
-            with self.assertRaises(InputDataError):
-                check_min_max_scaling(X=X, raise_on_fail=True)
-            with warnings.catch_warnings(record=True) as ws:
-                check_min_max_scaling(X=X, strict=True)
-                self.assertTrue(
-                    any(issubclass(w.category, InputDataWarning) for w in ws)
-                )
-                self.assertTrue(any("not contained" in str(w.message) for w in ws))
-            with self.assertRaises(InputDataError):
-                check_min_max_scaling(X=X, strict=True, raise_on_fail=True)
-            # check ignore_dims
-            with warnings.catch_warnings(record=True) as ws:
-                check_min_max_scaling(X=X, ignore_dims=[0])
-                self.assertFalse(
-                    any(issubclass(w.category, InputDataWarning) for w in ws)
-                )
+        with warnings.catch_warnings(record=True) as ws:
+            check_min_max_scaling(X=X, strict=True)
+            self.assertTrue(any(issubclass(w.category, InputDataWarning) for w in ws))
+            self.assertTrue(any("not contained" in str(w.message) for w in ws))
+        with self.assertRaises(InputDataError):
+            check_min_max_scaling(X=X, strict=True, raise_on_fail=True)
+        # check ignore_dims
+        with warnings.catch_warnings(record=True) as ws:
+            check_min_max_scaling(X=X, ignore_dims=[0])
+            self.assertFalse(any(issubclass(w.category, InputDataWarning) for w in ws))
 
     def test_check_standardization(self):
         # Ensure that it is not filtered out.
@@ -182,22 +169,18 @@ class TestInputDataChecks(BotorchTestCase):
         train_X = 2 + torch.rand(3, 4, 3)
         train_Y = torch.randn(3, 4, 2)
         # check that nothing is being checked
-        with settings.validate_input_scaling(False), settings.debug(True):
-            with warnings.catch_warnings(record=True) as ws:
-                validate_input_scaling(train_X=train_X, train_Y=train_Y)
-                self.assertFalse(
-                    any(issubclass(w.category, InputDataWarning) for w in ws)
-                )
-        # check that warnings are being issued
-        with settings.debug(True), warnings.catch_warnings(record=True) as ws:
+        with settings.validate_input_scaling(False), warnings.catch_warnings(
+            record=True
+        ) as ws:
             validate_input_scaling(train_X=train_X, train_Y=train_Y)
-            self.assertTrue(any(issubclass(w.category, InputDataWarning) for w in ws))
+        self.assertFalse(any(issubclass(w.category, InputDataWarning) for w in ws))
+        # check that warnings are being issued
+        with warnings.catch_warnings(record=True) as ws:
+            validate_input_scaling(train_X=train_X, train_Y=train_Y)
+        self.assertTrue(any(issubclass(w.category, InputDataWarning) for w in ws))
         # check that errors are raised when requested
-        with settings.debug(True):
-            with self.assertRaises(InputDataError):
-                validate_input_scaling(
-                    train_X=train_X, train_Y=train_Y, raise_on_fail=True
-                )
+        with self.assertRaises(InputDataError):
+            validate_input_scaling(train_X=train_X, train_Y=train_Y, raise_on_fail=True)
         # check that no errors are being raised if everything is standardized
         train_X_min = train_X.min(dim=-1, keepdim=True)[0]
         train_X_max = train_X.max(dim=-1, keepdim=True)[0]
@@ -205,22 +188,20 @@ class TestInputDataChecks(BotorchTestCase):
         train_Y_std = (train_Y - train_Y.mean(dim=-2, keepdim=True)) / train_Y.std(
             dim=-2, keepdim=True
         )
-        with settings.debug(True), warnings.catch_warnings(record=True) as ws:
+        with warnings.catch_warnings(record=True) as ws:
             validate_input_scaling(train_X=train_X_std, train_Y=train_Y_std)
-            self.assertFalse(any(issubclass(w.category, InputDataWarning) for w in ws))
+        self.assertFalse(any(issubclass(w.category, InputDataWarning) for w in ws))
         # test that negative variances raise an error
         train_Yvar = torch.rand_like(train_Y_std)
         train_Yvar[0, 0, 1] = -0.5
-        with settings.debug(True):
-            with self.assertRaises(InputDataError):
-                validate_input_scaling(
-                    train_X=train_X_std, train_Y=train_Y_std, train_Yvar=train_Yvar
-                )
+        with self.assertRaises(InputDataError):
+            validate_input_scaling(
+                train_X=train_X_std, train_Y=train_Y_std, train_Yvar=train_Yvar
+            )
         # check that NaNs raise errors
         train_X_std[0, 0, 0] = float("nan")
-        with settings.debug(True):
-            with self.assertRaises(InputDataError):
-                validate_input_scaling(train_X=train_X_std, train_Y=train_Y_std)
+        with self.assertRaises(InputDataError):
+            validate_input_scaling(train_X=train_X_std, train_Y=train_Y_std)
 
 
 class TestGPTPosteriorSettings(BotorchTestCase):

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -11,7 +11,6 @@ from random import random
 from unittest import mock
 
 import torch
-from botorch import settings
 from botorch.acquisition.analytic import PosteriorMean
 from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
@@ -109,7 +108,7 @@ class TestInitializeQBatch(BotorchTestCase):
             self.assertEqual(ics.dtype, X.dtype)
             # ensure raises correct warning
             acq_vals = torch.zeros(5, device=self.device, dtype=dtype)
-            with warnings.catch_warnings(record=True) as w, settings.debug(True):
+            with warnings.catch_warnings(record=True) as w:
                 ics, _ = initialize_q_batch_nonneg(X=X, acq_vals=acq_vals, n=2)
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, BadInitialCandidatesWarning))
@@ -148,7 +147,7 @@ class TestInitializeQBatch(BotorchTestCase):
                 self.assertTrue(torch.equal(acq_vals, ics_acq_vals))
                 # ensure raises correct warning
                 acq_vals = torch.zeros(5, device=self.device, dtype=dtype)
-                with warnings.catch_warnings(record=True) as w, settings.debug(True):
+                with warnings.catch_warnings(record=True) as w:
                     ics, _ = initialize_q_batch(X=X, acq_vals=acq_vals, n=2)
                 self.assertEqual(len(w), 1)
                 self.assertTrue(issubclass(w[-1].category, BadInitialCandidatesWarning))
@@ -261,7 +260,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
             for nonnegative, seed, ffs, sample_around_best in product(
                 [True, False], [None, 1234], [None, ffs_map], [True, False]
             ):
-                with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+                with warnings.catch_warnings(record=True) as ws:
                     warnings.simplefilter(
                         "ignore", category=BadInitialCandidatesWarning
                     )
@@ -1303,7 +1302,7 @@ class TestSampleAroundBest(BotorchTestCase):
             # test EI without X_baseline
             acqf = qExpectedImprovement(model, best_f=0.0)
 
-            with warnings.catch_warnings(record=True) as w, settings.debug(True):
+            with warnings.catch_warnings(record=True) as w:
                 X_rnd = sample_points_around_best(
                     acq_function=acqf,
                     n_discrete_points=4,
@@ -1345,7 +1344,7 @@ class TestSampleAroundBest(BotorchTestCase):
             ff = FixedFeatureAcquisitionFunction(pm, d=2, columns=[0], values=[0])
             # set X_baseline for testing purposes
             ff.X_baseline = X_train
-            with warnings.catch_warnings(record=True) as w, settings.debug(True):
+            with warnings.catch_warnings(record=True) as w:
                 X_rnd = sample_points_around_best(
                     acq_function=ff,
                     n_discrete_points=4,

--- a/test/optim/utils/test_acquisition_utils.py
+++ b/test/optim/utils/test_acquisition_utils.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import warnings
 
 import torch
-from botorch import settings
 from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
 from botorch.acquisition.monte_carlo import (
     qExpectedImprovement,
@@ -163,13 +162,13 @@ class TestGetXBaseline(BotorchTestCase):
             # test EI without X_baseline
             acqf = qExpectedImprovement(model, best_f=0.0)
 
-            with warnings.catch_warnings(record=True) as w, settings.debug(True):
+            with warnings.catch_warnings(record=True) as w:
                 X_rnd = get_X_baseline(
                     acq_function=acqf,
                 )
-                self.assertEqual(len(w), 1)
-                self.assertTrue(issubclass(w[-1].category, BotorchWarning))
-                self.assertIsNone(X_rnd)
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, BotorchWarning))
+            self.assertIsNone(X_rnd)
 
             # set train inputs
             model.train_inputs = (X_train,)
@@ -182,13 +181,13 @@ class TestGetXBaseline(BotorchTestCase):
 
             # test acquisition function without X_baseline or model
             acqf = FixedFeatureAcquisitionFunction(acqf, d=2, columns=[0], values=[0])
-            with warnings.catch_warnings(record=True) as w, settings.debug(True):
+            with warnings.catch_warnings(record=True) as w:
                 X_rnd = get_X_baseline(
                     acq_function=acqf,
                 )
-                self.assertEqual(len(w), 1)
-                self.assertTrue(issubclass(w[-1].category, BotorchWarning))
-                self.assertIsNone(X_rnd)
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, BotorchWarning))
+            self.assertIsNone(X_rnd)
 
             Y_train = 2 * X_train[:2] + 1
             moo_model = MockModel(MockPosterior(mean=Y_train, samples=Y_train))

--- a/test/optim/utils/test_model_utils.py
+++ b/test/optim/utils/test_model_utils.py
@@ -15,7 +15,6 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import torch
-from botorch import settings
 from botorch.models import SingleTaskGP
 from botorch.models.utils.gpytorch_modules import (
     get_covar_module_with_dim_scaled_prior,
@@ -204,10 +203,10 @@ class TestSampleAllPriors(BotorchTestCase):
                 outputscale_prior=GammaPrior(2.0, 0.15),
             )
             original_state_dict = dict(deepcopy(mll.model.state_dict()))
-            with warnings.catch_warnings(record=True) as ws, settings.debug(True):
+            with warnings.catch_warnings(record=True) as ws:
                 sample_all_priors(model)
-                self.assertEqual(len(ws), 1)
-                self.assertTrue("rsample" in str(ws[0].message))
+            self.assertEqual(len(ws), 1)
+            self.assertTrue("rsample" in str(ws[0].message))
 
             # change to dummy prior that raises an unrecognized RuntimeError
             model.covar_module = ScaleKernel(

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -24,7 +24,6 @@ from botorch.optim.closures import get_loss_closure_with_grads
 from botorch.optim.core import OptimizationResult, OptimizationStatus
 from botorch.optim.fit import fit_gpytorch_mll_scipy, fit_gpytorch_mll_torch
 from botorch.optim.utils import get_data_loader
-from botorch.settings import debug
 from botorch.utils.context_managers import module_rollback_ctx, TensorCheckpoint
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.kernels import RBFKernel
@@ -235,7 +234,6 @@ class TestFitFallback(BotorchTestCase):
                     else nullcontext()
                 )
                 ws = es.enter_context(catch_warnings(record=True))
-                es.enter_context(debug(True))
 
                 try:
                     fit._fit_fallback(

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -4,54 +4,23 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import warnings
 
 import gpytorch.settings as gp_settings
 import linear_operator.settings as linop_settings
 from botorch import settings
-from botorch.exceptions import BotorchWarning
 from botorch.utils.testing import BotorchTestCase
 
 
 class TestSettings(BotorchTestCase):
     def test_flags(self):
-        for flag in (settings.debug, settings.propagate_grads):
-            self.assertFalse(flag.on())
-            self.assertTrue(flag.off())
-            with flag(True):
-                self.assertTrue(flag.on())
-                self.assertFalse(flag.off())
-            self.assertFalse(flag.on())
-            self.assertTrue(flag.off())
-
-    def test_debug(self):
-        # Turn on debug.
-        settings.debug._set_state(True)
-        # Check that debug warnings are suppressed when it is turned off.
-        with settings.debug(False):
-            with warnings.catch_warnings(record=True) as ws:
-                if settings.debug.on():
-                    warnings.warn("test", BotorchWarning, stacklevel=1)
-            self.assertEqual(len(ws), 0)
-        # Check that warnings are not suppressed outside of context manager.
-        with warnings.catch_warnings(record=True) as ws:
-            if settings.debug.on():
-                warnings.warn("test", BotorchWarning, stacklevel=1)
-        self.assertEqual(len(ws), 1)
-
-        # Turn off debug.
-        settings.debug._set_state(False)
-        # Check that warnings are not suppressed within debug.
-        with settings.debug(True):
-            with warnings.catch_warnings(record=True) as ws:
-                if settings.debug.on():
-                    warnings.warn("test", BotorchWarning, stacklevel=1)
-            self.assertEqual(len(ws), 1)
-        # Check that warnings are suppressed outside of context manager.
-        with warnings.catch_warnings(record=True) as ws:
-            if settings.debug.on():
-                warnings.warn("test", BotorchWarning, stacklevel=1)
-        self.assertEqual(len(ws), 0)
+        flag = settings.propagate_grads
+        self.assertFalse(flag.on())
+        self.assertTrue(flag.off())
+        with flag(True):
+            self.assertTrue(flag.on())
+            self.assertFalse(flag.off())
+        self.assertFalse(flag.on())
+        self.assertTrue(flag.off())
 
 
 class TestDefaultGPyTorchLinOpSettings(BotorchTestCase):


### PR DESCRIPTION
Summary: In the past, `settings.debug` used to supress all `BoTorchWarnings`. Some time ago, we reduced its scope and started surfacing these warnings again. Since then, there are only a couple places where `settings.debug` is used. I was curious how much usage it had left and decided to clean it up completely while at it.

Differential Revision: D65498337


