### PR TITLE
Align Formatting to Meta Internal Standard

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,9 +11,3 @@ extend-select = D107, D417, D3, D207, D208, D214, D215
 max-line-length = 88
 exclude =
   build, dist, tutorials, website, .eggs
-
-[coverage:report]
-omit =
-    test/*
-    setup.py
-    botorch/generation/batched_lbfgs_b.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ first_party_detection = false
 
 [tool.ufmt]
 formatter = "ruff-api"
+
+[tool.coverage.report]
+omit = ["test/*", "setup.py", "botorch/generation/batched_lbfgs_b.py"]


### PR DESCRIPTION
Summary:
A lot of the contributions to this repo come from inside meta, which uses another formatter than this repo.

One big difference is that internally, long strings, comments and docstrings are allowed.

This diff allows them in BoTorch codebase, too.

Differential Revision: D77388799


