### PR TITLE
Fix edge case with NaNs in `is_non_dominated`

### DIFF
--- a/botorch/utils/multi_objective/pareto.py
+++ b/botorch/utils/multi_objective/pareto.py
@@ -56,13 +56,14 @@ def is_non_dominated(
     if n > 1000 or n**2 * Y.shape[:-2].numel() * el_size / 8 > MAX_BYTES:
         return _is_non_dominated_loop(Y, maximize=maximize, deduplicate=deduplicate)
 
+    is_all_nan = Y.isnan().all(dim=-1)  # edge case: all elements are NaN
     Y1 = Y.unsqueeze(-3)
     Y2 = Y.unsqueeze(-2)
     if maximize:
         dominates = (Y1 >= Y2).all(dim=-1) & (Y1 > Y2).any(dim=-1)
     else:
         dominates = (Y1 <= Y2).all(dim=-1) & (Y1 < Y2).any(dim=-1)
-    nd_mask = ~(dominates.any(dim=-1))
+    nd_mask = ~(dominates.any(dim=-1)) & ~is_all_nan
     if deduplicate:
         # remove duplicates
         # find index of first occurrence  of each unique element
@@ -281,9 +282,11 @@ try:
         res = minimize(
             problem=pymoo_problem,
             algorithm=algorithm,
-            termination=None
-            if max_gen is None
-            else MaximumGenerationTermination(n_max_gen=max_gen),
+            termination=(
+                None
+                if max_gen is None
+                else MaximumGenerationTermination(n_max_gen=max_gen)
+            ),
             seed=seed,
             verbose=False,
         )
@@ -292,5 +295,6 @@ try:
         Y = -torch.tensor(res.F, **tkwargs)
         pareto_mask = is_non_dominated(Y, deduplicate=True)
         return X[pareto_mask], Y[pareto_mask]
+
 except ImportError:  # pragma: no cover
     pass

--- a/test/utils/multi_objective/test_pareto.py
+++ b/test/utils/multi_objective/test_pareto.py
@@ -167,6 +167,12 @@ class TestPareto(BotorchTestCase):
         Y[3, 1] = float("nan")
         Y[7, 0] = float("nan")
         self.assertFalse(is_non_dominated(Y)[[3, 7]].any())
+        # Check edge case if all elements are NaN
+        nans = torch.full((2, 2, 3), torch.nan)
+        rands = torch.rand((2, 2, 3))
+        Y = torch.hstack([nans, rands])
+        non_dominated = is_non_dominated(Y)
+        self.assertFalse(non_dominated[..., :, :2].any().item())
 
     def test_is_non_dominated_loop(self):
         n = 20


### PR DESCRIPTION
Addresses an issue of elements being marked as non-dominated when all elements of a tensor are `NaN`.

Fixes #2924