### PR TITLE
Multi-Output Acquisition Functions

### DIFF
--- a/botorch/acquisition/__init__.py
+++ b/botorch/acquisition/__init__.py
@@ -64,6 +64,7 @@ from botorch.acquisition.monte_carlo import (
     SampleReducingMCAcquisitionFunction,
 )
 from botorch.acquisition.multi_step_lookahead import qMultiStepLookahead
+from botorch.acquisition.multioutput_acquisition import MultiOutputAcquisitionFunction
 from botorch.acquisition.objective import (
     ConstrainedMCObjective,
     GenericMCObjective,
@@ -136,4 +137,5 @@ __all__ = [
     "ScalarizedPosteriorTransform",
     "get_acquisition_function",
     "get_acqf_input_constructor",
+    "MultiOutputAcquisitionFunction",
 ]

--- a/botorch/acquisition/multioutput_acquisition.py
+++ b/botorch/acquisition/multioutput_acquisition.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""Abstract base module for multi-output acquisition functions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import torch
+from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.exceptions.errors import UnsupportedError
+from botorch.models.model import Model
+from botorch.utils.transforms import (
+    average_over_ensemble_models,
+    t_batch_mode_transform,
+)
+from torch import Tensor
+
+
+class MultiOutputAcquisitionFunction(AcquisitionFunction, ABC):
+    r"""Abstract base class for multi-output acquisition functions.
+
+    These are intended to be optimized with a multi-objective optimizer (e.g.
+    NSGA-II).
+    """
+
+    @abstractmethod
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Evaluate the acquisition function on the candidate set X.
+
+        Args:
+            X: A `(b) x q x d`-dim Tensor of `(b)` t-batches with `q` `d`-dim
+                design points each.
+
+        Returns:
+            A `(b) x m`-dim Tensor of acquisition function values at the given
+            design points `X`.
+        """
+
+    def set_X_pending(self, X_pending: Tensor | None) -> None:
+        r"""Set the pending points.
+
+        Args:
+            X_pending: A `batch_shape x m x d`-dim Tensor of `m` design points that
+                have points that have been submitted for function evaluation
+                (but may not yet have been evaluated).
+        """
+        raise UnsupportedError(
+            "X_pending is not supported for multi-output acquisition functions."
+        )
+
+
+class MultiOutputPosteriorMean(MultiOutputAcquisitionFunction):
+    def __init__(self, model: Model, weights: Tensor | None = None) -> None:
+        r"""Constructor for the MultiPosteriorMean.
+
+        Maximization of all outputs is assumed by default. Minimizing outputs can
+        be achieved by setting the corresponding weights to negative.
+
+        Args:
+            acqfs: A list of `m` acquisition functions.
+            weights: A one-dimensional tensor with `m` elements representing the
+                weights on the outputs.
+        """
+        super().__init__(model=model)
+        if self.model.num_outputs < 2:
+            raise NotImplementedError(
+                "MultiPosteriorMean only supports multi-output models."
+            )
+        # TODO: this could be done via a posterior transform
+        if weights is not None and weights.shape[0] != self.model.num_outputs:
+            raise ValueError(
+                f"weights must have {self.model.num_outputs} elements, but got"
+                f" {weights.shape[0]}."
+            )
+        self.register_buffer("weights", weights)
+
+    @t_batch_mode_transform(expected_q=1, assert_output_shape=False)
+    @average_over_ensemble_models
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Evaluate the acquisition function on the candidate set X.
+
+        Args:
+            X: A `(b) x q x d`-dim Tensor of `(b)` t-batches with `q` `d`-dim
+                design points each.
+
+        Returns:
+            A `(b) x m`-dim Tensor of acquisition function values at the given
+            design points `X`.
+        """
+        mean = self.model.posterior(X).mean.squeeze(-2)
+        if self.weights is not None:
+            return mean * self.weights
+        return mean
+
+
+class MultiOutputAcquisitionFunctionWrapper(MultiOutputAcquisitionFunction):
+    r"""Multi-output wrapper around single-output acquisition functions."""
+
+    def __init__(self, acqfs: list[AcquisitionFunction]) -> None:
+        r"""Constructor for the AcquisitionFunction base class.
+
+        Args:
+            acqfs: A list of `m` acquisition functions.
+        """
+        # We could set the model to be an ensemble model consistent of the
+        # model used in each acqf
+        super().__init__(model=acqfs[0].model)
+        self.acqfs: list[AcquisitionFunction] = acqfs
+
+    def forward(self, X: Tensor) -> Tensor:
+        r"""Evaluate the acquisition function on the candidate set X.
+
+        Args:
+            X: A `(b) x q x d`-dim Tensor of `(b)` t-batches with `q` `d`-dim
+                design points each.
+
+        Returns:
+            A `(b) x m`-dim Tensor of acquisition function values at the given
+            design points `X`.
+        """
+        return torch.stack([acqf(X) for acqf in self.acqfs], dim=-1)

--- a/sphinx/source/acquisition.rst
+++ b/sphinx/source/acquisition.rst
@@ -37,6 +37,11 @@ Monte-Carlo Acquisition Function API
 .. autoclass:: MCAcquisitionFunction
     :members:
 
+Multi-Output Acquisition Function API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.acquisition.multioutput_acquisition
+    :members:
+
 Base Classes for Multi-Objective Acquisition Function API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.acquisition.multi_objective.base

--- a/test/acquisition/test_multioutput_acquisition.py
+++ b/test/acquisition/test_multioutput_acquisition.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from botorch.acquisition.analytic import LogExpectedImprovement, UpperConfidenceBound
+from botorch.acquisition.multioutput_acquisition import (
+    MultiOutputAcquisitionFunction,
+    MultiOutputAcquisitionFunctionWrapper,
+    MultiOutputPosteriorMean,
+)
+from botorch.exceptions.errors import UnsupportedError
+from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
+
+
+class DummyMultiOutputAcqf(MultiOutputAcquisitionFunction):
+    def forward(self, X):
+        pass
+
+
+class TestMultiOutputAcquisitionFunction(BotorchTestCase):
+    def test_abstract_raises(self):
+        with self.assertRaises(TypeError):
+            MultiOutputAcquisitionFunction()
+
+    def test_set_X_pending(self) -> None:
+        with self.assertRaisesRegex(
+            UnsupportedError,
+            "X_pending is not supported for multi-output acquisition functions.",
+        ):
+            DummyMultiOutputAcqf(
+                model=MockModel(posterior=MockPosterior())
+            ).set_X_pending(torch.ones(1, 1))
+
+    def test_multioutput_posterior_mean(self) -> None:
+        # test single output model
+        with self.assertRaisesRegex(
+            NotImplementedError, "MultiPosteriorMean only supports multi-output models."
+        ):
+            MultiOutputPosteriorMean(
+                model=MockModel(posterior=MockPosterior(mean=torch.tensor([[1.0]])))
+            )
+        # test invalid weights
+        with self.assertRaisesRegex(
+            ValueError, "weights must have 2 elements, but got 1."
+        ):
+            MultiOutputPosteriorMean(
+                model=MockModel(
+                    posterior=MockPosterior(mean=torch.tensor([[1.0, 2.0]]))
+                ),
+                weights=torch.tensor([1.0]),
+            )
+        for dtype in (torch.float, torch.double):
+            # basic test
+            mean = torch.tensor([[1.0, 2.0]], dtype=dtype, device=self.device)
+            acqf = MultiOutputPosteriorMean(
+                model=MockModel(posterior=MockPosterior(mean=mean))
+            )
+            self.assertTrue(
+                torch.equal(
+                    acqf(torch.ones(1, 1, 1, dtype=dtype, device=self.device)),
+                    mean.squeeze(-2),
+                )
+            )
+            # test weights
+            weights = torch.tensor([-1.0, 1.0], dtype=dtype, device=self.device)
+            acqf = MultiOutputPosteriorMean(
+                model=MockModel(posterior=MockPosterior(mean=mean)), weights=weights
+            )
+            self.assertTrue(
+                torch.equal(
+                    acqf(torch.ones(1, 1, 1, dtype=dtype, device=self.device)),
+                    mean.squeeze(-2) * weights,
+                )
+            )
+
+    def test_multioutput_wrapper(self) -> None:
+        for dtype in (torch.float, torch.double):
+            model = MockModel(
+                posterior=MockPosterior(
+                    mean=torch.tensor([[1.0]], dtype=dtype, device=self.device),
+                    variance=torch.tensor([[0.1]], dtype=dtype, device=self.device),
+                )
+            )
+            ei = LogExpectedImprovement(model=model, best_f=0.0)
+            ucb = UpperConfidenceBound(model=model, beta=2.0)
+            acqf = MultiOutputAcquisitionFunctionWrapper(acqfs=[ei, ucb])
+            X = torch.ones(1, 1, 1, dtype=dtype, device=self.device)
+            expected_af_vals = torch.stack([ei(X=X), ucb(X=X)], dim=-1)
+            self.assertTrue(torch.equal(acqf(X), expected_af_vals))


### PR DESCRIPTION
Summary:
This adds implements an abstract MultiOutputAcquisitionFunction in botorch, as well as two subclasses:
- A MultiOutputPosteriorMean
- A wrapper around multiple single-output AFs.

Differential Revision: D77666057


