### PR TITLE
Use expm1 instead of exp - 1

### DIFF
--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -772,7 +772,7 @@ class Penicillin(MultiObjectiveTestProblem):
             F_loss = (
                 V[active]
                 * cls.lambd
-                * (torch.exp(5 * ((T[active] - cls.T_o) / (cls.T_v - cls.T_o))) - 1)
+                * torch.special.expm1(5 * ((T[active] - cls.T_o) / (cls.T_v - cls.T_o)))
             )
             dV_dt = F[active] - F_loss
             mu = (

--- a/test/models/transforms/test_utils.py
+++ b/test/models/transforms/test_utils.py
@@ -86,7 +86,7 @@ class TestTransformUtils(BotorchTestCase):
             mu_ln_expected = torch.tensor(
                 [1.0, 2.0, 3.0], device=self.device, dtype=dtype
             )
-            var_ln_expected = (torch.exp(var) - 1) * mu_ln_expected**2
+            var_ln_expected = torch.special.expm1(var) * mu_ln_expected**2
             self.assertAllClose(mu_ln, mu_ln_expected)
             self.assertAllClose(var_ln, var_ln_expected)
 


### PR DESCRIPTION
Similarly to https://github.com/pytorch/botorch/pull/2540 and https://github.com/pytorch/botorch/pull/2541: use more numerically stable `expm1`.

Found with TorchFix https://github.com/pytorch-labs/torchfix/.  This should be the last instance to replace in the current codebase. 