### PR TITLE
Add serialization for PFN model

### DIFF
--- a/botorch_community/models/prior_fitted_network.py
+++ b/botorch_community/models/prior_fitted_network.py
@@ -13,14 +13,22 @@ For the latter to work `pfns4bo` must be installed.
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
-import torch.nn as nn
+import torch
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.exceptions.errors import UnsupportedError
+
+from botorch.logging import logger
 from botorch.models.model import Model
+from botorch.models.transforms.input import InputTransform
+from botorch_community.models.utils.prior_fitted_network import (
+    download_model,
+    ModelPaths,
+)
 from botorch_community.posteriors.riemann import BoundedRiemannPosterior
 from torch import Tensor
+from torch.nn import Module
 
 
 class PFNModel(Model):
@@ -30,12 +38,21 @@ class PFNModel(Model):
         self,
         train_X: Tensor,
         train_Y: Tensor,
-        model: nn.Module,
+        model: Module | None = None,
+        checkpoint_url: str = ModelPaths.pfns4bo_hebo,
         train_Yvar: Tensor | None = None,
         batch_first: bool = False,
-        constant_model_kwargs: dict | None = None,
+        constant_model_kwargs: dict[str, Any] | None = None,
+        input_transform: InputTransform | None = None,
     ) -> None:
         """Initialize a PFNModel.
+
+        Either a pre-trained PFN model can be provided via the model kwarg,
+        or a checkpoint_url can be provided from which the model will be
+        downloaded. This defaults to the pfns4bo_hebo model.
+
+        Loading the model does an unsafe "weights_only=False" load, so
+        it is essential that checkpoint_url be a trusted source.
 
         Args:
             train_X: A `n x d` tensor of training features.
@@ -43,19 +60,27 @@ class PFNModel(Model):
             model: A pre-trained PFN model with the following
                 forward(train_X, train_Y, X) -> logit predictions of shape
                 `n x b x c` where c is the number of discrete buckets
-                borders: A `c+1`-dim tensor of bucket borders
-            train_Yvar: Not yet supported.
+                borders: A `c+1`-dim tensor of bucket borders.
+            checkpoint_url: The string URL of the PFN model to download and load.
+                Will be ignored if model is provided.
+            train_Yvar: Observed variance of train_Y. Currently ignored.
             batch_first: Whether the batch dimension is the first dimension of
                 the input tensors. This is needed to support different PFN
                 models. For batch-first x has shape `batch x seq_len x features`
                 and for non-batch-first it has shape `seq_len x batch x features`.
             constant_model_kwargs: A dictionary of model kwargs that
                 will be passed to the model in each forward pass.
+            input_transform: A Botorch input transform.
+
         """
         super().__init__()
+        if model is None:
+            model = download_model(
+                model_path=checkpoint_url,
+            )
 
         if train_Yvar is not None:
-            raise UnsupportedError("train_Yvar is not supported for PFNModel.")
+            logger.debug("train_Yvar provided but ignored for PFNModel.")
 
         if not (1 <= train_Y.dim() <= 3):
             raise UnsupportedError("train_Y must be 1- to 3-dimensional.")
@@ -81,11 +106,18 @@ class PFNModel(Model):
             train_X = train_X.unsqueeze(0)
             train_Y = train_Y.unsqueeze(0)
 
+        with torch.no_grad():
+            self.transformed_X = self.transform_inputs(
+                X=train_X, input_transform=input_transform
+            )
+
         self.train_X = train_X  # shape: `b x n x d`
         self.train_Y = train_Y  # shape: `b x n`
         self.pfn = model
         self.batch_first = batch_first
         self.constant_model_kwargs = constant_model_kwargs
+        if input_transform is not None:
+            self.input_transform = input_transform
 
     def posterior(
         self,
@@ -122,7 +154,9 @@ class PFNModel(Model):
                 "be a multi-output model."
             )
         if observation_noise:
-            raise UnsupportedError("observation_noise is not supported for PFNModel.")
+            logger.warning(
+                "observation_noise is not supported for PFNModel and is being ignored."
+            )
         if posterior_transform is not None:
             raise UnsupportedError("posterior_transform is not supported for PFNModel.")
 
@@ -150,8 +184,8 @@ class PFNModel(Model):
             raise UnsupportedError("Only q=1 is supported for PFNModel.")
 
         # X has shape `b' x b x q=1 x d`
-
-        train_X = self.train_X  # shape `b x n x d`
+        X = self.transform_inputs(X)
+        train_X = self.transformed_X  # shape `b x n x d`
         train_Y = self.train_Y  # shape `b x n`
         folded_X = X.transpose(0, 2).squeeze(0)  # shape `b x b' x d
 

--- a/botorch_community/models/utils/prior_fitted_network.py
+++ b/botorch_community/models/utils/prior_fitted_network.py
@@ -10,6 +10,8 @@ import os
 from enum import Enum
 from typing import Optional
 
+from botorch.logging import logger
+
 try:
     import requests
 except ImportError:  # pragma: no cover
@@ -18,6 +20,12 @@ except ImportError:  # pragma: no cover
         "You can install it using pip: `pip install requests`"
     )
 
+try:
+    import pfns4bo  # noqa: F401
+except ImportError:  # pragma: no cover
+    logger.warning(
+        "pfns4bo is not installed, unable to automatically download PFN model."
+    )
 
 import torch
 import torch.nn as nn
@@ -68,14 +76,16 @@ def download_model(
 
         # Decompress the gzipped model weights
         with gzip.GzipFile(fileobj=io.BytesIO(response.content)) as gz:
-            model = torch.load(gz, map_location=torch.device("cpu"))
+            model = torch.load(gz, weights_only=False, map_location=torch.device("cpu"))
 
         # Save the model to cache
         torch.save(model, cache_path)
-        print("saved at: ", cache_path)
+        logger.debug("Model file saved at: ", cache_path)
     else:
         # Load the model from cache
-        model = torch.load(cache_path, map_location=torch.device("cpu"))
-        print("loaded from cache: ", cache_path)
+        model = torch.load(
+            cache_path, weights_only=False, map_location=torch.device("cpu")
+        )
+        logger.debug("Model file loaded from cache: ", cache_path)
 
     return model


### PR DESCRIPTION
Summary: Makes a PFN model class that includes model fetching inside the class and enables serialization of that model class, and checks in the GeneratorSpec that should be used in Ax when using the PFN model.

Differential Revision: D77592661


