### PR TITLE
StratifiedStandardize OutcomeTransform

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -1116,7 +1116,7 @@ def _get_noiseless_fantasy_model(
         # Not transforming Yvar because 1e-7 is already close to 0 and it is a
         # relative, not absolute, value.
         Y_fantasized, _ = outcome_transform(
-            Y_fantasized.unsqueeze(-1), Yvar.unsqueeze(-1)
+            Y_fantasized.unsqueeze(-1), Yvar.unsqueeze(-1), X=batch_X_observed
         )
         Y_fantasized = Y_fantasized.squeeze(-1)
     input_transform = getattr(model, "input_transform", None)

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -172,7 +172,7 @@ class ApproximateGPyTorchModel(GPyTorchModel):
 
         posterior = GPyTorchPosterior(distribution=dist)
         if hasattr(self, "outcome_transform"):
-            posterior = self.outcome_transform.untransform_posterior(posterior)
+            posterior = self.outcome_transform.untransform_posterior(posterior, X=X)
         if posterior_transform is not None:
             posterior = posterior_transform(posterior)
         return posterior
@@ -397,7 +397,7 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
                     UserInputWarning,
                     stacklevel=3,
                 )
-                train_Y, _ = outcome_transform(train_Y)
+                train_Y, _ = outcome_transform(train_Y, X=transformed_X)
             self._validate_tensor_args(X=transformed_X, Y=train_Y)
             validate_input_scaling(train_X=transformed_X, train_Y=train_Y)
             if train_Y.shape[-1] != num_outputs:

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -79,7 +79,7 @@ class EnsembleModel(Model, ABC):
         # `posterior` (as is done in GP models). This is more general since it works
         # even if the transform doesn't support `untransform_posterior`.
         if hasattr(self, "outcome_transform"):
-            values, _ = self.outcome_transform.untransform(values)
+            values, _ = self.outcome_transform.untransform(values, X=X)
         if output_indices is not None:
             values = values[..., output_indices]
         posterior = EnsemblePosterior(values=values)

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -373,7 +373,9 @@ class SaasFullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel):
                 X=train_X, input_transform=input_transform
             )
         if outcome_transform is not None:
-            train_Y, train_Yvar = outcome_transform(train_Y, train_Yvar)
+            train_Y, train_Yvar = outcome_transform(
+                Y=train_Y, Yvar=train_Yvar, X=transformed_X
+            )
         self._validate_tensor_args(X=transformed_X, Y=train_Y)
         validate_input_scaling(
             train_X=transformed_X, train_Y=train_Y, train_Yvar=train_Yvar

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -242,7 +242,9 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
             )
         if outcome_transform is not None:
             outcome_transform.train()  # Ensure we learn parameters here on init
-            train_Y, train_Yvar = outcome_transform(train_Y, train_Yvar)
+            train_Y, train_Yvar = outcome_transform(
+                Y=train_Y, Yvar=train_Yvar, X=transformed_X
+            )
         if train_Yvar is not None:  # Clamp after transforming
             train_Yvar = train_Yvar.clamp(MIN_INFERRED_NOISE_LEVEL)
 

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -160,7 +160,9 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                 X=train_X, input_transform=input_transform
             )
         if outcome_transform is not None:
-            train_Y, train_Yvar = outcome_transform(train_Y, train_Yvar)
+            train_Y, train_Yvar = outcome_transform(
+                Y=train_Y, Yvar=train_Yvar, X=transformed_X
+            )
         # Validate again after applying the transforms
         self._validate_tensor_args(X=transformed_X, Y=train_Y, Yvar=train_Yvar)
         ignore_X_dims = getattr(self, "_ignore_X_dims_scaling_check", None)

--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -198,7 +198,7 @@ class GPyTorchModel(Model, ABC):
                     mvn = self.likelihood(mvn, X)
         posterior = GPyTorchPosterior(distribution=mvn)
         if hasattr(self, "outcome_transform"):
-            posterior = self.outcome_transform.untransform_posterior(posterior)
+            posterior = self.outcome_transform.untransform_posterior(posterior, X=X)
         if posterior_transform is not None:
             return posterior_transform(posterior)
         return posterior
@@ -244,7 +244,7 @@ class GPyTorchModel(Model, ABC):
             # (unless we've already trasnformed if BatchedMultiOutputGPyTorchModel)
             if not isinstance(self, BatchedMultiOutputGPyTorchModel):
                 # `noise` is assumed to already be outcome-transformed.
