### PR TITLE
Pin scipy to <1.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ gpytorch==1.13
 linear_operator==0.5.3
 torch>=2.0.1
 pyro-ppl>=1.8.4
-scipy
+scipy<1.15
 multipledispatch


### PR DESCRIPTION
Scipy 1.15 causes test failures with model fitting, presumably b/c `L-BFGS-B` was ported to C: https://scipy.github.io/devdocs/release/1.15.0-notes.html#scipy-optimize-improvements

Pinning this for now to resolve failures, to be fixed (and pin removed) in a bc-fashion in a separate PR.