### PR TITLE
`[q]LogProbabilityOfFeasibility`

### DIFF
--- a/botorch/acquisition/factory.py
+++ b/botorch/acquisition/factory.py
@@ -145,6 +145,16 @@ def get_acquisition_function(
             constraints=constraints,
             eta=eta,
         )
+    elif acquisition_function_name == "qLogPF":
+        return logei.qLogProbabilityOfFeasibility(
+            model=model,
+            constraints=constraints,
+            sampler=sampler,
+            objective=objective,
+            posterior_transform=posterior_transform,
+            X_pending=X_pending,
+            eta=eta,
+        )
     elif acquisition_function_name in ["qNEI", "qLogNEI"]:
         acqf_class = (
             monte_carlo.qNoisyExpectedImprovement

--- a/botorch/utils/probability/utils.py
+++ b/botorch/utils/probability/utils.py
@@ -355,9 +355,19 @@ def compute_log_prob_feas_from_bounds(
             equal in dimension to con_upper_inds.
         con_both: 2d Tensor of "both" bounds on the constraints
             equal in length to con_both_inds.
+
     Returns:
         A `b`-dim tensor of log feasibility probabilities
     """
+    # indices are integers, so we don't cast the type
+    con_upper_inds = con_upper_inds.to(device=means.device)
+    con_lower_inds = con_lower_inds.to(device=means.device)
+    con_both_inds = con_both_inds.to(device=means.device)
+
+    con_lower = con_lower.to(device=means.device, dtype=means.dtype)
+    con_upper = con_upper.to(device=means.device, dtype=means.dtype)
+    con_both = con_both.to(device=means.device, dtype=means.dtype)
+
     log_prob = torch.zeros_like(means[..., 0])
     if len(con_lower_inds) > 0:
         i = con_lower_inds


### PR DESCRIPTION
Summary: This commit adds `LogProbabilityOfFeasibility` and the corresponding batch Monte-Carlo version `qLogProbabilityOfFeasibility`. These new acquisition functions compute a probability of feasibility acquisition value that is particularly relevant for optimization runs that start out without any feasible observations. After a feasible observation is found, the acquisition function likely becomes over-exploitative, and one is better served switching to an acquisition function that also takes into account the objective value, e.g. `qLogNEI`.

Differential Revision: D72411936


