### PR TITLE
Rename ax/models -> ax/generators

### DIFF
--- a/docs/botorch_and_ax.md
+++ b/docs/botorch_and_ax.md
@@ -6,27 +6,22 @@ title: Using BoTorch with Ax
 [Ax](https://ax.dev) is a platform for sequential experimentation. It relies on
 BoTorch for implementing Bayesian Optimization algorithms, but provides
 higher-level APIs that make it easy and convenient to specify problems,
-visualize results, and benchmark new algorithms.
-It also comes with powerful metadata management, storage of results, and
-deployment-related APIs. Ax makes it convenient to use BoTorch in most standard
-Bayesian Optimization settings.
+visualize results, and benchmark new algorithms. It also comes with powerful
+metadata management, storage of results, and deployment-related APIs. Ax makes
+it convenient to use BoTorch in most standard Bayesian Optimization settings.
 Simply put, BoTorch provides the building blocks for the engine, while Ax makes
 it easy to drive the car.
 
-
 ![BoTorch and Ax](assets/botorch_and_ax.svg)
 
-
 Ax provides a
-[`BotorchModel`](https://https://ax.readthedocs.io/en/latest/models.html#ax.models.torch.botorch.BotorchModel)
+[`BotorchGenerator`](https://https://ax.readthedocs.io/en/latest/models.html#ax.generators.torch.botorch.BotorchModel)
 that is a sensible default for modeling and optimization which can be customized
 by specifying and passing in bespoke model constructors, acquisition functions,
-and optimization strategies.
-This model bridge utilizes a number of built-in transformations, such as
-normalizing input spaces and outputs to ensure reasonable fitting of GPs.
-See the [Ax Docs](https://ax.dev/docs/models.html#transforms) for more
-information.
-
+and optimization strategies. This model bridge utilizes a number of built-in
+transformations, such as normalizing input spaces and outputs to ensure
+reasonable fitting of GPs. See the
+[Ax Docs](https://ax.dev/docs/models.html#transforms) for more information.
 
 ## When to use BoTorch through Ax
 
@@ -46,7 +41,6 @@ management, data storage, etc. See Ax's
 [Modular BoTorch tutorial](https://ax.dev/docs/tutorials/modular_botorch/)
 tutorial for more on how to do this.
 
-
 ## When not to use Ax
 
 If you're working in a non-standard setting, such as structured feature or
@@ -61,7 +55,6 @@ You may also consider working purely in BoTorch if you want to be able to
 understand and control every single aspect of your BayesOpt loop - Ax's
 simplicity necessarily means that certain powerful BoTorch features will not be
 fully exposed to the user.
-
 
 ## Prototyping in BoTorch
 


### PR DESCRIPTION
Summary: This is a continuation of renaming of Models to Generators. In a previous diff, the classes have been renamed. This diff updates the directory / module names. Renaming of the attributes is the last remaining step. I will attempt that in a separate diff.

Differential Revision: D75161069
