### PR TITLE
NumericToCategoricalEncoding Input Transform.

### DIFF
--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -1699,16 +1699,18 @@ class NumericToCategoricalEncoding(InputTransform):
             )
 
         for idx, card in self.categorical_features.items():
-            if card == 1:
+            if card <= 1:
                 raise ValueError(
-                    f"Categorical feature at index {idx} has cardinality 1. "
+                    f"Categorical feature at index {idx} has cardinality {card}. "
                     f"All categorial features must have cardinality greater than 1."
                 )
 
         # check that the encoders match the categorical features
-        if (enc_keys := set(self.encoders)) != (cf_keys := set(self.categorical_features)):
+        if (enc_keys := set(self.encoders)) != (
+            cf_keys := set(self.categorical_features)
+        ):
             raise ValueError(
-                "The keys of `encoders` ({enc_keys}) must match the keys of "
+                f"The keys of `encoders` ({enc_keys}) must match the keys of "
                 f"of `categorical_features`  ({cf_keys})."
             )
 
@@ -1743,8 +1745,9 @@ class NumericToCategoricalEncoding(InputTransform):
             X: A `batch_shape x n x d`-dim tensor of inputs.
 
         Returns:
-            A `batch_shape x n x d'`-dim tensor with `d' = d + sum(categorical_features.values())`
-            in which the integer-encoded categoricals are transformed to a vector representation.
+            A `batch_shape x n x d'`-dim tensor with
+            `d' = d + sum(categorical_features.values())` in which the
+            integer-encoded categoricals are transformed to a vector representation.
         """
         s = list(X.shape)
         s[-1] = len(self.numerical_idx) + len(np.concatenate(self.encoded_idx))

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -1748,7 +1748,6 @@ class NumericToCategoricalEncoding(InputTransform):
             and (self.transform_on_eval == other.transform_on_eval)
             and (self.transform_on_fantasize == other.transform_on_fantasize)
             and self.categorical_features == other.categorical_features
-            and self.encoders == other.encoders
         )
 
 

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -1626,9 +1626,30 @@ class InputPerturbation(InputTransform):
 
 
 class NumericToCategoricalEncoding(InputTransform):
-    """Transform categorical parameters from an integer representation
+    """Transform categorical parameters from an integer/numeric representation
     to a vector based representation like one-hot encoding or a descriptor
     encoding.
+
+    The vector encoding is inserted at the position of the categorical feature
+    in the input tensor. This is demonstrated in the example below in which a
+    categorical feature of cardinality 3 at position 1 in the original
+    representation is one-hot encoded.
+
+    Example:
+
+        >>> import torch
+        >>> from torch.nn.functional import one_hot
+        >>> from functools import partial
+        >>> from botorch.models.transforms.input import NumericToCategoricalEncoding
+        >>> tf = NumericToCategoricalEncoding(
+        ...     dim=3,
+        ...     categorical_features={1: 3},
+        ...     encoders={1: partial(one_hot, num_classes=3)},
+        ... )
+        >>> X = torch.tensor([[0.5, 2, 1.2], [1.1, 0, 0.8]])
+        >>> tf.transform(X)
+        tensor([[0.5000, 0.0000, 0.0000, 1.0000, 1.2000],
+                [1.1000, 1.0000, 0.0000, 0.0000, 0.8000]])
     """
 
     def __init__(

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -1699,10 +1699,11 @@ class NumericToCategoricalEncoding(InputTransform):
             )
 
         for idx, card in self.categorical_features.items():
-            if card <= 1:
+            if card <= 1 or not isinstance(card, int):
                 raise ValueError(
                     f"Categorical feature at index {idx} has cardinality {card}. "
-                    f"All categorial features must have cardinality greater than 1."
+                    f"All categorical features must be an integer and have cardinality "
+                    "greater than 1."
                 )
 
         # check that the encoders match the categorical features

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -1255,6 +1255,15 @@ class TestInputTransforms(BotorchTestCase):
                 categorical_features={1: 1},
                 encoders={1: partial(one_hot, num_classes=1)},
             )
