### PR TITLE
Remove qMultiObjectiveMaxValueEntropy acquisition function

### DIFF
--- a/botorch/acquisition/multi_objective/max_value_entropy_search.py
+++ b/botorch/acquisition/multi_objective/max_value_entropy_search.py
@@ -19,7 +19,6 @@ References
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from math import pi
 
 import torch
@@ -28,153 +27,29 @@ from botorch.acquisition.multi_objective.base import MultiObjectiveMCAcquisition
 from botorch.acquisition.multi_objective.joint_entropy_search import (
     LowerBoundMultiObjectiveEntropySearch,
 )
-from botorch.models.converter import (
-    batched_multi_output_to_single_output,
-    model_list_to_batched,
-)
 from botorch.models.model import Model
-from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.posteriors.gpytorch import GPyTorchPosterior
-from botorch.sampling.base import MCSampler
-from botorch.sampling.normal import SobolQMCNormalSampler
 from botorch.utils.transforms import concatenate_pending_points, t_batch_mode_transform
 from torch import Tensor
 
 
+# Can be removed in version 0.15.0, or potentially sooner because the code has
+# already been raising deprecation warnings for a long time
 class qMultiObjectiveMaxValueEntropy(
     qMaxValueEntropy, MultiObjectiveMCAcquisitionFunction
 ):
     r"""The acquisition function for MESMO.
 
-    This acquisition function computes the mutual information of
-    Pareto frontier and a candidate point. See [Belakaria2019]_ for
-    a detailed discussion.
-
-    q > 1 is supported through cyclic optimization and fantasies.
-
-    Noisy observations are support by computing information gain with
-    observation noise as in Appendix C in [Takeno2020mfmves]_.
-
-    Note: this only supports maximization.
-
-    Attributes:
-        _default_sample_shape: The `sample_shape` for the default sampler.
-
-    Example:
-        >>> model = SingleTaskGP(train_X, train_Y, outcome_transform=None)
-        >>> MESMO = qMultiObjectiveMaxValueEntropy(model, sample_pfs)
-        >>> mesmo = MESMO(test_X)
+    This is no longer available. We recommend
+    `qLowerBoundMultiObjectiveMaxValueEntropySearch` as a replacement.
     """
 
