### PR TITLE
[RTD] Update url to official project

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -81,7 +81,7 @@ module.exports={
           "position": "left"
         },
         {
-          "href": "https://botorch-dev.readthedocs.io/",
+          "href": "https://botorch.readthedocs.io/",
           "label": "API Reference",
           "position": "left",
           "target": "_blank",
@@ -143,7 +143,7 @@ module.exports={
             },
             {
               label: 'API Reference',
-              to: 'https://botorch-dev.readthedocs.io/',
+              to: 'https://botorch.readthedocs.io/',
             },
             {
               label: 'Paper',


### PR DESCRIPTION
Followup to https://github.com/pytorch/botorch/pull/2715

The previous link was to the testing ReadTheDocs project, the new link is for the new RTD project linked to this repository, available at https://botorch.readthedocs.io/