### PR TITLE
Make fitting compatible with scipy 1.15 optimization changes

### DIFF
--- a/botorch/optim/core.py
+++ b/botorch/optim/core.py
@@ -34,7 +34,8 @@ except ImportError:  # pragma: no cover
 
 
 _LBFGSB_MAXITER_MAXFUN_REGEX = re.compile(  # regex for maxiter and maxfun messages
-    "TOTAL NO. of (ITERATIONS REACHED LIMIT|f AND g EVALUATIONS EXCEEDS LIMIT)"
+    # Note that the messages changed with scipy 1.15, hence the different matching here.
+    "STOP: TOTAL NO. (of|OF) (ITERATIONS REACHED LIMIT|(f AND g|F,G) EVALUATIONS EXCEEDS LIMIT)"
 )
 
 

--- a/botorch/optim/core.py
+++ b/botorch/optim/core.py
@@ -35,7 +35,8 @@ except ImportError:  # pragma: no cover
 
 _LBFGSB_MAXITER_MAXFUN_REGEX = re.compile(  # regex for maxiter and maxfun messages
     # Note that the messages changed with scipy 1.15, hence the different matching here.
-    "STOP: TOTAL NO. (of|OF) (ITERATIONS REACHED LIMIT|(f AND g|F,G) EVALUATIONS EXCEEDS LIMIT)"
+    "STOP: TOTAL NO. (of|OF) "
+    + "(ITERATIONS REACHED LIMIT|(f AND g|F,G) EVALUATIONS EXCEEDS LIMIT)"
 )
 
 

--- a/botorch/optim/core.py
+++ b/botorch/optim/core.py
@@ -35,7 +35,7 @@ except ImportError:  # pragma: no cover
 
 _LBFGSB_MAXITER_MAXFUN_REGEX = re.compile(  # regex for maxiter and maxfun messages
     # Note that the messages changed with scipy 1.15, hence the different matching here.
-    "STOP: TOTAL NO. (of|OF) "
+    "TOTAL NO. (of|OF) "
     + "(ITERATIONS REACHED LIMIT|(f AND g|F,G) EVALUATIONS EXCEEDS LIMIT)"
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ gpytorch==1.13
 linear_operator==0.5.3
 torch>=2.0.1
 pyro-ppl>=1.8.4
-scipy<1.15
+scipy
 multipledispatch

--- a/test/generation/test_gen.py
+++ b/test/generation/test_gen.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+import re
 import warnings
 from unittest import mock
 
@@ -225,13 +226,14 @@ class TestGenCandidates(TestBaseCandidateGeneration):
     def test_gen_candidates_scipy_warns_opt_failure(self):
         with warnings.catch_warnings(record=True) as ws:
             self.test_gen_candidates(options={"maxls": 1})
-        expected_msg = (
+        expected_msg = re.compile(
+            # The message changed with scipy 1.15, hence the different matching here.
             "Optimization failed within `scipy.optimize.minimize` with status 2"
-            " and message ABNORMAL_TERMINATION_IN_LNSRCH."
+            " and message ABNORMAL(|_TERMINATION_IN_LNSRCH)."
         )
         expected_warning_raised = any(
             issubclass(w.category, OptimizationWarning)
-            and expected_msg in str(w.message)
+            and expected_msg.search(str(w.message))
             for w in ws
         )
         self.assertTrue(expected_warning_raised)

--- a/test/test_utils/test_mock.py
+++ b/test/test_utils/test_mock.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import re
 import warnings
 from unittest.mock import patch
 
@@ -24,6 +25,12 @@ from botorch.optim.optimize_mixed import (
 )
 from botorch.test_utils.mock import mock_optimize, mock_optimize_context_manager
 from botorch.utils.testing import BotorchTestCase, MockAcquisitionFunction
+
+
+MAX_ITER_MSG = re.compile(
+    # Note that the message changed with scipy 1.15, hence the different matching here.
+    "TOTAL NO. (of|OF) ITERATIONS REACHED LIMIT"
+)
 
 
 class SinAcqusitionFunction(MockAcquisitionFunction):
@@ -56,9 +63,7 @@ class TestMock(BotorchTestCase):
 
             with mock_optimize_context_manager():
                 result = scipy_minimize(closure=closure, parameters={"x": x})
-            self.assertEqual(
-                result.message, "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT"
-            )
+            self.assertTrue(MAX_ITER_MSG.search(result.message))
 
         with self.subTest("optimize_acqf"):
             with mock_optimize_context_manager():


### PR DESCRIPTION
Resolves #2666 by updating the regexp that is used to filter out the optimization warning emitted when the maximium number of iterations is reached.

NOTE: This kind of regexp filtering is kind of brittle, but it's not necessarily obvious how to do this differently if scipy doesn't return these in a more structured form.