### PR TITLE
Tuple-based indexing for `MVar.get_mvar_set_via_counting`

### DIFF
--- a/botorch/acquisition/multi_objective/multi_output_risk_measures.py
+++ b/botorch/acquisition/multi_objective/multi_output_risk_measures.py
@@ -353,7 +353,7 @@ class MVaR(MultiOutputRiskMeasureMCObjective):
         Y_pruned = Y[mask]
         for y_ in Y_pruned:
             starting_idcs = [unique_outcomes[i].get(y_[i].item(), 0) for i in range(m)]
-            slices = [slice(s_idx, None) for s_idx in starting_idcs]
+            slices = tuple(slice(s_idx, None) for s_idx in starting_idcs)
             counter_tensor[slices] += 1
 
         # Get the count alpha-level points should have.


### PR DESCRIPTION
Summary:
This commit changes list-based indexing to a tuple-based indexing in `MVaR`, which is currently throwing a warning:
```
UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in an error or a different result
  counter_tensor[slices] += 1
```

Differential Revision: D76913735
