### PR TITLE
Update black version in `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
     -   id: ufmt
         additional_dependencies:
-        - black==24.4.2
+        - black==24.10.0
         - usort==1.0.8.post1
         - ruff-api==0.1.0
         - stdlibs==2024.1.28


### PR DESCRIPTION
https://github.com/pytorch/botorch/commit/ef1142b248d8f832a26d0c0a7f354199a345427e updated the black version, which caused a divergence with what was specified in the pre-commit config. This brings things back into sync.