### PR TITLE
ROBOT tutorial removed from full tutorial runs

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -18,7 +18,7 @@ from memory_profiler import memory_usage
 
 
 IGNORE_ALWAYS = set()  # ignored in smoke tests and full runs
-RUN_IF_SMOKE_TEST_IGNORE_IF_STANDARD = set()  # only used in smoke tests
+RUN_IF_SMOKE_TEST_IGNORE_IF_STANDARD = {"robot.ipynb"}  # only used in smoke tests
 
 
 def run_script(


### PR DESCRIPTION
Summary: This diff is a hotfix that removes the ROBOT tutorial from full tutorial runs due to the excessive runtime, which causes a timeout.

Differential Revision: D77443910


