### PR TITLE
Fix model paths in prior fitted networks

### DIFF
--- a/botorch_community/models/utils/prior_fitted_network.py
+++ b/botorch_community/models/utils/prior_fitted_network.py
@@ -28,15 +28,11 @@ class ModelPaths(Enum):
 
     pfns4bo_hebo = (
         "https://github.com/automl/PFNs4BO/raw/refs/heads/main/pfns4bo"
-        "/final_models/hebo_morebudget_9_unused_features_3_userpriorperdim2_8.pt.gz"
+        "/final_models/model_hebo_morebudget_9_unused_features_3.pt.gz"
     )
     pfns4bo_bnn = (
         "https://github.com/automl/PFNs4BO/raw/refs/heads/main/pfns4bo"
         "/final_models/model_sampled_warp_simple_mlp_for_hpob_46.pt.gz"
-    )
-    pfns4bo_hebo_userprior = (
-        "https://github.com/automl/PFNs4BO/raw/refs/heads/main/pfns4bo"
-        "/final_models/hebo_morebudget_9_unused_features_3_userpriorperdim2_8.pt.gz"
     )
 
 


### PR DESCRIPTION
Summary:
The model path for the main hebo model was misspecified in the prior fitted network code. I fixed that.

Additionally, I removed the path that accepts a user prior as input, as that is not supported by the botorch code yet.

You can test this via calling

```
from botorch_community.models.utils import prior_fitted_network as pfn_utils
m = pfn_utils.download_model(pfn_utils.ModelPaths.pfns4bo_hebo)
```

Reviewed By: esantorella

Differential Revision: D73131935


