### PR TITLE
Improve Documentation of Testing Base Classes in BoTorch

### DIFF
--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -50,6 +50,12 @@ class BotorchTestCase(TestCase):
     device = torch.device("cpu")
 
     def setUp(self, suppress_input_warnings: bool = True) -> None:
+        """Set up the test case.
+
+        Args:
+            suppress_input_warnings: If True, suppress common input warnings
+                (see below).
+        """
         warnings.resetwarnings()
         warnings.simplefilter("always", append=True)
         if suppress_input_warnings:
@@ -92,9 +98,19 @@ class BotorchTestCase(TestCase):
         atol: float = 1e-08,
         equal_nan: bool = False,
     ) -> None:
-        r"""
+        r"""Assert that two tensors are close.
+
         Calls torch.testing.assert_close, using the signature and default behavior
         of torch.allclose.
+
+        The formula asserted is abs(input - other) <= atol + rtol * abs(other).
+
+        Args:
+            input: First tensor or tensor-or-scalar-like to compare
+            other: Second tensor or tensor-or-scalar-like to compare
+            rtol: Relative tolerance
+            atol: Absolute tolerance
+            equal_nan: If True, consider NaN values as equal
 
         Example output:
             AssertionError: Scalars are not close!
@@ -116,7 +132,12 @@ class BotorchTestCase(TestCase):
 
 
 class BaseTestProblemTestCaseMixIn:
+    r"""Mixin for testing BaseTestProblem (functions) implementations."""
+
     def test_forward_and_evaluate_true(self):
+        r"""Run every BaseTestProblem in `self.functions` on random inputs.
+        Runs both `forward` and `evaluate_true`.
+        """
         dtypes = (torch.float, torch.double)
         batch_shapes = (torch.Size(), torch.Size([2]), torch.Size([2, 3]))
         for dtype, batch_shape, f in product(dtypes, batch_shapes, self.functions):
@@ -142,13 +163,19 @@ class BaseTestProblemTestCaseMixIn:
     @property
     @abstractmethod
     def functions(self) -> Sequence[BaseTestProblem]:
-        # The functions that should be tested. Typically defined as a class
-        # attribute on the test case subclassing this class.
-        pass  # pragma: no cover
+        r"""The functions that should be tested.
+
+        Typically defined as a class attribute on the test case subclassing this class.
+        """
 
 
 class SyntheticTestFunctionTestCaseMixin:
+    r"""Mixin for testing synthetic `BaseTestProblem` aka test functions."""
+
     def test_optimal_value(self):
+        """Test that a function's optimal_value is correctly computed,
+        and defined if it should be.
+        """
         for dtype in (torch.float, torch.double):
             for f in self.functions:
                 f.to(device=self.device, dtype=dtype)
@@ -161,6 +188,7 @@ class SyntheticTestFunctionTestCaseMixin:
                     self.assertEqual(optval, optval_exp)
 
     def test_optimizer(self):
+        r"""Test that optimizers are correctly computed."""
         for dtype in (torch.float, torch.double):
             for f in self.functions:
                 f.to(device=self.device, dtype=dtype)
@@ -176,15 +204,33 @@ class SyntheticTestFunctionTestCaseMixin:
                     grad = torch.autograd.grad([*res], Xopt)[0]
                     self.assertLess(grad.abs().max().item(), 1e-3)
 
+    @property
+    @abstractmethod
+    def functions(self) -> Sequence[BaseTestProblem]:
+        """The functions that should be tested.
+
+        Typically defined as a class attribute on the test case subclassing this class.
+        """
+        pass  # pragma: no cover
+
 
 class MultiObjectiveTestProblemTestCaseMixin:
+    r"""Mixin for testing multi-objective test problems.
+
+    This class provides test cases for attributes,
+    maximum hypervolume, and reference points
+    of multi-objective test problems.
+    """
+
     def test_attributes(self):
+        r"""Test that each function has the required attributes."""
         for f in self.functions:
             self.assertTrue(hasattr(f, "dim"))
             self.assertTrue(hasattr(f, "num_objectives"))
             self.assertEqual(f.bounds.shape, torch.Size([2, f.dim]))
 
     def test_max_hv(self):
+        r"""Test the maximum hypervolume (max_hv) attribute for each function."""
         for dtype in (torch.float, torch.double):
             for f in self.functions:
                 f.to(device=self.device, dtype=dtype)
@@ -195,6 +241,9 @@ class MultiObjectiveTestProblemTestCaseMixin:
                     self.assertEqual(f.max_hv, f._max_hv)
 
     def test_ref_point(self):
+        """Test the reference point (ref_point) attribute
+        for each function (for each dtype).
+        """
         for dtype in (torch.float, torch.double):
             for f in self.functions:
                 f.to(dtype=dtype, device=self.device)
@@ -205,13 +254,40 @@ class MultiObjectiveTestProblemTestCaseMixin:
                     )
                 )
 
+    @property
+    @abstractmethod
+    def functions(self) -> Sequence[BaseTestProblem]:
+        """The functions that should be tested.
+
+        Typically defined as a class attribute on the test case subclassing this class.
+        """
+        pass  # pragma: no cover
+
 
 class ConstrainedTestProblemTestCaseMixin:
+    """Mixin for testing constrained test problems.
+
+    This class provides test cases for attributes and methods
+    of constrained test problems, including testing the number of
+    constraints and the evaluation of constraint slack.
+    """
+
     def test_num_constraints(self):
+        """Test that each function has the required num_constraints attribute."""
         for f in self.functions:
             self.assertTrue(hasattr(f, "num_constraints"))
 
     def test_evaluate_slack(self):
+        """Test the evaluate_slack method for each function.
+
+        This test verifies that:
+
+        1. The evaluate_slack_true and evaluate_slack methods
+            return tensors of the expected shape
+
+        2. The relationship between evaluate_slack and evaluate_slack_true
+        is consistent with the constraint_noise_std attribute of the function
+        """
         for dtype in (torch.float, torch.double):
             for f in self.functions:
                 f.to(device=self.device, dtype=dtype)
@@ -245,14 +321,46 @@ class ConstrainedTestProblemTestCaseMixin:
                 else:
                     self.assertTrue(is_equal.all().item())
 
+    @property
+    @abstractmethod
+    def functions(self) -> Sequence[BaseTestProblem]:
+        r"""The functions that should be tested.
+
+        Typically defined as a class attribute on the test case subclassing this class.
+        """
+        pass  # pragma: no cover
+
 
 class TestCorruptedProblemsMixin(BotorchTestCase):
+    r"""Mixin for testing corrupted test problems.
+
+    This class provides setup and utility functions
+    for testing corrupted test problems using a specified outlier generator
+    and a Rosenbrock problem.
+    """
+
     def setUp(self, suppress_input_warnings: bool = True) -> None:
+        r"""Set up the test case with a dummy outlier generator
+        and a Rosenbrock problem.
+
+        Args:
+            suppress_input_warnings: If True, suppress common input warnings.
+        """
         super().setUp(suppress_input_warnings=suppress_input_warnings)
 
         def outlier_generator(
             problem: torch.Tensor | BaseTestProblem, X: Any, bounds: Any
         ) -> torch.Tensor:
+            r"""Generate outliers for the given problem.
+
+            Args:
+                problem: The test problem.
+                X: Input tensor.
+                bounds: Bounds for the input.
+
+            Returns:
+                A tensor of ones with the same shape as the input.
+            """
             return torch.ones(X.shape[0])
 
         self.outlier_generator = outlier_generator
@@ -266,19 +374,29 @@ class TestCorruptedProblemsMixin(BotorchTestCase):
 
 
 class MockPosterior(Posterior):
-    r"""Mock object that implements dummy methods and feeds through specified outputs"""
+    r"""This class is used to simulate a posterior with specified mean,
+    variance, and samples.
+
+    Everything is deterministic in this class.
+    """
 
     def __init__(
-        self, mean=None, variance=None, samples=None, base_shape=None, batch_range=None
+        self,
+        mean: torch.Tensor | None = None,
+        variance: torch.Tensor | None = None,
+        samples: torch.Tensor | None = None,
+        base_shape: torch.Size | None = None,
+        batch_range: tuple[int, int] | None = None,
     ) -> None:
-        r"""
+        r"""Initialize the MockPosterior with specified attributes.
+
         Args:
             mean: The mean of the posterior.
             variance: The variance of the posterior.