-                Y, _ = self.outcome_transform(Y=Y, Yvar=Yvar)
+                Y, _ = self.outcome_transform(Y=Y, Yvar=Yvar, X=X)
         # Validate using strict=False, since we cannot tell if Y has an explicit
         # output dimension. Do not check shapes when fantasizing as they are
         # not expected to match.
@@ -467,7 +467,7 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
 
         posterior = GPyTorchPosterior(distribution=mvn)
         if hasattr(self, "outcome_transform"):
-            posterior = self.outcome_transform.untransform_posterior(posterior)
+            posterior = self.outcome_transform.untransform_posterior(posterior, X=X)
         if posterior_transform is not None:
             return posterior_transform(posterior)
         return posterior
@@ -511,7 +511,7 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
         if hasattr(self, "outcome_transform"):
             # We need to apply transforms before shifting batch indices around.
             # `noise` is assumed to already be outcome-transformed.
-            Y, _ = self.outcome_transform(Y)
+            Y, _ = self.outcome_transform(Y, X=X)
         # Do not check shapes when fantasizing as they are not expected to match.
         if fantasize_flag.off():
             self._validate_tensor_args(X=X, Y=Y, Yvar=noise, strict=False)
@@ -924,7 +924,7 @@ class MultiTaskGPyTorchModel(GPyTorchModel, ABC):
             )
             posterior = GPyTorchPosterior(distribution=mtmvn)
         if hasattr(self, "outcome_transform"):
-            posterior = self.outcome_transform.untransform_posterior(posterior)
+            posterior = self.outcome_transform.untransform_posterior(posterior, X=X)
         if posterior_transform is not None:
             return posterior_transform(posterior)
         return posterior

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -91,7 +91,7 @@ class FlattenedStandardize(Standardize):
         return out
 
     def forward(
-        self, Y: Tensor, Yvar: Tensor | None = None
+        self, Y: Tensor, Yvar: Tensor | None = None, X: Tensor | None = None
     ) -> tuple[Tensor, Tensor | None]:
         Y = self._squeeze_to_single_output(Y)
         if Yvar is not None:
@@ -107,13 +107,13 @@ class FlattenedStandardize(Standardize):
         return Y_out, Yvar_out
 
     def untransform(
-        self, Y: Tensor, Yvar: Tensor | None = None
+        self, Y: Tensor, Yvar: Tensor | None = None, X: Tensor | None = None
     ) -> tuple[Tensor, Tensor | None]:
         Y = self._squeeze_to_single_output(Y)
         if Yvar is not None:
             Yvar = self._squeeze_to_single_output(Yvar)
 
-        Y, Yvar = super().untransform(Y, Yvar)
+        Y, Yvar = super().untransform(Y=Y, Yvar=Yvar, X=X)
 
         Y = self._return_to_output_shape(Y)
         if Yvar is not None:
@@ -121,7 +121,7 @@ class FlattenedStandardize(Standardize):
         return Y, Yvar
 
     def untransform_posterior(
-        self, posterior: HigherOrderGPPosterior
+        self, posterior: HigherOrderGPPosterior, X: Tensor | None = None
     ) -> TransformedPosterior:
         # TODO: return a HigherOrderGPPosterior once rescaling constant
         # muls * LinearOperators won't force a dense decomposition rather than a
@@ -227,7 +227,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                     output_shape=train_Y.shape[-num_output_dims:],
                     batch_shape=batch_shape,
                 )
-            train_Y, _ = outcome_transform(train_Y)
+            train_Y, _ = outcome_transform(train_Y, X=train_X)
 
         self._aug_batch_shape = batch_shape
         self._num_dimensions = num_output_dims + 1
