### PR TITLE
[Docusaurus] Fix label for archived versions

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -113,7 +113,7 @@ module.exports={
               },
               {
                 href: 'https://archive.botorch.org/versions',
-                label: '<= 0.11.3',
+                label: '<= 0.12.0',
               },
             ],
         },


### PR DESCRIPTION
Most recent archived version is 0.12.0

Similar issue was first caught on the Ax website: https://github.com/facebook/Ax/pull/3329#pullrequestreview-2602818116