### PR TITLE
LogEI: select cache_root based on model support

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -31,6 +31,7 @@ from botorch.acquisition.analytic import (
 from botorch.acquisition.bayesian_active_learning import (
     qBayesianActiveLearningByDisagreement,
 )
+from botorch.acquisition.cached_cholesky import supports_cache_root
 from botorch.acquisition.cost_aware import InverseCostWeightedUtility
 from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
 from botorch.acquisition.joint_entropy_search import qJointEntropySearch
@@ -644,7 +645,7 @@ def construct_inputs_qLogNEI(
     sampler: MCSampler | None = None,
     X_baseline: Tensor | None = None,
     prune_baseline: bool | None = True,
-    cache_root: bool | None = True,
+    cache_root: bool | None = None,
     constraints: list[Callable[[Tensor], Tensor]] | None = None,
     eta: Tensor | float = 1e-3,
     fat: bool = True,
@@ -692,6 +693,8 @@ def construct_inputs_qLogNEI(
     Returns:
         A dict mapping kwarg names of the constructor to values.
     """
+    if cache_root is None:
+        cache_root = supports_cache_root(model)
     return {
         **construct_inputs_qNEI(
             model=model,


### PR DESCRIPTION
Summary: This diff has the input constructor for LogEI check if the model can support cache_root rather than defaulting it to True. Currently anytime you use LogEI with a multi-task model it spews a log warning that cache_root is being disabled. This removes that log message by changing the default to be smarter.

Reviewed By: SebastianAment

Differential Revision: D72667330


