### PR TITLE
Patch codecov for botorch_community

### DIFF
--- a/botorch_community/models/prior_fitted_network.py
+++ b/botorch_community/models/prior_fitted_network.py
@@ -16,11 +16,9 @@ from __future__ import annotations
 from typing import Optional, Union
 
 import torch.nn as nn
-
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.model import Model
-
 from botorch_community.posteriors.riemann import BoundedRiemannPosterior
 from torch import Tensor
 

--- a/botorch_community/models/utils/prior_fitted_network.py
+++ b/botorch_community/models/utils/prior_fitted_network.py
@@ -61,9 +61,7 @@ def download_model(
     if isinstance(model_path, ModelPaths):
         model_path = model_path.value
 
-    if cache_dir is None:
-        cache_dir = "/tmp/botorch_pfn_models"
-
+    cache_dir = cache_dir if cache_dir is not None else "/tmp/botorch_pfn_models"
     os.makedirs(cache_dir, exist_ok=True)
     cache_path = os.path.join(cache_dir, model_path.split("/")[-1])
 

--- a/botorch_community/posteriors/riemann.py
+++ b/botorch_community/posteriors/riemann.py
@@ -78,8 +78,7 @@ class BoundedRiemannPosterior(Posterior):
             Samples from the posterior, a tensor of shape
             `self._extended_shape(sample_shape=sample_shape)`.
         """
-        if sample_shape is None:
-            sample_shape = torch.Size([1])
+        sample_shape = sample_shape if sample_shape is not None else torch.Size([1])
         z = torch.rand(sample_shape)
         return self.rsample_from_base_samples(sample_shape, z)
 


### PR DESCRIPTION
Summary:
These two lines were not covered. Made them into single line statements to bring coverage to 100%.

I know that this is just a symbolic change, but 100% is a lot easier to enforce than some 99.x% coverage.

Differential Revision: D72390615


