### PR TITLE
Put outcome transforms into `train` mode in model constructors

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -397,6 +397,7 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
                     UserInputWarning,
                     stacklevel=3,
                 )
+                outcome_transform.train()
                 train_Y, _ = outcome_transform(train_Y, X=transformed_X)
             self._validate_tensor_args(X=transformed_X, Y=train_Y)
             validate_input_scaling(

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -548,6 +548,8 @@ class FullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel, ABC):
                 training data during instantiation and to the posterior during
                 inference (that is, the `Posterior` obtained by calling
                 `.posterior` on the model will be on the original scale).
+                Note that `.train()` will be called on the outcome transform during
+                instantiation of the model.
             input_transform: An input transform that is applied in the model's
                 forward pass.
             pyro_model: The pyro model.

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -570,6 +570,7 @@ class FullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel, ABC):
                 X=train_X, input_transform=input_transform
             )
         if outcome_transform is not None:
+            outcome_transform.train()
             train_Y, train_Yvar = outcome_transform(
                 Y=train_Y, Yvar=train_Yvar, X=transformed_X
             )

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -224,6 +224,8 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
                 training data during instantiation and to the posterior during
                 inference (that is, the `Posterior` obtained by calling
                 `.posterior` on the model will be on the original scale).
+                Note that `.train()` will be called on the outcome transform during
+                instantiation of the model.
             input_transform: An input transform that is applied to the inputs `X`
                 in the model's forward pass.
             pyro_model: Optional `PyroModel` that has the same signature as

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -163,6 +163,7 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                 X=train_X, input_transform=input_transform
             )
         if outcome_transform is not None:
+            outcome_transform.train()
             train_Y, train_Yvar = outcome_transform(
                 Y=train_Y, Yvar=train_Yvar, X=transformed_X
             )

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -149,7 +149,8 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                 inference (that is, the `Posterior` obtained by calling
                 `.posterior` on the model will be on the original scale). We use a
                 `Standardize` transform if no `outcome_transform` is specified.
-                Pass down `None` to use no outcome transform.
+                Pass down `None` to use no outcome transform. Note that `.train()` will
+                be called on the outcome transform during instantiation of the model.
             input_transform: An input transform that is applied in the model's
                 forward pass.
         """

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -198,6 +198,15 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
             num_latent_dims: Sizes for the latent dimensions.
             learn_latent_pars: If true, learn the latent parameters.
             latent_init: [default or gp] how to initialize the latent parameters.
+            outcome_transform: An outcome transform that is applied to the
+                training data during instantiation and to the posterior during
+                inference (that is, the `Posterior` obtained by calling
+                `.posterior` on the model will be on the original scale). We use a
+                `Standardize` transform if no `outcome_transform` is specified.
+                Pass down `None` to use no outcome transform. Note that `.train()` will
+                be called on the outcome transform during instantiation of the model.
+            input_transform: An input transform that is applied in the model's
+                forward pass.
         """
         if input_transform is not None:
             input_transform.to(train_X)

--- a/botorch/models/higher_order_gp.py
+++ b/botorch/models/higher_order_gp.py
@@ -230,6 +230,7 @@ class HigherOrderGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
                     output_shape=train_Y.shape[-num_output_dims:],
                     batch_shape=batch_shape,
                 )
+            outcome_transform.train()
             train_Y, _ = outcome_transform(train_Y, X=train_X)
 
         self._aug_batch_shape = batch_shape

--- a/botorch/models/latent_kronecker_gp.py
+++ b/botorch/models/latent_kronecker_gp.py
@@ -240,6 +240,7 @@ class LatentKroneckerGP(GPyTorchModel, ExactGP, FantasizeMixin):
         if outcome_transform == DEFAULT:
             outcome_transform = MinMaxStandardize(batch_shape=batch_shape)
         if outcome_transform is not None:
