### PR TITLE
Remove mpmath dependency pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-multipledispatch
-scipy
-mpmath>=0.19,<=1.3
-torch>=2.0.1
-pyro-ppl>=1.8.4
 typing_extensions
 pyre_extensions
 gpytorch==1.13
 linear_operator==0.5.3
+torch>=2.0.1
+pyro-ppl>=1.8.4
+scipy
+multipledispatch


### PR DESCRIPTION
`mpmath` was pinned in 02e80143c0b0144ff22c78ac60a9670d460ae811 due to an issue with a sympy alpha release. This should not be necessary anymore.

Also re-ordered the dependency list to group deps together.