### PR TITLE
fix StratifiedStandardize dtype/nan issue

### DIFF
--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -532,7 +532,7 @@ class StratifiedStandardize(Standardize):
         OutcomeTransform.__init__(self)
         self._stratification_idx = stratification_idx
         task_values = task_values.unique(sorted=True)
-        self.strata_mapping = get_task_value_remapping(task_values, dtype=torch.long)
+        self.strata_mapping = get_task_value_remapping(task_values, dtype=torch.double)
         if self.strata_mapping is None:
             self.strata_mapping = task_values
         n_strata = self.strata_mapping.shape[0]
@@ -576,7 +576,7 @@ class StratifiedStandardize(Standardize):
             strata = X[..., self._stratification_idx].long()
             unique_strata = strata.unique()
             for s in unique_strata:
-                mapped_strata = self.strata_mapping[s]
+                mapped_strata = self.strata_mapping[s].long()
                 mask = strata != s
                 Y_strata = Y.clone()
                 Y_strata[..., mask, :] = float("nan")
@@ -616,7 +616,7 @@ class StratifiedStandardize(Standardize):
             - The per-input stdvs squared.
         """
         strata = X[..., self._stratification_idx].long()
-        mapped_strata = self.strata_mapping[strata].unsqueeze(-1)
+        mapped_strata = self.strata_mapping[strata].unsqueeze(-1).long()
         # get means and stdvs for each strata
         n_extra_batch_dims = mapped_strata.ndim - 2 - len(self._batch_shape)
         expand_shape = mapped_strata.shape[:n_extra_batch_dims] + self.means.shape

--- a/botorch/models/utils/assorted.py
+++ b/botorch/models/utils/assorted.py
@@ -422,6 +422,8 @@ def get_task_value_remapping(task_values: Tensor, dtype: torch.dtype) -> Tensor 
         return value will be `None`, when the task values are contiguous
         integers starting from zero.
     """
+    if dtype not in (torch.float, torch.double):
+        raise ValueError(f"dtype must be torch.float or torch.double, but got {dtype}.")
     task_range = torch.arange(
         len(task_values), dtype=task_values.dtype, device=task_values.device
     )

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -700,3 +700,12 @@ class TestMultiTaskUtils(BotorchTestCase):
             mapping = get_task_value_remapping(task_values, dtype)
             self.assertTrue(torch.equal(mapping[[1, 3]], expected_mapping_no_nan))
             self.assertTrue(torch.isnan(mapping[[0, 2]]).all())
+
+    def test_get_task_value_remapping_invalid_dtype(self) -> None:
+        task_values = torch.tensor([1, 3])
+        for dtype in (torch.int32, torch.long, torch.bool):
+            with self.assertRaisesRegex(
+                ValueError,
+                f"dtype must be torch.float or torch.double, but got {dtype}.",
+            ):
+                get_task_value_remapping(task_values, dtype)


### PR DESCRIPTION
Summary: If dtype passed to `get_task_value_remapping` is not float or double, an exception is raised because NaN cannot be used in an int/long tensor. The docstring states this, but we did it anyway in StratifiedStandardize, which meant that remapping didn't work. This fixes the issue.

Differential Revision: D70111086


