### PR TITLE
[GHA] Add permissions to test website build workflow

### DIFF
--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -20,3 +20,7 @@ jobs:
     with:
       dry_run: true
       run_tutorials: false
+    permissions:
+      contents: write
+      pages: write
+      id-token: write


### PR DESCRIPTION
The first run of this workflow failed https://github.com/pytorch/botorch/actions/runs/16153124002

```
Invalid workflow file: .github/workflows/test_website.yml#L17
The workflow is not valid. .github/workflows/test_website.yml (Line: 17, Col: 3): Error calling workflow 'pytorch/botorch/.github/workflows/publish_website.yml@669d1319910415f4aea3b446b0fb2c250fe90b6e'. The nested job 'build-website' is requesting 'contents: write', but is only allowed 'contents: read'. .github/workflows/test_website.yml (Line: 17, Col: 3): Error calling workflow 'pytorch/botorch/.github/workflows/publish_website.yml@669d1319910415f4aea3b446b0fb2c250fe90b6e'. The nested job 'deploy-website' is requesting 'pages: write, id-token: write', but is only allowed 'pages: none, id-token: none'.
```

It's correct that the publish_website.yml workflow uses these permissions to update the branch and deploy gh-pages but we enable the dry_run option which skips those steps.

Specifying these permissions wasn't required in the Ax counterpart for some reason... the GITHUB_TOKEN permissions may have been adjusted in that repo but I don't have access to those settings

https://github.com/facebook/Ax/blob/main/.github/workflows/test_website.yml

Test Plan:

Manually triggered the workflow targeting this branch from the UI and it now actually runs
https://github.com/pytorch/botorch/actions/runs/16153629735