### PR TITLE
Changes to enable benchmarking with PFNs within Ax

### DIFF
--- a/botorch_community/acquisition/input_constructors.py
+++ b/botorch_community/acquisition/input_constructors.py
@@ -13,20 +13,69 @@ Contributor: hvarfner (bayesian_active_learning, scorebo)
 
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+from typing import Any, Hashable, List, Optional, Tuple
 
 import torch
-from botorch.acquisition.input_constructors import acqf_input_constructor
-from botorch.acquisition.objective import ScalarizedPosteriorTransform
+
+from botorch.acquisition.input_constructors import (
+    acqf_input_constructor,
+    get_best_f_analytic,
+)
+from botorch.acquisition.objective import (
+    PosteriorTransform,
+    ScalarizedPosteriorTransform,
+)
 from botorch.acquisition.utils import get_optimal_samples
 from botorch.models.model import Model
+
+from botorch.utils.datasets import SupervisedDataset
 from botorch_community.acquisition.bayesian_active_learning import (
     qBayesianQueryByComittee,
     qBayesianVarianceReduction,
     qStatisticalDistanceActiveLearning,
 )
+
+from botorch_community.acquisition.discretized import (
+    DiscretizedExpectedImprovement,
+    DiscretizedProbabilityOfImprovement,
+)
 from botorch_community.acquisition.scorebo import qSelfCorrectingBayesianOptimization
 from torch import Tensor
+
+
+@acqf_input_constructor(
+    DiscretizedExpectedImprovement, DiscretizedProbabilityOfImprovement
+)
+def construct_inputs_best_f(
+    model: Model,
+    training_data: SupervisedDataset | dict[Hashable, SupervisedDataset],
+    posterior_transform: PosteriorTransform | None = None,
+    best_f: float | Tensor | None = None,
+) -> dict[str, Any]:
+    r"""Construct kwargs for the acquisition functions requiring `best_f`.
+
+    Args:
+        model: The model to be used in the acquisition function.
+        training_data: Dataset(s) used to train the model.
+            Used to determine default value for `best_f`.
+        best_f: Threshold above (or below) which improvement is defined.
+        posterior_transform: The posterior transform to be used in the
+            acquisition function.
+
+    Returns:
+        A dict mapping kwarg names of the constructor to values.
+    """
+    if best_f is None:
+        best_f = get_best_f_analytic(
+            training_data=training_data,
+            posterior_transform=posterior_transform,
+        )
+
+    return {
+        "model": model,
+        "posterior_transform": posterior_transform,
+        "best_f": best_f,
+    }
 
 
 @acqf_input_constructor(

--- a/botorch_community/models/prior_fitted_network.py
+++ b/botorch_community/models/prior_fitted_network.py
@@ -31,21 +31,61 @@ class PFNModel(Model):
         train_X: Tensor,
         train_Y: Tensor,
         model: nn.Module,
+        train_Yvar: Tensor | None = None,
+        batch_first: bool = False,
+        constant_model_kwargs: dict | None = None,
     ) -> None:
         """Initialize a PFNModel.
 
         Args:
-            train_X: A `batch_shape x n x d` tensor of training features.
-            train_Y: A `batch_shape x n x m` tensor of training observations.
+            train_X: A `n x d` tensor of training features.
+            train_Y: A `n x m` tensor of training observations.
             model: A pre-trained PFN model with the following
                 forward(train_X, train_Y, X) -> logit predictions of shape
                 `n x b x c` where c is the number of discrete buckets
                 borders: A `c+1`-dim tensor of bucket borders
+            train_Yvar: Not yet supported.
+            batch_first: Whether the batch dimension is the first dimension of
+                the input tensors. This is needed to support different PFN
+                models. For batch-first x has shape `batch x seq_len x features`
+                and for non-batch-first it has shape `seq_len x batch x features`.
+            constant_model_kwargs: A dictionary of model kwargs that
+                will be passed to the model in each forward pass.
         """
         super().__init__()
