### PR TITLE
Unpin scipy & use threadpoolctl in minimize_with_timeout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ gpytorch==1.14
 linear_operator==0.6
 torch>=2.0.1
 pyro-ppl>=1.8.4
-scipy<1.15
+scipy
 multipledispatch
+threadpoolctl


### PR DESCRIPTION
Scipy>=1.15 was leading to significant slowdowns in CI due to issues with OpenBLAS configuration (see https://github.com/scipy/scipy/issues/22438). Thanks to suggestions by SciPy maintainers, we've found a solution that resolves the slowdown without modifying and global configurations for OpenBLAS. 

This PR wraps `minimize` calls in `minimize_with_timeout` in a `with threadpool_limits(limits=1, user_api="blas")` context, which makes OpenBLAS operate single-threaded within the context. Since PyTorch relies on OpenMP & MKL rather than OpenBLAS, this does not affect the evaluations of the acquisition functions or the MLL.

Test Plan:
Compare runtimes in the following tutorial workflows
Baseline - with scipy 1.14.1, without `threadpool_limits`: https://github.com/pytorch/botorch/actions/runs/13044166839/job/36391816602
With scipy 1.14.1, with `threadpool_limits`: https://github.com/pytorch/botorch/actions/runs/13044167834/job/36391818438
With scipy 1.15.1, with `threadpool_limits`: https://github.com/pytorch/botorch/actions/runs/13044245918/job/36392026548