+        with self.assertRaises(
+            ValueError,
+            msg="Categorical feature at index 1",
+        ):
+            NumericToCategoricalEncoding(
+                dim=2,
+                categorical_features={1: 2.0},
+                encoders={1: partial(one_hot, num_classes=2)},
+            )
 
         torch.manual_seed(42)
         for dtype in (torch.float, torch.double):
@@ -1282,7 +1291,7 @@ class TestInputTransforms(BotorchTestCase):
             )
             X_one_hot = tf(X_numeric)
             self.assertTrue(torch.equal(X_one_hot, expected))
-            
+
             # two categoricals at end
             dim = 4
             categorical_features = {2: 3, 3: 2}
@@ -1316,7 +1325,7 @@ class TestInputTransforms(BotorchTestCase):
             )
             X_one_hot = tf(X_numeric)
             self.assertTrue(torch.equal(X_one_hot, expected))
-            
+
             # two categoricals, one at start, one at end
             dim = 4
             categorical_features = {0: 3, 3: 2}
@@ -1350,7 +1359,7 @@ class TestInputTransforms(BotorchTestCase):
             )
             X_one_hot = tf(X_numeric)
             self.assertTrue(torch.equal(X_one_hot, expected))
-            
+
             # only categoricals
             dim = 2
             categorical_features = {0: 3, 1: 2}
@@ -1382,7 +1391,7 @@ class TestInputTransforms(BotorchTestCase):
             )
             X_one_hot = tf(X_numeric)
             self.assertTrue(torch.equal(X_one_hot, expected))
-        
+
         # test no transform on eval
         tf = NumericToCategoricalEncoding(
             dim=dim,
@@ -1424,7 +1433,7 @@ class TestInputTransforms(BotorchTestCase):
             transform_on_train=False,
         )
         self.assertTrue(tf.equals(tf2))
-        
+
         # test different transform_on_train
         tf3 = NumericToCategoricalEncoding(
             dim=dim,
@@ -1436,7 +1445,7 @@ class TestInputTransforms(BotorchTestCase):
             transform_on_train=True,
         )
         self.assertFalse(tf3.equals(tf2))
-        
+
         # test categorical features
         tf4 = NumericToCategoricalEncoding(
             dim=dim,

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -1282,6 +1282,7 @@ class TestInputTransforms(BotorchTestCase):
             )
             X_one_hot = tf(X_numeric)
             self.assertTrue(torch.equal(X_one_hot, expected))
+            
             # two categoricals at end
             dim = 4
             categorical_features = {2: 3, 3: 2}
@@ -1315,6 +1316,7 @@ class TestInputTransforms(BotorchTestCase):
             )
             X_one_hot = tf(X_numeric)
             self.assertTrue(torch.equal(X_one_hot, expected))
+            
             # two categoricals, one at start, one at end
             dim = 4
             categorical_features = {0: 3, 3: 2}
@@ -1348,6 +1350,7 @@ class TestInputTransforms(BotorchTestCase):
             )
             X_one_hot = tf(X_numeric)
             self.assertTrue(torch.equal(X_one_hot, expected))
+            
             # only categoricals
             dim = 2
             categorical_features = {0: 3, 1: 2}
@@ -1379,6 +1382,7 @@ class TestInputTransforms(BotorchTestCase):
             )
             X_one_hot = tf(X_numeric)
             self.assertTrue(torch.equal(X_one_hot, expected))
+        
         # test no transform on eval
         tf = NumericToCategoricalEncoding(
             dim=dim,
@@ -1420,6 +1424,7 @@ class TestInputTransforms(BotorchTestCase):
             transform_on_train=False,
         )
         self.assertTrue(tf.equals(tf2))
+        
         # test different transform_on_train
         tf3 = NumericToCategoricalEncoding(
             dim=dim,
@@ -1431,6 +1436,7 @@ class TestInputTransforms(BotorchTestCase):
             transform_on_train=True,
         )
         self.assertFalse(tf3.equals(tf2))
