### PR TITLE
Refactor of MultiTask / FullyBayesianMultiTaskGP to use ProcuctKernel & IndexKernel

### DIFF
--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -14,6 +14,7 @@ import torch
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.fully_bayesian import (
     matern52_kernel,
+    MCMC_DIM,
     MIN_INFERRED_NOISE_LEVEL,
     reshape_and_detach,
     SaasPyroModel,
@@ -22,7 +23,7 @@ from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
 from botorch.models.multitask import MultiTaskGP
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
-from botorch.posteriors.fully_bayesian import GaussianMixturePosterior, MCMC_DIM
+from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
 from gpytorch.distributions import MultivariateNormal
 from gpytorch.kernels import MaternKernel
 from gpytorch.kernels.index_kernel import IndexKernel
@@ -66,6 +67,10 @@ class MultitaskSaasPyroModel(SaasPyroModel):
             task_rank: The num of learned task embeddings to be used in the task kernel.
                 If omitted, use a full rank (i.e. number of tasks) kernel.
         """
+        # NOTE PyTorch does not support negative indexing for tensors in index_select,
+        # (https://github.com/pytorch/pytorch/issues/76347), so we have to make sure
+        # that the task feature is positive.
+        task_feature = task_feature % train_X.shape[-1]
         super().set_inputs(train_X, train_Y, train_Yvar)
         # obtain a list of task indicies
         all_tasks = train_X[:, task_feature].unique().to(dtype=torch.long).tolist()
@@ -140,15 +145,19 @@ class MultitaskSaasPyroModel(SaasPyroModel):
         num_mcmc_samples = len(mcmc_samples["mean"])
         batch_shape = torch.Size([num_mcmc_samples])
 
-        mean_module, covar_module, likelihood, _ = super().load_mcmc_samples(
+        mean_module, data_covar_module, likelihood, _ = super().load_mcmc_samples(
             mcmc_samples=mcmc_samples
         )
+        data_indices = torch.arange(self.train_X.shape[-1] - 1)
+        data_indices[self.task_feature :] += 1  # exclude task feature
 
+        data_covar_module.active_dims = data_indices.to(device=tkwargs["device"])
         latent_covar_module = MaternKernel(
             nu=2.5,
             ard_num_dims=self.task_rank,
             batch_shape=batch_shape,
         ).to(**tkwargs)
+
         latent_covar_module.lengthscale = reshape_and_detach(
             target=latent_covar_module.lengthscale,
             new_value=mcmc_samples["task_lengthscale"],
@@ -159,22 +168,27 @@ class MultitaskSaasPyroModel(SaasPyroModel):
             num_tasks=self.num_tasks,
             rank=self.task_rank,
             batch_shape=latent_features.shape[:-2],
-        ).to(**tkwargs)
+            active_dims=torch.tensor([self.task_feature], device=tkwargs["device"]),
+        )
         task_covar_module.covar_factor = Parameter(
             task_covar.cholesky().to_dense().detach()
         )
+        task_covar_module = task_covar_module.to(**tkwargs)
+        # NOTE: The IndexKernel has a learnable 'var' parameter in addition to the
+        # task covariances, corresponding do task-specific variances along the diagonal
+        # of the task covariance matrix. As this parameter is not sampled in `sample()`
+        # we implicitly assume it to be zero. This is consistent with the previous
+        # SAASFBMTGP implementation, but means that the non-fully Bayesian and fully
+        # Bayesian models run on slightly different task covar modules.
 
-        # NOTE: 'var' is implicitly assumed to be zero from the sampling procedure in
-        # the FBMTGP model but not in the regular MTGP. I dont how if the var parameter
-        # affects predictions in practice, but setting it to zero is consistent with the
-        # previous implementation.
+        # We set the aforementioned task covar module var parameter to zero here.
         task_covar_module.var = torch.zeros_like(task_covar_module.var)
-        return mean_module, covar_module, likelihood, task_covar_module
+        covar_module = data_covar_module * task_covar_module
+        return mean_module, covar_module, likelihood, None
 
 
 class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
     r"""A fully Bayesian multi-task GP model with the SAAS prior.
-
     This model assumes that the inputs have been normalized to [0, 1]^d and that the
     output has been stratified standardized to have zero mean and unit variance for
     each task. The SAAS model [Eriksson2021saasbo]_ with a Matern-5/2 is used as data
@@ -286,8 +300,6 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
         self.mean_module = None
         self.covar_module = None
         self.likelihood = None
-        self.task_covar_module = None
-        self.register_buffer("latent_features", None)
         if pyro_model is None:
             pyro_model = MultitaskSaasPyroModel()
         pyro_model.set_inputs(
@@ -321,21 +333,20 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
             self.mean_module = None
             self.covar_module = None
             self.likelihood = None
-            self.task_covar_module = None
         return self
 
     @property
     def median_lengthscale(self) -> Tensor:
         r"""Median lengthscales across the MCMC samples."""
         self._check_if_fitted()
-        lengthscale = self.covar_module.base_kernel.lengthscale.clone()
+        lengthscale = self.covar_module.kernels[0].base_kernel.lengthscale.clone()
         return lengthscale.median(0).values.squeeze(0)
 
     @property
     def num_mcmc_samples(self) -> int:
         r"""Number of MCMC samples in the model."""
         self._check_if_fitted()
-        return len(self.covar_module.outputscale)
+        return self.covar_module.kernels[0].batch_shape[0]
 
     @property
     def batch_shape(self) -> torch.Size:
@@ -367,7 +378,7 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
             self.mean_module,
             self.covar_module,
             self.likelihood,
-            self.task_covar_module,
+            _,
         ) = self.pyro_model.load_mcmc_samples(mcmc_samples=mcmc_samples)
 
     def posterior(
@@ -438,7 +449,7 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
             self.mean_module,
             self.covar_module,
             self.likelihood,
-            self.task_covar_module,
+            _,  # Possibly space for input transform
         ) = self.pyro_model.load_mcmc_samples(mcmc_samples=mcmc_samples)
         # Load the actual samples from the state dict
         super().load_state_dict(state_dict=state_dict, strict=strict)

--- a/test/models/test_contextual_multioutput.py
+++ b/test/models/test_contextual_multioutput.py
@@ -13,6 +13,7 @@ from botorch.posteriors import GPyTorchPosterior
 from botorch.utils.test_helpers import gen_multi_task_dataset
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
+from gpytorch.kernels import MaternKernel
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from linear_operator.operators import LinearOperator
 from linear_operator.operators.interpolated_linear_operator import (
@@ -101,6 +102,16 @@ class ContextualMultiOutputTest(BotorchTestCase):
                 right_interp_indices=task_idcs,
             ).to_dense()
             self.assertAllClose(previous_covar, model.task_covar_module(task_idcs))
+            custom_covar_module = MaternKernel()
+            model_custom_covar = LCEMGP(
+                train_X=train_x,
+                train_Y=train_y,
+                task_feature=task_feature,
+                embs_dim_list=[2],  # increase dim from 1 to 2
+                context_emb_feature=torch.tensor([[0.2], [0.3]]),
+                covar_module=custom_covar_module,
+            )
+            self.assertIsInstance(model_custom_covar.covar_module, MaternKernel)
 
     def test_construct_inputs(self) -> None:
         for with_embedding_inputs, yvar, skip_task_features_in_datasets in zip(

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -57,16 +57,18 @@ from gpytorch.means import ConstantMean
 
 EXPECTED_KEYS = [
     "mean_module.raw_constant",
-    "covar_module.raw_outputscale",
-    "covar_module.base_kernel.raw_lengthscale",
-    "covar_module.base_kernel.raw_lengthscale_constraint.lower_bound",
-    "covar_module.base_kernel.raw_lengthscale_constraint.upper_bound",
-    "covar_module.raw_outputscale_constraint.lower_bound",
-    "covar_module.raw_outputscale_constraint.upper_bound",
-    "task_covar_module.covar_factor",
-    "task_covar_module.raw_var",
-    "task_covar_module.raw_var_constraint.lower_bound",
-    "task_covar_module.raw_var_constraint.upper_bound",
+    "covar_module.kernels.1.raw_var",
+    "covar_module.kernels.1.active_dims",
+    "covar_module.kernels.0.base_kernel.raw_lengthscale",
+    "covar_module.kernels.0.base_kernel.raw_lengthscale_constraint.lower_bound",
+    "covar_module.kernels.0.active_dims",
+    "covar_module.kernels.1.raw_var_constraint.upper_bound",
+    "covar_module.kernels.0.base_kernel.raw_lengthscale_constraint.upper_bound",
+    "covar_module.kernels.0.raw_outputscale_constraint.lower_bound",
+    "covar_module.kernels.1.covar_factor",
+    "covar_module.kernels.0.raw_outputscale_constraint.upper_bound",
+    "covar_module.kernels.1.raw_var_constraint.lower_bound",
+    "covar_module.kernels.0.raw_outputscale",
 ]
 EXPECTED_KEYS_NOISE = EXPECTED_KEYS + [
     "likelihood.noise_covar.raw_noise",
@@ -274,14 +276,15 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
         fit_fully_bayesian_model_nuts(
             model, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
         )
+        data_covar_module, task_covar_module = model.covar_module.kernels
         self.assertEqual(model.batch_shape, torch.Size([3]))
         self.assertIsInstance(model.mean_module, ConstantMean)
         self.assertEqual(model.mean_module.raw_constant.shape, model.batch_shape)
-        self.assertIsInstance(model.covar_module, ScaleKernel)
-        self.assertEqual(model.covar_module.outputscale.shape, model.batch_shape)
-        self.assertIsInstance(model.covar_module.base_kernel, MaternKernel)
+        self.assertIsInstance(data_covar_module, ScaleKernel)
+        self.assertEqual(data_covar_module.outputscale.shape, model.batch_shape)
+        self.assertIsInstance(data_covar_module.base_kernel, MaternKernel)
         self.assertEqual(
-            model.covar_module.base_kernel.lengthscale.shape, torch.Size([3, 1, d])
+            data_covar_module.base_kernel.lengthscale.shape, torch.Size([3, 1, d])
         )
         if infer_noise:
             self.assertIsInstance(model.likelihood, GaussianLikelihood)
@@ -290,7 +293,7 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
             )
         else:
             self.assertIsInstance(model.likelihood, FixedNoiseGaussianLikelihood)
-        self.assertIsInstance(model.task_covar_module, IndexKernel)
+        self.assertIsInstance(task_covar_module, IndexKernel)
         # Predict on some test points
         for batch_shape in [[5], [5, 2], [5, 2, 6]]:
             test_X = torch.rand(*batch_shape, d, **tkwargs)
@@ -465,7 +468,6 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
         self.assertIsNone(model.mean_module)
         self.assertIsNone(model.covar_module)
         self.assertIsNone(model.likelihood)
-        self.assertIsNone(model.task_covar_module)
 
     def test_fit_model_float(self):
         self.test_fit_model(dtype=torch.float)
@@ -743,16 +745,16 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                 **tkwargs,
             )
             model.load_mcmc_samples(mcmc_samples)
-
+            data_covar_module, task_covar_module = model.covar_module.kernels
             self.assertTrue(
                 torch.allclose(
-                    model.covar_module.base_kernel.lengthscale,
+                    data_covar_module.base_kernel.lengthscale,
                     mcmc_samples["lengthscale"],
                 )
             )
             self.assertTrue(
                 torch.allclose(
-                    model.covar_module.outputscale,
+                    data_covar_module.outputscale,
                     mcmc_samples["outputscale"],
                 )
             )
@@ -765,7 +767,7 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
 
             self.assertTrue(
                 torch.allclose(
-                    model.task_covar_module.covar_matrix.to_dense(),
+                    task_covar_module.covar_matrix.to_dense(),
                     matern52_kernel(
                         mcmc_samples["latent_features"],
                         mcmc_samples["task_lengthscale"],
@@ -821,3 +823,18 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
             self.assertEqual(data_dict["task_feature"], task_feature)
             self.assertEqual(data_dict["rank"], 1)
             self.assertTrue("task_covar_prior" not in data_dict)
+
+            task_feature = -1
+            datasets, (train_X, train_Y, train_Yvar) = gen_multi_task_dataset(
+                yvar=None if infer_noise else 0.05, **tkwargs
+            )
+
+            d = train_X.shape[1] - 1
+            model = SaasFullyBayesianMultiTaskGP(
+                train_X=train_X,
+                train_Y=train_Y,
+                train_Yvar=train_Yvar,
+                task_feature=task_feature,
+            )
+            self.assertEqual(model._task_feature, d)
+            self.assertEqual(model.pyro_model.task_feature, d)


### PR DESCRIPTION
Summary:
Modifed MultiTask and FullyBayesianMultiTask to use IndexKernel instead of two different covar modules. For large matrices, this constitutes a significant speed-up (2-3x anecdotally) and a seemingly even larger memory decrease.

In addition, this makes MultiTaskFBGP and SingleTaskFBGPs share a lot of code. I'll enable more code sharing between them in a subsequent diff.

With some additional functionality in IndexKernel (i.e. structured learning of the covar_matrix elements), this change would apply to other MTGPs as well.

NOTE: Providing negative indices to an IndexKernel is not supported: https://github.com/pytorch/pytorch/issues/76347

Differential Revision: D76317553


