### PR TITLE
Eliminate expensive indexing in separate_mtmvn

### DIFF
--- a/test/utils/test_multitask.py
+++ b/test/utils/test_multitask.py
@@ -7,7 +7,6 @@
 
 import torch
 from botorch.utils.multitask import separate_mtmvn
-
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.distributions import MultitaskMultivariateNormal
 from gpytorch.distributions.multivariate_normal import MultivariateNormal


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/botorch/issues/2919

The batched indexing of the covariance tensor was consuming extraordinary amounts of memory, enough to crash servers with moderately sized tensors.

Profiling `separate_mtmvn` with `n_test=64` (256 was crashing my server) using the repro from the above issue.

Before: Using >7GB ram and taking >800ms
{F1980143884}

After: Using ~5e-5 GB ram and taking ~20ms
{F1980143899}

Differential Revision: D78038356


