### PR TITLE
Detach tensor in `gen_candidates_scipy` to avoid test failure due to new warning

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -205,7 +205,7 @@ def gen_candidates_scipy(
                 if initial_conditions.dtype != torch.double:
                     msg += " Consider using `dtype=torch.double`."
                 raise OptimizationGradientError(msg, current_x=x)
-            fval = loss.item()
+            fval = loss.detach().item()
             return fval, gradf
 
     else:
@@ -215,7 +215,7 @@ def gen_candidates_scipy(
             with torch.no_grad():
                 X_fix = fix_features(X=X, fixed_features=fixed_features)
                 loss = f(X_fix).sum()
-            fval = loss.item()
+            fval = loss.detach().item()
             return fval
 
     if nonlinear_inequality_constraints:


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/143261 added a new warning to pytorch that gets raised when converting a tensor with gradients to a scalar without detaching it first.

This caused some test failues in botorch (which are likely a bit overzealous, but we can fix that separately). This makes a change in `gen_candidates_scipy` to fix this.

There are most likely other occurrences of this in botorch that we should fix, but here I'm quickly addressing the test failures first.

Reviewed By: saitcakmak

Differential Revision: D72286925


