### PR TITLE
Test against python 3.13

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Install dependencies
       run: |
         uv pip install .[test]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Install dependencies
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: uv pip install pre-commit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Install dependencies
       env:
         ALLOW_LATEST_GPYTORCH_LINOP: true

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - if: ${{ !inputs.new_version }}
       name: Install latest GPyTorch and Linear Operator
       run: |

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.13"]
     env:
       # `uv pip ...` requires venv by default. This skips that requirement.
       UV_SYSTEM_PYTHON: 1

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Fetch all history for all tags and branches
       # We need to do this so setuptools_scm knows how to set the BoTorch version.
       run: git fetch --prune --unshallow

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14"]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.13"]
     env:
       # `uv pip ...` requires venv by default. This skips that requirement.
       UV_SYSTEM_PYTHON: 1
@@ -34,12 +34,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        uv pip install setuptools  # Needed for next line on Python 3.12.
+        uv pip install setuptools  # Needed for next line on Python 3.13.
         python setup.py egg_info
         req_txt="botorch.egg-info/requires.txt"
         min_torch_version=$(grep '\btorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
-        # The earliest PyTorch version on Python 3.12 is 2.2.0.
-        min_torch_version="$(if ${{ matrix.python-version == '3.12' }}; then echo "2.2.0"; else echo "${min_torch_version}"; fi)"
+        # The earliest PyTorch version on Python 3.13 available for all OS is 2.6.0.
+        min_torch_version="$(if ${{ matrix.python-version == '3.13' }}; then echo "2.6.0"; else echo "${min_torch_version}"; fi)"
         min_gpytorch_version=$(grep '\bgpytorch[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         min_linear_operator_version=$(grep '\blinear_operator[>=]=' ${req_txt} | sed 's/[^0-9.]//g')
         uv pip install "numpy<2"  # Numpy >2.0 is not compatible with PyTorch <2.2.


### PR DESCRIPTION
Python 3.13 is out and used, so we should test against it.

This also require updating the minimum supported torch version in the install script. 

Side note: We should probably aim to bump the minium required pytorch version to 2.2.0 in new gpytorch / linear_operator / botorch releases so that we don't have to deal with the numpy<2.0 issues going forward.
