### PR TITLE
fix input constructor for LogProbabilityOfFeasibility

### DIFF
--- a/botorch/utils/transforms.py
+++ b/botorch/utils/transforms.py
@@ -422,8 +422,3 @@ def match_batch_shape(X: Tensor, Y: Tensor) -> Tensor:
 
     """
     return X.expand(X.shape[: -(Y.dim())] + Y.shape[:-2] + X.shape[-2:])
-
-
-def convert_to_target_pre_hook(module, *args):
-    r"""Pre-hook for automatically calling `.to(X)` on module prior to `forward`"""
-    module.to(args[0][0])

--- a/test/test_utils/test_mock.py
+++ b/test/test_utils/test_mock.py
@@ -140,7 +140,7 @@ class TestMock(BotorchTestCase):
             warnings.simplefilter("ignore", category=BadInitialCandidatesWarning)
             cand, value = optimize_acqf(
                 acq_function=acqf,
-                bounds=torch.tensor([[-2.0], [2.0]]),
+                bounds=torch.tensor([[-2.0], [2.0]], dtype=torch.double),
                 q=1,
                 num_restarts=32,
                 raw_samples=16,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/Ax/pull/4080

Constraints were being passed in the wrong format (a list of callables rather than a dictionary of indices to bounds).

This also removes `convert_to_target_pre_hook`, which only works for args and doesn't work for kwargs. Previously `LogProbabilityOfFeasibility` would error out if called with a kwarg---e.g. `acqf(X=X)` dtype and device are set in `_mean_and_sigma` for these AFs anyway.

Differential Revision: D79281274


