### PR TITLE
Require GPyTorch==1.14 & linear_operator==0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Optimization simply use Ax.
 **Installation Requirements**
 - Python >= 3.10
 - PyTorch >= 2.0.1
-- gpytorch == 1.13
-- linear_operator == 0.5.3
+- gpytorch == 1.14
+- linear_operator == 0.6
 - pyro-ppl >= 1.8.4
 - scipy
 - multiple-dispatch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 typing_extensions
 pyre_extensions
-gpytorch==1.13
-linear_operator==0.5.3
+gpytorch==1.14
+linear_operator==0.6
 torch>=2.0.1
 pyro-ppl>=1.8.4
 scipy<1.15


### PR DESCRIPTION
Updates the required linear_operator & gpytorch versions to the latest releases.