### PR TITLE
`RobustRelevancePursuitSingleTaskGP` with specialized `fit_gpytorch_mll`

### DIFF
--- a/botorch/models/__init__.py
+++ b/botorch/models/__init__.py
@@ -21,12 +21,16 @@ from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
 from botorch.models.higher_order_gp import HigherOrderGP
+
+from botorch.models.map_saas import add_saas_prior, AdditiveMapSaasSingleTaskGP
 from botorch.models.model import ModelList
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import KroneckerMultiTaskGP, MultiTaskGP
 from botorch.models.pairwise_gp import PairwiseGP, PairwiseLaplaceMarginalLogLikelihood
 
 __all__ = [
+    "add_saas_prior",
+    "AdditiveMapSaasSingleTaskGP",
     "AffineDeterministicModel",
     "AffineFidelityCostModel",
     "ApproximateGPyTorchModel",

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -186,6 +186,7 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                     noise=train_Yvar, batch_shape=self._aug_batch_shape
                 )
         else:
+            # This is used to check if the `model_list_to_batched` can be used
             self._is_custom_likelihood = True
         ExactGP.__init__(
             self, train_inputs=train_X, train_targets=train_Y, likelihood=likelihood

--- a/botorch/models/map_saas.py
+++ b/botorch/models/map_saas.py
@@ -1,0 +1,419 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+from botorch.exceptions import UnsupportedError
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.transforms.input import InputTransform
+from botorch.models.transforms.outcome import OutcomeTransform
+from botorch.utils.constraints import LogTransformedInterval
+from gpytorch.constraints import Interval
+from gpytorch.kernels import AdditiveKernel, Kernel, MaternKernel, ScaleKernel
+from gpytorch.likelihoods import FixedNoiseGaussianLikelihood, GaussianLikelihood
+from gpytorch.means import ConstantMean
+from gpytorch.priors import GammaPrior, HalfCauchyPrior, NormalPrior
+from torch import Tensor
+from torch.distributions.half_cauchy import HalfCauchy
+from torch.nn import Parameter
+
+
+EPS = 1e-8
+
+
+class SaasPriorHelper:
+    """Helper class for specifying parameter and setting closures."""
+
+    def __init__(self, tau: float | None = None):
+        """Instantiates a new helper object.
+
+        Args:
+            tau: Value of the global shrinkage parameter. If `None`, the tau will be
+                a free parameter and inferred from the data.
+        """
+        self._tau = torch.as_tensor(tau) if tau is not None else None
+
+    def tau(self, m: Kernel) -> Tensor:
+        """The global shrinkage parameter `tau`.
+
+        Args:
+            m: A kernel object equipped with a lengthscale.
+
+        Returns:
+            The global shrinkage parameter of the SAAS prior.
+        """
+        return (
+            self._tau.to(m.lengthscale)
+            if self._tau is not None
+            else m.raw_tau_constraint.transform(m.raw_tau)
+        )
+
+    def inv_lengthscale_prior_param_or_closure(self, m: Kernel) -> Tensor:
+        """Closure to compute the scaled inverse lengthscale parameter (`tau / l^2`)
+        to which the SAAS prior is applied.
+
+        Args:
+            m: A kernel object equipped with a lengthscale.
+
+        Returns:
+            The scaled inverse lengthscale parameter.
+        """
+        tau = self.tau(m)
+        return tau.view(*tau.shape, 1, 1) / (m.lengthscale**2)
+
+    def inv_lengthscale_prior_setting_closure(self, m: Kernel, value: Tensor) -> None:
+        """Closure to set the inverse lengthscale prior parameter.
+
+        Args:
+            m: A kernel object equipped with a lengthscale.
+            value: The value of the scaled inverse lengthscale parameter, (`tau / l^2`),
+                used to recover and set the lengthscale of the kernel.
+        """
+        # Lengthscale is batch x m x 1 x d, update tau to avoid unwanted broadcasting.
+        tau = self.tau(m)
+        tau = tau.view(*tau.shape, 1, 1)
+        lb = m.raw_lengthscale_constraint.lower_bound.to(tau)
+        ub = m.raw_lengthscale_constraint.upper_bound.to(tau)
+        m._set_lengthscale((tau / value.to(tau)).sqrt().clamp(lb + EPS, ub - EPS))
+
+    def tau_prior_param_or_closure(self, m: Kernel) -> Tensor:
+        """Closure to compute the global shrinkage parameter `tau`.
+
+        Args:
+            m: A kernel object equipped with a `raw_tau` parameter.
+
+        Returns:
+            The transformed global shrinkage parameter `tau`.
+        """
+        return m.raw_tau_constraint.transform(m.raw_tau)
+
+    def tau_prior_setting_closure(self, m: Kernel, value: Tensor) -> None:
+        """Closure to set the global shrinkage parameter `tau`.
+
+        Args:
+            m: A kernel object equipped with a `raw_tau` parameter.
+            value: The value of the global shrinkage parameter.
+        """
+        lb = m.raw_tau_constraint.lower_bound.to(m.raw_tau)
+        ub = m.raw_tau_constraint.upper_bound.to(m.raw_tau)
+        m.raw_tau.data.fill_(
+            m.raw_tau_constraint.inverse_transform(
+                value.to(m.raw_tau).clamp(lb + EPS, ub - EPS)
+            ).item()
+        )
+
+
+def add_saas_prior(
+    base_kernel: Kernel,
+    tau: float | None = None,
+    log_scale: bool = True,
+) -> Kernel:
+    """Add a SAAS prior to a given base_kernel.
+
+    The SAAS prior is given by tau / lengthscale^2 ~ HC(1.0). If tau is None,
+    we place an additional HC(0.1) prior on tau similar to the original SAAS prior
+    that relies on inference with NUTS.
+
+    Example:
+        >>> matern_kernel = MaternKernel(...)
+        >>> add_saas_prior(matern_kernel, tau=None)  # Add a SAAS prior
+
+    Args:
+        base_kernel: Base kernel that has a lengthscale and uses ARD.
+            Note that this function modifies the kernel object in place.
+        tau: Value of the global shrinkage. If `None`, infer the global
+            shrinkage parameter.
+        log_scale: Set to `True` if the lengthscale and tau should be optimized on
+            a log-scale without any domain rescaling. That is, we will learn
+            `raw_lengthscale := log(lengthscale)` and this hyperparameter needs to
+            satisfy the corresponding bound constraints. Setting this to `True` will
+            generally improve the numerical stability, but requires an optimizer that
+            can handle bound constraints, e.g., L-BFGS-B.
+
+    Returns:
+        Base kernel with SAAS priors added.
+    """
+    if not base_kernel.has_lengthscale:
+        raise UnsupportedError("base_kernel must have lengthscale(s)")
+    if hasattr(base_kernel, "lengthscale_prior"):
+        raise UnsupportedError("base_kernel must not specify a lengthscale prior")
+    tkwargs = {"device": base_kernel.device, "dtype": base_kernel.dtype}
+
+    batch_shape = base_kernel.raw_lengthscale.shape[:-2]
+    IntervalClass = LogTransformedInterval if log_scale else Interval
+    base_kernel.register_constraint(
+        param_name="raw_lengthscale",
+        constraint=IntervalClass(0.01, 1e4, initial_value=1),
+        replace=True,
+    )
+    prior_helper = SaasPriorHelper(tau=tau)
+    if tau is None:  # Place a HC(0.1) prior on tau
+        base_kernel.register_parameter(
+            name="raw_tau",
+            parameter=Parameter(torch.full(batch_shape, 0.1, **tkwargs)),
+        )
+        base_kernel.register_constraint(
+            param_name="raw_tau",
+            constraint=IntervalClass(1e-3, 10, initial_value=0.1),
+            replace=True,
+        )
+        base_kernel.register_prior(
+            name="tau_prior",
+            prior=HalfCauchyPrior(torch.tensor(0.1, **tkwargs)),
+            param_or_closure=prior_helper.tau_prior_param_or_closure,
+            setting_closure=prior_helper.tau_prior_setting_closure,
+        )
+    # Place a HC(1) prior on tau / lengthscale^2
+    base_kernel.register_prior(
+        name="inv_lengthscale_prior",
+        prior=HalfCauchyPrior(torch.tensor(1.0, **tkwargs)),
+        param_or_closure=prior_helper.inv_lengthscale_prior_param_or_closure,
+        setting_closure=prior_helper.inv_lengthscale_prior_setting_closure,
+    )
+    return base_kernel
+
+
+def get_map_saas_model(
+    train_X: Tensor,
+    train_Y: Tensor,
+    train_Yvar: Tensor | None = None,
+    input_transform: InputTransform | None = None,
+    outcome_transform: OutcomeTransform | None = None,
+    tau: float | None = None,
+) -> SingleTaskGP:
+    """Helper method for creating an unfitted MAP SAAS model.
+
+    Args:
+        train_X: Tensor of shape `n x d` with training inputs.
+        train_Y: Tensor of shape `n x 1` with training targets.
+        train_Yvar: Optional tensor of shape `n x 1` with observed noise,
+            inferred if None.
+        input_transform: An optional input transform.
+        outcome_transform: An optional outcome transforms.
+        tau: Fixed value of the global shrinkage tau. If None, the model
+            places a HC(0.1) prior on tau and infers it.
+
+    Returns:
+        A SingleTaskGP with a Matern kernel and a SAAS prior.
+    """
+    # TODO: Shape checks
+    _, aug_batch_shape = SingleTaskGP.get_batch_dimensions(
+        train_X=train_X, train_Y=train_Y
+    )
+    mean_module = get_mean_module_with_normal_prior(batch_shape=aug_batch_shape)
+    if input_transform is not None:
+        with torch.no_grad():
+            transformed_X = input_transform(train_X)
+        ard_num_dims = transformed_X.shape[-1]
+    else:
+        ard_num_dims = train_X.shape[-1]
+    base_kernel = MaternKernel(
+        nu=2.5, ard_num_dims=ard_num_dims, batch_shape=aug_batch_shape
+    )
+    # NOTE: need to call `to` to set device and dtype before calling `add_saas_prior`,
+    # since the SAAS prior contains tensors that are not parameters of the model, and
+    # terefore not automatically moved to the correct device with a `to` call on the
+    # model.
+    base_kernel.to(train_X)
+    add_saas_prior(base_kernel=base_kernel, tau=tau)
+    covar_module = ScaleKernel(
+        base_kernel=base_kernel,
+        outputscale_constraint=LogTransformedInterval(1e-2, 1e4, initial_value=10),
+        batch_shape=aug_batch_shape,
+    )
+    if train_Yvar is None:
+        likelihood = get_gaussian_likelihood_with_gamma_prior(
+            batch_shape=aug_batch_shape
+        )
+    else:
+        likelihood = None
+    model = SingleTaskGP(
+        train_X=train_X,
+        train_Y=train_Y,
+        train_Yvar=train_Yvar,
+        mean_module=mean_module,
+        covar_module=covar_module,
+        likelihood=likelihood,
+        input_transform=input_transform,
+        outcome_transform=outcome_transform,
+    )
+    model.to(train_X)
+    return model
+
+
+def get_mean_module_with_normal_prior(
+    batch_shape: torch.Size | None = None,
+) -> ConstantMean:
+    """Return constant mean with a N(0, 1) prior constrained to [-10, 10].
+
+    This prior assumes the outputs (targets) have been standardized to have zero mean
+    and unit variance.
+
+    Args:
+        batch_shape: Optional batch shape for the constant-mean module.
+
+    Returns:
+        ConstantMean module.
+    """
+    return ConstantMean(
+        constant_prior=NormalPrior(loc=0.0, scale=1.0),
+        constant_constraint=Interval(
+            -10,
+            10,
+            initial_value=0,
+            transform=None,
+        ),
+        batch_shape=batch_shape or torch.Size(),
+    )
+
+
+def get_gaussian_likelihood_with_gamma_prior(batch_shape: torch.Size | None = None):
+    """Return Gaussian likelihood with a Gamma(0.9, 10) prior.
+
+    This prior prefers small noise, but also has heavy tails.
+
+    Args:
+        batch_shape: Batch shape for the likelihood.
+
+    Returns:
+        GaussianLikelihood with Gamma(0.9, 10) prior constrained to [1e-4, 0.1].
+    """
+    return GaussianLikelihood(
+        noise_prior=GammaPrior(0.9, 10.0),
+        noise_constraint=LogTransformedInterval(1e-4, 1, initial_value=1e-2),
+        batch_shape=batch_shape or torch.Size(),
+    )
+
+
+def get_additive_map_saas_covar_module(
+    ard_num_dims: int,
+    num_taus: int = 4,
+    active_dims: tuple[int, ...] | None = None,
+    batch_shape: torch.Size | None = None,
+    dtype: torch.dtype | None = None,
+    device: torch.device | None = None,
+):
+    """Return an additive map SAAS covar module.
+
+    The constructed kernel is an additive kernel with `num_taus` terms. Each term is a
+    scaled Matern kernel with a SAAS prior and a tau sampled from a HalfCauchy(0, 1)
+    distrbution.
+
+    Args:
+        ard_num_dims: The number of inputs dimensions.
+        num_taus: The number of taus to use (4 if omitted).
+        active_dims: Active dims for the covar module. The kernel will be evaluated
+            only using these columns of the input tensor.
+        batch_shape: Batch shape for the covar module.
+
+    Returns:
+        An additive MAP SAAS covar module.
+    """
+    batch_shape = batch_shape or torch.Size()
+    kernels = []
+    for _ in range(num_taus):
+        base_kernel = MaternKernel(
+            nu=2.5,
+            ard_num_dims=ard_num_dims,
+            batch_shape=batch_shape,
+            active_dims=active_dims,
+        ).to(dtype=dtype, device=device)
+        add_saas_prior(base_kernel=base_kernel, tau=HalfCauchy(0.1).sample(batch_shape))
+        scaled_kernel = ScaleKernel(
+            base_kernel=base_kernel,
+            outputscale_constraint=LogTransformedInterval(1e-2, 1e4, initial_value=10),
+            batch_shape=batch_shape,
+        )
+        kernels.append(scaled_kernel)
+    return AdditiveKernel(*kernels)
+
+
+class AdditiveMapSaasSingleTaskGP(SingleTaskGP):
+    """An additive MAP SAAS single-task GP.
+
+    This is a maximum-a-posteriori (MAP) version of sparse axis-aligned subspace BO
+    (SAASBO), see `SaasFullyBayesianSingleTaskGP` for more details. SAASBO is a
+    high-dimensional Bayesian optimization approach that uses approximate fully
+    Bayesian inference via NUTS to learn the model hyperparameters. This works very
+    well, but is very computationally expensive which limits the use of SAASBO to a
+    small (~100) number of trials. Two of the main benefits with SAASBO are:
+
+    (1) A sparse prior on the inverse lengthscales that avoid overfitting.
+    (2) The ability to sample several (~16) sets of hyperparameters from the
+        posterior that we can average over when computing the acquisition
+        function (ensembling).
+
+    The goal of this Additive MAP SAAS model is to retain the main benefits of the SAAS
+    model while significantly speeding up the time to fit the model. We achieve this by
+    creating an additive kernel where each kernel in the sum is a Matern-5/2 kernel
+    with a SAAS prior and a separate outputscale. The sparsity level for each kernel
+    is sampled from an HC(0.1) distribution leading to a mix of sparsity levels (as is
+    often the case for the fully Bayesian SAAS model). We learn all the hyperparameters
+    using MAP inference which is significantly faster than using NUTS.
+
+    While we often find that the original SAAS model with NUTS performs better, the
+    additive MAP SAAS model can be several orders of magnitude faster to fit, which
+    makes it applicable to problems with potentially thousands of trials.
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        train_Yvar: Tensor | None = None,
+        outcome_transform: OutcomeTransform | None = None,
+        input_transform: InputTransform | None = None,
+        num_taus: int = 4,
+    ) -> None:
+        """Instantiates an AdditiveMapSaasSingleTaskGP.
+
+        Args:
+            train_X: A `batch_shape x n x d` tensor of training features.
+            train_Y: A `batch_shape x n x m` tensor of training observations.
+            train_Yvar: A `batch_shape x n x m` tensor of observed noise.
+            outcome_transform: An optional outcome transform.
+            input_transform: An optional input transform.
+            num_taus: The number of taus to use (4 if omitted).
+        """
+        self._set_dimensions(train_X=train_X, train_Y=train_Y)
+        mean_module = get_mean_module_with_normal_prior(
+            batch_shape=self._aug_batch_shape
+        )
+        if train_Yvar is not None:
+            _, _, train_Yvar = self._transform_tensor_args(
+                X=train_X, Y=train_Y, Yvar=train_Yvar
+            )
+        likelihood = (
+            FixedNoiseGaussianLikelihood(
+                noise=train_Yvar, batch_shape=self._aug_batch_shape
+            )
+            if train_Yvar is not None
+            else get_gaussian_likelihood_with_gamma_prior(
+                batch_shape=self._aug_batch_shape
+            )
+        )
+        covar_module = get_additive_map_saas_covar_module(
+            ard_num_dims=train_X.shape[-1],
+            num_taus=num_taus,
+            batch_shape=self._aug_batch_shape,
+            # Need to pass dtype and device at initialization of the covar_module
+            # because its priors contain tensors, and prior are currently not moved
+            # to the correct device/dtype when callling `to` on the model.
+            dtype=train_X.dtype,
+            device=train_X.device,
+        )
+
+        SingleTaskGP.__init__(
+            self=self,
+            train_X=train_X,
+            train_Y=train_Y,
+            mean_module=mean_module,
+            covar_module=covar_module,
+            likelihood=likelihood,
+            input_transform=input_transform,
+            outcome_transform=outcome_transform,
+        )
+        # Make sure that all buffers and parameters have the correct device and dtype
+        self.to(dtype=train_X.dtype, device=train_X.device)

--- a/botorch/models/robust_relevance_pursuit_model.py
+++ b/botorch/models/robust_relevance_pursuit_model.py
@@ -1,0 +1,376 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+This file contains a readily usable implementation of the robust Gaussian process
+model of [Ament2024pursuit]_, leveraging the Relevance Pursuit algorithm.
+
+In particular, this file contains a `RobustRelevancePursuitMixin` class, and a concrete
+implementation of a `SingleTaskGP` model, `RobustRelevancePursuitSingleTaskGP`, which
+has the same API as a standard `SingleTaskGP` model, but automatically instantiates the
+robust likelihood `SparseOutlierGaussianLikelihood` and dispatches the relevance pursuit
+algorithm during model fitting via `fit_gpytorch_mll`.
+
+Even though a standard `SingleTaskGP` model is expressive enough to implement the robust
+model by changing the likelihood, its optimization is more complex. So the main reason
+for the `RobustRelevancePursuitMixin` class is to hide this complexity by using multiple
+dispatch of `fit_gpytorch_mll`, which needs to do two distinct operations in the context
+of the robust model:
+
+(1) It needs to toggle the relevance pursuit discrete optimization algorithm that
+    changes the support, and as a sub-task,
+(2) it needs to still carry out the numerical optimization of the hyper-parameters given
+    a fixed support, but still with a `SparseOutlierGaussianLikelihood`. Since the types
+    of the marginal likelihood (`MarginalLogLikelihood`) and the likelihood
+    (`SparseOutlierGaussianLikelihood`) are the same in both calls, the only way we can
+    leverage the multiple dispatch mechanism is the model type.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+import torch
+from botorch.exceptions.errors import UnsupportedError
+from botorch.fit import FitGPyTorchMLL
+from botorch.models import SingleTaskGP
+from botorch.models.likelihoods.sparse_outlier_noise import (
+    SparseOutlierGaussianLikelihood,
+    SparseOutlierNoise,
+)
+from botorch.models.model import Model
+from botorch.models.relevance_pursuit import (
+    backward_relevance_pursuit,
+    get_posterior_over_support,
+)
+from botorch.models.transforms.input import InputTransform
+from botorch.models.transforms.outcome import OutcomeTransform
+from botorch.utils.types import _DefaultType, DEFAULT
+from gpytorch.likelihoods import (
+    FixedNoiseGaussianLikelihood,
+    GaussianLikelihood,
+    Likelihood,
+)
+from gpytorch.means.mean import Mean
+from gpytorch.mlls._approximate_mll import _ApproximateMarginalLogLikelihood
+from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
+from gpytorch.module import Module
+from torch import Tensor
+
+
+# default fractions of outliers to consider during relevance pursuit
+FRACTIONS_OF_OUTLIERS = [
+    0.0,
+    0.05,
+    0.1,
+    0.15,
+    0.2,
+    0.3,
+    0.4,
+    0.5,
+    0.75,
+    1.0,
+]
+
+
+class RobustRelevancePursuitMixin(ABC):
+    """A Mixin class for robust relevance pursuit models, which wraps a base likelihood
+    with a `SparseOutlierGaussianLikelihood` to detect outliers, and calls the
+    relevance pursuit algorithm during model fitting via `fit_gpytorch_mll`.
+
+    This is distinct from the `RelevancePursuitMixin` class, which is a Mixin class to
+    equip a specific module (the likelihood, in the case of the robust model) with the
+    relevance pursuit algorithms.
+    """
+
+    def __init__(
+        self,
+        base_likelihood: GaussianLikelihood | FixedNoiseGaussianLikelihood,
+        dim: int,
+        prior_mean_of_support: float | None = None,
+        convex_parameterization: bool = True,
+        cache_model_trace: bool = False,
+    ) -> None:
+        """Initializes a robust relevance pursuit model, which wraps a base likelihood
+        with a `SparseOutlierGaussianLikelihood` to detect outliers, and calls the
+        relevance pursuit algorithm during model fitting via `fit_gpytorch_mll`.
+
+        For details, see [Ament2024pursuit]_ or https://arxiv.org/abs/2410.24222.
+
+        Args:
+            base_likelihood: The base likelihood that will be wrapped by a
+                `SparseOutlierGaussianLikelihood` to detect outliers.
+            dim: The number of training data points, i.e. the maximum dimensionality
+                of the support set of the likelihood.
+            prior_mean_of_support: The mean value for the default exponential prior
+                distribution over the support size.
+            convex_parameterization: If True, use a convex parameterization of the
+                sparse noise model. See `SparseOutlierGaussianLikelihood` for details.
+            cache_model_trace: If True, cache the model trace during relevance pursuit.
+        """
+        self.likelihood = SparseOutlierGaussianLikelihood(
+            base_noise=base_likelihood.noise_covar,
+            dim=dim,
+            convex_parameterization=convex_parameterization,
+        )
+        self.bmc_support_size: Tensor | None = None
+        self.bmc_probability: Tensor | None = None
+        self.cache_model_trace = cache_model_trace
+        self.model_trace: list[SingleTaskGP] | None = None
+        self.prior_mean_of_support: float = (
+            int(0.2 * dim) if prior_mean_of_support is None else prior_mean_of_support
+        )
+
+    @abstractmethod
+    def to_standard_model(self) -> Model:
+        """Converts this `RobustRelevancePursuitMixin` to an equivalent standard model
+        with the same robust likelihood and hyper-parameters. This leaves the model
+        structure and predictions unchanged, but leads `fit_gpytorch_mll`'s dispatch to
+        *numerically* optimize the hyper-parameters of the model with a fixed support
+        set, as opposed to dispatching to the discrete optimization via the relevance
+        pursuit algorithm.
+
+        Returns:
+            A standard model.
+        """
+
+    def load_standard_model(self, standard_model: Model) -> RobustRelevancePursuitMixin:
+        """Loads the state dict of a model into the `RobustRelevancePursuitMixin`.
+
+        Args:
+            standard_model: A standard model with the same parameter structure and
+                likelihood as the `RobustRelevancePursuitMixin` model.
+
+        Returns:
+            The `RobustRelevancePursuitMixin` with the standard model's state dict.
+        """
+        # need special case for the likelihood because raw_rho's shape changes
+        # throughout the optimization
+        self.likelihood = standard_model.likelihood
+        # overwrite state_dict in place
+        self.load_state_dict(standard_model.state_dict())
+        return self
+
+
+class RobustRelevancePursuitSingleTaskGP(SingleTaskGP, RobustRelevancePursuitMixin):
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        train_Yvar: Tensor | None = None,
+        likelihood: Likelihood | None = None,
+        covar_module: Module | None = None,
+        mean_module: Mean | None = None,
+        outcome_transform: OutcomeTransform | _DefaultType | None = DEFAULT,
+        input_transform: InputTransform | None = None,
+        convex_parameterization: bool = True,
+        prior_mean_of_support: float | None = None,
+        cache_model_trace: bool = False,
+    ) -> None:
+        r"""A robust single-task GP model that toggles the relevance pursuit algorithm
+            during model fitting via `fit_gpytorch_mll`.
+
+        For details, see [Ament2024pursuit]_ or https://arxiv.org/abs/2410.24222.
+
+        Args:
+            train_X: A `batch_shape x n x d` tensor of training features.
+            train_Y: A `batch_shape x n x m` tensor of training observations.
+            train_Yvar: An optional `batch_shape x n x m` tensor of observed
+                measurement noise.
+            likelihood: A base likelihood that will be wrapped by a
+                `SparseOutlierGaussianLikelihood` to detect outliers. If omitted,
+                use a standard `GaussianLikelihood` with inferred noise level if
+                `train_Yvar` is None, and a `FixedNoiseGaussianLikelihood` with the
+                given noise observations if `train_Yvar` is not None.
+            covar_module: The module computing the covariance (Kernel) matrix.
+                If omitted, uses an `RBFKernel`.
+            mean_module: The mean function to be used. If omitted, use a
+                `ConstantMean`.
+            outcome_transform: An outcome transform that is applied to the
+                training data during instantiation and to the posterior during
+                inference (that is, the `Posterior` obtained by calling
+                `.posterior` on the model will be on the original scale). We use a
+                `Standardize` transform if no `outcome_transform` is specified.
+                Pass down `None` to use no outcome transform.
+            input_transform: An input transform that is applied in the model's
+                forward pass.
+            convex_parameterization: If True, use a convex parameterization of the
+                sparse noise model. See `SparseOutlierGaussianLikelihood` for details.
+            prior_mean_of_support: The mean value for the default exponential prior
+                distribution over the support size.
+            cache_model_trace: If True, cache the model trace during relevance pursuit.
+
+        Example:
+            >>> m = RobustRelevancePursuitSingleTaskGP(train_X=X, train_Y=Y)
+            >>> mll = ExactMarginalLogLikelihood(model=m, likelihood=m.likelihood)
+            >>> mll = fit_gpytorch_mll(mll)
+        """
+        self._original_X = train_X
+        self._original_Y = train_Y
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            likelihood=likelihood,
+            covar_module=covar_module,
+            mean_module=mean_module,
+            outcome_transform=outcome_transform,
+            input_transform=input_transform,
+        )
+        # After canonical GP is instantiated, modify the likelihood
+        RobustRelevancePursuitMixin.__init__(
+            self,
+            base_likelihood=self.likelihood,
+            dim=train_X.shape[-2],
+            prior_mean_of_support=prior_mean_of_support,
+            convex_parameterization=convex_parameterization,
+            cache_model_trace=cache_model_trace,
+        )
+
+    def to_standard_model(self) -> Model:
+        """Returns a standard SingleTaskGP with the same parameters as this model.
+        This is used to avoid recursion through the fit_gpytorch_mll dispatch."""
+        # don't need to put model into training mode to access the untransformed inputs,
+        # since we cached the original train_inputs
+        is_training = self.training
+        model = SingleTaskGP(
+            train_X=self._original_X,
+            train_Y=self._original_Y,
+            train_Yvar=None,  # not needed because likelihood is already instantiated
+            likelihood=self.likelihood,
+            covar_module=self.covar_module,
+            mean_module=self.mean_module,
+            outcome_transform=getattr(self, "outcome_transform", None),
+            input_transform=getattr(self, "input_transform", None),
+        )
+        if not is_training:
+            model.eval()
+        return model
+
+
+@FitGPyTorchMLL.register(
+    MarginalLogLikelihood,
+    SparseOutlierGaussianLikelihood,
+    RobustRelevancePursuitMixin,
+)
+def _fit_rrp(
+    mll: MarginalLogLikelihood,
+    _: type[SparseOutlierGaussianLikelihood],
+    __: type[RobustRelevancePursuitMixin],
+    *,
+    numbers_of_outliers: list[int] | None = None,
+    fractions_of_outliers: list[float] | None = None,
+    timeout_sec: float | None = None,
+    relevance_pursuit_optimizer: Callable = backward_relevance_pursuit,
+    reset_parameters: bool = True,
+    reset_dense_parameters: bool = False,
+    # fit_gpytorch_mll kwargs
+    closure: Callable[[], tuple[Tensor, Sequence[Tensor | None]]] | None = None,
+    optimizer: Callable | None = None,
+    closure_kwargs: dict[str, Any] | None = None,
+    optimizer_kwargs: Optional[Mapping[str, Any]] = None,
+) -> MarginalLogLikelihood:
+    """Fits a RobustRelevancePursuitGP model using the given marginal likelihood.
+
+    For details, see [Ament2024pursuit]_ or https://arxiv.org/abs/2410.24222.
+
+    Args:
+        mll: The marginal likelihood to fit.
+        _: A likelihood, only directly used for dispatching.
+        _: A model, only directly used for dispatching.
+        numbers_of_outliers: An optional list of numbers of outliers to consider during
+            relevance pursuit. By default, the algorithm falls back to a default list
+            of fractions of outliers, see below.
+        fractions_of_outliers: An optional list of fractions of outliers to consider if
+            numbers_of_outliers is None. By default, the algorithm uses
+            `[0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0]`.
+        relevance_pursuit_optimizer: The relevance pursuit optimizer to use. By default,
+            uses `backward_relevance_pursuit`, which is generally the most powerful
+            algorithm for challenging problems with a wide range of outliers. The
+            `forward_relevance_pursuit` algorithm can be efficient when the number of
+            outliers is relatively small.
+        reset_parameters: If True, we will reset the sparse parameters of the model
+            after each iteration of the relevance pursuit algorithm.
+        reset_dense_parameters: If True, we will reset the dense parameters of the model
+            after each iteration of the relevance pursuit algorithm.
+        closure: A closure to use to compute the loss and the gradients, see docstring
+            of `fit_gpytorch_mll` for details.
+        optimizer: The numerical optimizer, see docstring of `fit_gpytorch_mll`.
+        closure_kwargs: Additional arguments to pass to the `closure` function.
+        optimizer_kwargs: Additional arguments to pass to `fit_gpytorch_mll`.
+
+    Returns:
+        The fitted marginal likelihood.
+    """
+    sparse_module = SparseOutlierNoise._from_model(mll.model)
+    n = sparse_module.dim  # equal to the number of training data points
+
+    if numbers_of_outliers is None:
+        if fractions_of_outliers is None:
+            fractions_of_outliers = FRACTIONS_OF_OUTLIERS
+
+        # list from which BMC chooses
+        numbers_of_outliers = [int(p * n) for p in fractions_of_outliers]
+
+    optimizer_kwargs_: dict[str, Any] = (
+        {} if optimizer_kwargs is None else dict(optimizer_kwargs)
+    )
+    if timeout_sec is not None:
+        optimizer_kwargs_["timeout_sec"] = timeout_sec / len(numbers_of_outliers)
+
+    # Need to convert model to avoid recursion through fit_gpytorch_mll dispatch, since
+    # relevance pursuit expects to call the base fit_gpytorch_mll.
+    original_model = mll.model  # Robust Relevance Pursuit Model
+    mll.model = original_model.to_standard_model()
+    sparse_module = SparseOutlierNoise._from_model(mll.model)
+    sparse_module, model_trace = relevance_pursuit_optimizer(
+        sparse_module=sparse_module,
+        mll=mll,
+        sparsity_levels=numbers_of_outliers,
+        reset_parameters=reset_parameters,
+        reset_dense_parameters=reset_dense_parameters,
+        record_model_trace=True,
+        # These are the args of the canonical mll fit routine
+        closure=closure,
+        optimizer=optimizer,
+        closure_kwargs=closure_kwargs,
+        optimizer_kwargs=optimizer_kwargs_,
+    )
+
+    # Bayesian model comparison
+    bmc_support_sizes, bmc_probabilities = get_posterior_over_support(
+        SparseOutlierNoise,
+        model_trace,
+        prior_mean_of_support=original_model.prior_mean_of_support,
+    )
+    map_index = torch.argmax(bmc_probabilities)
+    map_model = model_trace[map_index]  # choosing model with highest BMC score
+    # overwrite mll.model with chosen model
+    mll.model = original_model  # first restore original model pointer
+    mll.model.load_standard_model(map_model)
+    # Store the bmc results
+    mll.model.bmc_support_sizes = bmc_support_sizes
+    mll.model.bmc_probabilities = bmc_probabilities
+    if mll.model.cache_model_trace:
+        mll.model.model_trace = model_trace
+    return mll
+
+
+@FitGPyTorchMLL.register(
+    _ApproximateMarginalLogLikelihood,
+    SparseOutlierGaussianLikelihood,
+    RobustRelevancePursuitMixin,
+)
+def _fit_rrp_approximate_mll(
+    mll: _ApproximateMarginalLogLikelihood,
+    _: type[SparseOutlierGaussianLikelihood],
+    __: type[RobustRelevancePursuitMixin],
+    **kwargs: Any,
+) -> None:
+    raise UnsupportedError(
+        "Relevance Pursuit does not yet support approximate inference. "
+    )

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -111,6 +111,9 @@ Sparse Axis-Aligned Subspaces (SAAS) GP Models
 
 Variational GP Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.robust_relevance_pursuit_model
+    :members:
+
 .. automodule:: botorch.models.approximate_gp
     :members:
 

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -39,46 +39,6 @@ Cost Models (for cost-aware optimization)
 .. automodule:: botorch.models.cost
     :members:
 
-GP Regression Models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: botorch.models.gp_regression
-    :members:
-
-Multi-Fidelity GP Regression Models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: botorch.models.gp_regression_fidelity
-    :members:
-
-GP Regression Models for Mixed Parameter Spaces
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: botorch.models.gp_regression_mixed
-    :members:
-
-Model List GP Regression Models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: botorch.models.model_list_gp_regression
-    :members:
-
-Multitask GP Models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: botorch.models.multitask
-    :members:
-
-Higher Order GP Models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: botorch.models.higher_order_gp
-    :members:
-
-Latent Kronecker GP Models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: botorch.models.latent_kronecker_gp
-    :members:
-
-Pairwise GP Models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: botorch.models.pairwise_gp
-    :members:
-
 Contextual GP Models with Aggregate Rewards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.models.contextual
@@ -87,11 +47,6 @@ Contextual GP Models with Aggregate Rewards
 Contextual GP Models with Context Rewards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.models.contextual_multioutput
-    :members:
-
-Variational GP Models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: botorch.models.approximate_gp
     :members:
 
 Fully Bayesian GP Models
@@ -104,9 +59,59 @@ Fully Bayesian Multitask GP Models
 .. automodule:: botorch.models.fully_bayesian_multitask
     :members:
 
+GP Regression Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.gp_regression
+    :members:
+
+GP Regression Models for Mixed Parameter Spaces
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.gp_regression_mixed
+    :members:
+
+Higher Order GP Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.higher_order_gp
+    :members:
+
+Latent Kronecker GP Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.latent_kronecker_gp
+    :members:
+
+Model List GP Regression Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.model_list_gp_regression
+    :members:
+
+Multitask GP Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.multitask
+    :members:
+
+Multi-Fidelity GP Regression Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.gp_regression_fidelity
+    :members:
+
+Pairwise GP Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.pairwise_gp
+    :members:
+
 Relevance Pursuit Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.models.relevance_pursuit
+    :members:
+
+Sparse Axis-Aligned Subspaces (SAAS) GP Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.map_saas
+    :members:
+
+Variational GP Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.approximate_gp
     :members:
 
 Model Components

--- a/test/models/test_map_saas.py
+++ b/test/models/test_map_saas.py
@@ -1,0 +1,694 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+import math
+import pickle
+from itertools import product
+from typing import Any
+from unittest import mock
+
+import torch
+
+from botorch.exceptions import UnsupportedError
+from botorch.fit import (
+    fit_gpytorch_mll,
+    get_fitted_map_saas_ensemble,
+    get_fitted_map_saas_model,
+)
+from botorch.models import SaasFullyBayesianSingleTaskGP, SingleTaskGP
+from botorch.models.map_saas import (
+    add_saas_prior,
+    AdditiveMapSaasSingleTaskGP,
+    get_additive_map_saas_covar_module,
+    get_gaussian_likelihood_with_gamma_prior,
+    get_mean_module_with_normal_prior,
+)
+from botorch.models.transforms.input import AppendFeatures, FilterFeatures, Normalize
+from botorch.models.transforms.outcome import Standardize
+from botorch.optim.utils import get_parameters_and_bounds, sample_all_priors
+from botorch.posteriors.gpytorch import GPyTorchPosterior
+from botorch.utils.constraints import LogTransformedInterval
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.constraints import Interval
+from gpytorch.kernels import AdditiveKernel, MaternKernel, ScaleKernel
+from gpytorch.likelihoods import FixedNoiseGaussianLikelihood, GaussianLikelihood
+from gpytorch.means import ConstantMean
+from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+from gpytorch.priors import GammaPrior, HalfCauchyPrior, NormalPrior
+from torch import Tensor
+
+
+class TestMapSaas(BotorchTestCase):
+    def _get_data(self, **tkwargs) -> tuple[Tensor, Tensor, Tensor]:
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = 1 + 2 * torch.rand(10, 3, **tkwargs)
+            train_Y = torch.sin(train_X[:, :1])
+            test_X = 1 + 2 * torch.rand(5, 3, **tkwargs)
+        return train_X, train_Y, test_X
+
+    def _get_data_hardcoded(self, **tkwargs) -> tuple[Tensor, Tensor, Tensor]:
+        """This is equal to _get_data on CPU with a seed of 0, and is hard-coded here
+        to ensure that the results are identical on GPUs, which have different RNGs.
+        """
+        train_X = torch.tensor(
+            [
+                [2.9401, 2.4156, 1.9188],
+                [2.8415, 2.2900, 2.5823],
+                [1.3572, 1.7022, 2.1627],
+                [1.5765, 1.9057, 1.3536],
+                [1.7105, 2.2438, 1.9637],
+                [1.8816, 1.8146, 1.4109],
+                [2.3301, 2.5697, 1.4207],
+                [2.3535, 1.2195, 2.0475],
+                [1.4520, 2.1165, 2.1751],
+                [2.3639, 2.4908, 1.4553],
+            ],
+            **tkwargs,
+        )
+        train_Y = torch.tensor(
+            [
+                [0.2001],
+                [0.2956],
+                [0.9773],
+                [1.0000],
+                [0.9903],
+                [0.9521],
+                [0.7253],
+                [0.7090],
+                [0.9930],
+                [0.7016],
+            ],
+            **tkwargs,
+        )
+        test_X = torch.tensor(
+            [
+                [2.6198, 2.2612, 1.3918],
+                [1.3055, 1.9630, 2.8350],
+                [2.1441, 1.9617, 2.5921],
+                [1.7359, 1.5444, 1.0829],
+                [2.4974, 1.6835, 2.0765],
+            ],
+            **tkwargs,
+        )
+        return train_X, train_Y, test_X
+
+    def test_add_saas_prior(self) -> None:
+        for dtype, infer_tau in itertools.product(
+            [torch.float, torch.double], [True, False]
+        ):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            train_X, _, _ = self._get_data(**tkwargs)
+            base_kernel = MaternKernel(nu=2.5, ard_num_dims=train_X.shape[-1]).to(
+                **tkwargs
+            )
+            tau = None if infer_tau else 0.1234
+            add_saas_prior(base_kernel=base_kernel, tau=tau)
+            pickle.loads(pickle.dumps(base_kernel))  # pickle and unpickle should work
+            if not infer_tau:  # Make sure there is no raw_tau parameter
+                self.assertFalse(hasattr(base_kernel, "raw_tau"))
+            else:
+                self.assertTrue(hasattr(base_kernel, "raw_tau"))
+                self.assertIsInstance(base_kernel.tau_prior, HalfCauchyPrior)
+                self.assertAlmostEqual(base_kernel.tau_prior.scale.item(), 0.1)
+                # Make sure there is a constraint on tau
+                self.assertIsInstance(base_kernel.raw_tau_constraint, Interval)
+                self.assertEqual(base_kernel.raw_tau_constraint.lower_bound, 1e-3)
+                self.assertEqual(base_kernel.raw_tau_constraint.upper_bound, 10.0)
+            self.assertIsInstance(base_kernel.inv_lengthscale_prior, HalfCauchyPrior)
+            self.assertAlmostEqual(base_kernel.inv_lengthscale_prior.scale.item(), 1.0)
+            # Make sure we have specified a constraint on the lengthscale
+            self.assertIsInstance(base_kernel.raw_lengthscale_constraint, Interval)
+            self.assertEqual(base_kernel.raw_lengthscale_constraint.lower_bound, 1e-2)
+            self.assertEqual(base_kernel.raw_lengthscale_constraint.upper_bound, 1e4)
+            # Lengthscale closures
+            _inv_lengthscale_prior = base_kernel._priors["inv_lengthscale_prior"]
+            self.assertIsInstance(_inv_lengthscale_prior[0], HalfCauchyPrior)
+            self.assertAlmostEqual(_inv_lengthscale_prior[0].scale.item(), 1.0)
+            base_kernel.lengthscale = 0.5678
+            true_value = (0.1 if infer_tau else tau) / (0.5678**2)  # tau / ell^2
+            self.assertAllClose(
+                _inv_lengthscale_prior[1](base_kernel),
+                true_value * torch.ones(1, train_X.shape[-1], **tkwargs),
+            )
+            _inv_lengthscale_prior[2](base_kernel, torch.tensor(5.55, **tkwargs))
+            true_value = math.sqrt((0.1 if infer_tau else tau) / 5.55)
+            self.assertAllClose(
+                base_kernel.lengthscale,
+                true_value * torch.ones(1, train_X.shape[-1], **tkwargs),
+            )
+            if infer_tau:  # Global shrinkage closures
+                _tau_prior = base_kernel._priors["tau_prior"]
+                self.assertIsInstance(_tau_prior[0], HalfCauchyPrior)
+                self.assertAlmostEqual(_tau_prior[0].scale.item(), 0.1)
+                _tau_prior[2](base_kernel, torch.tensor(1.234, **tkwargs))
+                self.assertAlmostEqual(
+                    _tau_prior[1](base_kernel).item(), 1.234, delta=1e-6
+                )
+
+            with self.assertRaisesRegex(UnsupportedError, "must have lengthscale"):
+                add_saas_prior(base_kernel=ScaleKernel(base_kernel))
+
+            kernel_with_prior = MaternKernel(
+                nu=2.5,
+                ard_num_dims=train_X.shape[-1],
+                lengthscale_prior=GammaPrior(3.0, 6.0),
+            ).to(**tkwargs)
+            with self.assertRaisesRegex(
+                UnsupportedError, "must not specify a lengthscale prior"
+            ):
+                add_saas_prior(base_kernel=kernel_with_prior)
+
+    def test_get_saas_model(self) -> None:
+        for infer_tau, infer_noise in itertools.product([True, False], [True, False]):
+            tkwargs = {"device": self.device, "dtype": torch.double}
+            train_X, train_Y, test_X = self._get_data_hardcoded(**tkwargs)
+
+            lb, ub = train_X.min(dim=0).values, train_X.max(dim=0).values
+            mu, sigma = train_Y.mean(), train_Y.std()
+            d = train_X.shape[-1]
+            tau = None if infer_tau else 0.1234
+            train_Yvar = (
+                None
+                if infer_noise
+                else 0.1 * torch.arange(len(train_X), **tkwargs).unsqueeze(-1)
+            )
+            # Fit with transforms
+            model = get_fitted_map_saas_model(
+                train_X=train_X,
+                train_Y=train_Y,
+                train_Yvar=train_Yvar,
+                input_transform=Normalize(d=d),
+                outcome_transform=Standardize(m=1),
+                tau=tau,
+            )
+            posterior = model.posterior(test_X)
+            pred_mean, pred_var = posterior.mean, posterior.variance
+            # Make sure the lengthscales are reasonable
+            self.assertTrue(
+                (model.covar_module.base_kernel.lengthscale[:, 1:] > 1e2).all()
+            )
+            self.assertTrue(model.covar_module.base_kernel.lengthscale[:, 0] < 10)
+            # Test with fitting without transforms and make sure predictions match
+            model2 = get_fitted_map_saas_model(
+                train_X=(train_X - lb) / (ub - lb),
+                train_Y=(train_Y - mu) / sigma,
+                train_Yvar=(
+                    train_Yvar / (sigma**2) if train_Yvar is not None else train_Yvar
+                ),
+                tau=tau,
+            )
+            posterior2 = model2.posterior((test_X - lb) / (ub - lb))
+            pred_mean2 = mu + sigma * posterior2.mean
+            pred_var2 = (sigma**2) * posterior2.variance
+            self.assertAllClose(pred_mean, pred_mean2)
+            self.assertAllClose(pred_var, pred_var2)
+
+            # testing optimizer_options: short optimization run with maxiter = 3
+            fit_gpytorch_mll_mock = mock.Mock(wraps=fit_gpytorch_mll)
+            with mock.patch(
+                "botorch.fit.fit_gpytorch_mll",
+                new=fit_gpytorch_mll_mock,
+            ):
+                maxiter = 3
+                model_short = get_fitted_map_saas_model(
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    train_Yvar=train_Yvar,
+                    input_transform=Normalize(d=d),
+                    outcome_transform=Standardize(m=1),
+                    tau=tau,
+                    optimizer_kwargs={"options": {"maxiter": maxiter}},
+                )
+                kwargs = fit_gpytorch_mll_mock.call_args.kwargs
+                # fit_gpytorch_mll has "option" kwarg, not "optimizer_options"
+                self.assertEqual(
+                    kwargs["optimizer_kwargs"]["options"]["maxiter"], maxiter
+                )
+
+            # Compute marginal likelihood after short run.
+            # Putting the MLL in train model to silence warnings.
+            mll_short = ExactMarginalLogLikelihood(
+                model=model_short, likelihood=model_short.likelihood
+            ).train()
+            train_inputs = mll_short.model.train_inputs
+            train_targets = mll_short.model.train_targets
+            output = mll_short.model(*train_inputs)
+            loss_short = -mll_short(output, train_targets).item()
+
+            # Make sure the correct bounds are extracted
+            _, bounds = get_parameters_and_bounds(mll_short)
+            if infer_noise:
+                self.assertAllClose(
+                    bounds["likelihood.noise_covar.raw_noise"][0].item(), math.log(1e-4)
+                )
+                self.assertAllClose(
+                    bounds["likelihood.noise_covar.raw_noise"][1].item(), math.log(1)
+                )
+            self.assertAllClose(
+                bounds["model.mean_module.raw_constant"][0].item(), -10.0
+            )
+            self.assertAllClose(
+                bounds["model.mean_module.raw_constant"][1].item(), 10.0
+            )
+            self.assertAllClose(
+                bounds["model.covar_module.raw_outputscale"][0].item(), math.log(1e-2)
+            )
+            self.assertAllClose(
+                bounds["model.covar_module.raw_outputscale"][1].item(), math.log(1e4)
+            )
+            self.assertAllClose(
+                bounds["model.covar_module.base_kernel.raw_lengthscale"][0].item(),
+                math.log(1e-2),
+            )
+            self.assertAllClose(
+                bounds["model.covar_module.base_kernel.raw_lengthscale"][1].item(),
+                math.log(1e4),
+            )
+            if infer_tau:
+                self.assertAllClose(
+                    bounds["model.covar_module.base_kernel.raw_tau"][0].item(),
+                    math.log(1e-3),
+                )
+                self.assertAllClose(
+                    bounds["model.covar_module.base_kernel.raw_tau"][1].item(),
+                    math.log(10.0),
+                )
+
+            # compute marginal likelihood after standard run
+            mll = ExactMarginalLogLikelihood(
+                model=model, likelihood=model.likelihood
+            ).train()
+            # reusing train_inputs and train_targets, since the transforms are the same
+            loss = -mll(model(*train_inputs), train_targets).item()
+            # longer running optimization should have smaller loss than the shorter one
+            self.assertTrue(loss < loss_short)
+
+    def test_get_saas_ensemble(self) -> None:
+        for infer_noise, taus in itertools.product([True, False], [None, [0.1, 0.2]]):
+            tkwargs = {"device": self.device, "dtype": torch.double}
+            train_X, train_Y, _ = self._get_data_hardcoded(**tkwargs)
+            d = train_X.shape[-1]
+            train_Yvar = (
+                None
+                if infer_noise
+                else 0.1 * torch.arange(len(train_X), **tkwargs).unsqueeze(-1)
+            )
+            # Fit without specifying tau
+            with torch.random.fork_rng():
+                torch.manual_seed(0)
+                model = get_fitted_map_saas_ensemble(
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    train_Yvar=train_Yvar,
+                    input_transform=Normalize(d=d),
+                    outcome_transform=Standardize(m=1),
+                    taus=taus,
+                )
+            self.assertIsInstance(model, SaasFullyBayesianSingleTaskGP)
+            num_taus = 4 if taus is None else len(taus)
+            self.assertEqual(
+                model.covar_module.base_kernel.lengthscale.shape,
+                torch.Size([num_taus, 1, d]),
+            )
+            self.assertEqual(model.batch_shape, torch.Size([num_taus]))
+            # Make sure the lengthscales are reasonable
+            self.assertGreater(
+                model.covar_module.base_kernel.lengthscale[..., 1:].min(), 50
+            )
+            self.assertLess(
+                model.covar_module.base_kernel.lengthscale[..., 0].max(), 10
+            )
+
+            # testing optimizer_options: short optimization run with maxiter = 3
+            with torch.random.fork_rng():
+                torch.manual_seed(0)
+                fit_gpytorch_mll_mock = mock.Mock(wraps=fit_gpytorch_mll)
+                with mock.patch(
+                    "botorch.fit.fit_gpytorch_mll",
+                    new=fit_gpytorch_mll_mock,
+                ):
+                    maxiter = 3
+                    model_short = get_fitted_map_saas_ensemble(
+                        train_X=train_X,
+                        train_Y=train_Y,
+                        train_Yvar=train_Yvar,
+                        input_transform=Normalize(d=d),
+                        outcome_transform=Standardize(m=1),
+                        taus=taus,
+                        optimizer_kwargs={"options": {"maxiter": maxiter}},
+                    )
+                    kwargs = fit_gpytorch_mll_mock.call_args.kwargs
+                    # fit_gpytorch_mll has "option" kwarg, not "optimizer_options"
+                    self.assertEqual(
+                        kwargs["optimizer_kwargs"]["options"]["maxiter"], maxiter
+                    )
+
+            # compute sum of marginal likelihoods of ensemble after short run
+            # NOTE: We can't put MLL in train mode here since
+            # SaasFullyBayesianSingleTaskGP requires NUTS for training.
+            mll_short = ExactMarginalLogLikelihood(
+                model=model_short, likelihood=model_short.likelihood
+            )
+            train_inputs = mll_short.model.train_inputs
+            train_targets = mll_short.model.train_targets
+            loss_short = -mll_short(model_short(*train_inputs), train_targets)
+            # compute sum of marginal likelihoods of ensemble after standard run
+            mll = ExactMarginalLogLikelihood(model=model, likelihood=model.likelihood)
+            # reusing train_inputs and train_targets, since the transforms are the same
+            loss = -mll(model(*train_inputs), train_targets)
+            # the longer running optimization should have smaller loss than the shorter
+            self.assertLess((loss - loss_short).max(), 0.0)
+
+            # test error message
+            with self.assertRaisesRegex(
+                ValueError, "if you only specify one value of tau"
+            ):
+                model_short = get_fitted_map_saas_ensemble(
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    train_Yvar=train_Yvar,
+                    input_transform=Normalize(d=d),
+                    outcome_transform=Standardize(m=1),
+                    taus=[0.1],
+                )
+
+    def test_input_transform_in_train(self) -> None:
+        train_X, train_Y, test_X = self._get_data()
+        # Use a transform that only works in eval mode.
+        append_tf = AppendFeatures(feature_set=torch.randn_like(train_X)).eval()
+        with mock.patch.object(SingleTaskGP, "_validate_tensor_args") as mock_validate:
+            get_fitted_map_saas_model(
+                train_X=train_X,
+                train_Y=train_Y,
+                input_transform=append_tf,
+                outcome_transform=Standardize(m=1),
+            )
+        call_X = mock_validate.call_args[1]["X"]
+        self.assertTrue(torch.equal(call_X, train_X))
+
+    def test_filterfeatures_input_transform(self) -> None:
+        train_X, train_Y, test_X = self._get_data()
+        idxs_to_filter = [0, 2]
+        filter_feature_transforn = FilterFeatures(
+            feature_indices=torch.tensor(idxs_to_filter)
+        )
+        # Use a transform that only works in eval mode.
+        model = get_fitted_map_saas_model(
+            train_X=train_X,
+            train_Y=train_Y,
+            input_transform=filter_feature_transforn,
+            outcome_transform=Standardize(m=1),
+        )
+        self.assertTrue(model.train_inputs[0].shape[-1] == len(idxs_to_filter))
+        self.assertAllClose(model.train_inputs[0], train_X[:, idxs_to_filter])
+        self.assertTrue(
+            model.covar_module.base_kernel.lengthscale.shape[-1] == len(idxs_to_filter)
+        )
+
+    def test_batch_model_fitting(self) -> None:
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = 1 + 2 * torch.rand(10, 3, **tkwargs)
+        train_Y = torch.cat(
+            (torch.sin(train_X[:, :1]), torch.cos(train_X[:, :1])), dim=-1
+        )
+
+        for tau in [0.1, None]:
+            batch_model = get_fitted_map_saas_model(
+                train_X=train_X, train_Y=train_Y, tau=tau
+            )
+            model_1 = get_fitted_map_saas_model(
+                train_X=train_X, train_Y=train_Y[:, :1], tau=tau
+            )
+            model_2 = get_fitted_map_saas_model(
+                train_X=train_X, train_Y=train_Y[:, 1:], tau=tau
+            )
+            # Check lengthscales
+            self.assertEqual(
+                batch_model.covar_module.base_kernel.lengthscale.shape,
+                torch.Size([2, 1, 3]),
+            )
+            self.assertEqual(
+                model_1.covar_module.base_kernel.lengthscale.shape,
+                torch.Size([1, 3]),
+            )
+            self.assertEqual(
+                model_2.covar_module.base_kernel.lengthscale.shape,
+                torch.Size([1, 3]),
+            )
+            self.assertAllClose(
+                batch_model.covar_module.base_kernel.lengthscale[0, :],
+                model_1.covar_module.base_kernel.lengthscale,
+                atol=1e-3,
+            )
+            self.assertAllClose(
+                batch_model.covar_module.base_kernel.lengthscale[1, :],
+                model_2.covar_module.base_kernel.lengthscale,
+                atol=1e-3,
+            )
+            # Check the outputscale
+            self.assertEqual(
+                batch_model.covar_module.outputscale.shape, torch.Size([2])
+            )
+            self.assertEqual(model_1.covar_module.outputscale.shape, torch.Size([]))
+            self.assertEqual(model_2.covar_module.outputscale.shape, torch.Size([]))
+            self.assertAllClose(
+                batch_model.covar_module.outputscale,
+                torch.stack(
+                    (
+                        model_1.covar_module.outputscale,
+                        model_2.covar_module.outputscale,
+                    )
+                ),
+                atol=1e-3,
+            )
+            # Check the mean
+            self.assertEqual(batch_model.mean_module.constant.shape, torch.Size([2]))
+            self.assertEqual(model_1.mean_module.constant.shape, torch.Size([]))
+            self.assertEqual(model_2.mean_module.constant.shape, torch.Size([]))
+            self.assertAllClose(
+                batch_model.mean_module.constant,
+                torch.stack(
+                    (model_1.mean_module.constant, model_2.mean_module.constant)
+                ),
+                atol=1e-3,
+            )
+            # Check noise
+            self.assertEqual(batch_model.likelihood.noise.shape, torch.Size([2, 1]))
+            self.assertEqual(model_1.likelihood.noise.shape, torch.Size([1]))
+            self.assertEqual(model_2.likelihood.noise.shape, torch.Size([1]))
+            self.assertAllClose(
+                batch_model.likelihood.noise,
+                torch.stack((model_1.likelihood.noise, model_2.likelihood.noise)),
+                atol=1e-3,
+            )
+            # Check tau
+            if tau is None:
+                self.assertEqual(
+                    batch_model.covar_module.base_kernel.raw_tau.shape, torch.Size([2])
+                )
+                self.assertEqual(
+                    model_1.covar_module.base_kernel.raw_tau.shape, torch.Size([])
+                )
+                self.assertEqual(
+                    model_2.covar_module.base_kernel.raw_tau.shape, torch.Size([])
+                )
+                self.assertAllClose(
+                    batch_model.covar_module.base_kernel.raw_tau,
+                    torch.stack(
+                        (
+                            model_1.covar_module.base_kernel.raw_tau,
+                            model_2.covar_module.base_kernel.raw_tau,
+                        )
+                    ),
+                    atol=1e-3,
+                )
+
+
+class TestAdditiveMapSaasSingleTaskGP(BotorchTestCase):
+    def _get_data_and_model(
+        self,
+        infer_noise: bool,
+        m: int = 1,
+        batch_shape: list[int] | None = None,
+        **tkwargs,
+    ):
+        batch_shape = batch_shape or []
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(batch_shape + [10, 4], **tkwargs)
+            train_Y = (
+                torch.sin(train_X)
+                .sum(dim=-1, keepdim=True)
+                .repeat(*[1] * (train_X.ndim - 1), m)
+            )
+            train_Yvar = (
+                None if infer_noise else torch.rand(batch_shape + [10, m], **tkwargs)
+            )
+            model = AdditiveMapSaasSingleTaskGP(
+                train_X=train_X,
+                train_Y=train_Y,
+                train_Yvar=train_Yvar,
+            )
+        return train_X, train_Y, train_Yvar, model
+
+    def test_construct_mean_module(self) -> None:
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        for batch_shape in [None, torch.Size([5])]:
+            mean_module = get_mean_module_with_normal_prior(batch_shape=batch_shape).to(
+                **tkwargs
+            )
+            self.assertIsInstance(mean_module, ConstantMean)
+            self.assertIsInstance(mean_module.mean_prior, NormalPrior)
+            self.assertEqual(mean_module.mean_prior.loc, torch.zeros(1, **tkwargs))
+            self.assertEqual(mean_module.mean_prior.scale, torch.ones(1, **tkwargs))
+            self.assertEqual(
+                mean_module.raw_constant.shape, batch_shape or torch.Size()
+            )
+            self.assertEqual(mean_module.raw_constant_constraint.lower_bound, -10.0)
+            self.assertEqual(mean_module.raw_constant_constraint.upper_bound, 10.0)
+
+    def test_construct_likelihood(self) -> None:
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        for batch_shape in [None, torch.Size([5])]:
+            likelihood = get_gaussian_likelihood_with_gamma_prior(
+                batch_shape=batch_shape
+            ).to(**tkwargs)
+            self.assertIsInstance(likelihood, GaussianLikelihood)
+            self.assertIsInstance(likelihood.noise_covar.noise_prior, GammaPrior)
+            self.assertAllClose(
+                likelihood.noise_covar.noise_prior.concentration,
+                torch.tensor(0.9, **tkwargs),
+            )
+            self.assertAllClose(
+                likelihood.noise_covar.noise_prior.rate, torch.tensor(10, **tkwargs)
+            )
+            self.assertEqual(
+                likelihood.noise_covar.raw_noise.shape,
+                torch.Size([1]) if batch_shape is None else torch.Size([5, 1]),
+            )
+            self.assertIsInstance(
+                likelihood.noise_covar.raw_noise_constraint, LogTransformedInterval
+            )
+            self.assertAllClose(
+                likelihood.noise_covar.raw_noise_constraint.lower_bound.item(), 1e-4
+            )
+            self.assertAllClose(
+                likelihood.noise_covar.raw_noise_constraint.upper_bound.item(), 1.0
+            )
+
+    def test_construct_covar_module(self) -> None:
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        for batch_shape in [None, torch.Size([5])]:
+            covar_module = get_additive_map_saas_covar_module(
+                ard_num_dims=10, num_taus=4, batch_shape=batch_shape
+            ).to(**tkwargs)
+            self.assertIsInstance(covar_module, AdditiveKernel)
+            self.assertEqual(len(covar_module.kernels), 4)
+            for kernel in covar_module.kernels:
+                self.assertIsInstance(kernel, ScaleKernel)
+                self.assertIsInstance(kernel.base_kernel, MaternKernel)
+                expected_shape = (
+                    torch.Size([1, 10])
+                    if batch_shape is None
+                    else torch.Size([5, 1, 10])
+                )
+                self.assertEqual(kernel.base_kernel.lengthscale.shape, expected_shape)
+                # Check for a SAAS prior
+                self.assertFalse(hasattr(kernel.base_kernel, "raw_tau"))
+                self.assertIsInstance(
+                    kernel.base_kernel.inv_lengthscale_prior, HalfCauchyPrior
+                )
+                self.assertAlmostEqual(
+                    kernel.base_kernel.inv_lengthscale_prior.scale.item(), 1.0
+                )
+
+    def test_fit_model(self) -> None:
+        for infer_noise, m, batch_shape in (
+            (True, 1, None),
+            (False, 1, [5]),
+            (True, 2, None),
+            (False, 2, [3]),
+            (True, 3, [5]),
+        ):
+            tkwargs = {"device": self.device, "dtype": torch.double}
+            train_X, train_Y, train_Yvar, model = self._get_data_and_model(
+                infer_noise=infer_noise, m=m, batch_shape=batch_shape, **tkwargs
+            )
+            expected_batch_shape = (
+                torch.Size(batch_shape) if batch_shape else torch.Size()
+            )
+            expected_aug_batch_shape = expected_batch_shape + torch.Size(
+                [m] if m > 1 else []
+            )
+
+            # Test init
+            self.assertIsInstance(model.mean_module, ConstantMean)
+            self.assertIsInstance(model.covar_module, AdditiveKernel)
+            self.assertIsInstance(
+                model.likelihood,
+                GaussianLikelihood if infer_noise else FixedNoiseGaussianLikelihood,
+            )
+            expected_X, expected_Y, expected_Yvar = model._transform_tensor_args(
+                X=train_X, Y=train_Y, Yvar=train_Yvar
+            )
+            self.assertAllClose(expected_X, model.train_inputs[0])
+            self.assertAllClose(expected_Y, model.train_targets)
+            if not infer_noise:
+                self.assertAllClose(model.likelihood.noise_covar.noise, expected_Yvar)
+
+            # Fit a model
+            mll = ExactMarginalLogLikelihood(likelihood=model.likelihood, model=model)
+            fit_gpytorch_mll(mll, optimizer_kwargs={"options": {"maxiter": 5}})
+            self.assertEqual(model.batch_shape, expected_batch_shape)
+            self.assertEqual(model._aug_batch_shape, expected_aug_batch_shape)
+
+            # Predict on some test points
+            test_X = torch.rand(13, train_X.shape[-1], **tkwargs)
+            posterior = model.posterior(test_X)
+            self.assertIsInstance(posterior, GPyTorchPosterior)
+            # Mean/variance
+            expected_shape = (*expected_batch_shape, 13, m)
+            mean, var = posterior.mean, posterior.variance
+            self.assertEqual(mean.shape, torch.Size(expected_shape))
+            self.assertEqual(var.shape, torch.Size(expected_shape))
+
+            # Test AdditiveMapSaasSingleTaskGP constructor
+            input_transform = Normalize(d=train_X.shape[-1])
+            outcome_transform = Standardize(m=m, batch_shape=expected_batch_shape)
+            with mock.patch.object(
+                SingleTaskGP, "__init__", wraps=SingleTaskGP.__init__
+            ) as mock_init:
+                model = AdditiveMapSaasSingleTaskGP(
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    train_Yvar=train_Yvar,
+                    input_transform=input_transform,
+                    outcome_transform=outcome_transform,
+                    num_taus=3,
+                )
+                self.assertEqual(
+                    input_transform, mock_init.call_args[1]["input_transform"]
+                )
+                self.assertEqual(
+                    outcome_transform, mock_init.call_args[1]["outcome_transform"]
+                )
+                self.assertIsInstance(
+                    mock_init.call_args[1]["covar_module"], AdditiveKernel
+                )
+                self.assertEqual(3, len(mock_init.call_args[1]["covar_module"].kernels))
+
+    def test_sample_from_prior_additive_map_saas(self) -> None:
+        tkwargs: dict[str, Any] = {"device": self.device, "dtype": torch.double}
+        for batch, m in product((torch.Size([]), torch.Size([3])), (1, 2)):
+            train_X = torch.rand(*batch, 10, 4, **tkwargs)
+            train_Y = torch.rand(*batch, 10, m, **tkwargs)
+            for _ in range(10):
+                model = AdditiveMapSaasSingleTaskGP(train_X=train_X, train_Y=train_Y)
+                sample_all_priors(model)

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -1036,7 +1036,7 @@ class TestInputTransforms(BotorchTestCase):
             eps = 1e-6 if dtype == torch.double else 1e-5
             if dtype == torch.float32:
                 # defaults are 1e-5, 1e-8
-                tols = {"rtol": 1e-4, "atol": 5e-7}
+                tols = {"rtol": 1e-4, "atol": 1e-6}
             else:
                 tols = {}
 

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -1036,7 +1036,7 @@ class TestInputTransforms(BotorchTestCase):
             eps = 1e-6 if dtype == torch.double else 1e-5
             if dtype == torch.float32:
                 # defaults are 1e-5, 1e-8
-                tols = {"rtol": 2e-5, "atol": 8e-8}
+                tols = {"rtol": 1e-4, "atol": 5e-7}
             else:
                 tols = {}
 


### PR DESCRIPTION
Summary: This commit introduces an abstract `RobustRelevancePursuitModel` and `RobustRelevancePursuitSingleTaskGP`, a specific implementation of the abstract class. The main purpose of the new class is to provide an identical interface to a canonical `SingleTaskGP`, but automatically extend the likelihood with the `SparseOutlierGaussianLikelihood`, and toggle the Relevance Pursuit algorithm automatically through the marginal likelihood optimization via `fit_gpytorch_mll` by dispatching on the model type. This makes the model and algorithm easy to use.

Differential Revision: D68353582


