### PR TITLE
Some clean-up for MES-based acqusition functions

### DIFF
--- a/botorch/acquisition/multi_objective/max_value_entropy_search.py
+++ b/botorch/acquisition/multi_objective/max_value_entropy_search.py
@@ -20,7 +20,6 @@ References
 from __future__ import annotations
 
 from collections.abc import Callable
-
 from math import pi
 
 import torch
@@ -139,19 +138,13 @@ class qMultiObjectiveMaxValueEntropy(
                 sampler=self.fantasies_sampler,
             )
             self.mo_model = fantasy_model
-            # convert model to batched single outcome model.
-            self.model = batched_multi_output_to_single_output(
-                batch_mo_model=self.mo_model
-            )
-            self._sample_max_values()
         else:
             # This is mainly for setting the model to the original model
             # after the sequential optimization at q > 1
             self.mo_model = self._init_model
-            self.model = batched_multi_output_to_single_output(
-                batch_mo_model=self.mo_model
-            )
-            self._sample_max_values()
+        # convert model to batched single outcome model.
+        self.model = batched_multi_output_to_single_output(batch_mo_model=self.mo_model)
+        self._sample_max_values()
 
     def _sample_max_values(self) -> None:
         """Sample max values for MC approximation of the expectation in MES.

--- a/test/acquisition/test_max_value_entropy_search.py
+++ b/test/acquisition/test_max_value_entropy_search.py
@@ -17,115 +17,56 @@ from botorch.acquisition.max_value_entropy_search import (
     qMultiFidelityLowerBoundMaxValueEntropy,
     qMultiFidelityMaxValueEntropy,
 )
-from botorch.acquisition.objective import (
-    PosteriorTransform,
-    ScalarizedPosteriorTransform,
-)
+from botorch.acquisition.objective import ScalarizedPosteriorTransform
 from botorch.exceptions.errors import UnsupportedError
-from botorch.posteriors import GPyTorchPosterior
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.sampling.normal import SobolQMCNormalSampler
-from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
-from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
-from torch import Tensor
-
-
-class MESMockModel(MockModel):
-    r"""Mock object that implements dummy methods and feeds through specified outputs"""
-
-    def __init__(self, num_outputs=1, batch_shape=None):
-        r"""
-        Args:
-            num_outputs: The number of outputs.
-            batch_shape: The batch shape of the model. For details see
-                `botorch.models.model.Model.batch_shape`.
-        """
-        super().__init__(None)
-        self._num_outputs = num_outputs
-        self._batch_shape = torch.Size() if batch_shape is None else batch_shape
-
-    def posterior(
-        self,
-        X: Tensor,
-        observation_noise: bool = False,
-        posterior_transform: PosteriorTransform | None = None,
-    ) -> MockPosterior:
-        m_shape = X.shape[:-1]
-        r_shape = list(X.shape[:-2]) + [1, 1]
-        mvn = MultivariateNormal(
-            mean=torch.zeros(m_shape, dtype=X.dtype, device=X.device),
-            covariance_matrix=torch.eye(
-                m_shape[-1], dtype=X.dtype, device=X.device
-            ).repeat(r_shape),
-        )
-        if self.num_outputs > 1:
-            mvn = mvn = MultitaskMultivariateNormal.from_independent_mvns(
-                mvns=[mvn] * self.num_outputs
-            )
-        posterior = GPyTorchPosterior(mvn)
-        if posterior_transform is not None:
-            return posterior_transform(posterior)
-        return posterior
-
-    def forward(self, X: Tensor) -> MultivariateNormal:
-        return self.posterior(X).distribution
-
-    @property
-    def batch_shape(self) -> torch.Size:
-        return self._batch_shape
-
-    @property
-    def num_outputs(self) -> int:
-        return self._num_outputs
-
-
-class NoBatchShapeMESMockModel(MESMockModel):
-    # For some reason it's really hard to mock this property to raise a
-    # NotImplementedError, so let's just make a class for it.
-    @property
-    def batch_shape(self) -> torch.Size:
-        raise NotImplementedError
+from botorch.utils.testing import BotorchTestCase
 
 
 class TestMaxValueEntropySearch(BotorchTestCase):
     def test_q_max_value_entropy(self):
         for dtype in (torch.float, torch.double):
             torch.manual_seed(7)
-            mm = MESMockModel()
-            with self.assertRaises(TypeError):
-                qMaxValueEntropy(mm)
-
+            model = SingleTaskGP(
+                train_X=torch.rand(10, 2, device=self.device, dtype=dtype),
+                train_Y=torch.rand(10, 1, device=self.device, dtype=dtype),
+            )
             candidate_set = torch.rand(1000, 2, device=self.device, dtype=dtype)
 
             # test error in case of batch GP model
-            mm = MESMockModel(batch_shape=torch.Size([2]))
-            with self.assertRaises(NotImplementedError):
-                qMaxValueEntropy(mm, candidate_set, num_mv_samples=10)
-            mm = MESMockModel()
-            train_inputs = torch.rand(5, 10, 2, device=self.device, dtype=dtype)
             with self.assertRaises(NotImplementedError):
                 qMaxValueEntropy(
-                    mm, candidate_set, num_mv_samples=10, train_inputs=train_inputs
+                    model=SingleTaskGP(
+                        train_X=torch.rand(5, 10, 2, device=self.device, dtype=dtype),
+                        train_Y=torch.rand(5, 10, 1, device=self.device, dtype=dtype),
+                    ),
+                    candidate_set=candidate_set,
                 )
 
             # test that init works if batch_shape is not implemented on the model
-            mm = NoBatchShapeMESMockModel()
-            qMaxValueEntropy(
-                mm,
-                candidate_set,
-                num_mv_samples=10,
-            )
+            with mock.patch.object(
+                SingleTaskGP, "batch_shape", side_effect=NotImplementedError
+            ):
+                qMaxValueEntropy(model=model, candidate_set=candidate_set)
 
-            # test error when number of outputs > 1 and no transform is given.
-            mm = MESMockModel()
-            mm._num_outputs = 2
-            with self.assertRaises(UnsupportedError):
-                qMaxValueEntropy(mm, candidate_set, num_mv_samples=10)
+            # test error when number of outputs > 1.
+            with self.assertRaisesRegex(
+                UnsupportedError, "Multi-output models are not supported by"
+            ):
+                qMaxValueEntropy(
+                    model=SingleTaskGP(
+                        train_X=torch.rand(10, 2, device=self.device, dtype=dtype),
+                        train_Y=torch.rand(10, 2, device=self.device, dtype=dtype),
+                    ),
+                    candidate_set=candidate_set,
+                )
 
             # test with X_pending is None
-            mm = MESMockModel()
-            train_inputs = torch.rand(10, 2, device=self.device, dtype=dtype)
-            mm.train_inputs = (train_inputs,)
-            qMVE = qMaxValueEntropy(mm, candidate_set, num_mv_samples=10)
+            qMVE = qMaxValueEntropy(
+                model=model, candidate_set=candidate_set, num_mv_samples=10
+            )
 
             # test initialization
             self.assertEqual(qMVE.num_fantasies, 16)
@@ -147,65 +88,35 @@ class TestMaxValueEntropySearch(BotorchTestCase):
 
             # test with use_gumbel = False
             qMVE = qMaxValueEntropy(
-                mm, candidate_set, num_mv_samples=10, use_gumbel=False
+                model=model,
+                candidate_set=candidate_set,
+                num_mv_samples=10,
+                use_gumbel=False,
             )
             self.assertEqual(qMVE(X).shape, torch.Size([1]))
 
             # test with X_pending is not None
-            with mock.patch.object(
-                MESMockModel, "fantasize", return_value=mm
-            ) as patch_f:
-                qMVE = qMaxValueEntropy(
-                    mm,
-                    candidate_set,
-                    num_mv_samples=10,
-                    X_pending=torch.rand(1, 2, device=self.device, dtype=dtype),
-                )
-                patch_f.assert_called_once()
-
-            # Test with multi-output model w/ transform.
-            mm = MESMockModel(num_outputs=2)
-            pt = ScalarizedPosteriorTransform(
-                weights=torch.ones(2, device=self.device, dtype=dtype)
+            qMVE = qMaxValueEntropy(
+                model=model,
+                candidate_set=candidate_set,
+                num_mv_samples=10,
+                X_pending=torch.rand(1, 2, device=self.device, dtype=dtype),
             )
-            for gumbel in (True, False):
-                qMVE = qMaxValueEntropy(
-                    mm,
-                    candidate_set,
-                    num_mv_samples=10,
-                    use_gumbel=gumbel,
-                    posterior_transform=pt,
-                )
-                self.assertEqual(qMVE(X).shape, torch.Size([1]))
+            self.assertEqual(qMVE(X.repeat(5, 1, 1)).shape, torch.Size([5]))
 
     def test_q_lower_bound_max_value_entropy(self):
         for dtype in (torch.float, torch.double):
             torch.manual_seed(7)
-            mm = MESMockModel()
-            with self.assertRaises(TypeError):
-                qLowerBoundMaxValueEntropy(mm)
-
+            model = SingleTaskGP(
+                train_X=torch.rand(10, 2, device=self.device, dtype=dtype),
+                train_Y=torch.rand(10, 1, device=self.device, dtype=dtype),
+            )
             candidate_set = torch.rand(1000, 2, device=self.device, dtype=dtype)
 
-            # test error in case of batch GP model
-            # train_inputs = torch.rand(5, 10, 2, device=self.device, dtype=dtype)
-            # mm.train_inputs = (train_inputs,)
-            mm = MESMockModel(batch_shape=torch.Size([2]))
-            with self.assertRaises(NotImplementedError):
-                qLowerBoundMaxValueEntropy(mm, candidate_set, num_mv_samples=10)
-
-            # test error when number of outputs > 1 and no transform
-            mm = MESMockModel()
-            mm._num_outputs = 2
-            with self.assertRaises(UnsupportedError):
-                qLowerBoundMaxValueEntropy(mm, candidate_set, num_mv_samples=10)
-            mm._num_outputs = 1
-
             # test with X_pending is None
-            mm = MESMockModel()
-            train_inputs = torch.rand(10, 2, device=self.device, dtype=dtype)
-            mm.train_inputs = (train_inputs,)
-            qGIBBON = qLowerBoundMaxValueEntropy(mm, candidate_set, num_mv_samples=10)
+            qGIBBON = qLowerBoundMaxValueEntropy(
+                model=model, candidate_set=candidate_set, num_mv_samples=10
+            )
 
             # test initialization
             self.assertEqual(qGIBBON.num_mv_samples, 10)
@@ -218,28 +129,30 @@ class TestMaxValueEntropySearch(BotorchTestCase):
 
             # test with use_gumbel = False
             qGIBBON = qLowerBoundMaxValueEntropy(
-                mm, candidate_set, num_mv_samples=10, use_gumbel=False
+                model=model,
+                candidate_set=candidate_set,
+                num_mv_samples=10,
+                use_gumbel=False,
             )
             self.assertEqual(qGIBBON(X).shape, torch.Size([1]))
 
             # test with X_pending is not None
             qGIBBON = qLowerBoundMaxValueEntropy(
-                mm,
-                candidate_set,
+                model=model,
+                candidate_set=candidate_set,
                 num_mv_samples=10,
                 use_gumbel=False,
                 X_pending=torch.rand(1, 2, device=self.device, dtype=dtype),
             )
             self.assertEqual(qGIBBON(X).shape, torch.Size([1]))
 
-            # Test with multi-output model w/ transform.
-            mm = MESMockModel(num_outputs=2)
+            # Test posterior transform with X_pending.
             pt = ScalarizedPosteriorTransform(
-                weights=torch.ones(2, device=self.device, dtype=dtype)
+                weights=torch.ones(1, device=self.device, dtype=dtype)
             )
             qGIBBON = qLowerBoundMaxValueEntropy(
-                mm,
-                candidate_set,
+                model=model,
+                candidate_set=candidate_set,
                 num_mv_samples=10,
                 use_gumbel=False,
                 X_pending=torch.rand(1, 2, device=self.device, dtype=dtype),
@@ -253,12 +166,13 @@ class TestMaxValueEntropySearch(BotorchTestCase):
     ):
         for dtype in (torch.float, torch.double):
             torch.manual_seed(7)
-            mm = MESMockModel()
-            train_inputs = torch.rand(10, 2, device=self.device, dtype=dtype)
-            mm.train_inputs = (train_inputs,)
+            model = SingleTaskGP(
+                train_X=torch.rand(10, 2, device=self.device, dtype=dtype),
+                train_Y=torch.rand(10, 1, device=self.device, dtype=dtype),
+            )
             candidate_set = torch.rand(10, 2, device=self.device, dtype=dtype)
             qMF_MVE = acqf_class(
-                model=mm, candidate_set=candidate_set, num_mv_samples=10
+                model=model, candidate_set=candidate_set, num_mv_samples=10
             )
 
             # test initialization
@@ -281,19 +195,34 @@ class TestMaxValueEntropySearch(BotorchTestCase):
             X = torch.rand(1, 2, device=self.device, dtype=dtype)
             self.assertEqual(qMF_MVE(X).shape, torch.Size([1]))
 
-            # Test with multi-output model w/ transform.
-            mm = MESMockModel(num_outputs=2)
-            pt = ScalarizedPosteriorTransform(
-                weights=torch.ones(2, device=self.device, dtype=dtype)
-            )
-            qMF_MVE = acqf_class(
-                model=mm,
-                candidate_set=candidate_set,
-                num_mv_samples=10,
-                posterior_transform=pt,
-            )
-            X = torch.rand(1, 2, device=self.device, dtype=dtype)
-            self.assertEqual(qMF_MVE(X).shape, torch.Size([1]))
+            # Test with multi-output model.
+            with self.assertRaisesRegex(
+                UnsupportedError, "Multi-output models are not supported"
+            ):
+                acqf_class(
+                    model=ModelListGP(model, model),
+                    candidate_set=candidate_set,
+                    num_mv_samples=10,
+                )
+
+            # Test with expand.
+            if acqf_class is qMultiFidelityMaxValueEntropy:
+                qMF_MVE = acqf_class(
+                    model=model,
+                    candidate_set=candidate_set,
+                    num_mv_samples=10,
+                    expand=lambda X: X.repeat(1, 2, 1),
+                )
+                X = torch.rand(1, 2, device=self.device, dtype=dtype)
+                self.assertEqual(qMF_MVE(X).shape, torch.Size([1]))
+            else:
+                with self.assertRaisesRegex(UnsupportedError, "does not support trace"):
+                    acqf_class(
+                        model=model,
+                        candidate_set=candidate_set,
+                        num_mv_samples=10,
+                        expand=lambda X: X.repeat(1, 2, 1),
+                    )
 
     def test_q_multi_fidelity_lower_bound_max_value_entropy(self):
         # Same test as for MF-MES since GIBBON only changes in the way it computes the
@@ -302,38 +231,32 @@ class TestMaxValueEntropySearch(BotorchTestCase):
             acqf_class=qMultiFidelityLowerBoundMaxValueEntropy
         )
 
-    def test_sample_max_value_Gumbel(self):
+    def _test_max_value_sampler_base(self, sampler) -> None:
         for dtype in (torch.float, torch.double):
             torch.manual_seed(7)
-            mm = MESMockModel()
+            model = SingleTaskGP(
+                train_X=torch.rand(10, 2, device=self.device, dtype=dtype),
+                train_Y=torch.rand(10, 1, device=self.device, dtype=dtype),
+            )
             candidate_set = torch.rand(3, 10, 2, device=self.device, dtype=dtype)
-            samples = _sample_max_value_Gumbel(mm, candidate_set, 5)
+            samples = sampler(model=model, candidate_set=candidate_set, num_samples=5)
             self.assertEqual(samples.shape, torch.Size([5, 3]))
 
             # Test with multi-output model w/ transform.
-            mm = MESMockModel(num_outputs=2)
+            model = ModelListGP(model, model)
             pt = ScalarizedPosteriorTransform(
                 weights=torch.ones(2, device=self.device, dtype=dtype)
             )
-            samples = _sample_max_value_Gumbel(
-                mm, candidate_set, 5, posterior_transform=pt
+            samples = sampler(
+                model=model,
+                candidate_set=candidate_set,
+                num_samples=5,
+                posterior_transform=pt,
             )
             self.assertEqual(samples.shape, torch.Size([5, 3]))
+
+    def test_sample_max_value_Gumbel(self):
+        self._test_max_value_sampler_base(sampler=_sample_max_value_Gumbel)
 
     def test_sample_max_value_Thompson(self):
-        for dtype in (torch.float, torch.double):
-            torch.manual_seed(7)
-            mm = MESMockModel()
-            candidate_set = torch.rand(3, 10, 2, device=self.device, dtype=dtype)
-            samples = _sample_max_value_Thompson(mm, candidate_set, 5)
-            self.assertEqual(samples.shape, torch.Size([5, 3]))
-
-            # Test with multi-output model w/ transform.
-            mm = MESMockModel(num_outputs=2)
-            pt = ScalarizedPosteriorTransform(
-                weights=torch.ones(2, device=self.device, dtype=dtype)
-            )
-            samples = _sample_max_value_Thompson(
-                mm, candidate_set, 5, posterior_transform=pt
-            )
-            self.assertEqual(samples.shape, torch.Size([5, 3]))
+        self._test_max_value_sampler_base(sampler=_sample_max_value_Thompson)


### PR DESCRIPTION
Summary:
- Merges `DiscreteMaxValueBase` into `MaxValueBase`. An abstract base class that only has one subclass, which is also an abstract base class, doesn't really provide much value and creates unreachable code that can only be tested by defining dummy subclasses.
- Adds an explicit error when multi-output models are used. Both batched `SingleTaskGP` and `ModelListGP` would error out with different reasons. I suspect the underlying code supports it but e2e support needs some modifications.
- Errors out if `expand` is provided to `qMultiFidelityLowerBoundMaxValueEntropy`. It produces outputs of wrong shape, which points to some missing handling of the different tensor shapes within the underlying code.
- Adds a very basic test for `expand` with `qMultiFidelityMaxValueEntropy`, which produces output of correct shape.
- Updates tests to use actual models rather than mock models. Testing that some functionality (like multi-output model support) works with a mock model doesn't actually mean it works. We should be using mock models a lot more sparingly in tests.

Differential Revision: D71051750