@@ -416,7 +416,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
         """
         if hasattr(self, "outcome_transform"):
             # we need to apply transforms before shifting batch indices around
-            Y, noise = self.outcome_transform(Y=Y, Yvar=noise)
+            Y, noise = self.outcome_transform(Y=Y, Yvar=noise, X=X)
         # Do not check shapes when fantasizing as they are not expected to match.
         if fantasize_flag.off():
             self._validate_tensor_args(X=X, Y=Y, Yvar=noise, strict=False)
@@ -540,7 +540,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                 num_outputs=self._num_outputs,
             )
             if hasattr(self, "outcome_transform"):
-                posterior = self.outcome_transform.untransform_posterior(posterior)
+                posterior = self.outcome_transform.untransform_posterior(posterior, X=X)
             return posterior
 
     def make_posterior_variances(

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -117,7 +117,7 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel, FantasizeMixin):
             else:
                 noise_i = torch.cat([noise[..., k] for k in range(i, j)], dim=-1)
             if hasattr(model, "outcome_transform"):
-                y_i, noise_i = model.outcome_transform(y_i, noise_i)
+                y_i, noise_i = model.outcome_transform(y_i, noise_i, X=X_i)
                 if noise_i is not None:
                     noise_i = noise_i.squeeze(0)
             targets.append(y_i)

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -219,7 +219,9 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
         if outcome_transform == DEFAULT:
             outcome_transform = Standardize(m=1, batch_shape=train_X.shape[:-2])
         if outcome_transform is not None:
-            train_Y, train_Yvar = outcome_transform(Y=train_Y, Yvar=train_Yvar)
+            train_Y, train_Yvar = outcome_transform(
+                Y=train_Y, Yvar=train_Yvar, X=transformed_X
+            )
 
         # squeeze output dim
         train_Y = train_Y.squeeze(-1)
@@ -464,7 +466,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
                 X=train_X, input_transform=input_transform
             )
         if outcome_transform is not None:
-            train_Y, _ = outcome_transform(train_Y)
+            train_Y, _ = outcome_transform(train_Y, X=transformed_X)
 
         self._validate_tensor_args(X=transformed_X, Y=train_Y)
         self._num_outputs = train_Y.shape[-1]
@@ -772,7 +774,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
         )
 
         if hasattr(self, "outcome_transform"):
-            posterior = self.outcome_transform.untransform_posterior(posterior)
+            posterior = self.outcome_transform.untransform_posterior(posterior, X=X)
         return posterior
 
     def train(self, val=True, *args, **kwargs):

--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -27,9 +27,11 @@ from collections import OrderedDict
 
 import torch
 from botorch.models.transforms.utils import (
+    nanstd,
     norm_to_lognorm_mean,
     norm_to_lognorm_variance,
 )
+from botorch.models.utils.assorted import get_task_value_remapping
 from botorch.posteriors import GPyTorchPosterior, Posterior, TransformedPosterior
 from botorch.utils.transforms import normalize_indices
 from linear_operator.operators import CholLinearOperator, DiagLinearOperator
@@ -259,6 +261,46 @@ class Standardize(OutcomeTransform):
         self._batch_shape = batch_shape
         self._min_stdv = min_stdv
 
+    def _get_per_input_means_stdvs(
+        self, X: Tensor, include_stdvs_sq: bool
+    ) -> tuple[Tensor, Tensor, Tensor | None]:
+        r"""Get per-input means and stdvs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of input parameters.
+            include_stdvs_sq: Whether to include the stdvs squared.
+                This parameter is not used by this method
+
+        Returns:
+            A three-tuple with the  means and stdvs:
+
+            - The per-input means.
+            - The per-input stdvs.
+            - The per-input stdvs squared.
+        """
+        return self.means, self.stdvs, self._stdvs_sq
+
+    def _validate_training_inputs(self, Y: Tensor, Yvar: Tensor | None = None) -> None:
+        """Validate training inputs.
+
+        Args:
+            Y: A `batch_shape x n x m`-dim tensor of training targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of observation noises.
+        """
+        if Y.shape[:-2] != self._batch_shape:
+            raise RuntimeError(
+                f"Expected Y.shape[:-2] to be {self._batch_shape}, matching "
+                f"the `batch_shape` argument to `{self.__class__.__name__}`, but got "
+                f"Y.shape[:-2]={Y.shape[:-2]}."
+            )
+        elif Y.shape[-2] < 1:
+            raise ValueError(f"Can't standardize with no observations. {Y.shape=}.")
+        elif Y.size(-1) != self._m:
+            raise RuntimeError(
+                f"Wrong output dimension. Y.size(-1) is {Y.size(-1)}; expected "
+                f"{self._m}."
+            )
+
     def forward(
         self, Y: Tensor, Yvar: Tensor | None = None, X: Tensor | None = None
     ) -> tuple[Tensor, Tensor | None]:
@@ -283,21 +325,8 @@ class Standardize(OutcomeTransform):
             - The transformed observation noise (if applicable).
         """
         if self.training:
