### PR TITLE
Silence input normalization / standardization warnings with custom covariance modules

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -399,7 +399,11 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
                 )
                 train_Y, _ = outcome_transform(train_Y, X=transformed_X)
             self._validate_tensor_args(X=transformed_X, Y=train_Y)
-            validate_input_scaling(train_X=transformed_X, train_Y=train_Y)
+            validate_input_scaling(
+                train_X=transformed_X,
+                train_Y=train_Y,
+                check_nans_only=covar_module is not None,
+            )
             if train_Y.shape[-1] != num_outputs:
                 num_outputs = train_Y.shape[-1]
 

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -171,6 +171,7 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
             train_Y=train_Y,
             train_Yvar=train_Yvar,
             ignore_X_dims=ignore_X_dims,
+            check_nans_only=covar_module is not None,
         )
         self._set_dimensions(train_X=train_X, train_Y=train_Y)
         train_X, train_Y, train_Yvar = self._transform_tensor_args(

--- a/botorch/models/utils/assorted.py
+++ b/botorch/models/utils/assorted.py
@@ -228,6 +228,7 @@ def validate_input_scaling(
     train_Yvar: Tensor | None = None,
     raise_on_fail: bool = False,
     ignore_X_dims: list[int] | None = None,
+    check_nans_only: bool = False,
 ) -> None:
     r"""Helper function to validate input data to models.
 
@@ -243,6 +244,10 @@ def validate_input_scaling(
             raised if NaN values are present).
         ignore_X_dims: For this subset of dimensions from `{1, ..., d}`, ignore the
             min-max scaling check.
+        check_nans_only: If True, only check for NaN values. Skips min-max scaling
+            and standardization checks. This is used when the model is provided
+            with a custom covariance module, to avoid potentially irrelevant
+            warnings.
 
     This function is typically called inside the constructor of standard BoTorch
     models. It validates the following:
@@ -261,10 +266,11 @@ def validate_input_scaling(
         check_no_nans(train_Yvar)
         if torch.any(train_Yvar < 0):
             raise InputDataError("Input data contains negative variances.")
-    check_min_max_scaling(
-        X=train_X, raise_on_fail=raise_on_fail, ignore_dims=ignore_X_dims
-    )
-    check_standardization(Y=train_Y, raise_on_fail=raise_on_fail)
+    if not check_nans_only:
+        check_min_max_scaling(
+            X=train_X, raise_on_fail=raise_on_fail, ignore_dims=ignore_X_dims
+        )
+        check_standardization(Y=train_Y, raise_on_fail=raise_on_fail)
 
 
 def mod_batch_shape(module: Module, names: list[str], b: int) -> None:


### PR DESCRIPTION
Summary:
The default covar modules are designed to work with normalized & standardized data. If the user has a custom covar module, they may need a different scaling of the data, which makes these warnings irrelevant.

This diff adds an option to restrict input data checks to NaNs only, and enables it whenever a custom covar module is given.

Differential Revision: D69613875


