### PR TITLE
pass option to reset submodules in train method for FullyBayesianModels

### DIFF
--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -629,11 +629,20 @@ class FullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel, ABC):
         return aug_batch_shape
 
     def train(
-        self: TFullyBayesianSingleTaskGP, mode: bool = True
+        self: TFullyBayesianSingleTaskGP, mode: bool = True, reset: bool = True
     ) -> TFullyBayesianSingleTaskGP:
-        r"""Puts the model in `train` mode."""
+        r"""Puts the model in `train` mode.
+
+        Args:
+            mode: A boolean indicating whether to put the model in training mode.
+            reset: A boolean indicating whether to reset the model to its initial
+                state if mode is True. If `mode` is False, this argument is ignored.
+
+        Returns:
+            The model itself.
+        """
         super().train(mode=mode)
-        if mode:
+        if mode and reset:
             self.mean_module = None
             self.covar_module = None
             self.likelihood = None

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -7,7 +7,7 @@
 r"""Multi-task Gaussian Process Regression models with fully Bayesian inference."""
 
 from collections.abc import Mapping
-from typing import Any, NoReturn
+from typing import Any, NoReturn, TypeVar
 
 import pyro
 import torch
@@ -29,6 +29,11 @@ from gpytorch.likelihoods.likelihood import Likelihood
 from gpytorch.means.mean import Mean
 from torch import Tensor
 from torch.nn.parameter import Parameter
+
+# Can replace with Self type once 3.11 is the minimum version
+TSaasFullyBayesianMultiTaskGP = TypeVar(
+    "TSaasFullyBayesianMultiTaskGP", bound="SaasFullyBayesianMultiTaskGP"
+)
 
 
 class MultitaskSaasPyroModel(SaasPyroModel):
@@ -289,14 +294,26 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
         if input_transform is not None:
             self.input_transform = input_transform
 
-    def train(self, mode: bool = True) -> None:
-        r"""Puts the model in `train` mode."""
+    def train(
+        self, mode: bool = True, reset: bool = True
+    ) -> TSaasFullyBayesianMultiTaskGP:
+        r"""Puts the model in `train` mode.
+
+        Args:
+            mode: A boolean indicating whether to put the model in training mode.
+            reset: A boolean indicating whether to reset the model to its initial
+                state. If `mode` is False, this argument is ignored.
+
+        Returns:
+            The model itself.
+        """
         super().train(mode=mode)
-        if mode:
+        if mode and reset:
             self.mean_module = None
             self.covar_module = None
             self.likelihood = None
             self.task_covar_module = None
+        return self
 
     @property
     def median_lengthscale(self) -> Tensor:

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -440,7 +440,22 @@ class TestSaasFullyBayesianSingleTaskGP(BotorchTestCase):
             # Make sure the model shapes are set correctly
             self.assertEqual(model.pyro_model.train_X.shape, torch.Size([n, d]))
             self.assertAllClose(model.pyro_model.train_X, train_X)
-            trained_model = model.train()  # Put the model in train mode
+            # Put the model in eval mode with reset=True (reset should be ignored)
+            trained_model = model.train(mode=False, reset=True)
+            self.assertIs(trained_model, model)
+            self.assertAllClose(train_X, model.pyro_model.train_X)
+            self.assertIsNotNone(model.mean_module)
+            self.assertIsNotNone(model.covar_module)
+            self.assertIsNotNone(model.likelihood)
+            # Put the model in train mode, without resetting
+            trained_model = model.train(reset=False)
+            self.assertIs(trained_model, model)
+            self.assertAllClose(train_X, model.pyro_model.train_X)
+            self.assertIsNotNone(model.mean_module)
+            self.assertIsNotNone(model.covar_module)
+            self.assertIsNotNone(model.likelihood)
+            # Put the model in train mode, with resetting
+            trained_model = model.train()
             self.assertIs(trained_model, model)
             self.assertAllClose(train_X, model.pyro_model.train_X)
             self.assertIsNone(model.mean_module)

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -401,7 +401,24 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
         # Make sure the model shapes are set correctly
         self.assertEqual(model.pyro_model.train_X.shape, torch.Size([n, d + 1]))
         self.assertAllClose(model.pyro_model.train_X, train_X)
-        model.train()  # Put the model in train mode
+
+        # Put the model in eval mode with reset=True (reset should be ignored)
+        trained_model = model.train(mode=False, reset=True)
+        self.assertIs(trained_model, model)
+        self.assertAllClose(train_X, model.pyro_model.train_X)
+        self.assertIsNotNone(model.mean_module)
+        self.assertIsNotNone(model.covar_module)
+        self.assertIsNotNone(model.likelihood)
+        # Put the model in train mode, without resetting
+        trained_model = model.train(reset=False)
+        self.assertIs(trained_model, model)
+        self.assertAllClose(train_X, model.pyro_model.train_X)
+        self.assertIsNotNone(model.mean_module)
+        self.assertIsNotNone(model.covar_module)
+        self.assertIsNotNone(model.likelihood)
+        # Put the model in train mode, with resetting
+        trained_model = model.train()
+        self.assertIs(trained_model, model)
         self.assertAllClose(train_X, model.pyro_model.train_X)
         self.assertIsNone(model.mean_module)
         self.assertIsNone(model.covar_module)


### PR DESCRIPTION
Summary: This enables evaluating the model in train mode, without reseting the submodules. This enables computing the marginal likelihood (as well as AIC, BIC) for fully-bayesian models

Differential Revision: D71770887