+        
         # test categorical features
         tf4 = NumericToCategoricalEncoding(
             dim=dim,

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -1238,7 +1238,7 @@ class TestInputTransforms(BotorchTestCase):
                 },
             )
 
-        torch.manual_seed(randint(0, 1000))
+        torch.manual_seed(42)
         for dtype in (torch.float, torch.double):
             # one categorical at start
             dim = 3
@@ -1249,12 +1249,12 @@ class TestInputTransforms(BotorchTestCase):
                 encoders={0: partial(one_hot, num_classes=3)},
             )
             tf.eval()
-            cat_numeric = torch.randint(0, 3, (3,), device=self.device)
+            cat_numeric = torch.randint(0, 3, (3,), device=self.device, dtype=dtype)
             cat_one_hot = one_hot(cat_numeric, num_classes=3)
             cont = torch.rand(3, 2, dtype=dtype, device=self.device)
 
             X_numeric = torch.cat(
-                [cat_numeric.view(-1, 1).to(dtype=dtype, device=self.device), cont],
+                [cat_numeric.view(-1, 1), cont],
                 dim=-1,
             )
 
@@ -1276,17 +1276,17 @@ class TestInputTransforms(BotorchTestCase):
                 },
             )
             tf.eval()
-            cat_numeric1 = torch.randint(0, 3, (3,), device=self.device)
+            cat_numeric1 = torch.randint(0, 3, (3,), device=self.device, dtype=dtype)
             cat_one_hot1 = one_hot(cat_numeric1, num_classes=3)
-            cat_numeric2 = torch.randint(0, 2, (3,), device=self.device)
+            cat_numeric2 = torch.randint(0, 2, (3,), device=self.device, dtype=dtype)
             cat_one_hot2 = one_hot(cat_numeric2, num_classes=2)
             cont = torch.rand(3, 2, dtype=dtype, device=self.device)
 
             X_numeric = torch.cat(
                 [
                     cont,
-                    cat_numeric1.view(-1, 1).to(dtype=dtype, device=self.device),
-                    cat_numeric2.view(-1, 1).to(dtype=dtype, device=self.device),
+                    cat_numeric1.view(-1, 1),
+                    cat_numeric2.view(-1, 1),
                 ],
                 dim=-1,
             )

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -1237,6 +1237,24 @@ class TestInputTransforms(BotorchTestCase):
                     2: partial(one_hot, num_classes=3),
                 },
             )
+        with self.assertRaises(
+            ValueError,
+            msg="The number of categorical features must be at least 1.",
+        ):
+            NumericToCategoricalEncoding(
+                dim=2,
+                categorical_features={},
+                encoders={},
+            )
+        with self.assertRaises(
+            ValueError,
+            msg="Categorical feature at index 1",
+        ):
+            NumericToCategoricalEncoding(
+                dim=2,
+                categorical_features={1: 1},
+                encoders={1: partial(one_hot, num_classes=1)},
+            )
 
         torch.manual_seed(42)
         for dtype in (torch.float, torch.double):
@@ -1249,14 +1267,14 @@ class TestInputTransforms(BotorchTestCase):
                 encoders={0: partial(one_hot, num_classes=3)},
             )
             tf.eval()
-            cat_numeric = torch.randint(0, 3, (3,), device=self.device, dtype=dtype)
+            cat_numeric = torch.randint(0, 3, (3,), device=self.device)
             cat_one_hot = one_hot(cat_numeric, num_classes=3)
             cont = torch.rand(3, 2, dtype=dtype, device=self.device)
 
             X_numeric = torch.cat(
                 [cat_numeric.view(-1, 1), cont],
                 dim=-1,
-            )
+            ).to(dtype=dtype)
 
             expected = torch.cat(
                 [cat_one_hot, cont],
@@ -1276,9 +1294,9 @@ class TestInputTransforms(BotorchTestCase):
                 },
             )
             tf.eval()
