### PR TITLE
Add original `X.shape` in output of `t_batch_mode_transform` error message

### DIFF
--- a/botorch/utils/transforms.py
+++ b/botorch/utils/transforms.py
@@ -293,6 +293,7 @@ def t_batch_mode_transform(
                     f"Expected X to be `batch_shape x q={expected_q} x d`, but"
                     f" got X with shape {X.shape}."
                 )
+            X_original_shape = X.shape
             # add t-batch dim
             X = X if X.dim() > 2 else X.unsqueeze(0)
             output = method(acqf, X, *args, **kwargs)
@@ -306,6 +307,13 @@ def t_batch_mode_transform(
                     "X, or the `model.batch_shape` in the case of acquisition "
                     "functions using batch models; but got output with shape "
                     f"{output.shape} for X with shape {X.shape}."
+                    + (
+                        ""
+                        if X_original_shape == X.shape
+                        else f" Note that `X.shape` was originally {X_original_shape} "
+                        "before the `t_batch_mode_transform` decorator added a batch "
+                        "dimension."
+                    )
                 )
             return output
 

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -316,8 +316,20 @@ class TestBatchModeTransform(BotorchTestCase):
         self.assertEqual(Xout.shape, torch.Size())
         # test with model batch shape
         c.model = MockModel(MockPosterior(mean=X))
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            "Expected the output shape to match either the t-batch shape of X",
+        ):
             c.broadcast_batch_shape_method(X)
+
+        # testing more informative error message when the decorator adds the batch dim
+        with self.assertRaisesRegex(
+            AssertionError,
+            "Expected the output shape to match either the t-batch shape of X"
+            r".*Note that `X\.shape` was originally torch\.Size\(\[1, 2\]\) before the "
+            r"`t_batch_mode_transform` decorator added a batch dimension\.",
+        ):
+            c.broadcast_batch_shape_method(X[0])
         c.model = MockModel(MockPosterior(mean=X.repeat(2, *[1] * X.dim())))
         Xout = c.broadcast_batch_shape_method(X)
         self.assertEqual(Xout.shape, c.model.batch_shape)


### PR DESCRIPTION
Summary: This commit adds the original `X.shape` to the shape error message in `t_batch_mode_transform`, if the decorator modified it. This makes it clear where the shape is coming from when debugging shape errors.

Differential Revision: D76516121
