### PR TITLE
Silence batch_initial_conditions warnings in optimize_acqf_mixed_alternating

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -117,7 +117,7 @@ class OptimizeAcqfInputs:
                 )
 
             if (
-                len(batch_initial_conditions_shape) == 2 
+                len(batch_initial_conditions_shape) == 2
                 and self.raw_samples is not None
             ):
                 warnings.warn(

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -116,7 +116,10 @@ class OptimizeAcqfInputs:
                     f"shape is {batch_initial_conditions_shape}."
                 )
 
-            if len(batch_initial_conditions_shape) == 2:
+            if (
+                len(batch_initial_conditions_shape) == 2 
+                and self.raw_samples is not None
+            ):
                 warnings.warn(
                     "If using a 2-dim `batch_initial_conditions` botorch will "
                     "default to old behavior of ignoring `num_restarts` and just "
@@ -132,6 +135,7 @@ class OptimizeAcqfInputs:
                 len(batch_initial_conditions_shape) == 3
                 and batch_initial_conditions_shape[0] < self.num_restarts
                 and batch_initial_conditions_shape[-2] != self.q
+                and self.raw_samples is not None
             ):
                 warnings.warn(
                     "If using a 3-dim `batch_initial_conditions` where the "

--- a/botorch/optim/optimize_mixed.py
+++ b/botorch/optim/optimize_mixed.py
@@ -533,6 +533,7 @@ def continuous_step(
         opt_inputs,
         q=1,
         num_restarts=1,
+        raw_samples=None,
         batch_initial_conditions=current_x.unsqueeze(0),
         fixed_features={
             **dict(zip(discrete_dims.tolist(), current_x[discrete_dims])),


### PR DESCRIPTION
We were getting a bunch of warnings due to `raw_samples` and `batch_initial_conditions` not matching, despite the underlying code behaving correctly. Updated the code to avoid unnecessary warnings. This change eliminates 74 warnings in TestOptimizeAcqfMixed.

Before:
<img width="854" alt="Screenshot 2025-02-18 at 6 36 49 PM" src="https://github.com/user-attachments/assets/eec54ade-14e7-4a97-a474-2d9320858886" />

After:
<img width="853" alt="Screenshot 2025-02-18 at 6 37 03 PM" src="https://github.com/user-attachments/assets/0052e9c9-5afb-490e-aa85-b8450d5d3846" />