-            if Y.shape[:-2] != self._batch_shape:
-                raise RuntimeError(
-                    f"Expected Y.shape[:-2] to be {self._batch_shape}, matching "
-                    "the `batch_shape` argument to `Standardize`, but got "
-                    f"Y.shape[:-2]={Y.shape[:-2]}."
-                )
-            if Y.size(-1) != self._m:
-                raise RuntimeError(
-                    f"Wrong output dimension. Y.size(-1) is {Y.size(-1)}; expected "
-                    f"{self._m}."
-                )
-            if Y.shape[-2] < 1:
-                raise ValueError(f"Can't standardize with no observations. {Y.shape=}.")
-
-            elif Y.shape[-2] == 1:
+            self._validate_training_inputs(Y=Y, Yvar=Yvar)
+            if Y.shape[-2] == 1:
                 stdvs = torch.ones(
                     (*Y.shape[:-2], 1, Y.shape[-1]), dtype=Y.dtype, device=Y.device
                 )
@@ -313,9 +342,12 @@ class Standardize(OutcomeTransform):
             self.stdvs = stdvs
             self._stdvs_sq = stdvs.pow(2)
             self._is_trained = torch.tensor(True)
-
-        Y_tf = (Y - self.means) / self.stdvs
-        Yvar_tf = Yvar / self._stdvs_sq if Yvar is not None else None
+        include_stdvs_sq = Yvar is not None
+        means, stdvs, stdvs_sq = self._get_per_input_means_stdvs(
+            X=X, include_stdvs_sq=include_stdvs_sq
+        )
+        Y_tf = (Y - means) / stdvs
+        Yvar_tf = Yvar / stdvs_sq if include_stdvs_sq else None
         return Y_tf, Yvar_tf
 
     def subset_output(self, idcs: list[int]) -> OutcomeTransform:
@@ -376,9 +408,12 @@ class Standardize(OutcomeTransform):
                 "(e.g. `transform(Y)`) before calling `untransform`, since "
                 "means and standard deviations need to be computed."
             )
-
-        Y_utf = self.means + self.stdvs * Y
-        Yvar_utf = self._stdvs_sq * Yvar if Yvar is not None else None
+        include_stdvs_sq = Yvar is not None
+        means, stdvs, stdvs_sq = self._get_per_input_means_stdvs(
+            X=X, include_stdvs_sq=include_stdvs_sq
+        )
+        Y_utf = means + stdvs * Y
+        Yvar_utf = stdvs_sq * Yvar if include_stdvs_sq else None
         return Y_utf, Yvar_utf
 
     @property
@@ -433,8 +468,9 @@ class Standardize(OutcomeTransform):
             )
         # GPyTorchPosterior (TODO: Should we Lazy-evaluate the mean here as well?)
         mvn = posterior.distribution
-        offset = self.means
-        scale_fac = self.stdvs
+        offset, scale_fac, _ = self._get_per_input_means_stdvs(
+            X=X, include_stdvs_sq=False
+        )
         if not posterior._is_mt:
             mean_tf = offset.squeeze(-1) + scale_fac.squeeze(-1) * mvn.mean
             scale_fac = scale_fac.squeeze(-1).expand_as(mean_tf)
@@ -449,7 +485,6 @@ class Standardize(OutcomeTransform):
 
         if (
             not mvn.islazy
-            # TODO: Figure out attribute namming weirdness here
             or mvn._MultivariateNormal__unbroadcasted_scale_tril is not None
         ):
             # if already computed, we can save a lot of time using scale_tril
@@ -463,6 +498,197 @@ class Standardize(OutcomeTransform):
         kwargs = {"interleaved": mvn._interleaved} if posterior._is_mt else {}
         mvn_tf = mvn.__class__(mean=mean_tf, covariance_matrix=covar_tf, **kwargs)
         return GPyTorchPosterior(mvn_tf)
