### PR TITLE
Performance & runtime improvements to info-theoretic acquisition functions (1/N)

### DIFF
--- a/botorch/acquisition/utils.py
+++ b/botorch/acquisition/utils.py
@@ -534,6 +534,7 @@ def get_optimal_samples(
     posterior_transform: ScalarizedPosteriorTransform | None = None,
     objective: MCAcquisitionObjective | None = None,
     return_transformed: bool = False,
+    options: dict | None = None,
 ) -> tuple[Tensor, Tensor]:
     """Draws sample paths from the posterior and maximizes the samples using GD.
 
@@ -551,7 +552,8 @@ def get_optimal_samples(
         objective: An MCAcquisitionObjective, used to negate the objective or otherwise
             transform sample outputs. Cannot be combined with `posterior_transform`.
         return_transformed: If True, return the transformed samples.
-
+        options: Options for generation of initial candidates, passed to
+            gen_batch_initial_conditions.
     Returns:
         The optimal input locations and corresponding outputs, x* and f*.
 
@@ -576,6 +578,12 @@ def get_optimal_samples(
         sample_transform = None
 
     paths = get_matheron_path_model(model=model, sample_shape=torch.Size([num_optima]))
+    suggested_points = prune_inferior_points(
+        model=model,
+        X=model.train_inputs[0],
+        posterior_transform=posterior_transform,
+        objective=objective,
+    )
     optimal_inputs, optimal_outputs = optimize_posterior_samples(
         paths=paths,
         bounds=bounds,
@@ -583,5 +591,7 @@ def get_optimal_samples(
         num_restarts=num_restarts,
         sample_transform=sample_transform,
         return_transformed=return_transformed,
+        suggested_points=suggested_points,
+        options=options,
     )
     return optimal_inputs, optimal_outputs

--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -27,12 +27,14 @@ import numpy as np
 import numpy.typing as npt
 import scipy
 import torch
+
 from botorch.exceptions.errors import BotorchError, InfeasibilityError
 from botorch.exceptions.warnings import UserInputWarning
 from botorch.sampling.qmc import NormalQMCEngine
 from botorch.utils.transforms import unnormalize
 from scipy.spatial import Delaunay, HalfspaceIntersection
 from torch import LongTensor, Tensor
+from torch.distributions import Multinomial
 from torch.quasirandom import SobolEngine
 
 
@@ -990,10 +992,12 @@ def sparse_to_dense_constraints(
 def optimize_posterior_samples(
     paths: GenericDeterministicModel,
     bounds: Tensor,
-    raw_samples: int = 1024,
-    num_restarts: int = 20,
+    raw_samples: int = 2048,
+    num_restarts: int = 4,
     sample_transform: Callable[[Tensor], Tensor] | None = None,
     return_transformed: bool = False,
+    suggested_points: Tensor | None = None,
+    options: dict | None = None,
 ) -> tuple[Tensor, Tensor]:
     r"""Cheaply maximizes posterior samples by random querying followed by
     gradient-based optimization using SciPy's L-BFGS-B routine.
