### PR TITLE
Fix bug in `optimize_objective` with fixed features

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -362,14 +362,11 @@ def _optimize_acqf_batch(opt_inputs: OptimizeAcqfInputs) -> tuple[Tensor, Tensor
         )
 
         bounds = opt_inputs.bounds
-        gen_kwargs: dict[str, Any] = {
-            "lower_bounds": None if bounds[0].isinf().all() else bounds[0],
-            "upper_bounds": None if bounds[1].isinf().all() else bounds[1],
-            "options": {k: v for k, v in options.items() if k not in INIT_OPTION_KEYS},
-            "fixed_features": opt_inputs.fixed_features,
-            "timeout_sec": timeout_sec,
-        }
+        lower_bounds = None if bounds[0].isinf().all() else bounds[0]
+        upper_bounds = None if bounds[1].isinf().all() else bounds[1]
+        gen_options = {k: v for k, v in options.items() if k not in INIT_OPTION_KEYS}
 
+        gen_kwargs = {}
         for constraint_name in [
             "inequality_constraints",
             "equality_constraints",
@@ -386,7 +383,14 @@ def _optimize_acqf_batch(opt_inputs: OptimizeAcqfInputs) -> tuple[Tensor, Tensor
                     batch_candidates_curr,
                     batch_acq_values_curr,
                 ) = opt_inputs.gen_candidates(
-                    batched_ics_, opt_inputs.acq_function, **gen_kwargs
+                    batched_ics_,
+                    opt_inputs.acq_function,
+                    lower_bounds=lower_bounds,
+                    upper_bounds=upper_bounds,
+                    options=gen_options,
+                    fixed_features=opt_inputs.fixed_features,
+                    timeout_sec=timeout_sec,
+                    **gen_kwargs,
                 )
             opt_warnings += ws
             batch_candidates_list.append(batch_candidates_curr)
@@ -624,7 +628,7 @@ def optimize_acqf(
         retry_on_optimization_warning=retry_on_optimization_warning,
         ic_gen_kwargs=ic_gen_kwargs,
     )
-    return _optimize_acqf(opt_acqf_inputs)
+    return _optimize_acqf(opt_inputs=opt_acqf_inputs)
 
 
 def _optimize_acqf(opt_inputs: OptimizeAcqfInputs) -> tuple[Tensor, Tensor]:

--- a/botorch/posteriors/gpytorch.py
+++ b/botorch/posteriors/gpytorch.py
@@ -45,7 +45,7 @@ class GPyTorchPosterior(TorchPosterior):
                 MultitaskMultivariateNormal (multi-output case).
         """
         super().__init__(distribution=distribution)
-        self._is_mt = isinstance(distribution, MultitaskMultivariateNormal)
+        self._is_mt: bool = isinstance(distribution, MultitaskMultivariateNormal)
 
     @property
     def mvn(self) -> MultivariateNormal:
@@ -224,7 +224,7 @@ def scalarize_posterior_gpytorch(
     """
     mean = posterior.mean
     q, m = mean.shape[-2:]
-    _validate_scalarize_inputs(weights, m)
+    _validate_scalarize_inputs(weights=weights, m=m)
     batch_shape = mean.shape[:-2]
     mvn = posterior.distribution
     cov = mvn.lazy_covariance_matrix if mvn.islazy else mvn.covariance_matrix


### PR DESCRIPTION
Summary:
**Context:** As per https://github.com/pytorch/botorch/issues/2686, bounds for `optimize_acqf` are not constructed correctly in `optimize_objective`, which is used in input constructors for qKG-type acquisition functions. This issue wasn't surfaced by unit tests because `optimize_acqf` was mocked out. In the process of shoring up the test, I discovered a second bug: This `optimize_objective` doesn't work with constraints, because the optimizer is set to be L-BFGS-B when it isn't otherwise specified, and L-BFGS-B doesn't work with BoTorch-style constraints (only simple box constraints, aka BoTorch bounds).

So I guess the input constructors for qKG-style acquisition functions haven't been working with fixed features or with constraints for a long time -- both usages would just error.

The existing unit test should have caught this but didn't due to use of mocks, so I removed the mocking.

**Changes:**

In `optimize_objective`:
* Use `bounds.shape` instead of `len(bounds)` when constructing a list of features for `fixed_features_list`
* Don't specify 'method' if the user doesn't pass it, so it can be automatically chosen based on the presence of constraints.

Other:
* In `optimize_acqf`, cleaned up some logic. This doesn't have any effect on behavior.
* Added a type annotation

Differential Revision: D68464825