+
+
+class StratifiedStandardize(Standardize):
+    r"""Standardize outcomes (zero mean, unit variance) along stratification dimension.
+
+    This module is stateful: If in train mode, calling forward updates the
+    module state (i.e. the mean/std normalizing constants). If in eval mode,
+    calling forward simply applies the standardization using the current module
+    state.
+    """
+
+    def __init__(
+        self,
+        task_values: Tensor,
+        stratification_idx: int,
+        batch_shape: torch.Size = torch.Size(),  # noqa: B008
+        min_stdv: float = 1e-8,
+        # dtype: torch.dtype = torch.double,
+    ) -> None:
+        r"""Standardize outcomes (zero mean, unit variance) along stratification dim.
+
+        Note: This currenlty only supports single output models
+        (including multi-task models that have a single output).
+
+        Args:
+            task_values: `t`-dim tensor of task values.
+            stratification_idx: The index of the stratification dimension.
+            batch_shape: The batch_shape of the training targets.
+            min_stddv: The minimum standard deviation for which to perform
+                standardization (if lower, only de-mean the data).
+        """
+        OutcomeTransform.__init__(self)
+        self._stratification_idx = stratification_idx
+        task_values = task_values.unique(sorted=True)
+        self.strata_mapping = get_task_value_remapping(task_values, dtype=torch.long)
+        if self.strata_mapping is None:
+            self.strata_mapping = task_values
+        n_strata = self.strata_mapping.shape[0]
+        self._min_stdv = min_stdv
+        self.register_buffer("means", torch.zeros(*batch_shape, n_strata, 1))
+        self.register_buffer("stdvs", torch.ones(*batch_shape, n_strata, 1))
+        self.register_buffer("_stdvs_sq", torch.ones(*batch_shape, n_strata, 1))
+        self.register_buffer("_is_trained", torch.tensor(False))
+        self._batch_shape = batch_shape
+        self._m = 1  # TODO: support multiple outputs
+        self._outputs = None
+
+    def forward(
+        self, Y: Tensor, Yvar: Tensor | None = None, X: Tensor | None = None
+    ) -> tuple[Tensor, Tensor | None]:
+        r"""Standardize outcomes.
+
+        If the module is in train mode, this updates the module state (i.e. the
+        mean/std normalizing constants). If the module is in eval mode, simply
+        applies the normalization using the module state.
+
+        Args:
+            Y: A `batch_shape x n x m`-dim tensor of training targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of observation noises
+                associated with the training targets (if applicable).
+            X: A `batch_shape x n x d`-dim tensor of input parameters.
+
+        Returns:
+            A two-tuple with the transformed outcomes:
+
+            - The transformed outcome observations.
+            - The transformed observation noise (if applicable).
+        """
+        if X is None:
+            raise ValueError("X is required for StratifiedStandardize.")
+        if self.training:
+            self._validate_training_inputs(Y=Y, Yvar=Yvar)
+            self.means = self.means.to(dtype=X.dtype, device=X.device)
+            self.stdvs = self.stdvs.to(dtype=X.dtype, device=X.device)
+            self._stdvs_sq = self._stdvs_sq.to(dtype=X.dtype, device=X.device)
+            strata = X[..., self._stratification_idx].long()
+            unique_strata = strata.unique()
+            for s in unique_strata:
+                mapped_strata = self.strata_mapping[s]
+                mask = strata != s
+                Y_strata = Y.clone()
+                Y_strata[..., mask, :] = float("nan")
+                stdvs = (
+                    torch.ones_like(Y_strata)
+                    if Y.shape[-2] == 1
+                    else nanstd(X=Y_strata, dim=-2)
+                )
+                stdvs = stdvs.where(
+                    stdvs >= self._min_stdv, torch.full_like(stdvs, 1.0)
+                )
+                means = Y_strata.nanmean(dim=-2)
+                self.means[..., mapped_strata, :] = means
+                self.stdvs[..., mapped_strata, :] = stdvs
+                self._stdvs_sq[..., mapped_strata, :] = stdvs.pow(2)
+            self._is_trained = torch.tensor(True)
+        training = self.training
+        self.training = False
+        tf_Y, tf_Yvar = super().forward(Y=Y, Yvar=Yvar, X=X)
+        self.training = training
+        return tf_Y, tf_Yvar
+
+    def _get_per_input_means_stdvs(
+        self, X: Tensor, include_stdvs_sq: bool
+    ) -> tuple[Tensor, Tensor, Tensor | None]:
+        r"""Get per-input means and stdvs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of input parameters.
+            include_stdvs_sq: Whether to include the stdvs squared.
+
+        Returns:
+            A three-tuple with the per-input means and stdvs:
+
+            - The per-input means.
+            - The per-input stdvs.
+            - The per-input stdvs squared.
+        """
+        strata = X[..., self._stratification_idx].long()
+        mapped_strata = self.strata_mapping[strata].unsqueeze(-1)
+        # get means and stdvs for each strata
+        n_extra_batch_dims = mapped_strata.ndim - 2 - len(self._batch_shape)
+        expand_shape = mapped_strata.shape[:n_extra_batch_dims] + self.means.shape
+        means = torch.gather(
+            input=self.means.expand(expand_shape),
+            dim=-2,
+            index=mapped_strata,
+        )
+        stdvs = torch.gather(
+            input=self.stdvs.expand(expand_shape),
+            dim=-2,
+            index=mapped_strata,
+        )
+        if include_stdvs_sq:
+            stdvs_sq = torch.gather(
+                input=self._stdvs_sq.expand(expand_shape),
+                dim=-2,
+                index=mapped_strata,
+            )
+        else:
+            stdvs_sq = None
+        return means, stdvs, stdvs_sq
+
+    def subset_output(self, idcs: list[int]) -> OutcomeTransform:
+        r"""Subset the transform along the output dimension.
+
+        Args:
+            idcs: The output indices to subset the transform to.
+
+        Returns:
+            The current outcome transform, subset to the specified output indices.
+        """
+        raise NotImplementedError
+
+    def untransform(
+        self, Y: Tensor, Yvar: Tensor | None = None, X: Tensor | None = None
+    ) -> tuple[Tensor, Tensor | None]:
+        r"""Un-standardize outcomes.
+
+        Args:
+            Y: A `batch_shape x n x m`-dim tensor of standardized targets.
+            Yvar: A `batch_shape x n x m`-dim tensor of standardized observation
+                noises associated with the targets (if applicable).
+            X: A `batch_shape x n x d`-dim tensor of input parameters.
+
+        Returns:
+            A two-tuple with the un-standardized outcomes:
+
+            - The un-standardized outcome observations.
+            - The un-standardized observation noise (if applicable).
+        """
+        if X is None:
+            raise ValueError("X is required for StratifiedStandardize.")
+        return super().untransform(Y=Y, Yvar=Yvar, X=X)
+
+    def untransform_posterior(
+        self, posterior: Posterior, X: Tensor | None = None
+    ) -> GPyTorchPosterior | TransformedPosterior:
+        r"""Un-standardize the posterior.
+
+        Args:
+            posterior: A posterior in the standardized space.
+            X: A `batch_shape x n x d`-dim tensor of training inputs (if applicable).
+
+        Returns:
+            The un-standardized posterior. If the input posterior is a
+            `GPyTorchPosterior`, return a `GPyTorchPosterior`. Otherwise, return a
+            `TransformedPosterior`.
+        """
+        if X is None:
+            raise ValueError("X is required for StratifiedStandardize.")
+        return super().untransform_posterior(posterior=posterior, X=X)
 
 
 class Log(OutcomeTransform):