+            outcome_transform.train()
             # transform outputs once and keep the results
             train_Y = outcome_transform(train_Y.unsqueeze(-1), X=transformed_X)[
                 0

--- a/botorch/models/latent_kronecker_gp.py
+++ b/botorch/models/latent_kronecker_gp.py
@@ -203,6 +203,10 @@ class LatentKroneckerGP(GPyTorchModel, ExactGP, FantasizeMixin):
                 If omitted, use a `MaternKernel`.
             input_transform: An input transform that is applied to X.
             outcome_transform: An outcome transform that is applied to Y.
+                Note that `.train()` will be called on the outcome transform during
+                instantiation of the model.
+            input_transform: An input transform that is applied in the model's
+                forward pass.
         """
         with torch.no_grad():
             # transform inputs here to check resulting shapes

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -153,6 +153,8 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
                 `Standardize` transform if no `outcome_transform` is specified.
                 Pass down `None` to use no outcome transform. NOTE: Standardization
                 should be applied in a stratified fashion, separately for each task.
+                Note that `.train()` will be called on the outcome transform during
+                instantiation of the model.
             input_transform: An input transform that is applied in the model's
                 forward pass.
 
@@ -401,8 +403,8 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
         data_covar_module: Module | None = None,
         task_covar_prior: Prior | None = None,
         rank: int | None = None,
-        input_transform: InputTransform | None = None,
         outcome_transform: OutcomeTransform | None = None,
+        input_transform: InputTransform | None = None,
         **kwargs: Any,
     ) -> None:
         r"""
@@ -419,6 +421,17 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
                 omitted, uses `LKJCovariancePrior` with `eta` parameter as specified
                 in the keyword arguments (if not specified, use `eta=1.5`).
             rank: The rank of the ICM kernel. If omitted, use a full rank kernel.
+            outcome_transform: An outcome transform that is applied to the
+                training data during instantiation and to the posterior during
+                inference (that is, the `Posterior` obtained by calling
+                `.posterior` on the model will be on the original scale). We use a
+                `Standardize` transform if no `outcome_transform` is specified.
+                Pass down `None` to use no outcome transform. NOTE: Standardization
+                should be applied in a stratified fashion, separately for each task.
+                Note that `.train()` will be called on the outcome transform during
+                instantiation of the model.
+            input_transform: An input transform that is applied in the model's
+                forward pass.
             kwargs: Additional arguments to override default settings of priors,
                 including:
                 - eta: The eta parameter on the default LKJ task_covar_prior.

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -186,6 +186,7 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
         if outcome_transform == DEFAULT:
             outcome_transform = Standardize(m=1, batch_shape=train_X.shape[:-2])
         if outcome_transform is not None:
+            outcome_transform.train()
             train_Y, train_Yvar = outcome_transform(
                 Y=train_Y, Yvar=train_Yvar, X=transformed_X
             )
@@ -433,6 +434,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
                 X=train_X, input_transform=input_transform
             )
         if outcome_transform is not None:
+            outcome_transform.train()
             train_Y, _ = outcome_transform(train_Y, X=transformed_X)
 
         self._validate_tensor_args(X=transformed_X, Y=train_Y)

--- a/botorch/utils/test_helpers.py
+++ b/botorch/utils/test_helpers.py
@@ -324,6 +324,7 @@ class SimpleGPyTorchModel(GPyTorchModel, ExactGP, FantasizeMixin):
                 X=train_X, input_transform=input_transform
             )
         if outcome_transform is not None:
+            outcome_transform.train()
             train_Y, _ = outcome_transform(train_Y)
         self._validate_tensor_args(transformed_X, train_Y)
         train_Y = train_Y.squeeze(-1)

--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -77,6 +77,7 @@ class SimpleBatchedMultiOutputGPyTorchModel(
                 X=train_X, input_transform=input_transform
             )
         if outcome_transform is not None:
+            outcome_transform.train()
             train_Y, _ = outcome_transform(train_Y)
         self._validate_tensor_args(transformed_X, train_Y)
         self._set_dimensions(train_X=train_X, train_Y=train_Y)


### PR DESCRIPTION
Fixes a bug where an outcome transform that is passed in `eval` mode is not put into `train` mode in the constructor of some `Model`s. As a result, the internal buffers of the transform (if applicable) are not updated and the outcome transform is not applied as intended.

This hasn't really been much of an issue in the past, since we typically either use a default transform (which we construct as needed and so is already in train mode) or we create a new `OutcomeTransform` object every time we construct a new `Model` instance.

Fixes #2812
