### PR TITLE
Add BaseTestProblem.is_minimization_problem property

### DIFF
--- a/botorch/test_functions/synthetic.py
+++ b/botorch/test_functions/synthetic.py
@@ -119,7 +119,11 @@ class SyntheticTestFunction(BaseTestProblem, ABC):
 
     @property
     def optimal_value(self) -> float:
-        r"""The global minimum (maximum if negate=True) of the function."""
+        r"""The global optimum of the function.
+
+        This can be either the minimum or maximum depending the value of
+        `self.is_minimization_problem`.
+        """
         if self._optimal_value is not None:
             return -self._optimal_value if self.negate else self._optimal_value
         else:
@@ -250,6 +254,7 @@ class Cosine8(SyntheticTestFunction):
     _bounds = [(-1.0, 1.0) for _ in range(8)]
     _optimal_value = 0.8
     _optimizers = [tuple(0.0 for _ in range(8))]
+    _is_minimization_by_default = False
 
     def _evaluate_true(self, X: Tensor) -> Tensor:
         return torch.sum(0.1 * torch.cos(5 * math.pi * X) - X.pow(2), dim=-1)
@@ -930,6 +935,7 @@ class Labs(SyntheticTestFunction):
     """
 
     _check_grad_at_opt = False
+    _is_minimization_by_default = False
 
     def __init__(
         self,

--- a/test/test_functions/test_base.py
+++ b/test/test_functions/test_base.py
@@ -30,6 +30,7 @@ class DummyMixedTestProblem(BaseTestProblem):
     discrete_inds = [0]
     categorical_inds = [2]
     _bounds = [(0.0, 1.0), (2.0, 3.0), (0.0, 2.0), (3.0, 4.0)]
+    _is_minimization_by_default = False
 
     def _evaluate_true(self, X: Tensor) -> Tensor:
         return -X.pow(2).sum(dim=-1)
@@ -113,6 +114,7 @@ class TestBaseTestProblems(BotorchTestCase):
             problem = DummyTestProblem()
             self.assertIsNone(problem.noise_std)
             self.assertFalse(problem.negate)
+            self.assertTrue(problem.is_minimization_problem)
             bnds_expected = torch.tensor([(0, 2), (1, 3)], dtype=torch.float)
             self.assertTrue(torch.equal(problem.bounds, bnds_expected))
             problem = problem.to(device=self.device, dtype=dtype)
@@ -125,10 +127,12 @@ class TestBaseTestProblems(BotorchTestCase):
             problem = DummyTestProblem(negate=True, noise_std=0.1)
             self.assertEqual(problem.noise_std, 0.1)
             self.assertTrue(problem.negate)
+            self.assertFalse(problem.is_minimization_problem)
 
     def test_mixed_base_test_problem(self):
         for dtype in (torch.float, torch.double):
             problem = DummyMixedTestProblem()
+            self.assertFalse(problem.is_minimization_problem)
             problem = problem.to(device=self.device, dtype=dtype)
             X = torch.rand(2, 4, device=self.device, dtype=dtype)
             with self.assertRaisesRegex(

--- a/test/test_functions/test_multi_objective.py
+++ b/test/test_functions/test_multi_objective.py
@@ -79,6 +79,8 @@ class TestBaseTestMultiObjectiveProblem(BotorchTestCase):
                 InputDataError, "must match the number of objectives"
             ):
                 f = DummyMOProblem(noise_std=[1.0, 2.0, 3.0], negate=negate)
+            with self.assertRaisesRegex(UnsupportedError, "is_minimization_problem"):
+                f.is_minimization_problem
 
 
 class TestBraninCurrin(


### PR DESCRIPTION
Summary:
Most, but not all, BoTorch test functions are defined as minimization problems. Whether a function defined for minimization or maximization is currently only communicated via docstrings and it is not exposed in the API. This diff adds a property, `is_minimization_problem` that allows us to check for this in the code.

Looked through the test functions and updated the property for any problem that specifies itself as maximization problem in the docstring. Problems that don't have this information are assumed to be minimization problems (this will be verified for those that have optimizers defined in the next diff).

Differential Revision: D79562000