-            cat_numeric1 = torch.randint(0, 3, (3,), device=self.device, dtype=dtype)
+            cat_numeric1 = torch.randint(0, 3, (3,), device=self.device)
             cat_one_hot1 = one_hot(cat_numeric1, num_classes=3)
-            cat_numeric2 = torch.randint(0, 2, (3,), device=self.device, dtype=dtype)
+            cat_numeric2 = torch.randint(0, 2, (3,), device=self.device)
             cat_one_hot2 = one_hot(cat_numeric2, num_classes=2)
             cont = torch.rand(3, 2, dtype=dtype, device=self.device)
 
@@ -1289,7 +1307,7 @@ class TestInputTransforms(BotorchTestCase):
                     cat_numeric2.view(-1, 1),
                 ],
                 dim=-1,
-            )
+            ).to(dtype=dtype)
 
             expected = torch.cat(
                 [cont, cat_one_hot1, cat_one_hot2],

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -1379,6 +1379,68 @@ class TestInputTransforms(BotorchTestCase):
             )
             X_one_hot = tf(X_numeric)
             self.assertTrue(torch.equal(X_one_hot, expected))
+        # test no transform on eval
+        tf = NumericToCategoricalEncoding(
+            dim=dim,
+            categorical_features=categorical_features,
+            encoders={
+                0: partial(one_hot, num_classes=3),
+                1: partial(one_hot, num_classes=2),
+            },
+            transform_on_eval=False,
+        )
+        tf.eval()
+        X_tf = tf(X_numeric)
+        self.assertTrue(torch.equal(X_numeric, X_tf))
+
+        # test no transform on train
+        tf = NumericToCategoricalEncoding(
+            dim=dim,
+            categorical_features=categorical_features,
+            encoders={
+                0: partial(one_hot, num_classes=3),
+                1: partial(one_hot, num_classes=2),
+            },
+            transform_on_train=False,
+        )
+        X_tf = tf(X_numeric)
+        self.assertTrue(torch.equal(X_numeric, X_tf))
+        tf.eval()
+        X_tf = tf(X_numeric)
+        self.assertFalse(torch.equal(X_numeric, X_tf))
+
+        # test equals
+        tf2 = NumericToCategoricalEncoding(
+            dim=dim,
+            categorical_features=categorical_features,
+            encoders={
+                0: partial(one_hot, num_classes=3),
+                1: partial(one_hot, num_classes=2),
+            },
+            transform_on_train=False,
+        )
+        self.assertTrue(tf.equals(tf2))
+        # test different transform_on_train
+        tf3 = NumericToCategoricalEncoding(
+            dim=dim,
+            categorical_features=categorical_features,
+            encoders={
+                0: partial(one_hot, num_classes=3),
+                1: partial(one_hot, num_classes=2),
+            },
+            transform_on_train=True,
+        )
+        self.assertFalse(tf3.equals(tf2))
+        # test categorical features
+        tf4 = NumericToCategoricalEncoding(
+            dim=dim,
+            categorical_features={0: 3},
+            encoders={
+                0: partial(one_hot, num_classes=3),
+            },
+            transform_on_train=True,
+        )
+        self.assertFalse(tf4.equals(tf3))
 
     def test_one_hot_to_numeric(self) -> None:
         dim = 8


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR refers to https://github.com/pytorch/botorch/issues/2879. It adds a new input transform that transforms a categorical degree of freedom encoded a an integer into some kind of vector based description. This could be for example a one-hot encoding, but also a descriptor encoding as it is often used in chemistry. It adds the possibility to use the alternating acqf optimizer also with surrogates that do not treat categoricals as integer based values. For example one could then also use a SAAS GP with the mixed alternating acqf optimizer and treat the categoricals under the hood as one-hots.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests, most of them are implemented (also to demonstrate the functionality), the ones which check the equality between transforms and correct behavior of transform on train etc. are still missing. My plan is to add them after a first feedback after a first review.


