### PR TITLE
Make input & outcome transforms first class attributes of Model

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -1107,9 +1107,8 @@ def _get_noiseless_fantasy_model(
 
     # Set the outcome and input transforms of the fantasy model.
     # The transforms should already be in eval mode but just set them to be sure
-    outcome_transform = getattr(model, "outcome_transform", None)
-    if outcome_transform is not None:
-        outcome_transform = deepcopy(outcome_transform).eval()
+    if model.outcome_transform is not None:
+        outcome_transform = deepcopy(model.outcome_transform).eval()
         fantasy_model.outcome_transform = outcome_transform
         # Need to transform the outcome just as in the SingleTaskGP constructor.
         # Need to unsqueeze for BoTorch and then squeeze again for GPyTorch.
@@ -1119,9 +1118,8 @@ def _get_noiseless_fantasy_model(
             Y_fantasized.unsqueeze(-1), Yvar.unsqueeze(-1)
         )
         Y_fantasized = Y_fantasized.squeeze(-1)
-    input_transform = getattr(model, "input_transform", None)
-    if input_transform is not None:
-        fantasy_model.input_transform = deepcopy(input_transform).eval()
+    if model.input_transform is not None:
+        fantasy_model.input_transform = deepcopy(model.input_transform).eval()
 
     # update training inputs/targets to be batch mode fantasies
     fantasy_model.set_train_data(

--- a/botorch/acquisition/cached_cholesky.py
+++ b/botorch/acquisition/cached_cholesky.py
@@ -45,7 +45,7 @@ def supports_cache_root(model: Model) -> bool:
     ) or not isinstance(model, GPyTorchModel):
         return False
     # Models that return a TransformedPosterior are not supported.
-    if hasattr(model, "outcome_transform") and (not model.outcome_transform._is_linear):
+    if model.outcome_transform is not None and not model.outcome_transform._is_linear:
         return False
     return True
 

--- a/botorch/acquisition/multi_objective/base.py
+++ b/botorch/acquisition/multi_objective/base.py
@@ -121,8 +121,7 @@ class MultiObjectiveMCAcquisitionFunction(AcquisitionFunction, MCSamplerMixin, A
                 "Multi-Objective MC acquisition functions."
             )
         if (
-            hasattr(model, "input_transform")
-            and isinstance(model.input_transform, InputPerturbation)
+            isinstance(model.input_transform, InputPerturbation)
             and constraints is not None
         ):
             raise UnsupportedError(

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -171,7 +171,7 @@ class ApproximateGPyTorchModel(GPyTorchModel):
             dist = self.likelihood(dist)
 
         posterior = GPyTorchPosterior(distribution=dist)
-        if hasattr(self, "outcome_transform"):
+        if self.outcome_transform is not None:
             posterior = self.outcome_transform.untransform_posterior(posterior)
         if posterior_transform is not None:
             posterior = posterior_transform(posterior)
@@ -449,15 +449,14 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
 
         super().__init__(model=model, likelihood=likelihood, num_outputs=num_outputs)
 
-        if outcome_transform is not None:
-            self.outcome_transform = outcome_transform
         if input_transform is not None:
             warnings.warn(
                 TRANSFORM_WARNING.format(ttype="input"),
                 UserInputWarning,
                 stacklevel=3,
             )
-            self.input_transform = input_transform
+        self.outcome_transform = outcome_transform
+        self.input_transform = input_transform
 
         # for model fitting utilities
         # TODO: make this a flag?

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -78,7 +78,7 @@ class EnsembleModel(Model, ABC):
         # NOTE: The `outcome_transform` `untransform`s the predictions rather than the
         # `posterior` (as is done in GP models). This is more general since it works
         # even if the transform doesn't support `untransform_posterior`.
-        if hasattr(self, "outcome_transform"):
+        if self.outcome_transform is not None:
             values, _ = self.outcome_transform.untransform(values)
         if output_indices is not None:
             values = values[..., output_indices]

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -396,10 +396,8 @@ class SaasFullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel):
             train_X=transformed_X, train_Y=train_Y, train_Yvar=train_Yvar
         )
         self.pyro_model: PyroModel = pyro_model
