### PR TITLE
Stop redirecting for the archived docs

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -110,20 +110,6 @@ class Footer extends React.Component {
           )}{' '}
           Copyright &copy; {currentYear} Meta Platforms, Inc
         </section>
-        {process.env.NODE_ENV !== 'development' &&
-          <script dangerouslySetInnerHTML={{__html:`
-            (function() {
-              var BAD_BASE = '/botorch/';
-              if (window.location.origin !== '${this.props.config.url}') {
-                var pathname = window.location.pathname;
-                var newPathname = pathname.slice(pathname.indexOf(BAD_BASE) === 0 ? BAD_BASE.length : 1);
-                var newLocation = '${this.props.config.url}${this.props.config.baseUrl}' + newPathname;
-                console.log('redirecting to ' + newLocation);
-                window.location.href = newLocation;
-              }
-            })();
-          `}} />
-        }
       </footer>
     );
   }


### PR DESCRIPTION
We won't need it. This will prevent a separate archive site from working.

## Test Plan

Generated static version and served locally. Redirected previously. Doesn't anymore.