### PR TITLE
Fix `test_optimize_acqf_mixed_binary_only`

### DIFF
--- a/test/optim/test_optimize_mixed.py
+++ b/test/optim/test_optimize_mixed.py
@@ -93,7 +93,7 @@ class QuadraticDeterministicModel(DeterministicModel):
         return -(X - self.root).square().sum(dim=-1, keepdim=True)
 
 
-class TestOptimizeAcqfMixed( BotorchTestCase):
+class TestOptimizeAcqfMixed(BotorchTestCase):
     def setUp(self):
         super().setUp()
         self.single_bound = torch.tensor([[0.0], [1.0]], device=self.device)

--- a/test/optim/test_optimize_mixed.py
+++ b/test/optim/test_optimize_mixed.py
@@ -4,13 +4,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import fields
 from itertools import product
 from typing import Any, Callable
 from unittest import mock
 
 import torch
 from botorch.acquisition.acquisition import AcquisitionFunction
-from botorch.acquisition.analytic import ExpectedImprovement
+from botorch.acquisition.analytic import ExpectedImprovement, LogExpectedImprovement
 from botorch.acquisition.logei import qLogNoisyExpectedImprovement
 from botorch.exceptions.errors import CandidateGenerationError, UnsupportedError
 from botorch.exceptions.warnings import OptimizationWarning
@@ -92,7 +93,7 @@ class QuadraticDeterministicModel(DeterministicModel):
         return -(X - self.root).square().sum(dim=-1, keepdim=True)
 
 
-class TestOptimizeAcqfMixed(BotorchTestCase):
+class TestOptimizeAcqfMixed( BotorchTestCase):
     def setUp(self):
         super().setUp()
         self.single_bound = torch.tensor([[0.0], [1.0]], device=self.device)
@@ -426,7 +427,7 @@ class TestOptimizeAcqfMixed(BotorchTestCase):
         bounds = self.single_bound.repeat(1, dim)
         torch.manual_seed(0)
         model = SingleTaskGP(train_X=train_X, train_Y=train_Y)
-        acqf = ExpectedImprovement(model=model, best_f=torch.max(train_Y))
+        acqf = LogExpectedImprovement(model=model, best_f=torch.max(train_Y))
         options = {
             "initialization_strategy": "random",
             "maxiter_alternating": 2,
@@ -544,16 +545,25 @@ class TestOptimizeAcqfMixed(BotorchTestCase):
                 raw_samples=20,
                 num_restarts=2,
             )
-        wrapped_optimize.assert_called_once_with(
-            opt_inputs=_make_opt_inputs(
-                acq_function=acqf,
-                bounds=bounds,
-                options=options,
-                q=1,
-                raw_samples=20,
-                num_restarts=2,
-            )
+        expected_opt_inputs = _make_opt_inputs(
+            acq_function=acqf,
+            bounds=bounds,
+            options=options,
+            q=1,
+            raw_samples=20,
+            num_restarts=2,
         )
+        # Can't just use `assert_called_once_with` here b/c of tensor ambiguity.
+        wrapped_optimize.assert_called_once()
+        opt_inputs = wrapped_optimize.call_args.kwargs["opt_inputs"]
+        for field in fields(opt_inputs):
+            opt_input = getattr(opt_inputs, field.name)
+            expected_opt_input = getattr(expected_opt_inputs, field.name)
+            if isinstance(opt_input, Tensor):
+                self.assertTrue(torch.equal(opt_input, expected_opt_input))
+            else:
+                self.assertEqual(opt_input, expected_opt_input)
+
         # Only discrete works fine.
         candidates, _ = optimize_acqf_mixed_alternating(
             acq_function=acqf,


### PR DESCRIPTION
I ran into some test failures locally with the following error:
```
/opt/miniconda3/envs/py313/lib/python3.13/unittest/mock.py:989: in assert_called_once_with
    return self.assert_called_with(*args, **kwargs)
/opt/miniconda3/envs/py313/lib/python3.13/unittest/mock.py:975: in assert_called_with
    if actual != expected:
/opt/miniconda3/envs/py313/lib/python3.13/unittest/mock.py:2645: in __eq__
    return (other_args, other_kwargs) == (self_args, self_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = OptimizeAcqfInputs(acq_function=qLogNoisyExpectedImprovement(
  (model): QuadraticDeterministicModel()
  (objective): ...rue, ic_generator=None, timeout_sec=None, return_full_tree=False, retry_on_optimization_warning=True, ic_gen_kwargs={})
other = OptimizeAcqfInputs(acq_function=qLogNoisyExpectedImprovement(
  (model): QuadraticDeterministicModel()
  (objective): ...rue, ic_generator=None, timeout_sec=None, return_full_tree=False, retry_on_optimization_warning=True, ic_gen_kwargs={})

>   ???
E   RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```

This change uses `torch.equal` for `Tensor` object comparisons instead. We may want to consider overwriting `assertEqual()` in the `BotorchTestCase` to use this more generally across the tests (similar to how we implement `assertAllClose` [here](https://github.com/pytorch/botorch/blob/main/botorch/utils/testing.py#L93C9-L93C23)).