### PR TITLE
Added `reset` method to StoppingCriterion

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -601,7 +601,7 @@ def gen_candidates_torch(
             return loss
 
         _optimizer.step(assign_grad)
-        stop = stopping_criterion.evaluate(fvals=loss.detach())
+        stop = stopping_criterion(fvals=loss.detach())
         if timeout_sec is not None:
             runtime = time.monotonic() - start_time
             if runtime > timeout_sec:

--- a/botorch/optim/core.py
+++ b/botorch/optim/core.py
@@ -20,6 +20,7 @@ from typing import Any
 import numpy.typing as npt
 
 from botorch.optim.closures import NdarrayOptimizationClosure
+from botorch.optim.stopping import StoppingCriterion
 from botorch.optim.utils.numpy_utils import get_bounds_as_ndarray
 from botorch.optim.utils.timeout import minimize_with_timeout
 from numpy import asarray, float64 as np_float64
@@ -153,7 +154,7 @@ def torch_minimize(
     scheduler: LRScheduler | Callable[[Optimizer], LRScheduler] | None = None,
     step_limit: int | None = None,
     timeout_sec: float | None = None,
-    stopping_criterion: Callable[[Tensor], bool] | None = None,
+    stopping_criterion: StoppingCriterion | None = None,
 ) -> OptimizationResult:
     r"""Generic torch.optim-based optimization routine.
 
@@ -189,6 +190,10 @@ def torch_minimize(
 
     if not (scheduler is None or isinstance(scheduler, LRScheduler)):
         scheduler = scheduler(optimizer)
+
+    if stopping_criterion is not None:
+        # Reset stopping criterion to ensure clean state for new optimization run
+        stopping_criterion.reset()
 
     _bounds = (
         {}

--- a/botorch/optim/fit.py
+++ b/botorch/optim/fit.py
@@ -22,7 +22,7 @@ from botorch.optim.core import (
     scipy_minimize,
     torch_minimize,
 )
-from botorch.optim.stopping import ExpMAStoppingCriterion
+from botorch.optim.stopping import ExpMAStoppingCriterion, StoppingCriterion
 from botorch.optim.utils import get_parameters_and_bounds, TorchAttr
 from botorch.utils.types import DEFAULT
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
@@ -118,7 +118,7 @@ def fit_gpytorch_mll_torch(
     closure: Callable[[], tuple[Tensor, Sequence[Tensor | None]]] | None = None,
     closure_kwargs: dict[str, Any] | None = None,
     step_limit: int | None = None,
-    stopping_criterion: Callable[[Tensor], bool] | None = DEFAULT,  # pyre-ignore [9]
+    stopping_criterion: StoppingCriterion | None = DEFAULT,
     optimizer: Optimizer | Callable[..., Optimizer] = Adam,
     scheduler: _LRScheduler | Callable[..., _LRScheduler] | None = None,
     callback: Callable[[dict[str, Tensor], OptimizationResult], None] | None = None,

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -826,7 +826,7 @@ def optimize_acqf_cyclic(
     if q > 1:
         cyclic_options = cyclic_options or {}
         stopping_criterion = ExpMAStoppingCriterion(**cyclic_options)
-        stop = stopping_criterion.evaluate(fvals=acq_vals)
+        stop = stopping_criterion(fvals=acq_vals)
         base_X_pending = acq_function.X_pending
         idxr = torch.ones(q, dtype=torch.bool, device=opt_inputs.bounds.device)
         while not stop:
@@ -847,7 +847,7 @@ def optimize_acqf_cyclic(
                 candidates[i] = candidate_i
                 acq_vals[i] = acq_val_i
                 idxr[i] = 1
-            stop = stopping_criterion.evaluate(fvals=acq_vals)
+            stop = stopping_criterion(fvals=acq_vals)
         acq_function.set_X_pending(base_X_pending)
     return candidates, acq_vals
 

--- a/test/optim/test_core.py
+++ b/test/optim/test_core.py
@@ -17,6 +17,7 @@ from botorch.optim.core import (
     scipy_minimize,
     torch_minimize,
 )
+from botorch.optim.stopping import ExpMAStoppingCriterion
 from botorch.utils.testing import BotorchTestCase
 from numpy import allclose
 from scipy.optimize import OptimizeResult
@@ -254,11 +255,11 @@ class TestTorchMinimize(BotorchTestCase):
             self.assertEqual(result.step, len(step_results))
 
             # Test `stopping_criterion`
-            stopping_decisions = iter((False, False, True, False))
+            max3_stopping_criterion = ExpMAStoppingCriterion(maxiter=3, n_window=5)
             result = torch_minimize(
                 closure=closure,
                 parameters=closure.parameters,
-                stopping_criterion=lambda fval: next(stopping_decisions),
+                stopping_criterion=max3_stopping_criterion,
             )
             self.assertEqual(result.step, 3)
             self.assertEqual(result.status, OptimizationStatus.STOPPED)


### PR DESCRIPTION
Summary:
A custom StoppingCriterion currently does not work as intended when multiple restarts are used in fit_gpytorch_mll.

Due to its preservation of state, the previous fitting attempt's data will be saved, and generally, the criterion will immediately be satisfied on the new attempt, thus stopping fitting on the first iteration.

Differential Revision: D78343624


