### PR TITLE
fix bug where input transforms are not applied in fully Bayesian models in train mode

### DIFF
--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -23,7 +23,7 @@ from botorch.logging import logger
 from botorch.models import SingleTaskGP
 from botorch.models.approximate_gp import ApproximateGPyTorchModel
 from botorch.models.fully_bayesian import (
-    FullyBayesianSingleTaskGP,
+    AbstractFullyBayesianSingleTaskGP,
     SaasFullyBayesianSingleTaskGP,
 )
 from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
@@ -337,7 +337,7 @@ def _fit_fallback_approximate(
 
 
 def fit_fully_bayesian_model_nuts(
-    model: FullyBayesianSingleTaskGP | SaasFullyBayesianMultiTaskGP,
+    model: AbstractFullyBayesianSingleTaskGP | SaasFullyBayesianMultiTaskGP,
     max_tree_depth: int = 6,
     warmup_steps: int = 512,
     num_samples: int = 256,
@@ -349,7 +349,7 @@ def fit_fully_bayesian_model_nuts(
 
 
     Args:
-        model: SaasFullyBayesianSingleTaskGP to be fitted.
+        model: Fully Bayesian GP to be fitted.
         max_tree_depth: Maximum tree depth for NUTS
         warmup_steps: The number of burn-in steps for NUTS.
         num_samples:  The number of MCMC samples. Note that with thinning,

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -794,6 +794,8 @@ class AbstractFullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel
         rest of this method will not run.
         """
         self._check_if_fitted()
+        if self.training:
+            X = self.transform_inputs(X=X)
         mean_x = self.mean_module(X)
         covar_x = self.covar_module(X)
         return MultivariateNormal(mean_x, covar_x)

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -129,6 +129,38 @@ class PyroModel:
     in combination with Pyro.
     """
 
+    def __init__(
+        self,
+        use_input_warping: bool = False,
+        indices_to_warp: list[int] | None = None,
+        eps: float = 1e-7,
+    ) -> None:
+        r"""Initialize the PyroModel.
+
+        Args:
+            use_input_warping: A boolean indicating whether to use input warping.
+            indices_to_warp: An optional list of indices to warp. The default
+                is to warp all inputs.
+            eps: A small value that is used to ensure inputs are not 0 or 1,
+                when using input warping.
+        """
+        self.use_input_warping = use_input_warping
+        self.indices = indices_to_warp
+        self._eps = eps
+
+    @subset_transform
+    def warp(self, X: Tensor, c0: Tensor, c1: Tensor) -> Tensor:
+        r"""Warp the input through a Kumaraswamy CDF."""
+        return kumaraswamy_warp(X=X, c0=c0, c1=c1, eps=self._eps)
+
+    def _maybe_input_warp(self, X: Tensor, **tkwargs: Any) -> Tensor:
+        if self.use_input_warping:
+            c0, c1 = self.sample_concentrations(**tkwargs)
+            # unnormalize X from [0, 1] to [eps, 1-eps]
+            return self.warp(X=self.train_X, c0=c0, c1=c1)
+        else:
+            return self.train_X
+
     def set_inputs(
         self, train_X: Tensor, train_Y: Tensor, train_Yvar: Tensor | None = None
     ) -> None:
@@ -186,6 +218,29 @@ class PyroModel:
             ),
         )
 
+    def sample_concentrations(self, **tkwargs: Any) -> tuple[Tensor, Tensor]:
+        r"""Sample concentrations for input warping.
+
+        The prior has a mean value of 1 for each concentration and is very
+        concentrated around the mean.
+        """
+        c0 = pyro.sample(
+            "c0",
+            pyro.distributions.LogNormal(
+                torch.tensor([0.0] * self.ard_num_dims, **tkwargs),
+                torch.tensor([0.1**0.5] * self.ard_num_dims, **tkwargs),
+            ),
+        )
+        c1 = pyro.sample(
+            "c1",
+            pyro.distributions.LogNormal(
+                torch.tensor([0.0] * self.ard_num_dims, **tkwargs),
+                torch.tensor([0.1**0.5] * self.ard_num_dims, **tkwargs),
+            ),
+        )
+
+        return c0, c1
+
 
 class MaternPyroModel(PyroModel):
     r"""Implementation of the a fully Bayesian model with a dimension-scaling prior.
@@ -212,10 +267,11 @@ class MaternPyroModel(PyroModel):
         mean = self.sample_mean(**tkwargs)
         noise = self.sample_noise(**tkwargs)
         lengthscale = self.sample_lengthscale(dim=self.ard_num_dims, **tkwargs)
+        X_tf = self._maybe_input_warp(self.train_X, **tkwargs)
         if self.train_Y.shape[-2] > 0:
             # Do not attempt to sample Y if the data is empty.
             # This leads to errors with empty data.
-            K = matern52_kernel(X=self.train_X, lengthscale=lengthscale)
+            K = matern52_kernel(X=X_tf, lengthscale=lengthscale)
             K = outputscale * K + noise * torch.eye(self.train_X.shape[0], **tkwargs)
             pyro.sample(
                 "Y",
@@ -303,7 +359,7 @@ class MaternPyroModel(PyroModel):
 
     def load_mcmc_samples(
         self, mcmc_samples: dict[str, Tensor]
-    ) -> tuple[Mean, Kernel, Likelihood]:
+    ) -> tuple[Mean, Kernel, Likelihood, Warp | None]:
         r"""Load the MCMC samples into the mean_module, covar_module, and likelihood."""
         tkwargs = {"device": self.train_X.device, "dtype": self.train_X.dtype}
         num_mcmc_samples = len(mcmc_samples["mean"])
@@ -347,7 +403,29 @@ class MaternPyroModel(PyroModel):
             target=mean_module.constant.data,
             new_value=mcmc_samples["mean"],
         )
-        return mean_module, covar_module, likelihood
+        if self.use_input_warping:
+            indices = (
+                list(range(self.ard_num_dims)) if self.indices is None else self.indices
+            )
+            bounds = torch.zeros(2, self.ard_num_dims, **tkwargs)
+            bounds[1] = 1
+            warping_function = Warp(
+                d=self.ard_num_dims,
+                batch_shape=batch_shape,
+                indices=indices,
+                bounds=bounds,
+            ).to(**tkwargs)
+            warping_function.concentration0.data = reshape_and_detach(
+                target=warping_function.concentration0,
+                new_value=mcmc_samples["c0"],
+            )
+            warping_function.concentration1.data = reshape_and_detach(
+                target=warping_function.concentration1,
+                new_value=mcmc_samples["c1"],
+            )
+        else:
+            warping_function = None
+        return mean_module, covar_module, likelihood, warping_function
 
 
 class SaasPyroModel(MaternPyroModel):
@@ -417,38 +495,12 @@ class LinearPyroModel(PyroModel):
     `covar_module`).
     """
 
-    def __init__(
-        self,
-        use_input_warping: bool = True,
-        indices_to_warp: list[int] | None = None,
-        eps: float = 1e-7,
-    ) -> None:
-        r"""Initialize the LinearPyroModel.
-
-        Args:
-            use_input_warping: If True, use input warping.
-        """
-        super().__init__()
-        self.use_input_warping = use_input_warping
-        self.indices = indices_to_warp
-        self._eps = eps
-
-    @subset_transform
-    def warp(self, X: Tensor, c0: Tensor, c1: Tensor) -> Tensor:
-        r"""Warp the input."""
-        return kumaraswamy_warp(X=X, c0=c0, c1=c1, eps=self._eps)
-
     def sample(self) -> None:
         r"""Sample from the model."""
         tkwargs = {"dtype": self.train_X.dtype, "device": self.train_X.device}
         mean = self.sample_mean(**tkwargs)
         weight_variance = self.sample_weight_variance(**tkwargs)
-        if self.use_input_warping:
-            c0, c1 = self.sample_concentrations(**tkwargs)
-            # unnormalize X from [0, 1] to [eps, 1-eps]
-            X_tf = self.warp(X=self.train_X, c0=c0, c1=c1)
-        else:
-            X_tf = self.train_X
+        X_tf = self._maybe_input_warp(X=self.train_X, **tkwargs)
         X_tf = X_tf - 0.5  # center transformed data at 0 (for linear model)
         K = linear_kernel(X=X_tf, weight_variance=weight_variance)
         noise = self.sample_noise(**tkwargs)
@@ -497,29 +549,6 @@ class LinearPyroModel(PyroModel):
         ).sqrt()
         del mcmc_samples["tau_sq"], mcmc_samples["_weight_variance_sq"]
         return mcmc_samples
