### PR TITLE
[Bug]: initialize_q_batch does not always include the maximum value when called in batch mode

### DIFF
--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -987,8 +987,9 @@ def initialize_q_batch(
     ).permute(-1, *range(len(batch_shape)))
 
     # make sure we get the maximum
-    if max_idx not in idcs:
-        idcs[-1] = max_idx
+    has_max = (max_idx == idcs).any(dim=0)
+    idcs[-1, ~has_max] = max_idx[~has_max]
+
     if batch_shape == torch.Size():
         return X[idcs], acq_vals[idcs]
     else:

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -987,8 +987,12 @@ def initialize_q_batch(
     ).permute(-1, *range(len(batch_shape)))
 
     # make sure we get the maximum
-    has_max = (max_idx == idcs).any(dim=0)
-    idcs[-1, ~has_max] = max_idx[~has_max]
+    if batch_shape == torch.Size():
+        if max_idx not in idcs:
+            idcs[-1] = max_idx
+    else:
+        has_max = (max_idx == idcs).any(dim=0)
+        idcs[-1, ~has_max] = max_idx[~has_max]
 
     if batch_shape == torch.Size():
         return X[idcs], acq_vals[idcs]


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation
Fix for #2772 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

  - Added assert to existing to ensure max value is included for every element of the batch.
  - Added a test case with large batch size
  - Verified test failed before making the change, and that it passes after

## Related PRs

No related PRs; no changes to docs required.