### PR TITLE
Add parameter types to test functions

### DIFF
--- a/botorch/test_functions/multi_fidelity.py
+++ b/botorch/test_functions/multi_fidelity.py
@@ -40,6 +40,7 @@ class AugmentedBranin(SyntheticTestFunction):
     """
 
     dim = 3
+    continuous_inds = list(range(dim))
     _bounds = [(-5.0, 10.0), (0.0, 15.0), (0.0, 1.0)]
     _optimal_value = 0.397887
     _optimizers = [  # this is a subset, ther are infinitely many optimizers
@@ -76,7 +77,8 @@ class AugmentedHartmann(SyntheticTestFunction):
     """
 
     dim = 7
-    _bounds = [(0.0, 1.0) for _ in range(7)]
+    continuous_inds = list(range(dim))
+    _bounds = [(0.0, 1.0) for _ in range(dim)]
     _optimal_value = -3.32237
     _optimizers = [(0.20169, 0.150011, 0.476874, 0.275332, 0.311652, 0.6573, 1.0)]
     _check_grad_at_opt = False
@@ -157,6 +159,7 @@ class AugmentedRosenbrock(SyntheticTestFunction):
                 "AugmentedRosenbrock must be defined it at least 3 dimensions"
             )
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         self._bounds = [(-5.0, 10.0) for _ in range(self.dim)]
         self._optimizers = [tuple(1.0 for _ in range(self.dim))]
         super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
@@ -194,6 +197,7 @@ class WingWeightMultiFidelity(SyntheticTestFunction):
     """
 
     dim = 11
+    continuous_inds = list(range(dim))
     _num_fidelities = 1
     _bounds = [
         (150.0, 200.0),  # s_w
@@ -284,6 +288,7 @@ class BoreholeMultiFidelity(SyntheticTestFunction):
     """
 
     dim = 9
