### PR TITLE
Fix docstring of `FullyBayesianSingleTaskGP`

### DIFF
--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -224,18 +224,19 @@ class PyroModel:
         The prior has a mean value of 1 for each concentration and is very
         concentrated around the mean.
         """
+        d = len(self.indices) if self.indices is not None else self.ard_num_dims
         c0 = pyro.sample(
             "c0",
             pyro.distributions.LogNormal(
-                torch.tensor([0.0] * self.ard_num_dims, **tkwargs),
-                torch.tensor([0.1**0.5] * self.ard_num_dims, **tkwargs),
+                torch.tensor([0.0] * d, **tkwargs),
+                torch.tensor([0.1**0.5] * d, **tkwargs),
             ),
         )
         c1 = pyro.sample(
             "c1",
             pyro.distributions.LogNormal(
-                torch.tensor([0.0] * self.ard_num_dims, **tkwargs),
-                torch.tensor([0.1**0.5] * self.ard_num_dims, **tkwargs),
+                torch.tensor([0.0] * d, **tkwargs),
+                torch.tensor([0.1**0.5] * d, **tkwargs),
             ),
         )
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

Docstring of `FullyBayesianSingleTaskGP` is wrong (looks like a copy-paste thingy). This PR fixes it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.


## Test Plan

No tests needed, only fix on docstrings.


