### PR TITLE
Fix output tensor dimension in degenerate `optimize_acqf` call

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -192,7 +192,7 @@ def _optimize_acqf_all_features_fixed(
     X = X.expand(q, *X.shape)
     with torch.no_grad():
         acq_value = acq_function(X)
-    return X, acq_value
+    return X, acq_value[0]
 
 
 def _validate_sequential_inputs(opt_inputs: OptimizeAcqfInputs) -> None:

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -14,10 +14,12 @@ from unittest import mock
 
 import numpy as np
 import torch
+
 from botorch.acquisition.acquisition import (
     AcquisitionFunction,
     OneShotAcquisitionFunction,
 )
+from botorch.acquisition.analytic import LogExpectedImprovement
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
 from botorch.acquisition.monte_carlo import qExpectedImprovement
 from botorch.acquisition.multi_objective.hypervolume_knowledge_gradient import (
@@ -1146,6 +1148,23 @@ class TestOptimizeAcqf(BotorchTestCase):
                     ),
                 ),
             )
+
+    def test_optimize_acqf_all_fixed_features(self):
+        train_X = torch.rand(3, 2)
+        train_Y = torch.rand(3, 1)
+        gp = SingleTaskGP(train_X=train_X, train_Y=train_Y)
+        gp.eval()
+        logEI = LogExpectedImprovement(model=gp, best_f=train_Y.max())
+        bounds = torch.stack([torch.zeros(2), torch.ones(2)])
+        _, acqf_value = optimize_acqf(
+            logEI,
+            bounds,
+            q=1,
+            num_restarts=1,
+            raw_samples=1,
+            fixed_features={0: 0, 1: 0},
+        )
+        self.assertEqual(acqf_value.ndim, 0)
 
     def test_constraint_caching(self):
         def nlc(x):


### PR DESCRIPTION
## Motivation

Fixes #2740 

@sdaulton: This is a draft for fixing the dimensionality issue. While the PR technically solves the problem, think it only addresses the symptom and not the underlying root cause. For the latter, I'd need some guidance from your end. 

Specifically, something seems fishy about the tensor dimensions promised by the [acquisition function base class](https://github.com/pytorch/botorch/blob/d74a11331c2efb89c9b5ea688d2a61c1d9fb1420/botorch/acquisition/acquisition.py#L64-L73). The docstring states that the input is a `(b) x q x d`-dim tensor and the output is a `(b)`-dim. The way I understand this is that `b` is an optional batching dimension. But if you read the contract, it would imply:
* If you pass a `b x q x d`-dim tensor, you get a `(b)`-dim tensor back.
* If you pass a `q x d`-dim tensor, you get a dimensionless tensor (i.e. scalar value) back.

Now the problem is that the second part seems to be actually violated, which causes the the problem in #2740. Interestingly, when writing the test, I wanted to use a `MockAcquisitionFunction()` object for it like done in other tests. However, that object *does seem* to fulfill the contract, so I couldn't even reproduce the problem with the mock but had to reuse the code from my original minimal example.

Any thoughts how we should go about this, i.e. is this actually a more fundamental problem in the acquisition function code?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

A corresponding test has been included.
