### PR TITLE
[GHA] Creating a new version only tracks relevant files to git

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -60,7 +60,7 @@ jobs:
         yarn
         yarn docusaurus docs:version ${{ inputs.new_version }}
 
-        git add --all
+        git add versioned_docs/ versioned_sidebars/ versions.json
         git commit -m "Create version ${{ inputs.new_version }} of site in Docusaurus"
         git push --force origin HEAD:docusaurus-versions
     - name: Build website


### PR DESCRIPTION
Fixes an issue where unrelated files could get added to the `docusaurus-versions` branch. This broke GHA in the Ax repo since this was adding the results of running tutorials. Botorch doesn't run tutorials in CI but we still fix this to avoid other possible issues down the road.

Same fix as the Ax counterpart: https://github.com/facebook/Ax/pull/3306