### PR TITLE
Tidy-up feasibility evaluation in `optimize_mixed_alternating`

### DIFF
--- a/botorch/optim/optimize_mixed.py
+++ b/botorch/optim/optimize_mixed.py
@@ -138,7 +138,7 @@ def _filter_infeasible(
     # X is reshaped to [n, 1, d] in order to be able to apply
     # `evaluate_feasibility` which operates on the batch level
     is_feasible = evaluate_feasibility(
-        X=X.reshape(X.shape[0], 1, X.shape[-1]),
+        X=X.unsqueeze(-2),
         inequality_constraints=inequality_constraints,
         equality_constraints=equality_constraints,
         nonlinear_inequality_constraints=None,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

As discussed with @esantorella in https://github.com/pytorch/botorch/pull/2944#discussion_r2250503884, this PR tidies-up the feasibility evaluation in `optimize_mixed_alternating.` It is now refactored in a way that it uses `optim.parameter_constraints.evaluate_feasibility`, which improves code sharing.

Regarding nonlinear inequality constraints that were also discussed in the thread above, I faced the problem that nonlinear constraints only work with a batch limit of 1, which would render `optimize_mixed_alternating` highly inefficient as it makes use of batch optimization. So, I think, we have to first get rid of the limitation of `batch_limit==1` for nonlinear constraints. Should I create a separate issue for this?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.


