### PR TITLE
Annotate SingleTaskGP train_inputs and train_targets

### DIFF
--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -116,6 +116,9 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
         ... )
     """
 
+    train_targets: Tensor
+    train_inputs: tuple[Tensor]
+
     def __init__(
         self,
         train_X: Tensor,


### PR DESCRIPTION
Summary:
Context: In the current version of GPyTorch, `ExactGP.train_targets` can be a tensor or None. Although `SingleTaskGP` subclasses `ExactGP`, it never will have `None` `train_targets`. Pyre thinks it might with the current version of GPyTorch, causing type-check errors downstream in Ax.

In `SingleTaskGP`, `train_targets` continues to always be a Tensor and `train_inputs` continues to be a tuple of Tensors.

Note that `ExactGP.train_targets` is annotated as `tuple[Tensor] | None` in GPyTorch, but this appears to be incorrect.

This PR:

* Annotates `SingleTaskGP.train_targets` and `SingleTaskGP.train_inputs`
* Fixes some other typecheck errors

Differential Revision: D72055682