-        if outcome_transform is not None:
-            self.outcome_transform = outcome_transform
-        if input_transform is not None:
-            self.input_transform = input_transform
+        self.outcome_transform = outcome_transform
+        self.input_transform = input_transform
 
     def _check_if_fitted(self):
         r"""Raise an exception if the model hasn't been fitted."""

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -282,10 +282,8 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
             task_rank=self._rank,
         )
         self.pyro_model: MultitaskSaasPyroModel = pyro_model
-        if outcome_transform is not None:
-            self.outcome_transform = outcome_transform
-        if input_transform is not None:
-            self.input_transform = input_transform
+        self.outcome_transform = outcome_transform
+        self.input_transform = input_transform
 
     def train(self, mode: bool = True) -> None:
         r"""Puts the model in `train` mode."""

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -203,12 +203,10 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
             }
             if train_Yvar is None:
                 self._subset_batch_dict["likelihood.noise_covar.raw_noise"] = -2
-        self.covar_module: Module = covar_module
         # TODO: Allow subsetting of other covar modules
-        if outcome_transform is not None:
-            self.outcome_transform = outcome_transform
-        if input_transform is not None:
-            self.input_transform = input_transform
+        self.covar_module: Module = covar_module
+        self.outcome_transform = outcome_transform
+        self.input_transform = input_transform
         self.to(train_X)
 
     @classmethod

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -274,10 +274,8 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
             dtype=train_Y.dtype,
         )
 
