### PR TITLE
Add suggested fix & PR fields to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,6 +48,18 @@ body:
       description: What operating system are you using?
     validations:
       required: false
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: [Optional] Describe any potential fixes you've considered to the issue outlined above.
+  - type: dropdown
+    id: pull-request
+    attributes:
+      label: Pull Request
+      description: Are you willing to open a pull request fixing the bug outlined in this issue? (See [Contributing to BoTorch](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md))
+      options:
+        - "Yes"
+        - "No"
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
   - type: textarea
     id: suggested-fix
     attributes:
-      label: [Optional] Describe any potential fixes you've considered to the issue outlined above.
+      label: (Optional) Describe any potential fixes you've considered to the issue outlined above.
   - type: dropdown
     id: pull-request
     attributes:


### PR DESCRIPTION
As titled. Adds these two fields (tested in fork):
<img width="780" alt="Screenshot 2025-04-15 at 2 45 20 PM" src="https://github.com/user-attachments/assets/096b1ffa-0446-4180-a7c7-3e7f35d88832" />
