### PR TITLE
[GHA] Add workflow to test website build

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -10,7 +10,19 @@ on:
         required: false
         type: boolean
         default: false
+      dry_run:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
+      run_tutorials:
+        required: true
+        type: boolean
+        default: false
+      dry_run:
+        required: true
+        type: boolean
+        default: false
 
 
 jobs:
@@ -70,7 +82,7 @@ jobs:
                 sed -i "/\"$OLD_VERSION\"/d" website/versions.json
             fi
         done
-    - if: ${{ inputs.new_version }}
+    - if: ${{ inputs.new_version && !inputs.dry_run }}
       name: Create new docusaurus version
       run: |
         python3 scripts/convert_ipynb_to_mdx.py --clean
@@ -91,6 +103,7 @@ jobs:
         path: website/build/
 
   deploy-website:
+    if: ${{ !inputs.dry_run }}
     needs: build-website
     permissions:
       pages: write

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -1,0 +1,22 @@
+name: Test Website
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "tutorials/**"
+      - "notebooks_community/**"
+      - "docs/**"
+      - "scripts/**"
+      - "website/**"
+  workflow_dispatch:
+
+jobs:
+  website:
+    name: Test building website
+    uses: ./.github/workflows/publish_website.yml
+    with:
+      dry_run: true
+      run_tutorials: false


### PR DESCRIPTION
_duplicate of https://github.com/facebook/Ax/pull/3769_

Before this there was nothing stopping us from merging website-breaking changes. This wouldn't get caught until our daily cron failed to build the website. Some of these errors can be caught by just running the website locally, but others require building the prod version of the website which involves merging in (but not deleting) the docusaurus-versions branch. It's much simpler if we can automate this as a workflow at PR creation.

I've configured this to run on PRs only when files directly relevant to the website build are modified (to reduce overhead for unrelated PRs). For the main branch this will be more thorough and run every time a PR is merged.

Test Plan:

In https://github.com/facebook/Ax/pull/3769 I previously opened a separate PR to trigger this new workflow as a test:
- PR: https://github.com/facebook/Ax/pull/3770
  - Workflow: https://github.com/facebook/Ax/actions/runs/14938483763/job/41971282706?pr=3770