-            samples: Samples to return from `rsample`, unless `base_samples` is
-                provided.
-            base_shape: If given, this is returned as `base_sample_shape`, and also
-                used as the base of the `_extended_shape`.
+            samples: Samples to return from `rsample`,
+                unless `base_samples` is provided.
+            base_shape: If given, this is returned as `base_sample_shape`,
+                and also used as the base of the `_extended_shape`.
             batch_range: If given, this is returned as `batch_range`.
                 Defaults to (0, -2).
         """
@@ -290,6 +408,7 @@ class MockPosterior(Posterior):
 
     @property
     def device(self) -> torch.device:
+        r"""Return the device of the posterior."""
         for t in (self._mean, self._variance, self._samples):
             if torch.is_tensor(t):
                 return t.device
@@ -297,6 +416,7 @@ class MockPosterior(Posterior):
 
     @property
     def dtype(self) -> torch.dtype:
+        r"""Return the data type of the posterior."""
         for t in (self._mean, self._variance, self._samples):
             if torch.is_tensor(t):
                 return t.dtype
@@ -304,6 +424,7 @@ class MockPosterior(Posterior):
 
     @property
     def batch_shape(self) -> torch.Size:
+        r"""Return the batch shape of the posterior."""
         for t in (self._mean, self._variance, self._samples):
             if torch.is_tensor(t):
                 return t.shape[:-2]
@@ -313,10 +434,12 @@ class MockPosterior(Posterior):
         self,
         sample_shape: torch.Size = torch.Size(),  # noqa: B008
     ) -> torch.Size:
+        r"""Return the extended shape of the posterior."""
         return sample_shape + self.base_sample_shape
 
     @property
     def base_sample_shape(self) -> torch.Size:
+        r"""Return the base sample shape of the posterior."""
         if self._base_shape is not None:
             return self._base_shape
         if self._samples is not None:
@@ -329,22 +452,32 @@ class MockPosterior(Posterior):
 
     @property
     def batch_range(self) -> tuple[int, int]:
+        r"""Return the batch range of the posterior."""
         return self._batch_range
 
     @property
     def mean(self):
+        r"""Return the mean of the posterior."""
         return self._mean
 
     @property
     def variance(self):
+        r"""Return the variance of the posterior."""
         return self._variance
 
     def rsample(
         self,
         sample_shape: torch.Size | None = None,
     ) -> Tensor:
-        """Mock sample by repeating self._samples. If base_samples is provided,
-        do a shape check but return the same mock samples."""
+        """Return mock samples by extending the shape
+        of the initially specified samples.
+
+        Args:
+            sample_shape: The shape of the samples to generate.
+
+        Returns:
+            A tensor of samples with the specified shape.
+        """
         if sample_shape is None:
             sample_shape = torch.Size()
         extended_shape = self._extended_shape(sample_shape)
@@ -364,17 +497,35 @@ class MockPosterior(Posterior):
 
 
 @GetSampler.register(MockPosterior)
-def _get_sampler_mock(
+def get_sampler_mock(
     posterior: MockPosterior, sample_shape: torch.Size, **kwargs: Any
 ) -> MCSampler:
-    r"""Get the dummy `StochasticSampler` for `MockPosterior`."""
+    """Get a `StochasticSampler` with the specified `sample_shape`.
+
+    Args:
+        posterior: Used only for dispatching so that `get_sampler`
+            works with a `MockPosterior`.
+        sample_shape: The shape of the samples to generate.
+        kwargs: Passed to `StochasticSampler`
+
+    Returns:
+        A `StochasticSampler` for the mock posterior.
+    """
     return StochasticSampler(sample_shape=sample_shape, **kwargs)
 
 
 class MockModel(Model, FantasizeMixin):
-    r"""Mock object that implements dummy methods and feeds through specified outputs"""
+    """Mock ``Model`` that implements dummy methods and feeds through specified outputs.
+
+    Its ``posterior`` is a ``MockPosterior``.
+    """
 
     def __init__(self, posterior: MockPosterior) -> None:  # noqa: D107
+        r"""Initialize the MockModel with a specified posterior.
+
+        Args:
+            posterior: The mock posterior to use for the model.
+        """
         super(Model, self).__init__()
         self._posterior = posterior
 
@@ -385,6 +536,17 @@ class MockModel(Model, FantasizeMixin):
         posterior_transform: PosteriorTransform | None = None,
         observation_noise: bool | torch.Tensor = False,
     ) -> MockPosterior:
+        r"""Return the posterior of the model.
+
+        Args:
+            X: Ignored; present for compatibility with super class.
+            output_indices: Ignored; present for compatibility with super class.
+            posterior_transform: Optional.
+            observation_noise: Ignored; present for compatibility with super class.
+
+        Returns:
+            The posterior of the model, possibly transformed.
+        """
         if posterior_transform is not None:
             return posterior_transform(self._posterior)
         else:
@@ -392,20 +554,30 @@ class MockModel(Model, FantasizeMixin):
 
     @property
     def num_outputs(self) -> int:
+        r"""Return the number of outputs of the model."""
         extended_shape = self._posterior._extended_shape()
         return extended_shape[-1] if len(extended_shape) > 0 else 0
 
     @property
     def batch_shape(self) -> torch.Size:
+        r"""Return the batch shape of the model."""
         extended_shape = self._posterior._extended_shape()
         return extended_shape[:-2]
 
     def state_dict(self, *args, **kwargs) -> None:
+        """Dummy method, has no effect"""
         pass
 
     def load_state_dict(
         self, state_dict: OrderedDict | None = None, strict: bool = False
     ) -> None:
+        """Dummy method, has no effect.
+
+        Args:
+            state_dict: The state dictionary to load.
+            strict: Whether to strictly enforce that the keys in state_dict match
+                the keys returned by this module's state_dict function.
+        """
         pass
 
 
@@ -423,7 +595,7 @@ class MockAcquisitionFunction:
         self.X_pending = X_pending
 
 
-def _get_random_data(
+def get_random_data(
     batch_shape: torch.Size, m: int, d: int = 1, n: int = 10, **tkwargs
 ) -> tuple[Tensor, Tensor]:
     r"""Generate random data for testing purposes.