-
-    def sample_concentrations(self, **tkwargs: Any) -> tuple[Tensor, Tensor]:
-        r"""Sample concentrations for input warping.
-
-        The prior has a mean value of 1 for each concentration and is very
-        concentrated around the mean.
-        """
-        c0 = pyro.sample(
-            "c0",
-            pyro.distributions.LogNormal(
-                torch.tensor([0.0] * self.ard_num_dims, **tkwargs),
-                torch.tensor([0.1**0.5] * self.ard_num_dims, **tkwargs),
-            ),
-        )
-        c1 = pyro.sample(
-            "c1",
-            pyro.distributions.LogNormal(
-                torch.tensor([0.0] * self.ard_num_dims, **tkwargs),
-                torch.tensor([0.1**0.5] * self.ard_num_dims, **tkwargs),
-            ),
-        )
-
-        return c0, c1
 
     def load_mcmc_samples(
         self, mcmc_samples: dict[str, Tensor]
@@ -606,22 +635,23 @@ class AbstractFullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel
 
     _is_fully_bayesian = True
     _is_ensemble = True
+    _pyro_model_class: type[PyroModel] = PyroModel
 
     def __init__(
         self,
         train_X: Tensor,
         train_Y: Tensor,
-        pyro_model: PyroModel,
         train_Yvar: Tensor | None = None,
         outcome_transform: OutcomeTransform | None = None,
         input_transform: InputTransform | None = None,
+        use_input_warping: bool = False,
+        indices_to_warp: list[int] = None,
     ) -> None:
         r"""Initialize the fully Bayesian single-task GP model.
 
         Args:
             train_X: Training inputs (n x d)
             train_Y: Training targets (n x 1)
-            pyro_model: The pyro model.
             train_Yvar: Observed noise variance (n x 1). Inferred if None.
             outcome_transform: An outcome transform that is applied to the
                 training data during instantiation and to the posterior during
@@ -631,6 +661,9 @@ class AbstractFullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel
                 instantiation of the model.
             input_transform: An input transform that is applied in the model's
                 forward pass.
+            use_input_warping: A boolean indicating whether to use input warping.
+            indices_to_warp: An optional list of indices to warp. The default
+                is to warp all inputs.
         """
         if not (
             train_X.ndim == train_Y.ndim == 2
@@ -670,10 +703,13 @@ class AbstractFullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel
         self.mean_module = None
         self.covar_module = None
         self.likelihood = None
-        pyro_model.set_inputs(
+        self.pyro_model = self._pyro_model_class(
+            use_input_warping=use_input_warping,
+            indices_to_warp=indices_to_warp,
+        )
+        self.pyro_model.set_inputs(
             train_X=transformed_X, train_Y=train_Y, train_Yvar=train_Yvar
         )
-        self.pyro_model = pyro_model
         if outcome_transform is not None:
             self.outcome_transform: OutcomeTransform = outcome_transform
         if input_transform is not None:
@@ -688,9 +724,10 @@ class AbstractFullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel
             )
 
     @property
-    @abstractmethod
     def num_mcmc_samples(self) -> int:
         r"""Number of MCMC samples in the model."""
+        self._check_if_fitted()
+        return self.covar_module.batch_shape[0]
 
     @property
     def batch_shape(self) -> torch.Size:
@@ -733,11 +770,21 @@ class AbstractFullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel
         This method will be called by `fit_fully_bayesian_model_nuts` when the model
         has been fitted in order to create a batched SingleTaskGP model.
         """
-        (
-            self.mean_module,
-            self.covar_module,
-            self.likelihood,
-        ) = self.pyro_model.load_mcmc_samples(mcmc_samples=mcmc_samples)
+        (self.mean_module, self.covar_module, self.likelihood, input_transform) = (
+            self.pyro_model.load_mcmc_samples(mcmc_samples=mcmc_samples)
+        )
+        if input_transform is not None:
+            if hasattr(self, "input_transform"):
+                tfs = [self.input_transform]
+                if isinstance(input_transform, ChainedInputTransform):
+                    tfs.extend(list(input_transform.values()))
+                else:
+                    tfs.append(input_transform)
+                self.input_transform = ChainedInputTransform(
+                    **{f"tf{i}": tf for i, tf in enumerate(tfs)}
+                )
+            else:
+                self.input_transform = input_transform
 
     def forward(self, X: Tensor) -> MultivariateNormal:
         """
@@ -825,6 +872,34 @@ class AbstractFullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel
 
         return super().condition_on_observations(X, Y, **kwargs)
 
+    @classmethod
+    def construct_inputs(
+        cls,
+        training_data: SupervisedDataset,
+        *,
+        use_input_warping: bool = False,
+        indices_to_warp: list[int] | None = None,
+    ) -> dict[str, BotorchContainer | Tensor | None]:
+        r"""Construct `SingleTaskGP` keyword arguments from a `SupervisedDataset`.
+
+        Args:
+            training_data: A `SupervisedDataset`, with attributes `train_X`,
+                `train_Y`, and, optionally, `train_Yvar`.
+            use_input_warping: A boolean indicating whether to use input warping.
+            indices_to_warp: An optional list of indices to warp. The default
+                is to warp all inputs.
+
+        Returns:
+            A dict of keyword arguments that can be used to initialize a
+            `FullyBayesianLinearSingleTaskGP`, with keys `train_X`, `train_Y`,
+            `use_input_warping`, `indices_to_warp`, and, optionally, `train_Yvar`.
+        """
+        return {
+            **super().construct_inputs(training_data=training_data),
+            "use_input_warping": use_input_warping,
+            "indices_to_warp": indices_to_warp,
+        }
+
 
 class FullyBayesianSingleTaskGP(AbstractFullyBayesianSingleTaskGP):
     r"""A fully Bayesian single-task GP model with the SAAS prior.
@@ -844,41 +919,7 @@ class FullyBayesianSingleTaskGP(AbstractFullyBayesianSingleTaskGP):
         >>> posterior = fully_bayesian_gp.posterior(test_X)
     """
 
-    def __init__(
-        self,
-        train_X: Tensor,
-        train_Y: Tensor,
-        train_Yvar: Tensor | None = None,
-        outcome_transform: OutcomeTransform | None = None,
-        input_transform: InputTransform | None = None,
-    ) -> None:
-        r"""Initialize the fully Bayesian single-task GP model.
-
-        Args:
-            train_X: Training inputs (n x d)
-            train_Y: Training targets (n x 1)
-            train_Yvar: Observed noise variance (n x 1). Inferred if None.
-            outcome_transform: An outcome transform that is applied to the
-                training data during instantiation and to the posterior during
-                inference (that is, the `Posterior` obtained by calling
-                `.posterior` on the model will be on the original scale).
-            input_transform: An input transform that is applied in the model's
-                forward pass.
-        """
-        super().__init__(
-            train_X=train_X,
-            train_Y=train_Y,
-            train_Yvar=train_Yvar,
-            input_transform=input_transform,
-            outcome_transform=outcome_transform,
-            pyro_model=MaternPyroModel(),
-        )
-
-    @property
-    def num_mcmc_samples(self) -> int:
-        r"""Number of MCMC samples in the model."""
-        self._check_if_fitted()
-        return len(self.mean_module.constant)
+    _pyro_model_class: type[PyroModel] = MaternPyroModel
 
     @property
     def median_lengthscale(self) -> Tensor:
@@ -906,6 +947,10 @@ class FullyBayesianSingleTaskGP(AbstractFullyBayesianSingleTaskGP):
         }
         if self.pyro_model.train_Yvar is None:
             mcmc_samples["noise"] = torch.ones(num_mcmc_samples, **tkwargs)
+
+        if self.pyro_model.use_input_warping:
+            mcmc_samples["c0"] = torch.ones(num_mcmc_samples, dim, **tkwargs)
+            mcmc_samples["c1"] = torch.ones(num_mcmc_samples, dim, **tkwargs)
         return mcmc_samples
 
     def load_state_dict(
@@ -929,11 +974,7 @@ class FullyBayesianSingleTaskGP(AbstractFullyBayesianSingleTaskGP):
             dtype=raw_mean.dtype,
             device=raw_mean.device,
         )
-        (
-            self.mean_module,
-            self.covar_module,
-            self.likelihood,
-        ) = self.pyro_model.load_mcmc_samples(mcmc_samples=mcmc_samples)
+        self.load_mcmc_samples(mcmc_samples=mcmc_samples)
         # Load the actual samples from the state dict
         super().load_state_dict(state_dict=state_dict, strict=strict)
 
@@ -956,36 +997,7 @@ class SaasFullyBayesianSingleTaskGP(FullyBayesianSingleTaskGP):
         >>> posterior = saas_gp.posterior(test_X)
     """
 
-    def __init__(
-        self,
-        train_X: Tensor,
-        train_Y: Tensor,
-        train_Yvar: Tensor | None = None,
-        outcome_transform: OutcomeTransform | None = None,
-        input_transform: InputTransform | None = None,
-    ) -> None:
-        r"""Initialize the fully Bayesian single-task GP model.
-
-        Args:
-            train_X: Training inputs (n x d)
-            train_Y: Training targets (n x 1)
-            train_Yvar: Observed noise variance (n x 1). Inferred if None.
-            outcome_transform: An outcome transform that is applied to the
-                training data during instantiation and to the posterior during
-                inference (that is, the `Posterior` obtained by calling
-                `.posterior` on the model will be on the original scale).
-            input_transform: An input transform that is applied in the model's
-                forward pass.
-        """
-        AbstractFullyBayesianSingleTaskGP.__init__(
-            self,
-            train_X=train_X,
-            train_Y=train_Y,
-            train_Yvar=train_Yvar,
-            input_transform=input_transform,
-            outcome_transform=outcome_transform,
-            pyro_model=SaasPyroModel(),
-        )
+    _pyro_model_class: type[PyroModel] = SaasPyroModel
 
     def _get_dummy_mcmc_samples(
         self,
@@ -1021,49 +1033,7 @@ class FullyBayesianLinearSingleTaskGP(AbstractFullyBayesianSingleTaskGP):
         >>> posterior = gp.posterior(test_X)
     """
 
-    def __init__(
-        self,
-        train_X: Tensor,
-        train_Y: Tensor,
-        train_Yvar: Tensor | None = None,
-        outcome_transform: OutcomeTransform | None = None,
-        input_transform: InputTransform | None = None,
-        use_input_warping: bool = True,
-        indices_to_warp: list[int] = None,
-    ) -> None:
-        r"""Initialize the fully Bayesian single-task GP model.
-
-        Args:
-            train_X: Training inputs (n x d)
-            train_Y: Training targets (n x 1)
-            train_Yvar: Observed noise variance (n x 1). Inferred if None.
-            outcome_transform: An outcome transform that is applied to the
-                training data during instantiation and to the posterior during
-                inference (that is, the `Posterior` obtained by calling
-                `.posterior` on the model will be on the original scale).
-            input_transform: An input transform that is applied in the model's
-                forward pass.
-            use_input_warping: A boolean indicating whether to use input warping.
-            indices_to_warp: An optional list of indices to warp. The default
-                is to warp all inputs.
-        """
-        pyro_model = LinearPyroModel(
-            use_input_warping=use_input_warping, indices_to_warp=indices_to_warp
-        )
-        super().__init__(
-            train_X=train_X,
-            train_Y=train_Y,
-            train_Yvar=train_Yvar,
-            input_transform=input_transform,
-            outcome_transform=outcome_transform,
-            pyro_model=pyro_model,
-        )
-
-    @property
-    def num_mcmc_samples(self) -> int:
-        r"""Number of MCMC samples in the model."""
-        self._check_if_fitted()
-        return self.covar_module.batch_shape[0]
+    _pyro_model_class: type[PyroModel] = LinearPyroModel
 
     @property
     def median_weight_variance(self) -> Tensor:
@@ -1071,27 +1041,6 @@ class FullyBayesianLinearSingleTaskGP(AbstractFullyBayesianSingleTaskGP):
         self._check_if_fitted()
         weight_variance = self.covar_module.variance.clone()
         return weight_variance.median(0).values.squeeze(0)
-
-    def load_mcmc_samples(self, mcmc_samples: dict[str, Tensor]) -> None:
-        r"""Load the MCMC hyperparameter samples into the model.
-
-        This method will be called by `fit_fully_bayesian_model_nuts` when the model
-        has been fitted in order to create a batched SingleTaskGP model.
-        """
-        (self.mean_module, self.covar_module, self.likelihood, input_transform) = (
-            self.pyro_model.load_mcmc_samples(mcmc_samples=mcmc_samples)
-        )
-        if hasattr(self, "input_transform"):
-            tfs = [self.input_transform]
-            if isinstance(input_transform, ChainedInputTransform):
-                tfs.extend(list(input_transform.values()))
-            else:
-                tfs.append(input_transform)
-            self.input_transform = ChainedInputTransform(
-                **{f"tf{i}": tf for i, tf in enumerate(tfs)}
-            )
-        else:
-            self.input_transform = input_transform
 
     def load_state_dict(
         self, state_dict: Mapping[str, Any], strict: bool = True
@@ -1125,31 +1074,3 @@ class FullyBayesianLinearSingleTaskGP(AbstractFullyBayesianSingleTaskGP):
         self.load_mcmc_samples(mcmc_samples=mcmc_samples)
         # Load the actual samples from the state dict
         super().load_state_dict(state_dict=state_dict, strict=strict)
-
-    @classmethod
-    def construct_inputs(
-        cls,
-        training_data: SupervisedDataset,
-        *,
-        use_input_warping: bool = True,
-        indices_to_warp: list[int] | None = None,
-    ) -> dict[str, BotorchContainer | Tensor | None]:
-        r"""Construct `SingleTaskGP` keyword arguments from a `SupervisedDataset`.
-
-        Args:
-            training_data: A `SupervisedDataset`, with attributes `train_X`,
-                `train_Y`, and, optionally, `train_Yvar`.
-            use_input_warping: A boolean indicating whether to use input warping.
-            indices_to_warp: An optional list of indices to warp. The default
-                is to warp all inputs.
-
-        Returns:
-            A dict of keyword arguments that can be used to initialize a
-            `FullyBayesianLinearSingleTaskGP`, with keys `train_X`, `train_Y`,
-            `use_input_warping`, `indices_to_warp`, and, optionally, `train_Yvar`.
-        """
-        return {
-            **super().construct_inputs(training_data=training_data),
-            "use_input_warping": use_input_warping,
-            "indices_to_warp": indices_to_warp,
-        }

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -138,7 +138,7 @@ class MultitaskSaasPyroModel(SaasPyroModel):
         num_mcmc_samples = len(mcmc_samples["mean"])
         batch_shape = torch.Size([num_mcmc_samples])
 
-        mean_module, covar_module, likelihood = super().load_mcmc_samples(
+        mean_module, covar_module, likelihood, _ = super().load_mcmc_samples(
             mcmc_samples=mcmc_samples
         )
 

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -97,6 +97,21 @@ class TestSaasFullyBayesianSingleTaskGP(BotorchTestCase):
     model_kwargs = {}
 
     @property
+    def expected_keys_warp(self) -> list[str]:
+        return [
+            "input_transform.concentration1_constraint.upper_bound",
+            "input_transform.concentration0",
+            "input_transform.concentration1_constraint.lower_bound",
+            "input_transform._normalize._coefficient",
+            "input_transform.concentration0_constraint.upper_bound",
+            "input_transform._normalize.indices",
+            "input_transform.concentration0_constraint.lower_bound",
+            "input_transform.concentration1",
+            "input_transform._normalize._offset",
+            "input_transform.indices",
+        ]
+
+    @property
     def expected_keys(self) -> list[str]:
         expected_keys = [
             "mean_module.raw_constant",
@@ -123,6 +138,8 @@ class TestSaasFullyBayesianSingleTaskGP(BotorchTestCase):
                 )
             ]
         )
+        if self.model_kwargs.get("use_input_warping", False):
+            expected_keys.extend(self.expected_keys_warp)
         return expected_keys
 
     @property
@@ -192,6 +209,9 @@ class TestSaasFullyBayesianSingleTaskGP(BotorchTestCase):
             mcmc_samples["noise"] = torch.rand(num_samples, 1, **tkwargs)
         if self.model_cls is SaasFullyBayesianSingleTaskGP:
             mcmc_samples["outputscale"] = torch.rand(num_samples, **tkwargs)
+        if self.model_kwargs.get("use_input_warping", False):
+            for k in ("c0", "c1"):
+                mcmc_samples[k] = torch.rand(num_samples, 1, dim, **tkwargs)
         return mcmc_samples
 
     def test_raises(self) -> None:
@@ -545,19 +565,21 @@ class TestSaasFullyBayesianSingleTaskGP(BotorchTestCase):
             self.assertAllClose(pred_var1, pred_var2)
 
             # check the transforms
-            if issubclass(self.model_cls, FullyBayesianSingleTaskGP):
-                self.assertIsInstance(gp2.input_transform, Normalize)
-            else:
+            use_input_warping = self.model_kwargs.get("use_input_warping", False)
+            if use_input_warping or (self.model_cls is FullyBayesianLinearSingleTaskGP):
                 self.assertIsInstance(gp2.input_transform, ChainedInputTransform)
                 tf_iter = iter(gp2.input_transform.values())
                 tf = next(tf_iter)
                 self.assertIsInstance(tf, Normalize)
-                if self.model_kwargs["use_input_warping"]:
+                if use_input_warping:
                     tf = next(tf_iter)
                     self.assertIsInstance(tf, Warp)
-                tf = next(tf_iter)
-                self.assertIsInstance(tf, Normalize)
-                self.assertEqual(tf.center, 0.0)
+                if self.model_cls is FullyBayesianLinearSingleTaskGP:
+                    tf = next(tf_iter)
+                    self.assertIsInstance(tf, Normalize)
+                    self.assertEqual(tf.center, 0.0)
+            else:
+                self.assertIsInstance(gp2.input_transform, Normalize)
 
     def test_acquisition_functions(self) -> None:
         tkwargs = {"device": self.device, "dtype": torch.double}
@@ -940,6 +962,14 @@ class TestFullyBayesianSingleTaskGP(TestSaasFullyBayesianSingleTaskGP):
     pyro_model_cls: type[PyroModel] = MaternPyroModel
 
 
+class TestSaasFullyBayesianSingleTaskGPWarped(TestSaasFullyBayesianSingleTaskGP):
+    model_kwargs = {"use_input_warping": True}
+
+
+class TestFullyBayesianSingleTaskGPWarped(TestFullyBayesianSingleTaskGP):
+    model_kwargs = {"use_input_warping": True}
+
+
 class TestPyroCatchNumericalErrors(BotorchTestCase):
     def tearDown(self) -> None:
         super().tearDown()
@@ -1009,6 +1039,23 @@ class TestFullyBayesianLinearSingleTaskGP(TestSaasFullyBayesianSingleTaskGP):
         return X.sum(dim=-1, keepdim=True)
 
     @property
+    def expected_keys_warp(self) -> list[str]:
+        return [
+            "input_transform.warp.concentration1_constraint.upper_bound",
+            "input_transform.warp.concentration0",
+            "input_transform.warp.concentration1_constraint.lower_bound",
+            "input_transform.normalize._coefficient",
+            "input_transform.warp._normalize._coefficient",
+            "input_transform.warp.concentration0_constraint.upper_bound",
+            "input_transform.normalize._offset",
+            "input_transform.warp._normalize.indices",
+            "input_transform.warp.concentration0_constraint.lower_bound",
+            "input_transform.warp.concentration1",
+            "input_transform.warp._normalize._offset",
+            "input_transform.warp.indices",
+        ]
+
+    @property
     def expected_keys(self) -> list[str]:
         expected_keys = [
             "mean_module.raw_constant",
@@ -1017,22 +1064,7 @@ class TestFullyBayesianLinearSingleTaskGP(TestSaasFullyBayesianSingleTaskGP):
             "covar_module.raw_variance_constraint.upper_bound",
         ]
         if self.model_kwargs["use_input_warping"]:
-            expected_keys.extend(
-                [
-                    "input_transform.warp.concentration1_constraint.upper_bound",
-                    "input_transform.warp.concentration0",
-                    "input_transform.warp.concentration1_constraint.lower_bound",
-                    "input_transform.normalize._coefficient",
-                    "input_transform.warp._normalize._coefficient",
-                    "input_transform.warp.concentration0_constraint.upper_bound",
-                    "input_transform.normalize._offset",
-                    "input_transform.warp._normalize.indices",
-                    "input_transform.warp.concentration0_constraint.lower_bound",
-                    "input_transform.warp.concentration1",
-                    "input_transform.warp._normalize._offset",
-                    "input_transform.warp.indices",
-                ]
-            )
+            expected_keys.extend(self.expected_keys_warp)
         else:
             expected_keys.extend(
                 ["input_transform._offset", "input_transform._coefficient"]


### PR DESCRIPTION
Summary: This fixes a bug where input transforms were not applied to fully Bayesian GPs in training mode. This only affects computing MLL, AIC, and BIC (which previously where computing without applying normalization/warping) for fully Bayesian GPs.  We don't evaluate fully Bayesian models in `train` mode.

Reviewed By: saitcakmak

Differential Revision: D74827275


