### PR TITLE
Small typo in a tutorial fixed.

### DIFF
--- a/tutorials/closed_loop_botorch_only/closed_loop_botorch_only.ipynb
+++ b/tutorials/closed_loop_botorch_only/closed_loop_botorch_only.ipynb
@@ -116,7 +116,7 @@
       "source": [
         "#### Model initialization\n",
         "\n",
-        "We use a `MultiOutputGP` to model the objective (output 0) and the constraint (output 1). We assume known homoskedastic observation noise on both the objective and constraint with standard error $\\sigma = 0.5$. \n",
+        "We use a `ModelListGP` to model the objective (output 0) and the constraint (output 1). We assume known homoskedastic observation noise on both the objective and constraint with standard error $\\sigma = 0.5$. \n",
         "\n",
         "Each component is a `SingleTaskGP`. The models are initialized with 10 points drawn randomly from $[0,1]^6$."
       ]


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

I spotted a small typo in the qNoisy constrained BO tutorial. There is no 'MultiOutputGP', so that should have been 'ModelListGP' I guess.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