-        if outcome_transform is not None:
-            self.outcome_transform = outcome_transform
-        if input_transform is not None:
-            self.input_transform = input_transform
+        self.outcome_transform = outcome_transform
+        self.input_transform = input_transform
 
     def _initialize_latents(
         self,
@@ -414,7 +412,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
             conditioned on the new observations `(X, Y)` (and possibly noise
             observations passed in via kwargs).
         """
-        if hasattr(self, "outcome_transform"):
+        if self.outcome_transform is not None:
             # we need to apply transforms before shifting batch indices around
             Y, noise = self.outcome_transform(Y=Y, Yvar=noise)
         # Do not check shapes when fantasizing as they are not expected to match.
@@ -539,7 +537,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                 output_shape=X.shape[:-1] + self.target_shape,
                 num_outputs=self._num_outputs,
             )
-            if hasattr(self, "outcome_transform"):
+            if self.outcome_transform is not None:
                 posterior = self.outcome_transform.untransform_posterior(posterior)
             return posterior
 

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -116,7 +116,7 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel, FantasizeMixin):
                 noise_i = None
             else:
                 noise_i = torch.cat([noise[..., k] for k in range(i, j)], dim=-1)
-            if hasattr(model, "outcome_transform"):
+            if model.outcome_transform is not None:
                 y_i, noise_i = model.outcome_transform(y_i, noise_i)
                 if noise_i is not None:
                     noise_i = noise_i.squeeze(0)

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -266,10 +266,8 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
         )
         self.register_buffer("_task_mapper", task_mapper)
         self._expected_task_values = set(all_tasks)
-        if input_transform is not None:
-            self.input_transform = input_transform
-        if outcome_transform is not None:
-            self.outcome_transform = outcome_transform
+        self.input_transform = input_transform
+        self.outcome_transform = outcome_transform
         self.to(train_X)
 
     def _split_inputs(self, x: Tensor) -> tuple[Tensor, Tensor]:
@@ -515,10 +513,8 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
             task_covar_prior=task_covar_prior,
         )
 
-        if outcome_transform is not None:
-            self.outcome_transform = outcome_transform
-        if input_transform is not None:
-            self.input_transform = input_transform
+        self.outcome_transform = outcome_transform
+        self.input_transform = input_transform
         self.to(train_X)
 
     def forward(self, X: Tensor) -> MultitaskMultivariateNormal:
@@ -771,7 +767,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
             test_noise=test_noise,
         )
 
-        if hasattr(self, "outcome_transform"):
+        if self.outcome_transform is not None:
             posterior = self.outcome_transform.untransform_posterior(posterior)
         return posterior
 

--- a/botorch/models/pairwise_gp.py
+++ b/botorch/models/pairwise_gp.py
@@ -219,8 +219,8 @@ class PairwiseGP(Model, GP, FantasizeMixin):
 
         if input_transform is not None:
             input_transform.to(datapoints)
-            # input transformation is applied in set_train_data
-            self.input_transform = input_transform
+        # input transformation is applied in set_train_data
+        self.input_transform = input_transform
 
         # Compatibility variables with fit_gpytorch_*: Dummy likelihood
         # Likelihood is tightly tied with this model and

--- a/botorch/sampling/pathwise/posterior_samplers.py
+++ b/botorch/sampling/pathwise/posterior_samplers.py
@@ -36,7 +36,7 @@ from botorch.sampling.pathwise.utils import (
     TInputTransform,
     TOutputTransform,
 )
-from botorch.utils.context_managers import delattr_ctx
+from botorch.utils.context_managers import disable_attr_ctx
 from botorch.utils.dispatcher import Dispatcher
 from botorch.utils.transforms import is_ensemble
 from gpytorch.models import ApproximateGP, ExactGP, GP
@@ -203,7 +203,7 @@ def _draw_matheron_paths_ExactGP(
 ) -> MatheronPath:
     (train_X,) = get_train_inputs(model, transformed=True)
     train_Y = get_train_targets(model, transformed=True)
-    with delattr_ctx(model, "outcome_transform"):
+    with disable_attr_ctx(model, "outcome_transform"):
         # Generate draws from the prior
         prior_paths = prior_sampler(model=model, sample_shape=sample_shape)
         sample_values = prior_paths.forward(train_X)
@@ -236,7 +236,7 @@ def _draw_matheron_paths_ApproximateGP(
         if isinstance(model, ApproximateGPyTorchModel)
         else model.variational_strategy.inducing_points
     )
-    with delattr_ctx(model, "outcome_transform"):
+    with disable_attr_ctx(model, "outcome_transform"):
         # Generate draws from the prior
         prior_paths = prior_sampler(model=model, sample_shape=sample_shape)
         sample_values = prior_paths.forward(Z)  # `forward` bypasses transforms

--- a/botorch/sampling/pathwise/prior_samplers.py
+++ b/botorch/sampling/pathwise/prior_samplers.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-
 from typing import Any
 
 from botorch.models.approximate_gp import ApproximateGPyTorchModel
@@ -16,7 +15,6 @@ from botorch.sampling.pathwise.features import gen_kernel_features
 from botorch.sampling.pathwise.features.generators import TKernelFeatureMapGenerator
 from botorch.sampling.pathwise.paths import GeneralizedLinearPath, PathList, SamplePath
 from botorch.sampling.pathwise.utils import (
-    get_input_transform,
     get_output_transform,
     get_train_inputs,
     TInputTransform,
@@ -101,7 +99,7 @@ def _draw_kernel_feature_paths_ExactGP(
         num_inputs=train_X.shape[-1],
         mean_module=model.mean_module,
         covar_module=model.covar_module,
-        input_transform=get_input_transform(model),
+        input_transform=model.input_transform,
         output_transform=get_output_transform(model),
         **kwargs,
     )
@@ -125,7 +123,7 @@ def _draw_kernel_feature_paths_ApproximateGPyTorchModel(
     return DrawKernelFeaturePaths(
         model.model,
         num_inputs=train_X.shape[-1],
-        input_transform=get_input_transform(model),
+        input_transform=model.input_transform,
         output_transform=get_output_transform(model),
         **kwargs,
     )

--- a/botorch/sampling/pathwise/update_strategies.py
+++ b/botorch/sampling/pathwise/update_strategies.py
@@ -18,7 +18,6 @@ from botorch.models.transforms.input import InputTransform
 from botorch.sampling.pathwise.features import KernelEvaluationMap
 from botorch.sampling.pathwise.paths import GeneralizedLinearPath, SamplePath
 from botorch.sampling.pathwise.utils import (
-    get_input_transform,
     get_train_inputs,
     get_train_targets,
     TInputTransform,
@@ -133,7 +132,7 @@ def _gaussian_update_ExactGP(
         sample_values=sample_values,
         noise_covariance=noise_covariance,
         scale_tril=scale_tril,
-        input_transform=get_input_transform(model),
+        input_transform=model.input_transform,
     )
 
 
@@ -144,7 +143,7 @@ def _gaussian_update_ApproximateGPyTorchModel(
     **kwargs: Any,
 ) -> GeneralizedLinearPath:
     return GaussianUpdate(
-        model.model, likelihood, input_transform=get_input_transform(model), **kwargs
+        model.model, likelihood, input_transform=model.input_transform, **kwargs
     )
 
 

--- a/botorch/sampling/pathwise/utils.py
+++ b/botorch/sampling/pathwise/utils.py
@@ -193,14 +193,9 @@ class OutcomeUntransformer(TensorTransform):
         return output_values.transpose(-2, -1)
 
 
-def get_input_transform(model: GPyTorchModel) -> InputTransform | None:
-    r"""Returns a model's input_transform or None."""
-    return getattr(model, "input_transform", None)
-
-
 def get_output_transform(model: GPyTorchModel) -> OutcomeUntransformer | None:
     r"""Returns a wrapped version of a model's outcome_transform or None."""
-    transform = getattr(model, "outcome_transform", None)
+    transform = model.outcome_transform
     if transform is None:
         return None
 
@@ -229,7 +224,7 @@ def _get_train_inputs_Model(model: Model, transformed: bool = False) -> tuple[Te
             return (original_train_input,)
 
     (X,) = model.train_inputs
-    transform = get_input_transform(model)
+    transform = model.input_transform
     if transform is None:
         return (X,)
 
@@ -246,7 +241,7 @@ def _get_train_inputs_SingleTaskVariationalGP(
     if model.training != transformed:
         return (X,)
 
-    transform = get_input_transform(model)
+    transform = model.input_transform
     if transform is None:
         return (X,)
 
@@ -279,7 +274,7 @@ def _get_train_targets_Model(model: Model, transformed: bool = False) -> Tensor:
     Y = model.train_targets
 
     # Note: Avoid using `get_output_transform` here since it creates a Module
-    transform = getattr(model, "outcome_transform", None)
+    transform = model.outcome_transform
     if transformed or transform is None:
         return Y
 
@@ -293,7 +288,7 @@ def _get_train_targets_SingleTaskVariationalGP(
     model: Model, transformed: bool = False
 ) -> Tensor:
     Y = model.model.train_targets
-    transform = getattr(model, "outcome_transform", None)
+    transform = model.outcome_transform
     if transformed or transform is None:
         return Y
 

--- a/botorch/utils/context_managers.py
+++ b/botorch/utils/context_managers.py
@@ -26,16 +26,16 @@ class TensorCheckpoint(NamedTuple):
 
 
 @contextmanager
-def delattr_ctx(
+def disable_attr_ctx(
     instance: object, *attrs: str, enforce_hasattr: bool = False
 ) -> Generator[None, None, None]:
-    r"""Contextmanager for temporarily deleting attributes."""
+    r"""Contextmanager for temporarily setting attributes to None."""
     try:
         cache = {}
         for key in attrs:
             if hasattr(instance, key):
                 cache[key] = getattr(instance, key)
-                delattr(instance, key)
+                setattr(instance, key, None)
             elif enforce_hasattr:
                 raise ValueError(
                     f"Attribute {key} missing from {type(instance)} instance."

--- a/botorch/utils/gp_sampling.py
+++ b/botorch/utils/gp_sampling.py
@@ -445,13 +445,13 @@ def get_gp_samples(
         stacklevel=2,
     )
     # Get transforms from the model.
-    intf = getattr(model, "input_transform", None)
-    octf = getattr(model, "outcome_transform", None)
+    intf = model.input_transform
+    octf = model.outcome_transform
     # Remove the outcome transform - leads to buggy draws.
     if octf is not None:
-        del model.outcome_transform
+        model.outcome_transform = None
     if intf is not None:
-        del model.input_transform
+        model.input_transform = None
 
     if num_outputs > 1:
         if not isinstance(model, ModelListGP):
@@ -471,11 +471,11 @@ def get_gp_samples(
         train_X = models[m].train_inputs[0]
         train_targets = models[m].train_targets
         _model = models[m]
-        _intf = getattr(_model, "input_transform", None)
-        _octf = getattr(_model, "outcome_transform", None)
+        _intf = _model.input_transform
+        _octf = _model.outcome_transform
         # Remove the outcome transform - leads to buggy draws.
         if _octf is not None:
-            del _model.outcome_transform
+            _model.outcome_transform = None
 
         octfs.append(_octf)
         intfs.append(_intf)

--- a/botorch/utils/test_helpers.py
+++ b/botorch/utils/test_helpers.py
@@ -289,7 +289,7 @@ def get_pvar_expected(
 
     # If the model has an outcome transform, we need to untransform the
     # variance according to that transform.
-    if hasattr(model, "outcome_transform"):
+    if model.outcome_transform is not None:
         _, pvar_exp = model.outcome_transform.untransform(
             Y=torch.zeros_like(pvar_exp), Yvar=pvar_exp
         )
@@ -331,10 +331,8 @@ class SimpleGPyTorchModel(GPyTorchModel, ExactGP, FantasizeMixin):
         super().__init__(train_X, train_Y, likelihood)
         self.mean_module = ConstantMean()
         self.covar_module = ScaleKernel(RBFKernel())
-        if outcome_transform is not None:
-            self.outcome_transform = outcome_transform
-        if input_transform is not None:
-            self.input_transform = input_transform
+        self.outcome_transform = outcome_transform
+        self.input_transform = input_transform
         self._num_outputs = 1
         self.to(train_X)
         self.transformed_call_args = []

--- a/test/models/test_approximate_gp.py
+++ b/test/models/test_approximate_gp.py
@@ -193,14 +193,14 @@ class TestSingleTaskVariationalGP(BotorchTestCase):
             if inp_trans is not None:
                 self.assertIsInstance(model.input_transform, Normalize)
             else:
-                self.assertFalse(hasattr(model, "input_transform"))
+                self.assertIsNone(model.input_transform)
             if out_trans is not None:
                 self.assertIsInstance(model.outcome_transform, Log)
 
                 posterior = model.posterior(test_X)
                 self.assertIsInstance(posterior, TransformedPosterior)
             else:
-                self.assertFalse(hasattr(model, "outcome_transform"))
+                self.assertIsNone(model.outcome_transform)
 
         # test user warnings when using transforms
         with self.assertWarnsRegex(

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -199,11 +199,11 @@ class TestGPRegressionBase(BotorchTestCase):
                 self.assertEqual(model.outcome_transform._batch_shape, batch_shape)
                 self.assertEqual(model.outcome_transform._m, m)
             elif octf == "None":
-                self.assertFalse(hasattr(model, "outcome_transform"))
+                self.assertIsNone(model.outcome_transform)
             else:
                 self.assertIsInstance(model.outcome_transform, Log)
             # Make sure there is no input transform
-            self.assertFalse(hasattr(model, "input_transform"))
+            self.assertIsNone(model.input_transform)
 
     def test_custom_init(self):
         extra_model_kwargs = self._get_extra_model_kwargs()

--- a/test/models/test_gp_regression_fidelity.py
+++ b/test/models/test_gp_regression_fidelity.py
@@ -181,7 +181,7 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
                 if use_octf:
                     # ensure un-transformation is applied
                     tmp_tf = model.outcome_transform
-                    del model.outcome_transform
+                    model.outcome_transform = None
                     pp_tf = model.posterior(X)
                     model.outcome_transform = tmp_tf
                     expected_var = tmp_tf.untransform_posterior(pp_tf).variance
@@ -197,7 +197,7 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
                 if use_octf:
                     # ensure un-transformation is applied
                     tmp_tf = model.outcome_transform
-                    del model.outcome_transform
+                    model.outcome_transform = None
                     pp_tf = model.posterior(X)
                     model.outcome_transform = tmp_tf
                     expected_var = tmp_tf.untransform_posterior(pp_tf).variance

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -88,10 +88,8 @@ class SimpleBatchedMultiOutputGPyTorchModel(
             RBFKernel(batch_shape=self._aug_batch_shape),
             batch_shape=self._aug_batch_shape,
         )
-        if outcome_transform is not None:
-            self.outcome_transform = outcome_transform
-        if input_transform is not None:
-            self.input_transform = input_transform
+        self.outcome_transform = outcome_transform
+        self.input_transform = input_transform
         self.to(train_X)
 
     def forward(self, x):
@@ -137,7 +135,7 @@ class TestGPyTorchModel(BotorchTestCase):
             if use_octf:
                 # ensure un-transformation is applied
                 tmp_tf = model.outcome_transform
-                del model.outcome_transform
+                model.outcome_transform = None
                 p_tf = model.posterior(test_X)
                 model.outcome_transform = tmp_tf
                 expected_var = tmp_tf.untransform_posterior(p_tf).variance

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -110,7 +110,7 @@ class TestModelListGP(BotorchTestCase):
                     m.outcome_transform, (Log, Standardize, ChainedOutcomeTransform)
                 )
             else:
-                assert not hasattr(m, "outcome_transform")
+                self.assertIsNone(m.outcome_transform)
 
         # test constructing likelihood wrapper
         mll = SumMarginalLogLikelihood(model.likelihood, model)
@@ -161,7 +161,7 @@ class TestModelListGP(BotorchTestCase):
             submodel = model.models[0]
             p0 = submodel.posterior(test_x)
             tmp_tf = submodel.outcome_transform
-            del submodel.outcome_transform
+            submodel.outcome_transform = None
             p0_tf = submodel.posterior(test_x)
             submodel.outcome_transform = tmp_tf
             expected_var = tmp_tf.untransform_posterior(p0_tf).variance

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -283,7 +283,7 @@ class TestMultiTaskGP(BotorchTestCase):
             if use_octf:
                 # ensure un-transformation is applied
                 tmp_tf = model.outcome_transform
-                del model.outcome_transform
+                model.outcome_transform = None
                 p_utf = model.posterior(test_x)
                 model.outcome_transform = tmp_tf
                 expected_var = tmp_tf.untransform_posterior(p_utf).variance
@@ -562,7 +562,7 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
             if use_octf:
                 # ensure un-transformation is applied
                 tmp_tf = model.outcome_transform
-                del model.outcome_transform
+                model.outcome_transform = None
                 p_tf = model.posterior(test_x)
                 model.outcome_transform = tmp_tf
                 expected_var = tmp_tf.untransform_posterior(p_tf).variance

--- a/test/posteriors/test_higher_order.py
+++ b/test/posteriors/test_higher_order.py
@@ -106,7 +106,7 @@ class TestHigherOrderGPPosterior(BotorchTestCase):
 
             model.eval()
             eval_mode_variance = model(test_x).variance.reshape_as(posterior_variance)
-            if hasattr(model, "outcome_transform"):
+            if model.outcome_transform is not None:
                 eval_mode_variance = model.outcome_transform.untransform(
                     eval_mode_variance, eval_mode_variance
                 )[1]

--- a/test/sampling/pathwise/test_posterior_samplers.py
+++ b/test/sampling/pathwise/test_posterior_samplers.py
@@ -109,7 +109,7 @@ class TestPosteriorSamplers(BotorchTestCase):
         self.assertEqual(samples.shape, sample_shape + batch_shape + X.shape[-2:-1])
 
         sample_moments = get_sample_moments(samples, sample_shape)
-        if hasattr(model, "outcome_transform"):
+        if model.outcome_transform is not None:
             # Do this instead of untransforming exact moments
             sample_moments = standardize_moments(
                 model.outcome_transform, *sample_moments

--- a/test/sampling/pathwise/test_prior_samplers.py
+++ b/test/sampling/pathwise/test_prior_samplers.py
@@ -161,7 +161,7 @@ class TestPriorSamplers(BotorchTestCase):
 
         # Calculate sample statistics
         sample_moments = get_sample_moments(samples, sample_shape)
-        if hasattr(model, "outcome_transform"):
+        if model.outcome_transform is not None:
             # Do this instead of untransforming exact moments
             sample_moments = standardize_moments(
                 model.outcome_transform, *sample_moments

--- a/test/sampling/pathwise/test_utils.py
+++ b/test/sampling/pathwise/test_utils.py
@@ -14,14 +14,13 @@ from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.transforms.input import Normalize
 from botorch.models.transforms.outcome import Standardize
 from botorch.sampling.pathwise.utils import (
-    get_input_transform,
     get_output_transform,
     get_train_inputs,
     get_train_targets,
     InverseLengthscaleTransform,
     OutcomeUntransformer,
 )
-from botorch.utils.context_managers import delattr_ctx
+from botorch.utils.context_managers import disable_attr_ctx
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.kernels import MaternKernel, ScaleKernel
 
@@ -77,10 +76,6 @@ class TestGetters(BotorchTestCase):
                 )
             )
 
-    def test_get_input_transform(self):
-        for model in self.models:
-            self.assertIs(get_input_transform(model), model.input_transform)
-
     def test_get_output_transform(self):
         for model in self.models:
             transform = get_output_transform(model)
@@ -106,7 +101,7 @@ class TestGetters(BotorchTestCase):
             model.eval()
             self.assertTrue(X.equal(get_train_inputs(model, transformed=False)[0]))
             self.assertTrue(Z.equal(get_train_inputs(model, transformed=True)[0]))
-            with delattr_ctx(model, "input_transform"), patch.object(
+            with disable_attr_ctx(model, "input_transform"), patch.object(
                 model, "_original_train_inputs", new=None
             ):
                 self.assertTrue(Z.equal(get_train_inputs(model, transformed=False)[0]))
@@ -137,7 +132,7 @@ class TestGetters(BotorchTestCase):
             model.eval()
             self.assertTrue(F.equal(get_train_targets(model, transformed=True)))
             self.assertTrue(Y.equal(get_train_targets(model, transformed=False)))
-            with delattr_ctx(model, "outcome_transform"):
+            with disable_attr_ctx(model, "outcome_transform"):
                 self.assertTrue(F.equal(get_train_targets(model, transformed=True)))
                 self.assertTrue(F.equal(get_train_targets(model, transformed=False)))
 

--- a/test/utils/test_context_managers.py
+++ b/test/utils/test_context_managers.py
@@ -10,7 +10,7 @@ from string import ascii_lowercase
 
 import torch
 from botorch.utils.context_managers import (
-    delattr_ctx,
+    disable_attr_ctx,
     module_rollback_ctx,
     parameter_rollback_ctx,
     TensorCheckpoint,
@@ -29,11 +29,11 @@ class TestContextManagers(BotorchTestCase):
             param = Parameter(values.to(torch.float64), requires_grad=bool(i % 2))
             module.register_parameter(name, param)
 
-    def test_delattr_ctx(self):
+    def test_disable_attr_ctx(self):
         # Test temporary removal of attributes
         a = self.module.a
         b = self.module.b
-        with delattr_ctx(self.module, "a", "b"):
+        with disable_attr_ctx(self.module, "a", "b"):
             self.assertIsNone(getattr(self.module, "a", None))
             self.assertIsNone(getattr(self.module, "b", None))
             self.assertTrue(self.module.c is not None)
@@ -43,7 +43,7 @@ class TestContextManagers(BotorchTestCase):
         self.assertTrue(self.module.b.equal(b))
 
         with self.assertRaisesRegex(ValueError, "Attribute .* missing"):
-            with delattr_ctx(self.module, "z", enforce_hasattr=True):
+            with disable_attr_ctx(self.module, "z", enforce_hasattr=True):
                 pass  # pragma: no cover
 
     def test_parameter_rollback_ctx(self):
@@ -115,7 +115,7 @@ class TestContextManagers(BotorchTestCase):
         self.assertTrue(self.module.c.equal(c))
 
         # Test that items in checkpoint get inserted into state_dict
-        with delattr_ctx(self.module, "a"):
+        with disable_attr_ctx(self.module, "a"):
             with self.assertRaisesRegex(  # should fail when attempting to rollback
                 RuntimeError, r'Unexpected key\(s\) in state_dict: "a"'
             ):

--- a/test_community/models/test_gp_regression_multisource.py
+++ b/test_community/models/test_gp_regression_multisource.py
@@ -215,7 +215,7 @@ class TestAugmentedSingleTaskGP(BotorchTestCase):
             if use_octf:
                 # ensure un-transformation is applied
                 tmp_tf = model.outcome_transform
-                del model.outcome_transform
+                model.outcome_transform = None
                 pp_tf = model.posterior(X, observation_noise=True)
                 model.outcome_transform = tmp_tf
                 expected_var = tmp_tf.untransform_posterior(pp_tf).variance


### PR DESCRIPTION
Summary: These were previously only set when they were not None, which lead to a lot of `hasattr`, `getattr` usage throughout the codebase to check for them. This diff adds them as attributes to base `Model` class with default values of `None`. With this change, we can now access `model.input/outcome_transform` on all models.

Differential Revision: D66012223
