### PR TITLE
Simplify closure dispatch

### DIFF
--- a/botorch/optim/closures/core.py
+++ b/botorch/optim/closures/core.py
@@ -15,7 +15,6 @@ from typing import Any
 
 import numpy.typing as npt
 
-import torch
 from botorch.optim.utils import (
     _handle_numerical_errors,
     get_tensors_as_ndarray_1d,
@@ -31,48 +30,24 @@ class ForwardBackwardClosure:
     r"""Wrapper for fused forward and backward closures."""
 
     def __init__(
-        self,
-        forward: Callable[[], Tensor],
-        parameters: dict[str, Tensor],
-        backward: Callable[[Tensor], None] = Tensor.backward,
-        reducer: Callable[[Tensor], Tensor] | None = torch.sum,
-        callback: Callable[[Tensor, Sequence[Tensor | None]], None] | None = None,
-        context_manager: Callable = None,  # pyre-ignore [9]
+        self, forward: Callable[[], Tensor], parameters: dict[str, Tensor]
     ) -> None:
         r"""Initializes a ForwardBackwardClosure instance.
 
         Args:
-            closure: Callable that returns a tensor.
+            forward: Callable that returns a tensor.
             parameters: A dictionary of tensors whose `grad` fields are to be returned.
-            backward: Callable that takes the (reduced) output of `forward` and sets the
-                `grad` attributes of tensors in `parameters`.
-            reducer: Optional callable used to reduce the output of the forward pass.
-            callback: Optional callable that takes the reduced output of `forward` and
-                the gradients of `parameters` as positional arguments.
-            context_manager: A ContextManager used to wrap each forward-backward call.
-                When passed as `None`, `context_manager` defaults to a `zero_grad_ctx`
-                that zeroes the gradients of `parameters` upon entry.
         """
-        if context_manager is None:
-            context_manager = partial(zero_grad_ctx, parameters)
-
         self.forward = forward
-        self.backward = backward
         self.parameters = parameters
-        self.reducer = reducer
-        self.callback = callback
-        self.context_manager = context_manager
+        self.context_manager = partial(zero_grad_ctx, parameters)
 
     def __call__(self, **kwargs: Any) -> tuple[Tensor, tuple[Tensor | None, ...]]:
         with self.context_manager():
-            values = self.forward(**kwargs)
-            value = values if self.reducer is None else self.reducer(values)
-            self.backward(value)
+            value = self.forward(**kwargs).sum()
+            value.backward()
 
             grads = tuple(param.grad for param in self.parameters.values())
-            if self.callback:
-                self.callback(value, grads)
-
             return value, grads
 
 
@@ -88,7 +63,6 @@ class NdarrayOptimizationClosure:
         get_state: Callable[[], npt.NDArray] = None,  # pyre-ignore [9]
         set_state: Callable[[npt.NDArray], None] = None,  # pyre-ignore [9]
         fill_value: float = 0.0,
-        persistent: bool = True,
     ) -> None:
         r"""Initializes a NdarrayOptimizationClosure instance.
 

--- a/botorch/optim/closures/core.py
+++ b/botorch/optim/closures/core.py
@@ -63,6 +63,7 @@ class NdarrayOptimizationClosure:
         get_state: Callable[[], npt.NDArray] = None,  # pyre-ignore [9]
         set_state: Callable[[npt.NDArray], None] = None,  # pyre-ignore [9]
         fill_value: float = 0.0,
+        persistent: bool = True,
     ) -> None:
         r"""Initializes a NdarrayOptimizationClosure instance.
 

--- a/test/optim/closures/test_core.py
+++ b/test/optim/closures/test_core.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from contextlib import nullcontext
 from functools import partial
 from unittest.mock import MagicMock
 
@@ -68,6 +67,7 @@ class TestForwardBackwardClosure(BotorchTestCase):
             self.assertTrue(dw.equal(module.x))
             self.assertTrue(dx.equal(module.w))
             self.assertEqual(dd, None)
+
 
 class TestNdarrayOptimizationClosure(BotorchTestCase):
     def setUp(self, suppress_input_warnings: bool = True) -> None:

--- a/test/optim/closures/test_core.py
+++ b/test/optim/closures/test_core.py
@@ -40,8 +40,8 @@ class ToyModule(Module):
 
 
 class TestForwardBackwardClosure(BotorchTestCase):
-    def setUp(self):
-        super().setUp()
+    def setUp(self, suppress_input_warnings: bool = True) -> None:
+        super().setUp(suppress_input_warnings=suppress_input_warnings)
         module = ToyModule(
             w=Parameter(torch.tensor(2.0)),
             b=Parameter(torch.tensor(3.0), requires_grad=False),
@@ -69,36 +69,9 @@ class TestForwardBackwardClosure(BotorchTestCase):
             self.assertTrue(dx.equal(module.w))
             self.assertEqual(dd, None)
 
-            # Test `callback`` and `reducer``
-            closure = ForwardBackwardClosure(module, module.free_parameters)
-            mock_reducer = MagicMock(return_value=closure.forward())
-            mock_callback = MagicMock()
-            closure = ForwardBackwardClosure(
-                forward=module,
-                parameters=module.free_parameters,
-                reducer=mock_reducer,
-                callback=mock_callback,
-            )
-            value, grads = closure()
-            mock_reducer.assert_called_once_with(value)
-            mock_callback.assert_called_once_with(value, grads)
-
-            # Test `backward`` and `context_manager`
-            closure = ForwardBackwardClosure(
-                forward=module,
-                parameters=module.free_parameters,
-                backward=partial(torch.Tensor.backward, retain_graph=True),
-                context_manager=nullcontext,
-            )
-            _, (dw, dx, dd) = closure()  # x2 because `grad` is no longer zeroed
-            self.assertTrue(dw.equal(2 * module.x))
-            self.assertTrue(dx.equal(2 * module.w))
-            self.assertEqual(dd, None)
-
-
 class TestNdarrayOptimizationClosure(BotorchTestCase):
-    def setUp(self):
-        super().setUp()
+    def setUp(self, suppress_input_warnings: bool = True) -> None:
+        super().setUp(suppress_input_warnings=suppress_input_warnings)
         self.module = ToyModule(
             w=Parameter(torch.tensor(2.0)),
             b=Parameter(torch.tensor(3.0), requires_grad=False),

--- a/test/optim/closures/test_model_closures.py
+++ b/test/optim/closures/test_model_closures.py
@@ -111,9 +111,9 @@ class TestLossClosures(BotorchTestCase):
             with gpytorch_settings.debug(False):  # disables GPyTorch's internal check
                 (b, dbs) = B()
 
-            self.assertTrue(a.allclose(b))
+            self.assertAllClose(a, b)
             for da, db in zip_longest(das, dbs):
-                self.assertTrue(da.allclose(db))
+                self.assertAllClose(da, db)
 
         loader = DataLoader(mll.model.train_targets, len(mll.model.train_targets))
         closure = get_loss_closure_with_grads(mll, params, data_loader=loader)


### PR DESCRIPTION
## Motivation

**Context**:

We have heard that some community members find the model-fitting code that involves dispatchers is confusing. This is a small step towards making it less confusing.

**This PR:**

* Removes `GetLossClosureWithGrads`, which is not meaningfully used (it only dispatches to one function).
* Removes arguments from `get_loss_closure_with_grads` and `ForwardBackwardClosure` that are never used.

## Test Plan

Existing units