-        self.train_X = train_X
-        self.train_Y = train_Y
-        self.pfn = model.to(train_X)
+
+        if train_Yvar is not None:
+            raise UnsupportedError("train_Yvar is not supported for PFNModel.")
+
+        if not (1 <= train_Y.dim() <= 3):
+            raise UnsupportedError("train_Y must be 1- to 3-dimensional.")
+
+        if not (2 <= train_X.dim() <= 3):
+            raise UnsupportedError("train_X must be 2- to 3-dimensional.")
+
+        if train_Y.dim() == train_X.dim():
+            if train_Y.shape[-1] > 1:
+                raise UnsupportedError("Only 1 target allowed for PFNModel.")
+            train_Y = train_Y.squeeze(-1)
+
+        if (len(train_X.shape) != len(train_Y.shape) + 1) or (
+            train_Y.shape != train_X.shape[:-1]
+        ):
+            raise UnsupportedError(
+                "train_X and train_Y must have the same shape except "
+                "for the last dimension."
+            )
+
+        if len(train_X.shape) == 2:
+            # adding batch dimension
+            train_X = train_X.unsqueeze(0)
+            train_Y = train_Y.unsqueeze(0)
+
+        self.train_X = train_X  # shape: `b x n x d`
+        self.train_Y = train_Y  # shape: `b x n`
+        self.pfn = model
+        self.batch_first = batch_first
+        self.constant_model_kwargs = constant_model_kwargs
 
     def posterior(
         self,
@@ -61,7 +101,7 @@ class PFNModel(Model):
             any `model.forward` or `model.likelihood` calls.
 
         Args:
-            X: A `b x q x d`-dim Tensor, where `d` is the dimension of the
+            X: A `b'? x b? x q x d`-dim Tensor, where `d` is the dimension of the
                 feature space, `q` is the number of points considered jointly,
                 and `b` is the batch dimension.
                 We only allow `q=1` for PFNModel, so q can also be omitted, i.e.
@@ -86,11 +126,59 @@ class PFNModel(Model):
         if posterior_transform is not None:
             raise UnsupportedError("posterior_transform is not supported for PFNModel.")
 
-        if len(X.shape) > 2 and X.shape[-2] > 1:
-            raise NotImplementedError("q must be 1 for PFNModel.")  # add support later
+        if not (1 <= len(X.shape) <= 4):
+            raise UnsupportedError("X must be 1- to 4-dimensional.")
 
-        # flatten batch dimensions for PFN input
-        logits = self.pfn(self.train_X, self.train_Y, X)
+        # X has shape b'? x b? x q? x d
+
+        orig_X_shape = X.shape
+        q_in_orig_X_shape = len(X.shape) > 2
+
+        if len(X.shape) == 1:
+            X = X.unsqueeze(0).unsqueeze(0).unsqueeze(0)  # shape `b'=1 x b=1 x q=1 x d`
+        elif len(X.shape) == 2:
+            X = X.unsqueeze(1).unsqueeze(1)  # shape `b' x b=1 x q=1 x d`
+        elif len(X.shape) == 3:
+            if self.train_X.shape[0] == 1:
+                X = X.unsqueeze(1)  # shape `b' x b=1 x q x d`
+            else:
+                X = X.unsqueeze(0)  # shape `b'=1 x b x q x d`
+
+        # X has shape `b' x b x q x d`
+
+        if X.shape[2] != 1:
+            raise UnsupportedError("Only q=1 is supported for PFNModel.")
+
+        # X has shape `b' x b x q=1 x d`
+
+        train_X = self.train_X  # shape `b x n x d`
+        train_Y = self.train_Y  # shape `b x n`
+        folded_X = X.transpose(0, 2).squeeze(0)  # shape `b x b' x d
+
+        constant_model_kwargs = self.constant_model_kwargs or {}
+
+        if self.batch_first:
+            logits = self.pfn(
+                train_X.float(),
+                train_X.float(),
+                folded_X.float(),
+                **constant_model_kwargs,
+            ).transpose(0, 1)
+        else:
+            logits = self.pfn(
+                train_X.float().transpose(0, 1),
+                train_Y.float().transpose(0, 1),
+                folded_X.float().transpose(0, 1),
+                **constant_model_kwargs,
+            )
+
+        # logits shape `b' x b x logits_dim`
+
+        logits = logits.view(
+            *orig_X_shape[:-1], -1
+        )  # orig shape w/o q but logits_dim at end: `b'? x b? x q? x logits_dim`
+        if q_in_orig_X_shape:
+            logits = logits.squeeze(-2)  # shape `b'? x b? x logits_dim`
 
         probabilities = logits.softmax(dim=-1)
 

--- a/botorch_community/posteriors/riemann.py
+++ b/botorch_community/posteriors/riemann.py
@@ -33,8 +33,8 @@ class BoundedRiemannPosterior(Posterior):
         Args:
             borders: A tensor of shape `(n_buckets + 1,)` defining the boundaries of
                 the buckets. Must be monotonically increasing.
-            probabilities: A tensor of shape `(n_buckets,)` defining the probability
-                mass in each bucket. Must sum to 1.
+            probabilities: A tensor of shape `(..., n_buckets,)` defining the
+                probability mass in each bucket. Must sum to 1 in the last dim.
         """
 
         assert torch.allclose(
@@ -61,7 +61,7 @@ class BoundedRiemannPosterior(Posterior):
         all_lower = self.borders[:-1]
         all_upper = self.borders[1:]
         bucket_results = ag_integrate_fn(all_lower, all_upper)
-        return (bucket_results * (self.probabilities)).sum(-1)
+        return (bucket_results * (self.probabilities / (all_upper - all_lower))).sum(-1)
 
     def rsample(
         self,
@@ -108,6 +108,23 @@ class BoundedRiemannPosterior(Posterior):
         bucket_widths = self.borders[1:] - self.borders[:-1]
         bucket_means = self.borders[:-1] + bucket_widths / 2
         return (bucket_means * (self.probabilities)).sum(-1, keepdim=True)
+
+    @property
+    def mean_of_square(self) -> torch.Tensor:
+        """Computes E[x^2]."""
+        left_borders = self.borders[:-1]
+        right_borders = self.borders[1:]
+        bucket_mean_of_square = (
+            left_borders.square()
+            + right_borders.square()
+            + left_borders * right_borders
+        ) / 3.0
+        return self.probabilities @ bucket_mean_of_square
+
+    @property
+    def variance(self) -> torch.Tensor:
+        """Computes the variance via Var[x] = E[x^2] - E[x]^2."""
+        return self.mean_of_square - self.mean.square()
 
     def confidence_region(
         self, confidence_level: float = 0.95

--- a/test_community/acquisition/test_discretized.py
+++ b/test_community/acquisition/test_discretized.py
@@ -7,7 +7,12 @@
 from typing import Optional, Union
 
 import torch
-from botorch.acquisition.objective import PosteriorTransform
+from botorch.acquisition.objective import (
+    ExpectationPosteriorTransform,
+    PosteriorTransform,
+    ScalarizedPosteriorTransform,
+)
+from botorch.exceptions.errors import UnsupportedError
 from botorch.utils.testing import BotorchTestCase
 from botorch_community.acquisition.discretized import (
     DiscretizedExpectedImprovement,
@@ -58,13 +63,13 @@ class TestDiscretizedExpectedImprovement(BotorchTestCase):
             lower_bound = torch.tensor(1.0)
             upper_bound = torch.tensor(3.0)
             improvement = acqf.ag_integrate(lower_bound, upper_bound)
-            self.assertEqual(improvement, 0.5)
+            self.assertEqual(improvement, (2.0 + 3.0) / 2 - 2.0)
 
             # upper <= best_f
             lower_bound = torch.tensor(3.0)
             upper_bound = torch.tensor(5.0)
             improvement = acqf.ag_integrate(lower_bound, upper_bound)
-            self.assertEqual(improvement, 2.0)
+            self.assertEqual(improvement, ((5.0 + 3.0) / 2 - 2.0) * 2.0)
 
     def test_ag_integrate_batch(self):
         for dtype in (torch.float, torch.double):
@@ -77,10 +82,10 @@ class TestDiscretizedExpectedImprovement(BotorchTestCase):
             upper_bound = torch.tensor([[1.5], [6.0]], **tkwargs)
             improvement = acqf.ag_integrate(lower_bound, upper_bound)
             self.assertEqual(improvement[0], 0.0)
-            self.assertEqual(improvement[1], 1.5)
+            self.assertEqual(improvement[1], 3.0**2 / 2)
 
     def test_forward(self):
-        for dtype in (torch.float, torch.double):
+        for dtype in (torch.double, torch.float):
             tkwargs = {"device": self.device, "dtype": dtype}
 
             borders = torch.tensor([0.0, 1.0, 3.0, 6.0], **tkwargs)
@@ -92,9 +97,73 @@ class TestDiscretizedExpectedImprovement(BotorchTestCase):
             X = torch.tensor([[1.0]])
             acqf_values = acqf(X)
 
-            # EI is 0 for bucket 1, 0.5 for bucket 2, and 2.5 for bucket 3
-            # so the expected value is 0.2 * 0 + 0.3 * 0.5 + 0.5 * 2.5 = 1.4
-            self.assertAlmostEqual(acqf_values.item(), 1.4)
+            # EI is 0 for bucket 1, (1.0**2)/2 = 0.5 for bucket 2,
+            # and 2.5*3. = 7.5 for bucket 3
+            # so the expected value is
+            # 0.2 / 1. * 0 + 0.3 / 2. * 0.5 + 0.5 / 3. * 7.5 = 1.325
+            self.assertAlmostEqual(acqf_values.item(), 1.325)
+
+    def test_forward_approximating_normal(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        borders = torch.linspace(-8, 8, 10_000, **tkwargs)
+
+        mean = 1.1
+        std = 1.3
+        target_dist = torch.distributions.Normal(mean, std)
+        probs = target_dist.cdf(borders[1:]) - target_dist.cdf(borders[:-1])
+
+        mock_model = MockDiscretizedModel(borders, probs)
+        # Test that the discretized EI approximates the analytical EI
+        # for a normal distribution
+        best_f = 0.5
+        acqf = DiscretizedExpectedImprovement(mock_model, best_f=best_f)
+        X = torch.tensor([[1.0]])  # value will not be used since posterior is mocked
+        acqf_values = acqf(X)
+
+        # Calculate analytical EI for normal distribution
+        improvement = mean - best_f
+        z = torch.tensor(improvement / std)
+        normal_dist = torch.distributions.Normal(0, 1)
+        analytical_ei = (
+            improvement * normal_dist.cdf(z) + std * normal_dist.log_prob(z).exp()
+        )
+
+        # Check that the discretized EI is close to the analytical EI
+        self.assertLess(torch.abs(acqf_values - analytical_ei) / analytical_ei, 0.01)
+
+        # minimization task
+        acqf = DiscretizedExpectedImprovement(
+            mock_model,
+            best_f=-best_f,
+            posterior_transform=ScalarizedPosteriorTransform(
+                weights=torch.tensor([-1.0])
+            ),
+        )
+        acqf_values = acqf(X)
+
+        # Calculate analytical EI for normal distribution
+        improvement = -mean + best_f
+        z = torch.tensor(improvement / std)
+        normal_dist = torch.distributions.Normal(0, 1)
+        analytical_ei = (
+            improvement * normal_dist.cdf(z) + std * normal_dist.log_prob(z).exp()
+        )
+
+        # Check that the discretized EI is close to the analytical EI
+        self.assertLess(torch.abs(acqf_values - analytical_ei) / analytical_ei, 0.01)
+
+    def test_unsupported_posterior_transform(self):
+        """Test that UnsupportedError is raised for non-ScalarizedPosteriorTransform."""
+        mock_model = MockDiscretizedModel(
+            torch.tensor([0.0, 1.0, 2.0]), torch.tensor([0.5, 0.5])
+        )
+
+        # Test with ExpectationPosteriorTransform
+        expectation_transform = ExpectationPosteriorTransform(n_w=2)
+        with self.assertRaises(UnsupportedError):
+            DiscretizedExpectedImprovement(
+                mock_model, best_f=1.0, posterior_transform=expectation_transform
+            )
 
 
 class TestDiscretizedProbabilityofImprovement(BotorchTestCase):
@@ -113,13 +182,13 @@ class TestDiscretizedProbabilityofImprovement(BotorchTestCase):
             lower_bound = torch.tensor(1.0)
             upper_bound = torch.tensor(3.0)
             improvement = acqf.ag_integrate(lower_bound, upper_bound)
-            self.assertEqual(improvement, 0.5)
+            self.assertEqual(improvement, 1.0)
 
             # upper <= best_f
             lower_bound = torch.tensor(3.0)
             upper_bound = torch.tensor(5.0)
             improvement = acqf.ag_integrate(lower_bound, upper_bound)
-            self.assertEqual(improvement, 1.0)
+            self.assertEqual(improvement, 2.0)
 
     def test_ag_integrate_batch(self):
         for dtype in (torch.float, torch.double):
@@ -132,7 +201,7 @@ class TestDiscretizedProbabilityofImprovement(BotorchTestCase):
             upper_bound = torch.tensor([[1.5], [6.0]], **tkwargs)
             improvement = acqf.ag_integrate(lower_bound, upper_bound)
             self.assertEqual(improvement[0], 0.0)
-            self.assertEqual(improvement[1], 0.75)
+            self.assertEqual(improvement[1], 3.0)
 
     def test_forward(self):
         borders = torch.tensor([0.0, 1.0, 3.0, 6.0])
@@ -146,3 +215,46 @@ class TestDiscretizedProbabilityofImprovement(BotorchTestCase):
         # PI is 0 for bucket 1, 0.5 for bucket 2, and 1 for bucket 3
         # so the final probability is 0.2 * 0 + 0.3 * 0.5 + 0.5 * 1 = 1.4
         self.assertAlmostEqual(acqf_values.item(), 0.65)
+
+    def test_forward_approximating_normal(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        borders = torch.linspace(-8, 8, 10_000, **tkwargs)
+
+        mean = 1.1
+        std = 1.3
+        target_dist = torch.distributions.Normal(mean, std)
+        probs = target_dist.cdf(borders[1:]) - target_dist.cdf(borders[:-1])
+
+        mock_model = MockDiscretizedModel(borders, probs)
+
+        # Compute PI
+        best_f = 0.5
+        acqf = DiscretizedProbabilityOfImprovement(mock_model, best_f=best_f)
+        X = torch.tensor([[1.0]])  # value will not be used since posterior is mocked
+        acqf_values = acqf(X)
+
+        # Calculate analytical PI for normal distribution
+        prob_improvement = 1.0 - target_dist.cdf(torch.tensor(best_f))
+
+        # Check that the discretized EI is close to the analytical EI
+        self.assertLess(
+            torch.abs(acqf_values - prob_improvement) / prob_improvement, 0.01
+        )
+
+        # minimization task
+        acqf = DiscretizedProbabilityOfImprovement(
+            mock_model,
+            best_f=-best_f,
+            posterior_transform=ScalarizedPosteriorTransform(
+                weights=torch.tensor([-1.0])
+            ),
+        )
+        acqf_values = acqf(X)
+
+        # Calculate analytical PI for normal distribution
+        prob_improvement = target_dist.cdf(torch.tensor(best_f))
+
+        # Check that the discretized EI is close to the analytical EI
+        self.assertLess(
+            torch.abs(acqf_values - prob_improvement) / prob_improvement, 0.01
+        )

--- a/test_community/models/test_prior_fitted_network.py
+++ b/test_community/models/test_prior_fitted_network.py
@@ -47,7 +47,26 @@ class TestPriorFittedNetwork(BotorchTestCase):
             tkwargs = {"device": self.device, "dtype": dtype}
             train_X = torch.rand(10, 3, **tkwargs)
             train_Y = torch.rand(10, 1, **tkwargs)
+            train_Yvar = torch.rand(10, 1, **tkwargs)
             test_X = torch.rand(5, 3, **tkwargs)
+
+            # Test that UnsupportedError is raised when train_Yvar is passed
+            with self.assertRaises(UnsupportedError):
+                PFNModel(train_X, train_Y, DummyPFN(), train_Yvar=train_Yvar)
+
+            train_Y_4d = torch.rand(10, 2, 2, 1, **tkwargs)
+            with self.assertRaises(UnsupportedError):
+                PFNModel(train_X, train_Y_4d, DummyPFN())
+
+            train_Y_2d = torch.rand(10, 2, **tkwargs)
+            with self.assertRaises(UnsupportedError):
+                PFNModel(train_X, train_Y_2d, DummyPFN())
+
+            with self.assertRaises(UnsupportedError):
+                PFNModel(torch.rand(10, 3, 3, 2, **tkwargs), train_Y, DummyPFN())
+
+            with self.assertRaises(UnsupportedError):
+                PFNModel(train_X, torch.rand(11, **tkwargs), DummyPFN())
 
             pfn = PFNModel(train_X, train_Y, DummyPFN())
 
@@ -65,36 +84,64 @@ class TestPriorFittedNetwork(BotorchTestCase):
 
             # q should be 1
             test_X = torch.rand(5, 4, 2, **tkwargs)
-            with self.assertRaises(NotImplementedError):
+            with self.assertRaises(UnsupportedError):
+                pfn.posterior(test_X)
+
+            # X dims should be 1 to 4
+            test_X = torch.rand(5, 4, 2, 1, 2, **tkwargs)
+            with self.assertRaises(UnsupportedError):
                 pfn.posterior(test_X)
 
     def test_shapes(self):
-        for dtype in (torch.float, torch.double):
-            tkwargs = {"device": self.device, "dtype": dtype}
+        tkwargs = {"device": self.device, "dtype": torch.float}
 
-            # no batch dimension
-            train_X = torch.rand(10, 3, **tkwargs)
-            train_Y = torch.rand(10, 1, **tkwargs)
-            test_X = torch.rand(5, 3, **tkwargs)
+        # no q dimension
+        train_X = torch.rand(10, 3, **tkwargs)
+        train_Y = torch.rand(10, 1, **tkwargs)
+        test_X = torch.rand(5, 3, **tkwargs)
 
-            pfn = PFNModel(train_X, train_Y, DummyPFN(n_buckets=100))
-            posterior = pfn.posterior(test_X)
+        pfn = PFNModel(train_X, train_Y, DummyPFN(n_buckets=100))
 
-            self.assertEqual(posterior.probabilities.shape, torch.Size([5, 100]))
-            self.assertEqual(posterior.mean.shape, torch.Size([5, 1]))
+        for batch_first in [True, False]:
+            with self.subTest(batch_first=batch_first):
+                pfn.batch_first = batch_first
+                posterior = pfn.posterior(test_X)
 
-            # batch dimensions
-            train_X = torch.rand(2, 3, 4, 10, 3, **tkwargs)
-            train_Y = torch.rand(2, 3, 4, 10, 1, **tkwargs)
-            test_X = torch.rand(2, 3, 4, 1, 3, **tkwargs)
+                self.assertEqual(posterior.probabilities.shape, torch.Size([5, 100]))
+                self.assertEqual(posterior.mean.shape, torch.Size([5, 1]))
 
-            pfn = PFNModel(train_X, train_Y, DummyPFN(n_buckets=100))
-            posterior = pfn.posterior(test_X)
+        # q=1
+        test_X = torch.rand(5, 1, 3, **tkwargs)
+        posterior = pfn.posterior(test_X)
 
-            self.assertEqual(
-                posterior.probabilities.shape, torch.Size([2, 3, 4, 1, 100])
-            )
-            self.assertEqual(posterior.mean.shape, torch.Size([2, 3, 4, 1, 1]))
+        self.assertEqual(posterior.probabilities.shape, torch.Size([5, 100]))
+        self.assertEqual(posterior.mean.shape, torch.Size([5, 1]))
+
+        # no shape basically
+        test_X = torch.rand(3, **tkwargs)
+        posterior = pfn.posterior(test_X)
+
+        self.assertEqual(posterior.probabilities.shape, torch.Size([100]))
+        self.assertEqual(posterior.mean.shape, torch.Size([1]))
+
+    def test_batching(self):
+        tkwargs = {"device": self.device, "dtype": torch.float}
+
+        # no q dimension
+        train_X = torch.rand(2, 10, 3, **tkwargs)
+        train_Y = torch.rand(2, 10, 1, **tkwargs)
+
+        pfn = PFNModel(train_X, train_Y, DummyPFN(n_buckets=100))
+
+        test_X = torch.rand(5, 2, 1, 3, **tkwargs)
+        posterior = pfn.posterior(test_X)
+
+        self.assertEqual(posterior.probabilities.shape, torch.Size([5, 2, 100]))
+
+        test_X = torch.rand(2, 1, 3, **tkwargs)
+        posterior = pfn.posterior(test_X)
+
+        self.assertEqual(posterior.probabilities.shape, torch.Size([2, 100]))
 
 
 class TestPriorFittedNetworkUtils(BotorchTestCase):


### PR DESCRIPTION
Summary:
These are all the basic changes needed for the PFNs to work within Ax.

While this removes a bunch of problems encountered it also fixes a particular bug that led to worse optimization performance: an issue in the way EI is computed. This also adds tests to see that the acquisition functions compute the right thing when approximating a normal distribution.


Discussion point:

Should we get rid of the ag_integrate logic again. I overtook it from whoever wrote this before, but have to say that just implementing acquisition functions using the raw logits seems easier to me.

This is how you implement EI, which I believe to be simpler than our current EI implementation (which already had a bug twice). It even has only the same amount of lines, but does not require you to understand the concept of splitting up an integration into a product that is worked on separately.

```
def ei(
        self,
        logits: torch.Tensor,
        best_f: float | torch.Tensor,
        *,
        maximize: bool = True,
    ) -> torch.Tensor:  # logits: evaluation_points x batch x feature_dim
        bucket_diffs = self.borders[1:] - self.borders[:-1]
        assert maximize
        if not torch.is_tensor(best_f) or not len(best_f.shape):  # type: ignore
            best_f = torch.full(
                logits[..., 0].shape, best_f, device=logits.device
            )  # type: ignore

        best_f = best_f[..., None].repeat(
            *[1] * len(best_f.shape), logits.shape[-1]
        )  # type: ignore
        clamped_best_f = best_f.clamp(self.borders[:-1], self.borders[1:])

        # > bucket_contributions =
        # >     (best_f[...,None] < self.borders[:-1]).float() * bucket_means
        # true bucket contributions
        bucket_contributions = (
            (self.borders[1:] ** 2 - clamped_best_f**2) / 2
            - best_f * (self.borders[1:] - clamped_best_f)
        ) / bucket_diffs

        p = torch.softmax(logits, -1)
        return torch.einsum("...b,...b->...", p, bucket_contributions)
```

Differential Revision: D77884839


