### PR TITLE
Do not count STOPPED as a model fitting failure

### DIFF
--- a/botorch/optim/fit.py
+++ b/botorch/optim/fit.py
@@ -100,11 +100,12 @@ def fit_gpytorch_mll_scipy(
         callback=callback,
         timeout_sec=timeout_sec,
     )
-    if result.status != OptimizationStatus.SUCCESS:
+    if result.status not in [OptimizationStatus.SUCCESS, OptimizationStatus.STOPPED]:
         warn(
             f"`scipy_minimize` terminated with status {result.status}, displaying"
             f" original message from `scipy.optimize.minimize`: {result.message}",
             OptimizationWarning,
+            stacklevel=2,
         )
 
     return result


### PR DESCRIPTION
Summary:
Discovered this while debugging a CUDA test failure. I don't know why this was only raised when running on GPU but it was failing model fitting with status `STOPPED` (maybe it was slower and somehow timed out in `scipy_minimize`?).

Either way, we shouldn't count termination due to user specified criterion as a model fitting failure.

Differential Revision: D70994718