+    continuous_inds = list(range(dim))
     _num_fidelities = 1
     _bounds = [
         (0.05, 0.15),  # r_w

--- a/botorch/test_functions/multi_objective.py
+++ b/botorch/test_functions/multi_objective.py
@@ -110,6 +110,7 @@ class BraninCurrin(MultiObjectiveTestProblem):
     """
 
     dim = 2
+    continuous_inds = list(range(2))
     num_objectives = 2
     _bounds = [(0.0, 1.0), (0.0, 1.0)]
     _ref_point = [18.0, 6.0]
@@ -193,6 +194,7 @@ class DH(MultiObjectiveTestProblem, ABC):
         if dim < self._min_dim:
             raise ValueError(f"dim must be >= {self._min_dim}, but got dim={dim}!")
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         self._bounds = [(0.0, 1.0), (self._x_1_lb, 1.0)] + [
             (-1.0, 1.0) for _ in range(dim - 2)
         ]
@@ -359,6 +361,7 @@ class DTLZ(MultiObjectiveTestProblem):
             )
         self.num_objectives = num_objectives
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         self.k = self.dim - self.num_objectives + 1
         self._bounds = [(0.0, 1.0) for _ in range(self.dim)]
         self._ref_point = [self._ref_val for _ in range(num_objectives)]
@@ -607,6 +610,7 @@ class GMM(MultiObjectiveTestProblem):
     """
 
     dim = 2
+    continuous_inds = list(range(dim))
     _bounds = [(0.0, 1.0), (0.0, 1.0)]
 
     def __init__(
@@ -710,6 +714,7 @@ class Penicillin(MultiObjectiveTestProblem):
 
     _max_hv = 2183455.909507436
     dim = 7
+    continuous_inds = list(range(dim))
     num_objectives = 3
     _bounds = [
         (60.0, 120.0),
@@ -844,6 +849,7 @@ class ToyRobust(MultiObjectiveTestProblem):
     """
 
     dim = 1
+    continuous_inds = list(range(dim))
     _bounds = [(0.0, 0.7)]
     _ref_point = [-6.1397, -8.1942]
     num_objectives = 2
@@ -888,6 +894,7 @@ class VehicleSafety(MultiObjectiveTestProblem):
     _max_hv = 246.81607081187002
     _bounds = [(1.0, 3.0)] * 5
     dim = 5
+    continuous_inds = list(range(dim))
     num_objectives = 3
 
     def evaluate_true(self, X: Tensor) -> Tensor:
@@ -964,6 +971,7 @@ class ZDT(MultiObjectiveTestProblem):
             )
         self.num_objectives = num_objectives
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         self._bounds = [(0.0, 1.0) for _ in range(self.dim)]
         super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
 
@@ -1114,6 +1122,7 @@ class CarSideImpact(MultiObjectiveTestProblem):
 
     num_objectives: int = 4
     dim: int = 7
+    continuous_inds = list(range(dim))
     _bounds = [
         (0.5, 1.5),
         (0.45, 1.35),
@@ -1198,6 +1207,7 @@ class BNH(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     """
 
     dim = 2
+    continuous_inds = list(range(dim))
     num_objectives = 2
     num_constraints = 2
     _bounds = [(0.0, 5.0), (0.0, 3.0)]
@@ -1222,6 +1232,7 @@ class CONSTR(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     """
 
     dim = 2
+    continuous_inds = list(range(dim))
     num_objectives = 2
     num_constraints = 2
     _bounds = [(0.1, 10.0), (0.0, 5.0)]
@@ -1245,6 +1256,7 @@ class ConstrainedBraninCurrin(BraninCurrin, ConstrainedBaseTestProblem):
     """
 
     dim = 2
+    continuous_inds = list(range(dim))
     num_objectives = 2
     num_constraints = 1
     _bounds = [(0.0, 1.0), (0.0, 1.0)]
@@ -1319,6 +1331,7 @@ class DiscBrake(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     """
 
     dim = 4
+    continuous_inds = list(range(dim))
     num_objectives = 2
     num_constraints = 4
     _bounds = [(55.0, 80.0), (75.0, 110.0), (1000.0, 3000.0), (11.0, 20.0)]
@@ -1384,6 +1397,7 @@ class MW7(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
         if dim < 2:
             raise ValueError("dim must be greater than or equal to 2.")
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         self._bounds = [(0.0, 1.0) for _ in range(self.dim)]
         super().__init__(noise_std=noise_std, negate=negate, dtype=dtype)
         self.constraint_noise_std = constraint_noise_std
@@ -1421,6 +1435,7 @@ class OSY(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     """
 
     dim = 6
+    continuous_inds = list(range(dim))
     num_constraints = 6
     num_objectives = 2
     _bounds = [
@@ -1462,6 +1477,7 @@ class SRN(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     """
 
     dim = 2
+    continuous_inds = list(range(dim))
     num_objectives = 2
     num_constraints = 2
     _bounds = [(-20.0, 20.0), (-20.0, 20.0)]
@@ -1490,6 +1506,7 @@ class WeldedBeam(MultiObjectiveTestProblem, ConstrainedBaseTestProblem):
     """
 
     dim = 4
+    continuous_inds = list(range(dim))
     num_constraints = 4
     num_objectives = 2
     _bounds = [

--- a/botorch/test_functions/multi_objective_multi_fidelity.py
+++ b/botorch/test_functions/multi_objective_multi_fidelity.py
@@ -50,6 +50,7 @@ class MOMFBraninCurrin(MultiObjectiveTestProblem):
     """
 
     dim = 3
+    continuous_inds = list(range(3))
     num_objectives = 2
     _bounds = [(0.0, 1.0) for _ in range(dim)]
     _ref_point = [0, 0]
@@ -110,6 +111,7 @@ class MOMFPark(MultiObjectiveTestProblem):
     """
 
     dim = 5
+    continuous_inds = list(range(5))
     num_objectives = 2
     _bounds = [(0.0, 1.0) for _ in range(dim)]
     _ref_point = [0, 0]

--- a/botorch/test_functions/sensitivity_analysis.py
+++ b/botorch/test_functions/sensitivity_analysis.py
@@ -41,6 +41,7 @@ class Ishigami(SyntheticTestFunction):
         if b not in (0.1, 0.05):
             raise ValueError("b parameter should be 0.1 or 0.05")
         self.dim = 3
+        self.continuous_inds = list(range(self.dim))
         if b == 0.1:
             self.si = [0.3138, 0.4424, 0]
             self.si_t = [0.558, 0.442, 0.244]
@@ -144,6 +145,7 @@ class Gsobol(SyntheticTestFunction):
         """
         self._optimizers = None
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         self._bounds = [(0, 1) for _ in range(self.dim)]
         if self.dim == 6:
             self.a = [0, 0.5, 3, 9, 99, 99]
@@ -228,6 +230,7 @@ class Morris(SyntheticTestFunction):
         """
         self._optimizers = None
         self.dim = 20
+        self.continuous_inds = list(range(self.dim))
         self._bounds = [(0, 1) for _ in range(self.dim)]
         self.si = [
             0.005,

--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -155,6 +155,7 @@ class Ackley(SyntheticTestFunction):
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
         """
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         if bounds is None:
             bounds = [(-32.768, 32.768) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
@@ -172,6 +173,7 @@ class Ackley(SyntheticTestFunction):
 
 class Beale(SyntheticTestFunction):
     dim = 2
+    continuous_inds = list(range(dim))
     _optimal_value = 0.0
     _bounds = [(-4.5, 4.5), (-4.5, 4.5)]
     _optimizers = [(3.0, 0.5)]
@@ -198,6 +200,7 @@ class Branin(SyntheticTestFunction):
     """
 
     dim = 2
+    continuous_inds = list(range(dim))
     _bounds = [(-5.0, 10.0), (0.0, 15.0)]
     _optimal_value = 0.397887
     _optimizers = [(-math.pi, 12.275), (math.pi, 2.275), (9.42478, 2.475)]
@@ -215,6 +218,7 @@ class Branin(SyntheticTestFunction):
 
 class Bukin(SyntheticTestFunction):
     dim = 2
+    continuous_inds = list(range(dim))
     _bounds = [(-15.0, -5.0), (-3.0, 3.0)]
     _optimal_value = 0.0
     _optimizers = [(-10.0, 1.0)]
@@ -238,6 +242,7 @@ class Cosine8(SyntheticTestFunction):
     """
 
     dim = 8
+    continuous_inds = list(range(dim))
     _bounds = [(-1.0, 1.0) for _ in range(8)]
     _optimal_value = 0.8
     _optimizers = [tuple(0.0 for _ in range(8))]
@@ -248,6 +253,7 @@ class Cosine8(SyntheticTestFunction):
 
 class DropWave(SyntheticTestFunction):
     dim = 2
+    continuous_inds = list(range(dim))
     _bounds = [(-5.12, 5.12), (-5.12, 5.12)]
     _optimal_value = -1.0
     _optimizers = [(0.0, 0.0)]
@@ -279,6 +285,7 @@ class DixonPrice(SyntheticTestFunction):
             dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         if bounds is None:
             bounds = [(-10.0, 10.0) for _ in range(self.dim)]
         self._optimizers = [
@@ -308,6 +315,7 @@ class EggHolder(SyntheticTestFunction):
     """
 
     dim = 2
+    continuous_inds = list(range(dim))
     _bounds = [(-512.0, 512.0), (-512.0, 512.0)]
     _optimal_value = -959.6407
     _optimizers = [(512.0, 404.2319)]
@@ -351,6 +359,7 @@ class Griewank(SyntheticTestFunction):
             dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         if bounds is None:
             bounds = [(-600.0, 600.0) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
@@ -397,6 +406,7 @@ class Hartmann(SyntheticTestFunction):
         if dim not in (3, 4, 6):
             raise ValueError(f"Hartmann with dim {dim} not defined")
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         if bounds is None:
             bounds = [(0.0, 1.0) for _ in range(self.dim)]
         # optimizers and optimal values for dim=4 not implemented
@@ -481,6 +491,7 @@ class HolderTable(SyntheticTestFunction):
     """
 
     dim = 2
+    continuous_inds = list(range(dim))
     _bounds = [(-10.0, 10.0), (-10.0, 10.0)]
     _optimal_value = -19.2085
     _optimizers = [
@@ -531,6 +542,7 @@ class Levy(SyntheticTestFunction):
             dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         if bounds is None:
             bounds = [(-10.0, 10.0) for _ in range(self.dim)]
         self._optimizers = [tuple(1.0 for _ in range(self.dim))]
@@ -574,6 +586,7 @@ class Michalewicz(SyntheticTestFunction):
             bounds: Custom bounds for the function specified as (lower, upper) pairs.
         """
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         if bounds is None:
             bounds = [(0.0, math.pi) for _ in range(self.dim)]
         optvals = {2: -1.80130341, 5: -4.687658, 10: -9.66015}
@@ -636,6 +649,7 @@ class Powell(SyntheticTestFunction):
             dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         if bounds is None:
             bounds = [(-4.0, 5.0) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
@@ -673,6 +687,7 @@ class Rastrigin(SyntheticTestFunction):
             dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         if bounds is None:
             bounds = [(-5.12, 5.12) for _ in range(self.dim)]
         self._optimizers = [tuple(0.0 for _ in range(self.dim))]
@@ -714,6 +729,7 @@ class Rosenbrock(SyntheticTestFunction):
             dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         if bounds is None:
             bounds = [(-5.0, 10.0) for _ in range(self.dim)]
         self._optimizers = [tuple(1.0 for _ in range(self.dim))]
@@ -738,6 +754,7 @@ class Shekel(SyntheticTestFunction):
     """
 
     dim = 4
+    continuous_inds = list(range(dim))
     _bounds = [(0.0, 10.0), (0.0, 10.0), (0.0, 10.0), (0.0, 10.0)]
     _optimizers = [(4.000747, 3.99951, 4.00075, 3.99951)]
 
@@ -785,6 +802,7 @@ class Shekel(SyntheticTestFunction):
 
 class SixHumpCamel(SyntheticTestFunction):
     dim = 2
+    continuous_inds = list(range(dim))
     _bounds = [(-3.0, 3.0), (-2.0, 2.0)]
     _optimal_value = -1.0316
     _optimizers = [(0.0898, -0.7126), (-0.0898, 0.7126)]
@@ -825,6 +843,7 @@ class StyblinskiTang(SyntheticTestFunction):
             dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         if bounds is None:
             bounds = [(-5.0, 5.0) for _ in range(self.dim)]
         self._optimal_value = -39.166166 * self.dim
@@ -837,6 +856,7 @@ class StyblinskiTang(SyntheticTestFunction):
 
 class ThreeHumpCamel(SyntheticTestFunction):
     dim = 2
+    continuous_inds = list(range(dim))
     _bounds = [(-5.0, 5.0), (-5.0, 5.0)]
     _optimal_value = 0.0
     _optimizers = [(0.0, 0.0)]
@@ -919,6 +939,7 @@ class ConstrainedGramacy(ConstrainedSyntheticTestFunction):
     num_objectives = 1
     num_constraints = 2
     dim = 2
+    continuous_inds = list(range(dim))
     _bounds = [(0.0, 1.0), (0.0, 1.0)]
     _optimizers = [(0.1954, 0.4044)]
     _optimal_value = 0.5998  # approximate from [Gramacy2016]_
@@ -1038,6 +1059,7 @@ class PressureVessel(ConstrainedSyntheticTestFunction):
     """
 
     dim = 4
+    continuous_inds = list(range(dim))
     num_constraints = 4
     _bounds = [(0.0, 10.0), (0.0, 10.0), (10.0, 50.0), (150.0, 200.0)]
     _optimal_value = 6059.946341  # from [CoelloCoello2002constraint]
@@ -1077,6 +1099,7 @@ class WeldedBeamSO(ConstrainedSyntheticTestFunction):
     """
 
     dim = 4
+    continuous_inds = list(range(dim))
     num_constraints = 6
     _bounds = [(0.125, 10.0), (0.1, 10.0), (0.1, 10.0), (0.1, 10.0)]
     _optimal_value = 1.728226  # from [CoelloCoello2002constraint]
@@ -1131,6 +1154,7 @@ class TensionCompressionString(ConstrainedSyntheticTestFunction):
     """
 
     dim = 3
+    continuous_inds = list(range(dim))
     num_constraints = 4
     _bounds = [(0.01, 1.0), (0.01, 1.0), (0.01, 20.0)]
     _optimal_value = 0.012681  # from [CoelloCoello2002constraint]
@@ -1163,6 +1187,7 @@ class SpeedReducer(ConstrainedSyntheticTestFunction):
     """
 
     dim = 7
+    continuous_inds = list(range(dim))
     num_constraints = 11
     _bounds = [
         (2.6, 3.6),
@@ -1253,6 +1278,7 @@ class KeaneBumpFunction(ConstrainedSyntheticTestFunction):
             dtype: The dtype that is used for the bounds of the function.
         """
         self.dim = dim
+        self.continuous_inds = list(range(dim))
         if bounds is None:
             bounds = [(0.0, 10.0) for _ in range(dim)]
         if dim in self._optimal_value_lookup.keys():

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -144,6 +144,8 @@ class BaseTestProblemTestCaseMixIn:
             f.to(device=self.device, dtype=dtype)
             X = torch.rand(*batch_shape, f.dim, device=self.device, dtype=dtype)
             X = f.bounds[0] + X * (f.bounds[1] - f.bounds[0])
+            for inds in [f.discrete_inds, f.categorical_inds]:
+                X[..., inds] = X[..., inds].round()
             res_forward = f(X)
             res_evaluate_true = f.evaluate_true(X)
             for method, res in {

--- a/test/test_functions/test_multi_objective.py
+++ b/test/test_functions/test_multi_objective.py
@@ -53,6 +53,7 @@ class DummyMOProblem(MultiObjectiveTestProblem):
     _num_objectives = 2
     _bounds = [(0.0, 1.0)] * 2
     dim = 2
+    continuous_inds = list(range(dim))
 
     def evaluate_true(self, X):
         f_X = X + 2

--- a/test/test_functions/test_synthetic.py
+++ b/test/test_functions/test_synthetic.py
@@ -49,6 +49,7 @@ from torch import Tensor
 
 class DummySyntheticTestFunction(SyntheticTestFunction):
     dim = 2
+    continuous_inds = list(range(dim))
     _bounds = [(-1, 1), (-1, 1)]
     _optimal_value = 0
 
@@ -116,6 +117,7 @@ class TestCustomBounds(BotorchTestCase):
 
 class DummyConstrainedSyntheticTestFunction(ConstrainedSyntheticTestFunction):
     dim = 2
+    continuous_inds = list(range(dim))
     num_constraints = 1
     _bounds = [(-1, 1), (-1, 1)]
     _optimal_value = 0


### PR DESCRIPTION
Summary:
This adds explicit parameter types to the BoTorch test functions. This will make it easier to add discrete, mixed, and categorical problems. As of right now there are three different parameter types:
- `continuous_inds`: Float-valued range parameters
- `discrete_inds`: Ordered integer parameters (`bounds` are inclusive)
- `categorical_inds`: Unordered integer parameters (`bounds` are inclusive)

Reviewed By: Balandat

Differential Revision: D72607219