@@ -1008,6 +1012,9 @@ def optimize_posterior_samples(
             negate the objective or otherwise transform the output.
         return_transformed: A boolean indicating whether to return the transformed
             or non-transformed samples.
+        suggested_points
+        options: Options for generation of initial candidates, passed to
+            gen_batch_initial_conditions.
 
     Returns:
         A two-element tuple containing:
@@ -1015,6 +1022,7 @@ def optimize_posterior_samples(
             - f_opt: A `num_optima x [batch_size] x m`-dim, optionally
                 `num_optima x [batch_size] x 1`-dim,  tensor of optimal outputs f*.
     """
+    options = {} if options is None else options
 
     def path_func(x) -> Tensor:
         res = paths(x)
@@ -1023,21 +1031,46 @@ def optimize_posterior_samples(
 
         return res.squeeze(-1)
 
-    candidate_set = unnormalize(
-        SobolEngine(dimension=bounds.shape[1], scramble=True).draw(n=raw_samples),
-        bounds=bounds,
-    )
     # queries all samples on all candidates - output shape
     # raw_samples * num_optima * num_models
+    frac_random = options.get("frac_random", 0.9)
+    candidate_set = draw_sobol_samples(
+        bounds=bounds, n=round(raw_samples * frac_random), q=1
+    ).squeeze(-2)
+    if suggested_points is not None:
+        from botorch.optim.initializers import sample_truncated_normal_perturbations
+
+        perturbed_suggestions = sample_truncated_normal_perturbations(
+            X=suggested_points,
+            n_discrete_points=round(raw_samples * (1 - frac_random)),
+            sigma=options.get("sample_around_best_sigma", 1e-2),
+            bounds=bounds,
+        )
+        candidate_set = torch.cat((candidate_set, perturbed_suggestions))
+
     candidate_queries = path_func(candidate_set)
-    argtop_k = torch.topk(candidate_queries, num_restarts, dim=-1).indices
-    X_top_k = candidate_set[argtop_k, :]
+    weights = (
+        candidate_queries - candidate_queries.mean(dim=-1, keepdim=True)
+    ) / candidate_queries.std(dim=-1, keepdim=True)
+    eta = options.get("eta", 2.0)
+    weights = torch.exp(eta * weights)
+
+    # weights can be more than 2D, which is not supported by torch.multinomial
+    # the argsort picks out the indices that are nonzero, i.e. those that are drawn
+    # (without replacement, so we will always have num_restarts nonzero ones)
+    idx = (
+        Multinomial(num_restarts, probs=weights)
+        .sample()
+        .argsort(descending=True)[..., :num_restarts]
+    )
+
+    ics = candidate_set[idx, :]
 
     # to avoid circular import, the import occurs here
     from botorch.generation.gen import gen_candidates_scipy
 
     X_top_k, f_top_k = gen_candidates_scipy(
-        X_top_k,
+        ics,
         path_func,
         lower_bounds=bounds[0],
         upper_bounds=bounds[1],


### PR DESCRIPTION
A series of improvements directed towards improving the performance of PES & JES, as well as their MultiObj counterparts.

## Motivation
As pointed out by @SebastianAment in [this paper](https://arxiv.org/pdf/2310.20708), the BoTorch variant of JES, and to an extent PES, is brutally slow an suspiciously ill-performing. To bring them up to their potential, I've added a series of performance improvements:

**1. Improvement to get_optimal_samples and optimal_posterior_samples**: As this is an integral part of their efficiency, I've added `suggestions` (similar to `sample_around_best`) to `optimize_posterior_samples`. 
Marginal runtime improvement in acquisition optimization (sampling time practically unchanged):
![runtime_pr1](https://github.com/user-attachments/assets/a4e6d24b-2d77-4f6f-bb79-4dea8ac9304a)
Substantial performance improvement: ![pr1_regret](https://github.com/user-attachments/assets/d534f716-9a78-43db-acf4-3a795ca1e597).



**2. Added initializer to acquisition funcction optimization**: Similar to KG, ES methods have sensible suggestions for acquisition function optimization in the form of the sampled optima. This drastically reduces the time of acquisition function optimization, which could on occasion take 30+ seconds when `num_restarts` was large `>4`.

Benchmarking INC

**2b. Multi-objective support for initializer**: By re-naming arguments of the multi-objective variants, we get consistency and support for MO variants.

**3. Enabled gradient-based optimization for PES**: The current implementation contains a while-loop which forces the gradients to be recursively computed. This commonly causes NaN gradients, which is why the recommended option is `"with_grad": False` in the tutorial. One `detach()` alleviates this issue, enabling gradient-based optimization. 

NOTE: this has NOT been ablated, since the non-grad optimization is extremely computationally demanding.

## Test Plan

Unit tests and benchmarking.

## Related PRs

First of a couple!

Bonus: while benchmarking, I had issues repro'ing the LogEI performance initially. I found that `sample_around_best` made LogEI worse on Mich5. All experiments are otherwise a repro of the settings used in the LogEI paper.
![LogEI_sample_around_best](https://github.com/user-attachments/assets/d70b1494-7cf8-462d-9754-4f43088b25c4)
