### PR TITLE
Check for feasibility in gen_candidates_scipy and error out for infeasible candidates

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -1027,7 +1027,7 @@ def optimize_acqf_mixed(
 
     if isinstance(acq_function, OneShotAcquisitionFunction):
         if not hasattr(acq_function, "evaluate") and q > 1:
-            raise ValueError(
+            raise UnsupportedError(
                 "`OneShotAcquisitionFunction`s that do not implement `evaluate` "
                 "are currently not supported when `q > 1`. This is needed to "
                 "compute the joint acquisition value."

--- a/botorch/test_utils/mock.py
+++ b/botorch/test_utils/mock.py
@@ -38,11 +38,11 @@ def mock_optimize_context_manager(
             USE RESPONSIBLY.
     """
 
-    def one_iteration_minimize(*args: Any, **kwargs: Any) -> OptimizeResult:
+    def two_iteration_minimize(*args: Any, **kwargs: Any) -> OptimizeResult:
         if kwargs["options"] is None:
             kwargs["options"] = {}
-
-        kwargs["options"]["maxiter"] = 1
+        # Using two iterations here to allow SLSQP to adapt to constraints.
+        kwargs["options"]["maxiter"] = 2
         return minimize_with_timeout(*args, **kwargs)
 
     def minimal_gen_ics(*args: Any, **kwargs: Any) -> Tensor:
@@ -64,7 +64,7 @@ def mock_optimize_context_manager(
         mock_generation = es.enter_context(
             mock.patch(
                 "botorch.generation.gen.minimize_with_timeout",
-                wraps=one_iteration_minimize,
+                wraps=two_iteration_minimize,
             )
         )
 
@@ -73,7 +73,7 @@ def mock_optimize_context_manager(
         mock_fit = es.enter_context(
             mock.patch(
                 "botorch.optim.core.minimize_with_timeout",
-                wraps=one_iteration_minimize,
+                wraps=two_iteration_minimize,
             )
         )
 

--- a/test/test_utils/test_mock.py
+++ b/test/test_utils/test_mock.py
@@ -40,7 +40,7 @@ class SinAcqusitionFunction(MockAcquisitionFunction):
         return
 
     def __call__(self, X):
-        return torch.sin(X[..., 0].max(dim=-1).values)
+        return torch.sin(2 * X[..., 0].max(dim=-1).values)
 
 
 class TestMock(BotorchTestCase):
@@ -52,7 +52,7 @@ class TestMock(BotorchTestCase):
                     acquisition_function=SinAcqusitionFunction(),
                 )
             # When not using `mock_optimize`, the value is 1.0. With it, the value is
-            # around 0.84
+            # around 0.9875
             self.assertLess(value.item(), 0.99)
 
         with self.subTest("scipy_minimize"):


### PR DESCRIPTION
Summary:
As titled. Previously, it was possible to return infeasible candidates to the user, with or without warnings alerting the user to the issue. This diff makes it so that the optimizer will error out when infeasible candidates are generated, so that the user can adjust the setup as needed.

Resolves https://github.com/pytorch/botorch/issues/2708

Also includes a couple lint fixes in optimizer tests.

Differential Revision: D69314159