-    _default_sample_shape = torch.Size([128])
-
-    def __init__(
-        self,
-        model: Model,
-        sample_pareto_frontiers: Callable[[Model], Tensor],
-        num_fantasies: int = 16,
-        X_pending: Tensor | None = None,
-        sampler: MCSampler | None = None,
-    ) -> None:
-        r"""Multi-objective max-value entropy search acquisition function.
-
-        Args:
-            model: A fitted multi-output model.
-            sample_pareto_frontiers: A callable that takes a model and returns a
-                `num_samples x n' x m`-dim tensor of outcomes to use for constructing
-                `num_samples` sampled Pareto frontiers.
-            num_fantasies: Number of fantasies to generate. The higher this
-                number the more accurate the model (at the expense of model
-                complexity, wall time and memory). Ignored if `X_pending` is `None`.
-            X_pending: A `m x d`-dim Tensor of `m` design points that have been
-                submitted for function evaluation, but have not yet been evaluated.
-        """
-        MultiObjectiveMCAcquisitionFunction.__init__(self, model=model, sampler=sampler)
-
-        # Batch GP models (e.g. fantasized models) are not currently supported
-        if isinstance(model, ModelListGP):
-            train_X = model.models[0].train_inputs[0]
-        else:
-            train_X = model.train_inputs[0]
-        if train_X.ndim > 3:
-            raise NotImplementedError(
-                "Batch GP models (e.g. fantasized models) "
-                "are not yet supported by qMultiObjectiveMaxValueEntropy"
-            )
-        # convert to batched MO model
-        batched_mo_model = (
-            model_list_to_batched(model) if isinstance(model, ModelListGP) else model
+    def __init__(self, *args, **kwargs) -> None:
+        """Multi-objective max-value entropy search acquisition function."""
+        raise NotImplementedError(
+            "qMultiObjectiveMaxValueEntropy is no longer available. We suggest "
+            "qLowerBoundMultiObjectiveMaxValueEntropySearch as a replacement."
         )
-        self._init_model = batched_mo_model
-        self.fantasies_sampler = SobolQMCNormalSampler(
-            sample_shape=torch.Size([num_fantasies])
-        )
-        self.num_fantasies = num_fantasies
-        # weight is used in _compute_information_gain
-        self.maximize = True
-        self.weight = 1.0
-        self.sample_pareto_frontiers = sample_pareto_frontiers
-        # Set X_pending, register converted model and sample max values.
-        self.set_X_pending(X_pending)
-        # This avoids attribute errors in qMaxValueEntropy code.
-        self.posterior_transform = None
-
-    def set_X_pending(self, X_pending: Tensor | None = None) -> None:
-        r"""Set pending points.
-
-        Informs the acquisition function about pending design points,
-        fantasizes the model on the pending points and draws max-value samples
-        from the fantasized model posterior.
-
-        Args:
-            X_pending: `m x d` Tensor with `m` `d`-dim design points that have
-                been submitted for evaluation but have not yet been evaluated.
-        """
-        MultiObjectiveMCAcquisitionFunction.set_X_pending(self, X_pending=X_pending)
-        if X_pending is not None:
-            # fantasize the model
-            fantasy_model = self._init_model.fantasize(
-                X=X_pending,
-                sampler=self.fantasies_sampler,
-            )
-            self.mo_model = fantasy_model
-        else:
-            # This is mainly for setting the model to the original model
-            # after the sequential optimization at q > 1
-            self.mo_model = self._init_model
-        # convert model to batched single outcome model.
-        self.model = batched_multi_output_to_single_output(batch_mo_model=self.mo_model)
-        self._sample_max_values()
-
-    def _sample_max_values(self) -> None:
-        """Sample max values for MC approximation of the expectation in MES.
-
-        Sets self.posterior_max_values."""
-        with torch.no_grad():
-            # num_samples x (num_fantasies) x n_pareto_points x m
-            sampled_pfs = self.sample_pareto_frontiers(self.mo_model)
-            if sampled_pfs.ndim == 3:
-                # add fantasy dim
-                sampled_pfs = sampled_pfs.unsqueeze(-3)
-            # take component-wise max value
-            self.posterior_max_values = sampled_pfs.max(dim=-2).values
-
-    @t_batch_mode_transform(expected_q=1)
-    def forward(self, X: Tensor) -> Tensor:
-        r"""Compute max-value entropy at the design points `X`.
-
-        Args:
-            X: A `batch_shape x 1 x d`-dim Tensor of `batch_shape` t-batches
-                with `1` `d`-dim design points each.
-
-        Returns:
-            A `batch_shape`-dim Tensor of MVE values at the given design points `X`.
-        """
-        # `m` dim tensor of information gains
-        # unsqueeze X to add a batch-dim for the batched model
-        igs = qMaxValueEntropy.forward(self, X=X.unsqueeze(-3))
-        # sum over objectives
-        return igs.sum(dim=-1)
 
 
 class qLowerBoundMultiObjectiveMaxValueEntropySearch(

--- a/test/acquisition/multi_objective/test_max_value_entropy_search.py
+++ b/test/acquisition/multi_objective/test_max_value_entropy_search.py
@@ -5,17 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 
 from itertools import product
-from unittest import mock
 
 import torch
-from botorch.acquisition.max_value_entropy_search import qMaxValueEntropy
 from botorch.acquisition.multi_objective.max_value_entropy_search import (
     qLowerBoundMultiObjectiveMaxValueEntropySearch,
     qMultiObjectiveMaxValueEntropy,
 )
 from botorch.acquisition.multi_objective.utils import compute_sample_box_decomposition
-from botorch.exceptions.errors import UnsupportedError
-from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.sampling.normal import SobolQMCNormalSampler
 from botorch.utils.test_helpers import get_model
@@ -33,130 +29,11 @@ def dummy_sample_pareto_frontiers(model):
     )
 
 
+# TODO: remove all references
 class TestMultiObjectiveMaxValueEntropy(BotorchTestCase):
-    def test_multi_objective_max_value_entropy(self):
-        for dtype, m in product((torch.float, torch.double), (2, 3)):
-            torch.manual_seed(7)
-            # test batched model
-            train_X = torch.rand(1, 1, 2, dtype=dtype, device=self.device)
-            train_Y = torch.rand(1, 1, m, dtype=dtype, device=self.device)
-            model = SingleTaskGP(train_X, train_Y, outcome_transform=None)
-            with self.assertRaises(NotImplementedError):
-                qMultiObjectiveMaxValueEntropy(
-                    model=model, sample_pareto_frontiers=dummy_sample_pareto_frontiers
-                )
-            # test initialization
-            train_X = torch.rand(4, 2, dtype=dtype, device=self.device)
-            train_Y = torch.rand(4, m, dtype=dtype, device=self.device)
-            # Models with outcome transforms aren't supported.
-            model = SingleTaskGP(train_X, train_Y)
-            with self.assertRaisesRegex(
-                UnsupportedError,
-                "Conversion of models with outcome transforms is unsupported. "
-                "To fix this error, explicitly pass `outcome_transform=None`.",
-            ):
-                qMultiObjectiveMaxValueEntropy(
-                    model=ModelListGP(model, model),
-                    sample_pareto_frontiers=dummy_sample_pareto_frontiers,
-                )
-            # test batched MO model
-            model = SingleTaskGP(train_X, train_Y, outcome_transform=None)
-            mesmo = qMultiObjectiveMaxValueEntropy(
-                model=model, sample_pareto_frontiers=dummy_sample_pareto_frontiers
-            )
-            self.assertEqual(mesmo.num_fantasies, 16)
-            # Initialize the sampler.
-            dummy_post = model.posterior(train_X[:1])
-            mesmo.get_posterior_samples(dummy_post)
-            self.assertIsInstance(mesmo.sampler, SobolQMCNormalSampler)
-            self.assertEqual(mesmo.sampler.sample_shape, torch.Size([128]))
-            self.assertIsInstance(mesmo.fantasies_sampler, SobolQMCNormalSampler)
-            self.assertEqual(mesmo.posterior_max_values.shape, torch.Size([3, 1, m]))
-            # test conversion to single-output model
-            self.assertIs(mesmo.mo_model, model)
-            self.assertEqual(mesmo.mo_model.num_outputs, m)
-            self.assertIsInstance(mesmo.model, SingleTaskGP)
-            self.assertEqual(mesmo.model.num_outputs, 1)
-            self.assertEqual(
-                mesmo.model._aug_batch_shape, mesmo.model._input_batch_shape
-            )
-            # test ModelListGP
-            model = ModelListGP(
-                *[
-                    SingleTaskGP(train_X, train_Y[:, i : i + 1], outcome_transform=None)
-                    for i in range(m)
-                ]
-            )
-            mock_sample_pfs = mock.Mock()
-            mock_sample_pfs.return_value = dummy_sample_pareto_frontiers(model=model)
-            mesmo = qMultiObjectiveMaxValueEntropy(
-                model=model, sample_pareto_frontiers=mock_sample_pfs
-            )
-            self.assertEqual(mesmo.num_fantasies, 16)
-            # Initialize the sampler.
-            dummy_post = model.posterior(train_X[:1])
-            mesmo.get_posterior_samples(dummy_post)
-            self.assertIsInstance(mesmo.sampler, SobolQMCNormalSampler)
-            self.assertEqual(mesmo.sampler.sample_shape, torch.Size([128]))
-            self.assertIsInstance(mesmo.fantasies_sampler, SobolQMCNormalSampler)
-            self.assertEqual(mesmo.posterior_max_values.shape, torch.Size([3, 1, m]))
-            # test conversion to batched MO model
-            self.assertIsInstance(mesmo.mo_model, SingleTaskGP)
-            self.assertEqual(mesmo.mo_model.num_outputs, m)
-            self.assertIs(mesmo.mo_model, mesmo._init_model)
-            # test conversion to single-output model
-            self.assertIsInstance(mesmo.model, SingleTaskGP)
-            self.assertEqual(mesmo.model.num_outputs, 1)
-            self.assertEqual(
-                mesmo.model._aug_batch_shape, mesmo.model._input_batch_shape
-            )
-            # test that we call sample_pareto_frontiers with the multi-output model
-            mock_sample_pfs.assert_called_once_with(mesmo.mo_model)
-            # test basic evaluation
-            X = torch.rand(1, 2, device=self.device, dtype=dtype)
-            with torch.no_grad():
-                vals = mesmo(X)
-                igs = qMaxValueEntropy.forward(mesmo, X=X.view(1, 1, 1, 2))
-            self.assertEqual(vals.shape, torch.Size([1]))
-            self.assertTrue(torch.equal(vals, igs.sum(dim=-1)))
-
-            # test batched evaluation
-            X = torch.rand(4, 1, 2, device=self.device, dtype=dtype)
-            with torch.no_grad():
-                vals = mesmo(X)
-                igs = qMaxValueEntropy.forward(mesmo, X=X.view(4, 1, 1, 2))
-            self.assertEqual(vals.shape, torch.Size([4]))
-            self.assertTrue(torch.equal(vals, igs.sum(dim=-1)))
-
-            # test set X pending to None
-            mesmo.set_X_pending(None)
-            self.assertIs(mesmo.mo_model, mesmo._init_model)
-            fant_X = torch.cat(
-                [
-                    train_X.expand(16, 4, 2),
-                    torch.rand(16, 1, 2, device=self.device, dtype=dtype),
-                ],
-                dim=1,
-            )
-            fant_Y = torch.cat(
-                [
-                    train_Y.expand(16, 4, m),
-                    torch.rand(16, 1, m, device=self.device, dtype=dtype),
-                ],
-                dim=1,
-            )
-            fantasy_model = SingleTaskGP(fant_X, fant_Y, outcome_transform=None)
-
-            # test with X_pending is not None
-            with mock.patch.object(
-                SingleTaskGP, "fantasize", return_value=fantasy_model
-            ) as mock_fantasize:
-                qMultiObjectiveMaxValueEntropy(
-                    model,
-                    dummy_sample_pareto_frontiers,
-                    X_pending=torch.rand(1, 2, device=self.device, dtype=dtype),
-                )
-                mock_fantasize.assert_called_once()
+    def test_multi_objective_max_value_entropy(self) -> None:
+        with self.assertRaisesRegex(NotImplementedError, "no longer available"):
+            qMultiObjectiveMaxValueEntropy()
 
 
 class TestQLowerBoundMultiObjectiveMaxValueEntropySearch(BotorchTestCase):

--- a/test/optim/utils/test_acquisition_utils.py
+++ b/test/optim/utils/test_acquisition_utils.py
@@ -145,7 +145,7 @@ class TestFixFeatures(BotorchTestCase):
 
 
 class TestGetXBaseline(BotorchTestCase):
-    def test_get_X_baseline(self):
+    def test_get_X_baseline(self) -> None:
         tkwargs = {"device": self.device}
         for dtype in (torch.float, torch.double):
             tkwargs["dtype"] = dtype
@@ -227,15 +227,6 @@ class TestGetXBaseline(BotorchTestCase):
             X = get_X_baseline(acq_function=acqf)
             self.assertTrue(torch.equal(X, X_train))
 
-            # test MESMO for which we need to use
-            # `acqf.mo_model`
-            batched_mo_model = SingleTaskGP(X_train, Y_train, outcome_transform=None)
-            acqf = qMultiObjectiveMaxValueEntropy(
-                batched_mo_model,
-                sample_pareto_frontiers=lambda model: torch.rand(10, 2, **tkwargs),
-            )
-            X = get_X_baseline(acq_function=acqf)
-            self.assertTrue(torch.equal(X, X_train))
             # test that if there is an input transform that is applied
             # to the train_inputs when the model is in eval mode, we
             # extract the untransformed train_inputs


### PR DESCRIPTION
Summary:
Context:

This acquisition function
* Probably doesn't perform well generally, as per the literature
* Is likely not as good as `qLowerBoundMultiObjectiveMaxValueEntropySearch`
* Cannot be used with outcome transforms
* Uses deprecated functionality that is overdue to be reaped

This PR:

* Replaces `qMultiObjectiveMaxValueEntropy.__init__` with a `NotImplementedError` that recommends using `qLowerBoundMultiObjectiveMaxValueEntropySearch`
* Adds a comment recommending this be removed in 0.15.0

Reviewed By: sdaulton, saitcakmak

Differential Revision: D72332368


