### PR TITLE
[Documentation] fix Inaccurate and incomplete documentation for `SingleTaskMultiFidelityGP`

### DIFF
--- a/botorch/models/kernels/linear_truncated_fidelity.py
+++ b/botorch/models/kernels/linear_truncated_fidelity.py
@@ -40,6 +40,15 @@ class LinearTruncatedFidelityKernel(Kernel):
         polynomial kernel between `x_1[..., [f_1, f_2]]` and
         `x_2[..., [f_1, f_2]]`.
 
+    Note:
+        Fidelity interpretation:
+        - Higher numerical values represent higher fidelities (e.g., 3 > 2 > 1 > 0)
+        - The kernel implementation internally clamps fidelity values to the range [0,1]
+        - The kernel is designed so that higher fidelity points have higher correlation
+            with each other than with lower fidelity points
+        - When using with SingleTaskMultiFidelityGP, ensure your fidelity values
+            follow this convention (higher numeric value = higher fidelity)
+
     Example:
         >>> x = torch.randn(10, 5)
         >>> # Non-batch: Simple option


### PR DESCRIPTION
closes [#2403](https://github.com/pytorch/botorch/issues/2403)

Hi @esantorella !
I've Improved the documentation related to `SingleTaskMultiFidelityGP` and `LinearTruncatedFidelityKernel` to clearly express that higher numerical values represent higher fidelities. Add the details about kernel behavior with fidelity values, including internal clamping to [0,1] range and correlation structure. Could you please review my PR .
Thank You !