### PR TITLE
Clean up support for legacy format non-linear constraints

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -22,10 +22,7 @@ import torch
 from botorch.acquisition import AcquisitionFunction
 from botorch.exceptions.errors import OptimizationGradientError
 from botorch.exceptions.warnings import OptimizationWarning
-from botorch.generation.utils import (
-    _convert_nonlinear_inequality_constraints,
-    _remove_fixed_features_from_optimization,
-)
+from botorch.generation.utils import _remove_fixed_features_from_optimization
 from botorch.logging import logger
 from botorch.optim.parameter_constraints import (
     _arrayify,
@@ -135,16 +132,6 @@ def gen_candidates_scipy(
         # if there are we need to make sure features are fixed to specific values
         else:
             reduced_domain = None not in fixed_features.values()
-
-    if nonlinear_inequality_constraints:
-        if not isinstance(nonlinear_inequality_constraints, list):
-            raise ValueError(
-                "`nonlinear_inequality_constraints` must be a list of tuples, "
-                f"got {type(nonlinear_inequality_constraints)}."
-            )
-        nonlinear_inequality_constraints = _convert_nonlinear_inequality_constraints(
-            nonlinear_inequality_constraints
-        )
 
     if reduced_domain:
         _no_fixed_features = _remove_fixed_features_from_optimization(

--- a/botorch/generation/utils.py
+++ b/botorch/generation/utils.py
@@ -6,46 +6,16 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 
 import torch
-
 from botorch.acquisition import AcquisitionFunction, FixedFeatureAcquisitionFunction
 from botorch.optim.parameter_constraints import (
     _generate_unfixed_lin_constraints,
     _generate_unfixed_nonlin_constraints,
 )
 from torch import Tensor
-
-
-def _convert_nonlinear_inequality_constraints(
-    nonlinear_inequality_constraints: list[Callable | tuple[Callable, bool]],
-) -> list[tuple[Callable, bool]]:
-    """Convert legacy defintions of nonlinear inequality constraints into the new
-    format. Assumes intra-point constraints.
-    """
-    nlcs = []
-    legacy = False
-    # return nonlinear_inequality_constraints
-    for nlc in nonlinear_inequality_constraints:
-        if callable(nlc):
-            # old style --> convert
-            nlcs.append((nlc, True))
-            legacy = True
-        else:
-            nlcs.append(nlc)
-    if legacy:
-        warnings.warn(
-            "The `nonlinear_inequality_constraints` argument is expected "
-            "take a list of tuples. Passing a list of callables "
-            "will result in an error in future versions.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-
-    return nlcs
 
 
 def _flip_sub_unique(x: Tensor, k: int) -> Tensor:

--- a/botorch/utils/datasets.py
+++ b/botorch/utils/datasets.py
@@ -8,7 +8,6 @@ r"""Representations for different kinds of datasets."""
 
 from __future__ import annotations
 
-import warnings
 from typing import Any
 
 import torch
@@ -146,39 +145,6 @@ class SupervisedDataset:
             )
             and self.feature_names == other.feature_names
             and self.outcome_names == other.outcome_names
-        )
-
-
-class FixedNoiseDataset(SupervisedDataset):
-    r"""A SupervisedDataset with an additional field `Yvar` that stipulates
-    observations variances so that `Y[i] ~ N(f(X[i]), Yvar[i])`.
-
-    NOTE: This is deprecated. Use `SupervisedDataset` instead.
-    Will be removed in a future release (~v0.11).
-    """
-
-    def __init__(
-        self,
-        X: BotorchContainer | Tensor,
-        Y: BotorchContainer | Tensor,
-        Yvar: BotorchContainer | Tensor,
-        feature_names: list[str],
-        outcome_names: list[str],
-        validate_init: bool = True,
-    ) -> None:
-        r"""Initialize a `FixedNoiseDataset` -- deprecated!"""
-        warnings.warn(
-            "`FixedNoiseDataset` is deprecated. Use `SupervisedDataset` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(
-            X=X,
-            Y=Y,
-            feature_names=feature_names,
-            outcome_names=outcome_names,
-            Yvar=Yvar,
-            validate_init=validate_init,
         )
 
 

--- a/test/generation/test_utils.py
+++ b/test/generation/test_utils.py
@@ -12,7 +12,6 @@ import torch
 
 from botorch.acquisition import FixedFeatureAcquisitionFunction
 from botorch.generation.utils import (
-    _convert_nonlinear_inequality_constraints,
     _flip_sub_unique,
     _remove_fixed_features_from_optimization,
 )
@@ -20,27 +19,6 @@ from botorch.utils.testing import BotorchTestCase, MockAcquisitionFunction
 
 
 class TestGenerationUtils(BotorchTestCase):
-    def test_convert_nonlinear_inequality_constraints(self):
-        def nlc(x):
-            return x[..., 2]
-
-        def nlc2(x):
-            return x[..., 3]
-
-        nlcs = [nlc]
-        with self.assertWarns(DeprecationWarning):
-            new_nlcs = _convert_nonlinear_inequality_constraints(nlcs)
-        self.assertEqual(new_nlcs, [(nlc, True)])
-
-        nlcs = [(nlc, False)]
-        new_nlcs = _convert_nonlinear_inequality_constraints(nlcs)
-        self.assertEqual(new_nlcs, [(nlc, False)])
-
-        nlcs = [(nlc, False), nlc2]
-        with self.assertWarns(DeprecationWarning):
-            new_nlcs = _convert_nonlinear_inequality_constraints(nlcs)
-        self.assertEqual(new_nlcs, [(nlc, False), (nlc2, True)])
-
     def test_flip_sub_unique(self):
         for dtype in (torch.float, torch.double):
             tkwargs = {"device": self.device, "dtype": dtype}

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -953,20 +953,6 @@ class TestOptimizeAcqf(BotorchTestCase):
                 )
                 self.assertEqual(candidates.size(), torch.Size([1, 3]))
 
-            # Constraints must be passed in as lists
-            with self.assertRaisesRegex(
-                ValueError,
-                "`nonlinear_inequality_constraints` must be a list of tuples, "
-                "got <class 'function'>.",
-            ):
-                optimize_acqf(
-                    acq_function=mock_acq_function,
-                    bounds=bounds,
-                    q=1,
-                    nonlinear_inequality_constraints=nlc1,
-                    num_restarts=num_restarts,
-                    batch_initial_conditions=batch_initial_conditions,
-                )
             # batch_initial_conditions must be feasible
             with self.assertRaisesRegex(
                 ValueError,

--- a/test/utils/test_datasets.py
+++ b/test/utils/test_datasets.py
@@ -10,7 +10,6 @@ from botorch.exceptions.errors import InputDataError, UnsupportedError
 from botorch.utils.containers import DenseContainer, SliceContainer
 from botorch.utils.datasets import (
     ContextualDataset,
-    FixedNoiseDataset,
     MultiTaskDataset,
     RankingDataset,
     SupervisedDataset,
@@ -129,7 +128,7 @@ class TestDatasets(BotorchTestCase):
         Yvar = rand(3, 1)
         feature_names = ["x1", "x2"]
         outcome_names = ["y"]
-        dataset = FixedNoiseDataset(
+        dataset = SupervisedDataset(
             X=X,
             Y=Y,
             Yvar=Yvar,
@@ -141,17 +140,6 @@ class TestDatasets(BotorchTestCase):
         self.assertTrue(torch.equal(dataset.Yvar, Yvar))
         self.assertEqual(dataset.feature_names, feature_names)
         self.assertEqual(dataset.outcome_names, outcome_names)
-
-        with self.assertRaisesRegex(
-            ValueError, "`Y` and `Yvar`"
-        ), self.assertWarnsRegex(DeprecationWarning, "SupervisedDataset"):
-            FixedNoiseDataset(
-                X=X,
-                Y=Y,
-                Yvar=Yvar.squeeze(),
-                feature_names=feature_names,
-                outcome_names=outcome_names,
-            )
 
     def test_ranking(self):
         # Test `_validate`


### PR DESCRIPTION
Summary: Legacy non-linear inequality constraint format has been deprecated since https://github.com/pytorch/botorch/pull/1793.

Differential Revision: D66003879


