### PR TITLE
Do not use deprecated last_dim_is_batch=True in OAK kernel

### DIFF
--- a/botorch/models/kernels/orthogonal_additive_kernel.py
+++ b/botorch/models/kernels/orthogonal_additive_kernel.py
@@ -146,7 +146,10 @@ class OrthogonalAdditiveKernel(Kernel):
         Returns:
             A `batch_shape x d x n1 x n2`-dim Tensor of kernel matrices.
         """
-        return self.base_kernel(x1, x2, last_dim_is_batch=True).to_dense()
+        # This replicates deprecated `last_dim_is_batch` functionality.
+        x1 = x1.transpose(-1, -2).unsqueeze(-1)
+        x2 = x2.transpose(-1, -2).unsqueeze(-1)
+        return self.base_kernel(x1, x2).to_dense()
 
     @property
     def offset(self) -> Tensor:


### PR DESCRIPTION
Summary:
This was producing a lot of `DeprecationWarning('The last_dim_is_batch argument is deprecated, and will be removed in GPyTorch 2.0. If you are using it as part of AdditiveStructureKernel or ProductStructureKernel, please update your code according to the "Kernels with Additive or Product Structure" tutorial in the GPyTorch docs.')`.

Updated to manually apply the transform rather than relying on it. We can remove support for the kwarg from custom kernel definition once the argument is fully deprecated in GPyTorch.

Differential Revision: D70992085


