### PR TITLE
[GHA] Specify permissions when deviating from defaults

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -85,4 +85,7 @@ jobs:
     uses: ./.github/workflows/publish_website.yml
     with:
       new_version: ${{ github.event.release.tag_name }}
-    secrets: inherit
+    permissions:
+      pages: write
+      id-token: write
+      contents: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,7 +69,10 @@ jobs:
     name: Publish latest website
     needs: [tests-and-coverage-nightly, package-test-deploy-pypi]
     uses: ./.github/workflows/publish_website.yml
-    secrets: inherit
+    permissions:
+      pages: write
+      id-token: write
+      contents: write
 
   run_tutorials:
     name: Run tutorials without smoke test on latest PyTorch / GPyTorch / Ax

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -20,6 +20,8 @@ jobs:
     env:
       # `uv pip ...` requires venv by default. This skips that requirement.
       UV_SYSTEM_PYTHON: 1
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Motivation

The `publish_website.yml` workflow requires write permissions to
1. create new docusaurus versions by pushing a commit to `docusaurus-versions` branch
2. push new website to gh-pages

This was not an issue in the fork that introduced these changes because Meta's organization / the official repo has more restrictive permissions than the defaults. More restrictive default permissions are definitely the way to go, here we elevate permissions only when necessary.

## Test Plan

I made the default permissions in my fork more restrictive such that the same workflows would fail then verified that this change results in successful workflow runs. https://github.com/CristianLara/botorch/actions/runs/13107635487/job/36565023833