--- a/botorch/models/transforms/utils.py
+++ b/botorch/models/transforms/utils.py
@@ -141,3 +141,20 @@ def interaction_features(X: Tensor) -> Tensor:
     dim = X.shape[-1]
     row_idcs, col_idcs = torch.triu_indices(dim, dim, offset=1)
     return (X.unsqueeze(-1) @ X.unsqueeze(-2))[..., row_idcs, col_idcs].unsqueeze(-2)
+
+
+def nanstd(X: Tensor, dim: int, keepdim: bool = False) -> Tensor:
+    """Computes the standard deviation of the input, ignoring NaNs.
+
+    Args:
+        X: A `batch_shape x n x d`-dim tensor of inputs.
+        dim: The dimension along which to compute the standard deviation.
+        keepdim: If True, the dimension along which the standard deviation is
+            compute is kept.
+    """
+    n = (~torch.isnan(X)).sum(dim=dim)
+    return (
+        (X - X.nanmean(dim=dim, keepdim=True)).pow(2).nanmean(dim=dim, keepdim=keepdim)
+        * n
+        / (n - 1)
+    ).sqrt()

--- a/botorch/utils/test_helpers.py
+++ b/botorch/utils/test_helpers.py
@@ -291,7 +291,7 @@ def get_pvar_expected(
     # variance according to that transform.
     if hasattr(model, "outcome_transform"):
         _, pvar_exp = model.outcome_transform.untransform(
-            Y=torch.zeros_like(pvar_exp), Yvar=pvar_exp
+            Y=torch.zeros_like(pvar_exp), Yvar=pvar_exp, X=X
         )
 
     return pvar_exp


### PR DESCRIPTION
Summary: see title. This allows applying stratified standardization at the model level, which will enable selecting whether to use a Single-task or multi-task model in Ax while using the appropriate transform. I.e. One could specify ModelConfigs that use 1) `SingleTaskGP` + `Standardize`, 2) `MultiTaskGP` + `StratifiedStandardize`.

Differential Revision: D67728920


