### PR TITLE
Export NumericsWarning and UserInputWarning from botorch.exceptions

### DIFF
--- a/botorch/exceptions/__init__.py
+++ b/botorch/exceptions/__init__.py
@@ -22,7 +22,7 @@ from botorch.exceptions.warnings import (
     NumericsWarning,
     OptimizationWarning,
     SamplingWarning,
-    UserInputWarning
+    UserInputWarning,
 )
 
 

--- a/botorch/exceptions/__init__.py
+++ b/botorch/exceptions/__init__.py
@@ -19,8 +19,10 @@ from botorch.exceptions.warnings import (
     BotorchWarning,
     CostAwareWarning,
     InputDataWarning,
+    NumericsWarning,
     OptimizationWarning,
     SamplingWarning,
+    UserInputWarning
 )
 
 
@@ -36,8 +38,10 @@ __all__ = [
     "BadInitialCandidatesWarning",
     "CandidateGenerationError",
     "ModelFittingError",
+    "NumericsWarning",
     "OptimizationTimeoutError",
     "OptimizationWarning",
     "SamplingWarning",
     "UnsupportedError",
+    "UserInputWarning",
 ]


### PR DESCRIPTION
## Motivation

Using `botorch.acquisition.ExpectedImprovement` (instead of LogEI) now triggers a `botorch.exceptions.warnings.NumericsWarning`. I'd like to be able to suppress this warning in cases that I actually intend to use EI instead of LogEI, such as when I am comparing the two.

I'd like to be able to write the following:

```python
import warnings

import botorch

with warnings.catch_warnings():
    warnings.filterwarnings('ignore', category=botorch.exceptions.NumericsWarning)
    acqf = botorch.acquisition.ExpectedImprovement(...)
```

However, `botorch.exceptions` does not export `NumericsWarning` as a symbol, so code editors (_e.g._, Visual Studio Code) complain that the symbol `botorch.exceptions.NumericsWarning` is not found. This pull request updates `botorch/exceptions/__init__.py` to export `NumericsWarning` and `UserInputWarning`, the only two warnings from `botorch/exceptions/warnings.py` that were previously unexported.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

N/A

## Related PRs

I believe it may have been a simple oversight of commit 6892be9 (from pull request #2429) to add `NumericsWarning` to the list of exported symbols in `botorch/exceptions/__init__.py`.