### PR TITLE
Allow for observation noise without mask in ModelListGP

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -661,6 +661,8 @@ class ModelList(Model):
                 sampler_i = (
                     sampler.samplers[i] if isinstance(sampler, ListSampler) else sampler
                 )
+                if observation_noise is not None:
+                    observation_noise_i = observation_noise[..., i : i + 1]
 
             fant_model = self.models[i].fantasize(
                 X=X_i,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

Fixes https://github.com/pytorch/botorch/issues/2734

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan

I've added a test to the unit test, in addition, a separate example:

```python
import torch
from botorch.fit import fit_gpytorch_mll
from botorch.models.gp_regression import SingleTaskGP
from botorch.models.model_list_gp_regression import ModelListGP
from botorch.sampling.list_sampler import ListSampler
from botorch.sampling.normal import SobolQMCNormalSampler
from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood

model = ModelListGP(
    *[SingleTaskGP(train_X=torch.tensor([[0.0], [1.0]]), train_Y=torch.tensor([[0.0], [1.0]])) for _ in range(2)]
)
mll = SumMarginalLogLikelihood(model.likelihood, model)
mll = fit_gpytorch_mll(mll)
sampler = ListSampler(*[SobolQMCNormalSampler(sample_shape=torch.Size([1])) for _ in range(2)])

# Works:
model.fantasize(
    torch.tensor([[0.5]]),
    sampler=sampler,
    observation_noise=torch.tensor([[0.2, 0.2]]),
    evaluation_mask=torch.tensor([[1.0, 1.0]], dtype=torch.bool),
)

# Now also works:
model.fantasize(
    torch.tensor([[0.5]]),
    sampler=sampler,
    observation_noise=torch.tensor([[0.2, 0.2]]),
)
```
