### PR TITLE
Pin scipy to <1.15 (again) to avoid slowdowns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ gpytorch==1.13
 linear_operator==0.5.3
 torch>=2.0.1
 pyro-ppl>=1.8.4
-scipy
+scipy<1.15
 multipledispatch


### PR DESCRIPTION
There appear to be substantial slowdowns with the optimization (presumably both for fitting and candidate generation) with scipy 1.15: #2668 

This pins the scipy version to <1.15 for now to avoid these slowdowns and terrible user experiences (at least on the `main` branch) until we've figured out the root cause of these slowdowns.