@@ -449,7 +621,7 @@ def _get_random_data(
     return train_x, train_y
 
 
-def _get_test_posterior(
+def get_test_posterior(
     batch_shape: torch.Size,
     q: int = 1,
     m: int = 1,
@@ -495,7 +667,7 @@ def _get_test_posterior(
     return GPyTorchPosterior(mtmvn)
 
 
-def _get_max_violation_of_bounds(samples: torch.Tensor, bounds: torch.Tensor) -> float:
+def get_max_violation_of_bounds(samples: torch.Tensor, bounds: torch.Tensor) -> float:
     """
     The maximum value by which samples lie outside bounds.
 
@@ -515,7 +687,7 @@ def _get_max_violation_of_bounds(samples: torch.Tensor, bounds: torch.Tensor) ->
     return max(lower_dist, upper_dist)
 
 
-def _get_max_violation_of_constraints(
+def get_max_violation_of_constraints(
     samples: torch.Tensor,
     constraints: list[tuple[Tensor, Tensor, float]] | None,
     equality: bool,

--- a/test/acquisition/test_objective.py
+++ b/test/acquisition/test_objective.py
@@ -28,7 +28,7 @@ from botorch.models.pairwise_gp import PairwiseGP
 from botorch.models.transforms.input import Normalize
 from botorch.posteriors import GPyTorchPosterior
 from botorch.utils import apply_constraints
-from botorch.utils.testing import _get_test_posterior, BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, get_test_posterior
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
 from linear_operator.operators.dense_linear_operator import to_linear_operator
 
@@ -67,7 +67,7 @@ class TestScalarizedPosteriorTransform(BotorchTestCase):
             offset = torch.rand(1).item()
             weights = torch.randn(m, device=self.device, dtype=dtype)
             obj = ScalarizedPosteriorTransform(weights=weights, offset=offset)
-            posterior = _get_test_posterior(
+            posterior = get_test_posterior(
                 batch_shape, m=m, device=self.device, dtype=dtype
             )
             mean, covar = (

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -19,7 +19,7 @@ from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling import SobolQMCNormalSampler
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.test_helpers import get_pvar_expected
-from botorch.utils.testing import _get_random_data, BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, get_random_data
 from gpytorch.kernels import RBFKernel
 from gpytorch.likelihoods import FixedNoiseGaussianLikelihood, GaussianLikelihood
 from gpytorch.means import ConstantMean, ZeroMean
@@ -38,7 +38,7 @@ class TestGPRegressionBase(BotorchTestCase):
         **tkwargs,
     ):
         extra_model_kwargs = extra_model_kwargs or {}
-        train_X, train_Y = _get_random_data(batch_shape=batch_shape, m=m, **tkwargs)
+        train_X, train_Y = get_random_data(batch_shape=batch_shape, m=m, **tkwargs)
         model_kwargs = {
             "train_X": train_X,
             "train_Y": train_Y,
@@ -182,7 +182,7 @@ class TestGPRegressionBase(BotorchTestCase):
             ("Default", "None", "Log"),  # Outcome transform
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
-            train_X, train_Y = _get_random_data(batch_shape=batch_shape, m=m, **tkwargs)
+            train_X, train_Y = get_random_data(batch_shape=batch_shape, m=m, **tkwargs)
 
             model_kwargs = {}
             if octf == "None":
@@ -241,7 +241,7 @@ class TestGPRegressionBase(BotorchTestCase):
             # test condition_on_observations
             fant_shape = torch.Size([2])
             # fantasize at different input points
-            X_fant, Y_fant = _get_random_data(
+            X_fant, Y_fant = get_random_data(
                 batch_shape=fant_shape + batch_shape, m=m, n=3, **tkwargs
             )
             c_kwargs = (
@@ -459,7 +459,7 @@ class TestSingleTaskGPFixedNoise(TestSingleTaskGP):
         **tkwargs,
     ):
         extra_model_kwargs = extra_model_kwargs or {}
-        train_X, train_Y = _get_random_data(batch_shape=batch_shape, m=m, **tkwargs)
+        train_X, train_Y = get_random_data(batch_shape=batch_shape, m=m, **tkwargs)
         model_kwargs = {
             "train_X": train_X,
             "train_Y": train_Y,

--- a/test/models/test_gp_regression_fidelity.py
+++ b/test/models/test_gp_regression_fidelity.py
@@ -16,7 +16,7 @@ from botorch.models.transforms import Normalize, Standardize
 from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling import SobolQMCNormalSampler
 from botorch.utils.datasets import SupervisedDataset
-from botorch.utils.testing import _get_random_data, BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, get_random_data
 from gpytorch.kernels.scale_kernel import ScaleKernel
 from gpytorch.likelihoods import FixedNoiseGaussianLikelihood
 from gpytorch.means import ConstantMean
@@ -30,7 +30,7 @@ def _get_random_data_with_fidelity(
     r"""Construct test data.
     For this test, by convention the trailing dimensions are the fidelity dimensions
     """
-    train_x, train_y = _get_random_data(
+    train_x, train_y = get_random_data(
         batch_shape=batch_shape, m=m, d=d, n=n, **tkwargs
     )
     s = torch.rand(n, n_fidelity, **tkwargs).repeat(batch_shape + torch.Size([1, 1]))

--- a/test/models/test_gp_regression_mixed.py
+++ b/test/models/test_gp_regression_mixed.py
@@ -18,7 +18,7 @@ from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling import SobolQMCNormalSampler
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.test_helpers import get_pvar_expected
-from botorch.utils.testing import _get_random_data, BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, get_random_data
 from gpytorch.kernels.kernel import AdditiveKernel, ProductKernel
 from gpytorch.kernels.rbf_kernel import RBFKernel
 from gpytorch.kernels.scale_kernel import ScaleKernel
@@ -44,7 +44,7 @@ class TestMixedSingleTaskGP(BotorchTestCase):
             # to test without that transform we need to explicitly pass in `None`.
             outcome_transform_kwargs = {} if use_octf else {"outcome_transform": None}
 
-            train_X, train_Y = _get_random_data(
+            train_X, train_Y = get_random_data(
                 batch_shape=batch_shape, m=m, d=d, **tkwargs
             )
             cat_dims = list(range(ncat))
@@ -151,7 +151,7 @@ class TestMixedSingleTaskGP(BotorchTestCase):
             (torch.Size([2]), 1, 2, torch.double, False),
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
-            train_X, train_Y = _get_random_data(
+            train_X, train_Y = get_random_data(
                 batch_shape=batch_shape, m=m, d=d, **tkwargs
             )
             cat_dims = list(range(ncat))
@@ -169,7 +169,7 @@ class TestMixedSingleTaskGP(BotorchTestCase):
             fant_shape = torch.Size([2])
 
             # fantasize at different input points
-            X_fant, Y_fant = _get_random_data(
+            X_fant, Y_fant = get_random_data(
                 fant_shape + batch_shape, m=m, d=d, n=3, **tkwargs
             )
             additional_kwargs = (
@@ -255,7 +255,7 @@ class TestMixedSingleTaskGP(BotorchTestCase):
             (torch.Size([2]), 1, 2, torch.double, False),
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
-            train_X, train_Y = _get_random_data(
+            train_X, train_Y = get_random_data(
                 batch_shape=batch_shape, m=m, d=d, **tkwargs
             )
             train_Yvar = torch.full_like(train_Y, 0.1) if observed_noise else None
@@ -281,7 +281,7 @@ class TestMixedSingleTaskGP(BotorchTestCase):
             (torch.float, torch.double),
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
-            train_X, train_Y = _get_random_data(
+            train_X, train_Y = get_random_data(
                 batch_shape=batch_shape, m=m, d=d, **tkwargs
             )
             cat_dims = list(range(ncat))
@@ -307,7 +307,7 @@ class TestMixedSingleTaskGP(BotorchTestCase):
             (torch.Size(), torch.Size([2])), (1, 2), (torch.float, torch.double)
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
-            X, Y = _get_random_data(batch_shape=batch_shape, m=1, d=d, **tkwargs)
+            X, Y = get_random_data(batch_shape=batch_shape, m=1, d=d, **tkwargs)
             cat_dims = list(range(ncat))
             training_data = SupervisedDataset(
                 X,

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -29,7 +29,7 @@ from botorch.models.utils import fantasize
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.sampling.normal import SobolQMCNormalSampler
 from botorch.utils.test_helpers import SimpleGPyTorchModel
-from botorch.utils.testing import _get_random_data, BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, get_random_data
 from gpytorch import ExactMarginalLogLikelihood
 from gpytorch.distributions import MultivariateNormal
 from gpytorch.kernels import RBFKernel, ScaleKernel
@@ -492,7 +492,7 @@ class TestModelListGPyTorchModel(BotorchTestCase):
             self.assertIsInstance(posterior, GPyTorchPosterior)
             self.assertEqual(posterior.mean.shape, torch.Size([2, 2]))
             # test multioutput
-            train_x_raw, train_y = _get_random_data(
+            train_x_raw, train_y = get_random_data(
                 batch_shape=torch.Size(), m=1, n=10, **tkwargs
             )
             task_idx = torch.cat(

--- a/test/models/test_latent_kronecker_gp.py
+++ b/test/models/test_latent_kronecker_gp.py
@@ -14,7 +14,7 @@ from botorch.exceptions.warnings import OptimizationWarning
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.latent_kronecker_gp import LatentKroneckerGP, MinMaxStandardize
 from botorch.models.transforms import Normalize
-from botorch.utils.testing import _get_random_data, BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, get_random_data
 from botorch.utils.types import DEFAULT
 from gpytorch.kernels import MaternKernel, RBFKernel, ScaleKernel
 from gpytorch.likelihoods import FixedNoiseGaussianLikelihood, GaussianLikelihood
@@ -27,7 +27,7 @@ from linear_operator.utils.warnings import NumericalWarning, PerformanceWarning
 def _get_data_with_missing_entries(
     n_train: int, d: int, m: int, batch_shape: torch.Size, tkwargs: dict
 ):
-    train_X, train_Y = _get_random_data(
+    train_X, train_Y = get_random_data(
         batch_shape=batch_shape, m=m, d=d, n=n_train, **tkwargs
     )
 
@@ -586,7 +586,7 @@ class TestLatentKroneckerGP(BotorchTestCase):
             (torch.float, torch.double),  # dtype
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
-            train_X, train_Y = _get_random_data(
+            train_X, train_Y = get_random_data(
                 batch_shape=batch_shape, m=m, d=d, n=n_train, **tkwargs
             )
 
@@ -619,7 +619,7 @@ class TestLatentKroneckerGP(BotorchTestCase):
     def test_not_implemented(self):
         batch_shape = torch.Size([])
         tkwargs = {"device": self.device, "dtype": torch.double}
-        train_X, train_Y = _get_random_data(batch_shape=batch_shape, m=1, **tkwargs)
+        train_X, train_Y = get_random_data(batch_shape=batch_shape, m=1, **tkwargs)
 
         model = LatentKroneckerGP(
             train_X=train_X,

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -23,7 +23,7 @@ from botorch.posteriors import GPyTorchPosterior, PosteriorList, TransformedPost
 from botorch.sampling.base import MCSampler
 from botorch.sampling.list_sampler import ListSampler
 from botorch.sampling.normal import IIDNormalSampler
-from botorch.utils.testing import _get_random_data, BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, get_random_data
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
 from gpytorch.kernels import RBFKernel
 from gpytorch.likelihoods import LikelihoodList
@@ -41,13 +41,9 @@ from torch import Tensor
 def _get_model(
     fixed_noise=False, outcome_transform: str = "None", use_intf=False, **tkwargs
 ) -> ModelListGP:
-    train_x1, train_y1 = _get_random_data(
-        batch_shape=torch.Size(), m=1, n=10, **tkwargs
-    )
+    train_x1, train_y1 = get_random_data(batch_shape=torch.Size(), m=1, n=10, **tkwargs)
     train_y1 = torch.exp(train_y1)
-    train_x2, train_y2 = _get_random_data(
-        batch_shape=torch.Size(), m=1, n=11, **tkwargs
-    )
+    train_x2, train_y2 = get_random_data(batch_shape=torch.Size(), m=1, n=11, **tkwargs)
     if outcome_transform == "Standardize":
         octfs = [Standardize(m=1), Standardize(m=1)]
     elif outcome_transform == "Log":
@@ -280,7 +276,7 @@ class TestModelListGP(BotorchTestCase):
 
     def test_ModelListGP_single(self):
         tkwargs = {"device": self.device, "dtype": torch.float}
-        train_x1, train_y1 = _get_random_data(
+        train_x1, train_y1 = get_random_data(
             batch_shape=torch.Size(), m=1, n=10, **tkwargs
         )
         model1 = SingleTaskGP(train_X=train_x1, train_Y=train_y1)
@@ -296,7 +292,7 @@ class TestModelListGP(BotorchTestCase):
         outcome_transform_kwargs = (
             {} if use_outcome_transform else {"outcome_transform": None}
         )
-        train_x_raw, train_y = _get_random_data(
+        train_x_raw, train_y = get_random_data(
             batch_shape=torch.Size(), m=1, n=10, **tkwargs
         )
         task_idx = torch.cat(

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -48,9 +48,9 @@ from botorch.optim.initializers import (
 from botorch.sampling.normal import IIDNormalSampler
 from botorch.utils.sampling import manual_seed, unnormalize
 from botorch.utils.testing import (
-    _get_max_violation_of_bounds,
-    _get_max_violation_of_constraints,
     BotorchTestCase,
+    get_max_violation_of_bounds,
+    get_max_violation_of_constraints,
     MockAcquisitionFunction,
     MockModel,
     MockPosterior,
@@ -61,11 +61,11 @@ class TestBoundsAndConstraintCheckers(BotorchTestCase):
     def test_bounds_check(self) -> None:
         bounds = torch.tensor([[1, 2], [3, 4]], device=self.device)
         samples = torch.tensor([[2, 3], [2, 3.1]], device=self.device)[None, :, :]
-        result = _get_max_violation_of_bounds(samples, bounds)
+        result = get_max_violation_of_bounds(samples, bounds)
         self.assertAlmostEqual(result, -0.9, delta=1e-6)
 
         samples = torch.tensor([[2, 3], [2, 4.1]], device=self.device)[None, :, :]
-        result = _get_max_violation_of_bounds(samples, bounds)
+        result = get_max_violation_of_bounds(samples, bounds)
         self.assertAlmostEqual(result, 0.1, delta=1e-6)
 
     def test_constraint_check(self) -> None:
@@ -77,10 +77,10 @@ class TestBoundsAndConstraintCheckers(BotorchTestCase):
             )
         ]
         samples = torch.tensor([[2, 3], [2, 3.1]], device=self.device)[None, :, :]
-        result = _get_max_violation_of_constraints(samples, constraints, equality=True)
+        result = get_max_violation_of_constraints(samples, constraints, equality=True)
         self.assertAlmostEqual(result, 0.1, delta=1e-6)
 
-        result = _get_max_violation_of_constraints(samples, constraints, equality=False)
+        result = get_max_violation_of_constraints(samples, constraints, equality=False)
         self.assertAlmostEqual(result, 0.0, delta=1e-6)
 
 
@@ -268,7 +268,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
             self.assertEqual(batch_initial_conditions.device, bounds.device)
             self.assertEqual(batch_initial_conditions.dtype, bounds.dtype)
             self.assertLess(
-                _get_max_violation_of_bounds(batch_initial_conditions, bounds),
+                get_max_violation_of_bounds(batch_initial_conditions, bounds),
                 1e-6,
             )
             batch_shape = (
@@ -347,7 +347,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
             self.assertEqual(batch_initial_conditions.device, bounds.device)
             self.assertEqual(batch_initial_conditions.dtype, bounds.dtype)
             self.assertLess(
-                _get_max_violation_of_bounds(batch_initial_conditions, bounds),
+                get_max_violation_of_bounds(batch_initial_conditions, bounds),
                 1e-6,
             )
             batch_shape = (
@@ -409,7 +409,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
             self.assertEqual(batch_initial_conditions.device, bounds.device)
             self.assertEqual(batch_initial_conditions.dtype, bounds.dtype)
             self.assertLess(
-                _get_max_violation_of_bounds(batch_initial_conditions, bounds), 1e-6
+                get_max_violation_of_bounds(batch_initial_conditions, bounds), 1e-6
             )
             if ffs is not None:
                 for idx, val in ffs.items():
@@ -637,18 +637,18 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                     return None if x is None else x.to(device=self.device)
 
                 self.assertLess(
-                    _get_max_violation_of_bounds(_to_self_device(samples), bounds), tol
+                    get_max_violation_of_bounds(_to_self_device(samples), bounds), tol
                 )
 
                 self.assertLess(
-                    _get_max_violation_of_constraints(
+                    get_max_violation_of_constraints(
                         _to_self_device(samples), constraints=equalities, equality=True
                     ),
                     tol,
                 )
 
                 self.assertLess(
-                    _get_max_violation_of_constraints(
+                    get_max_violation_of_constraints(
                         _to_self_device(samples),
                         constraints=inequalities,
                         equality=False,
@@ -708,11 +708,11 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                 self.assertEqual(batch_initial_conditions.device, bounds.device)
                 self.assertEqual(batch_initial_conditions.dtype, bounds.dtype)
                 self.assertLess(
-                    _get_max_violation_of_bounds(batch_initial_conditions, bounds),
+                    get_max_violation_of_bounds(batch_initial_conditions, bounds),
                     1e-6,
                 )
                 self.assertLess(
-                    _get_max_violation_of_constraints(
+                    get_max_violation_of_constraints(
                         batch_initial_conditions,
                         inequality_constraints,
                         equality=False,
@@ -720,7 +720,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                     1e-6,
                 )
                 self.assertLess(
-                    _get_max_violation_of_constraints(
+                    get_max_violation_of_constraints(
                         batch_initial_conditions,
                         equality_constraints,
                         equality=True,
@@ -821,7 +821,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                     batch_initial_conditions[1, 2, 0],
                 )
                 self.assertLess(
-                    _get_max_violation_of_constraints(
+                    get_max_violation_of_constraints(
                         batch_initial_conditions,
                         inequality_constraints,
                         equality=False,
@@ -886,7 +886,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                 self.assertEqual(batch_initial_conditions.dtype, bounds.dtype)
                 self.assertTrue((batch_initial_conditions[..., -1] == 0.42).all())
                 self.assertLess(
-                    _get_max_violation_of_bounds(batch_initial_conditions, bounds),
+                    get_max_violation_of_bounds(batch_initial_conditions, bounds),
                     1e-6,
                 )
                 if ffs is not None:
@@ -981,7 +981,7 @@ class TestGenBatchInitialCandidates(BotorchTestCase):
                 self.assertEqual(batch_initial_conditions.device, bounds.device)
                 self.assertEqual(batch_initial_conditions.dtype, bounds.dtype)
                 self.assertLess(
-                    _get_max_violation_of_bounds(batch_initial_conditions, bounds),
+                    get_max_violation_of_bounds(batch_initial_conditions, bounds),
                     1e-6,
                 )
                 batch_shape = (

--- a/test/posteriors/test_gpytorch.py
+++ b/test/posteriors/test_gpytorch.py
@@ -12,7 +12,7 @@ from unittest import mock
 import torch
 from botorch.exceptions import BotorchTensorDimensionError
 from botorch.posteriors.gpytorch import GPyTorchPosterior, scalarize_posterior
-from botorch.utils.testing import _get_test_posterior, BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, get_test_posterior
 from gpytorch import settings as gpt_settings
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
 from linear_operator.operators import to_linear_operator
@@ -201,7 +201,7 @@ class TestGPyTorchPosterior(BotorchTestCase):
             while torch.any(weights.abs() < 0.1):
                 weights = torch.randn(m, **tkwargs)
             # test q=1
-            posterior = _get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
+            posterior = get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
             mean, covar = (
                 posterior.distribution.mean,
                 posterior.distribution.covariance_matrix,
@@ -218,7 +218,7 @@ class TestGPyTorchPosterior(BotorchTestCase):
             )
             # test q=2, interleaved
             q = 2
-            posterior = _get_test_posterior(
+            posterior = get_test_posterior(
                 batch_shape, q=q, m=m, lazy=lazy, interleaved=True, **tkwargs
             )
             mean, covar = (
@@ -243,7 +243,7 @@ class TestGPyTorchPosterior(BotorchTestCase):
             # test q=2, non-interleaved
             # test independent special case as well
             for independent in (False, True) if m > 1 else (False,):
-                posterior = _get_test_posterior(
+                posterior = get_test_posterior(
                     batch_shape,
                     q=q,
                     m=m,

--- a/test/posteriors/test_posteriorlist.py
+++ b/test/posteriors/test_posteriorlist.py
@@ -9,7 +9,7 @@ import itertools
 import torch
 from botorch.posteriors.gpytorch import scalarize_posterior
 from botorch.posteriors.posterior_list import PosteriorList
-from botorch.utils.testing import _get_test_posterior, BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, get_test_posterior
 
 
 class TestPosteriorList(BotorchTestCase):
@@ -25,7 +25,7 @@ class TestPosteriorList(BotorchTestCase):
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
 
-            posterior = _get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
+            posterior = get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
             posterior_list = PosteriorList(posterior, posterior)
             scalarized_posterior = scalarize_posterior(
                 posterior, weights=torch.ones(1, **tkwargs)
@@ -65,7 +65,7 @@ class TestPosteriorList(BotorchTestCase):
             while torch.any(weights.abs() < 0.1):
                 weights = torch.randn(m, **tkwargs)
             # test q=1
-            posterior = _get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
+            posterior = get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
             posterior_list = PosteriorList(posterior)
             new_posterior = scalarize_posterior(posterior, weights, offset)
             new_post_from_list = scalarize_posterior(posterior_list, weights, offset)
@@ -90,7 +90,7 @@ class TestPosteriorList(BotorchTestCase):
             while torch.any(weights.abs() < 0.1):
                 weights = torch.randn(m, **tkwargs)
             # test q=1
-            posterior = _get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
+            posterior = get_test_posterior(batch_shape, m=m, lazy=lazy, **tkwargs)
             posterior_list = PosteriorList(posterior)
             if m > 1:
                 with self.assertRaisesRegex(
@@ -102,7 +102,7 @@ class TestPosteriorList(BotorchTestCase):
 
             # test q=2, interleaved
             q = 2
-            posterior = _get_test_posterior(
+            posterior = get_test_posterior(
                 batch_shape, q=q, m=m, lazy=lazy, interleaved=True, **tkwargs
             )
             posterior_list = PosteriorList(posterior)
@@ -116,7 +116,7 @@ class TestPosteriorList(BotorchTestCase):
             # test q=2, non-interleaved
             # test independent special case as well
             for independent in (False, True) if m > 1 else (False,):
-                posterior = _get_test_posterior(
+                posterior = get_test_posterior(
                     batch_shape,
                     q=q,
                     m=m,

--- a/test/test_cross_validation.py
+++ b/test/test_cross_validation.py
@@ -15,7 +15,7 @@ from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.multitask import MultiTaskGP
 from botorch.models.transforms.input import Normalize
 from botorch.models.transforms.outcome import Standardize
-from botorch.utils.testing import _get_random_data, BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, get_random_data
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 
 
@@ -29,7 +29,7 @@ class TestFitBatchCrossValidation(BotorchTestCase):
             (False, True),
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
-            train_X, train_Y = _get_random_data(
+            train_X, train_Y = get_random_data(
                 batch_shape=batch_shape, m=m, n=n, **tkwargs
             )
             if m == 1:
@@ -111,7 +111,7 @@ class TestFitBatchCrossValidation(BotorchTestCase):
                 self.assertIs(cv_results.posterior.mean.dtype, dtype)
 
     def test_mtgp(self):
-        train_X, train_Y = _get_random_data(
+        train_X, train_Y = get_random_data(
             batch_shape=torch.Size(), m=1, n=3, device=self.device
         )
         cv_folds = gen_loo_cv_folds(train_X=train_X, train_Y=train_Y)

--- a/test_community/models/test_gp_regression_multisource.py
+++ b/test_community/models/test_gp_regression_multisource.py
@@ -21,7 +21,7 @@ from botorch.models.utils.gpytorch_modules import (
 from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling import SobolQMCNormalSampler
 from botorch.utils.test_helpers import get_pvar_expected
-from botorch.utils.testing import _get_random_data, BotorchTestCase
+from botorch.utils.testing import BotorchTestCase, get_random_data
 from botorch_community.models.gp_regression_multisource import (
     _get_reliable_observations,
     get_random_x_for_agp,
@@ -257,7 +257,7 @@ class TestAugmentedSingleTaskGP(BotorchTestCase):
             # test condition_on_observations
             fant_shape = torch.Size([2])
             # fantasize at different input points
-            X_fant, Y_fant = _get_random_data(
+            X_fant, Y_fant = get_random_data(
                 batch_shape=fant_shape, m=1, d=d, n=3, **tkwargs
             )
             c_kwargs = (


### PR DESCRIPTION
I added doc strings, and some abstract methods and we renamed some of the actually public functions, that had a leading `_`.


