### PR TITLE
Add support for missing tasks in mtgp

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -784,39 +784,6 @@ class MultiTaskGPyTorchModel(GPyTorchModel, ABC):
     "long-format" multi-task GP in the style of `MultiTaskGP`.
     """
 
-    def _map_tasks(self, task_values: Tensor) -> Tensor:
-        """Map raw task values to the task indices used by the model.
-
-        Args:
-            task_values: A tensor of task values.
-
-        Returns:
-            A tensor of task indices with the same shape as the input
-                tensor.
-        """
-        if self._task_mapper is None:
-            if not (
-                torch.all(0 <= task_values) and torch.all(task_values < self.num_tasks)
-            ):
-                raise ValueError(
-                    "Expected all task features in `X` to be between 0 and "
-                    f"self.num_tasks - 1. Got {task_values}."
-                )
-        else:
-            task_values = task_values.long()
-
-            unexpected_task_values = set(task_values.unique().tolist()).difference(
-                self._expected_task_values
-            )
-            if len(unexpected_task_values) > 0:
-                raise ValueError(
-                    "Received invalid raw task values. Expected raw value to be in"
-                    f" {self._expected_task_values}, but got unexpected task values:"
-                    f" {unexpected_task_values}."
-                )
-            task_values = self._task_mapper[task_values]
-        return task_values
-
     def _apply_noise(
         self,
         X: Tensor,

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -115,6 +115,7 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
         all_tasks: list[int] | None = None,
         outcome_transform: OutcomeTransform | _DefaultType | None = DEFAULT,
         input_transform: InputTransform | None = None,
+        validate_task_values: bool = True,
     ) -> None:
         r"""Multi-Task GP model using an ICM kernel.
 
@@ -157,6 +158,9 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
                 instantiation of the model.
             input_transform: An input transform that is applied in the model's
                 forward pass.
+            validate_task_values: If True, validate that the task values supplied in the
+                input are expected tasks values. If false, unexpected task values
+                will be mapped to the first output_task if supplied.
 
         Example:
             >>> X1, X2 = torch.rand(10, 2), torch.rand(20, 2)
@@ -189,7 +193,7 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
                 "This is not allowed as it will lead to errors during model training."
             )
         all_tasks = all_tasks or all_tasks_inferred
-        self.num_tasks = len(all_tasks)
+        self.num_tasks = len(all_tasks_inferred)
         if outcome_transform == DEFAULT:
             outcome_transform = Standardize(m=1, batch_shape=train_X.shape[:-2])
         if outcome_transform is not None:
@@ -249,18 +253,60 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
 
         self.covar_module = data_covar_module * task_covar_module
         task_mapper = get_task_value_remapping(
-            task_values=torch.tensor(
-                all_tasks, dtype=torch.long, device=train_X.device
+            observed_task_values=torch.tensor(
+                all_tasks_inferred, dtype=torch.long, device=train_X.device
+            ),
+            all_task_values=torch.tensor(
+                sorted(all_tasks), dtype=torch.long, device=train_X.device
             ),
             dtype=train_X.dtype,
+            default_task_value=None if output_tasks is None else output_tasks[0],
         )
         self.register_buffer("_task_mapper", task_mapper)
-        self._expected_task_values = set(all_tasks)
+        self._expected_task_values = set(all_tasks_inferred)
         if input_transform is not None:
             self.input_transform = input_transform
         if outcome_transform is not None:
             self.outcome_transform = outcome_transform
+        self._validate_task_values = validate_task_values
         self.to(train_X)
+
+    def _map_tasks(self, task_values: Tensor) -> Tensor:
+        """Map raw task values to the task indices used by the model.
+
+        Args:
+            task_values: A tensor of task values.
+
+        Returns:
+            A tensor of task indices with the same shape as the input
+                tensor.
+        """
+        long_task_values = task_values.long()
+        if self._validate_task_values:
+            if self._task_mapper is None:
+                if not (
+                    torch.all(0 <= task_values)
+                    and torch.all(task_values < self.num_tasks)
+                ):
+                    raise ValueError(
+                        "Expected all task features in `X` to be between 0 and "
+                        f"self.num_tasks - 1. Got {task_values}."
+                    )
+            else:
+                unexpected_task_values = set(
+                    long_task_values.unique().tolist()
+                ).difference(self._expected_task_values)
+                if len(unexpected_task_values) > 0:
+                    raise ValueError(
+                        "Received invalid raw task values. Expected raw value to be in"
+                        f" {self._expected_task_values}, but got unexpected task"
+                        f" values: {unexpected_task_values}."
+                    )
+                task_values = self._task_mapper[long_task_values]
+        elif self._task_mapper is not None:
+            task_values = self._task_mapper[long_task_values]
+
+        return task_values
 
     def _split_inputs(self, x: Tensor) -> tuple[Tensor, Tensor, Tensor]:
         r"""Extracts features before task feature, task indices, and features after
@@ -274,7 +320,7 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
             3-element tuple containing
 
             - A  `q x d` or `b x q x d` tensor with features before the task feature
-            - A  `q` or `b x q` tensor with mapped task indices
+            - A  `q` or `b x q x 1` tensor with mapped task indices
             - A  `q x d` or `b x q x d` tensor with features after the task feature
         """
         batch_shape = x.shape[:-2]
@@ -314,7 +360,7 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
             raise ValueError(f"Must have that -{d} <= task_feature <= {d}")
         task_feature = task_feature % (d + 1)
         all_tasks = (
-            train_X[..., task_feature].unique(sorted=True).to(dtype=torch.long).tolist()
+            train_X[..., task_feature].to(dtype=torch.long).unique(sorted=True).tolist()
         )
         return all_tasks, task_feature, d
 

--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -511,11 +511,13 @@ class StratifiedStandardize(Standardize):
 
     def __init__(
         self,
-        task_values: Tensor,
         stratification_idx: int,
+        observed_task_values: Tensor,
+        all_task_values: Tensor,
         batch_shape: torch.Size = torch.Size(),  # noqa: B008
         min_stdv: float = 1e-8,
-        # dtype: torch.dtype = torch.double,
+        dtype: torch.dtype = torch.double,
+        default_task_value: int | None = None,
     ) -> None:
         r"""Standardize outcomes (zero mean, unit variance) along stratification dim.
 
@@ -528,13 +530,21 @@ class StratifiedStandardize(Standardize):
             batch_shape: The batch_shape of the training targets.
             min_stddv: The minimum standard deviation for which to perform
                 standardization (if lower, only de-mean the data).
+            default_task_value: The default task value that unexpected tasks are
+                mapped to. This is used in `get_task_value_remapping`.
+
         """
         OutcomeTransform.__init__(self)
         self._stratification_idx = stratification_idx
-        task_values = task_values.unique(sorted=True)
-        self.strata_mapping = get_task_value_remapping(task_values, dtype=torch.double)
+        observed_task_values = observed_task_values.unique(sorted=True)
+        self.strata_mapping = get_task_value_remapping(
+            observed_task_values=observed_task_values,
+            all_task_values=all_task_values.unique(sorted=True),
+            dtype=dtype,
+            default_task_value=default_task_value,
+        )
         if self.strata_mapping is None:
-            self.strata_mapping = task_values
+            self.strata_mapping = observed_task_values
         n_strata = self.strata_mapping.shape[0]
         self._min_stdv = min_stdv
         self.register_buffer("means", torch.zeros(*batch_shape, n_strata, 1))

--- a/botorch/models/utils/assorted.py
+++ b/botorch/models/utils/assorted.py
@@ -405,13 +405,20 @@ class fantasize(_Flag):
     _state: bool = False
 
 
-def get_task_value_remapping(task_values: Tensor, dtype: torch.dtype) -> Tensor | None:
-    """Construct an mapping of discrete task values to contiguous int-valued floats.
+def get_task_value_remapping(
+    observed_task_values: Tensor,
+    all_task_values: Tensor,
+    dtype: torch.dtype,
+    default_task_value: int | None,
+) -> Tensor | None:
+    """Construct an mapping of observed task values to contiguous int-valued floats.
 
     Args:
-        task_values: A sorted long-valued tensor of task values.
+        observed_task_values: A sorted long-valued tensor of task values.
+        all_task_values: A sorted long-valued tensor of task values.
         dtype: The dtype of the model inputs (e.g. `X`), which the new
             task values should have mapped to (e.g. float, double).
+        default_task_value: The default task value to use for missing task values.
 
     Returns:
         A tensor of shape `task_values.max() + 1` that maps task values
@@ -425,17 +432,31 @@ def get_task_value_remapping(task_values: Tensor, dtype: torch.dtype) -> Tensor 
     if dtype not in (torch.float, torch.double):
         raise ValueError(f"dtype must be torch.float or torch.double, but got {dtype}.")
     task_range = torch.arange(
-        len(task_values), dtype=task_values.dtype, device=task_values.device
+        len(observed_task_values),
+        dtype=all_task_values.dtype,
+        device=all_task_values.device,
     )
     mapper = None
-    if not torch.equal(task_values, task_range):
+
+    if default_task_value is None:
+        fill_value = float("nan")
+    else:
+        mask = observed_task_values == default_task_value
+        if not mask.any():
+            fill_value = float("nan")
+        else:
+            idx = mask.nonzero().item()
+            fill_value = task_range[idx]
+    # if not all tasks are observed or they are not contiguous integers
+    # then map them to contiguous integers
+    if not torch.equal(task_range, all_task_values):
         # Create a tensor that maps task values to new task values.
         # The number of tasks should be small, so this should be quite efficient.
         mapper = torch.full(
-            (int(task_values.max().item()) + 1,),
-            float("nan"),
+            (int(all_task_values.max().item()) + 1,),
+            fill_value,
             dtype=dtype,
-            device=task_values.device,
+            device=all_task_values.device,
         )
-        mapper[task_values] = task_range.to(dtype=dtype)
+        mapper[observed_task_values] = task_range.to(dtype=dtype)
     return mapper

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -84,13 +84,19 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
         output_tasks: list[int] | None = None,
         infer_noise: bool = False,
         use_outcome_transform: bool = True,
+        observed_task_values: list[int] | None = None,
+        all_tasks: list[int] | None = None,
+        validate_task_values: bool = True,
         **tkwargs,
     ):
         with torch.random.fork_rng():
             torch.manual_seed(0)
             train_X = torch.rand(10, 4, **tkwargs)
+        if observed_task_values is None:
+            observed_task_values = [0, 1]
         task_indices = torch.cat(
-            [torch.zeros(5, 1, **tkwargs), torch.ones(5, 1, **tkwargs)], dim=0
+            [torch.full((5, 1), observed_task_values[i], **tkwargs) for i in (0, 1)],
+            dim=0,
         )
         self.num_tasks = 2
         train_X = torch.cat([train_X, task_indices], dim=1)
@@ -101,6 +107,7 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
             train_Y=train_Y,
             train_Yvar=None if infer_noise else train_Yvar,
             task_feature=4,
+            all_tasks=all_tasks,
             output_tasks=output_tasks,
             rank=task_rank,
             outcome_transform=(
@@ -108,6 +115,7 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                 if use_outcome_transform
                 else None
             ),
+            validate_task_values=validate_task_values,
         )
         return train_X, train_Y, train_Yvar, model
 
@@ -198,16 +206,7 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                 train_Yvar=torch.rand(10, **tkwargs),
                 task_feature=4,
             )
-        train_X, train_Y, train_Yvar, model = self._get_data_and_model(**tkwargs)
-        with self.assertRaisesRegex(
-            NotImplementedError, "`all_tasks` argument is not supported"
-        ):
-            SaasFullyBayesianMultiTaskGP(
-                train_X=train_X,
-                train_Y=train_Y,
-                task_feature=-1,
-                all_tasks=[0, 1, 2, 3],
-            )
+        _, _, _, model = self._get_data_and_model(**tkwargs)
         sampler = IIDNormalSampler(sample_shape=torch.Size([2]))
         with self.assertRaisesRegex(
             NotImplementedError, "Fantasize is not implemented!"
@@ -239,12 +238,20 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
         infer_noise: bool = False,
         task_rank: int = 1,
         use_outcome_transform: bool = False,
+        observed_task_values: list[int] | None = None,
+        all_tasks: list[int] | None = None,
+        output_tasks: list[int] | None = None,
+        validate_task_values: bool = True,
     ):
         tkwargs = {"device": self.device, "dtype": dtype}
         train_X, train_Y, train_Yvar, model = self._get_data_and_model(
             infer_noise=infer_noise,
             task_rank=task_rank,
             use_outcome_transform=use_outcome_transform,
+            observed_task_values=observed_task_values,
+            all_tasks=all_tasks,
+            output_tasks=output_tasks,
+            validate_task_values=validate_task_values,
             **tkwargs,
         )
         n = train_X.shape[0]
@@ -256,13 +263,18 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
             train_Y_tf, train_Yvar_tf = model.outcome_transform(
                 Y=train_Y, Yvar=train_Yvar
             )
+        expected_mapped_task_values = torch.zeros(10, **tkwargs)
+        expected_mapped_task_values[5:] = 1
 
         # Test init
         self.assertIsNone(model.mean_module)
         self.assertIsNone(model.covar_module)
         self.assertIsNone(model.likelihood)
         self.assertIsInstance(model.pyro_model, MultitaskSaasPyroModel)
-        self.assertAllClose(train_X, model.pyro_model.train_X)
+        self.assertAllClose(train_X[:, :-1], model.pyro_model.train_X[:, :-1])
+        self.assertAllClose(
+            model.pyro_model.train_X[:, -1], expected_mapped_task_values
+        )
         self.assertAllClose(train_Y_tf, model.pyro_model.train_Y)
         if infer_noise:
             self.assertIsNone(model.pyro_model.train_Yvar)
@@ -331,11 +343,12 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                 )
 
             # Mean/variance
+            num_outputs = self.num_tasks if output_tasks is None else 1
             expected_shape = (
                 *batch_shape[: MCMC_DIM + 2],
                 *model.batch_shape,
                 *batch_shape[MCMC_DIM + 2 :],
-                self.num_tasks,
+                num_outputs,
             )
             expected_shape = torch.Size(expected_shape)
             mean, var = posterior.mean, posterior.variance
@@ -350,18 +363,14 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
 
             # Marginalized mean/variance
             self.assertEqual(
-                mixture_mean.shape, torch.Size(batch_shape + [self.num_tasks])
+                mixture_mean.shape, torch.Size(batch_shape + [num_outputs])
             )
             self.assertEqual(
-                mixture_variance.shape, torch.Size(batch_shape + [self.num_tasks])
+                mixture_variance.shape, torch.Size(batch_shape + [num_outputs])
             )
             self.assertTrue(mixture_variance.min() > 0.0)
-            self.assertEqual(
-                quantile1.shape, torch.Size(batch_shape + [self.num_tasks])
-            )
-            self.assertEqual(
-                quantile2.shape, torch.Size(batch_shape + [self.num_tasks])
-            )
+            self.assertEqual(quantile1.shape, torch.Size(batch_shape + [num_outputs]))
+            self.assertEqual(quantile2.shape, torch.Size(batch_shape + [num_outputs]))
             self.assertTrue((quantile2 > quantile1).all())
 
             dist = torch.distributions.Normal(
@@ -387,7 +396,7 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
             for ModelListClass, models, expected_outputs in zip(
                 [ModelList, ModelListGP],
                 [[deterministic, model], [model, model]],
-                [3, 4],
+                [num_outputs + 1, num_outputs * 2],
             ):
                 expected_shape = (
                     *batch_shape[: MCMC_DIM + 2],
@@ -409,14 +418,17 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
 
         # Check the keys in the state dict
         true_keys = EXPECTED_KEYS_NOISE if infer_noise else EXPECTED_KEYS
+        extra_keys = []
         if use_outcome_transform:
-            true_keys = true_keys + [
+            extra_keys = [
                 "outcome_transform.stdvs",
                 "outcome_transform._is_trained",
                 "outcome_transform._stdvs_sq",
                 "outcome_transform.means",
             ]
-        self.assertEqual(set(model.state_dict().keys()), set(true_keys))
+        if model._task_mapper is not None:
+            extra_keys.append("_task_mapper")
+        self.assertEqual(set(model.state_dict().keys()), {*true_keys, *extra_keys})
 
         # Check that we can load the state dict.
         state_dict = model.state_dict()
@@ -424,6 +436,9 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
             infer_noise=infer_noise,
             task_rank=task_rank,
             use_outcome_transform=use_outcome_transform,
+            observed_task_values=observed_task_values,
+            all_tasks=all_tasks,
+            output_tasks=output_tasks,
             **tkwargs,
         )
         expected_state_dict = {}
@@ -434,7 +449,14 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
                     for k, v in model.outcome_transform.state_dict().items()
                 }
             )
-        self.assertEqual(m_new.state_dict(), expected_state_dict)
+        if m_new._task_mapper is not None:
+            expected_state_dict.update({"_task_mapper": model._task_mapper})
+        for k, v in m_new.state_dict().items():
+            if k != "_task_mapper":
+                self.assertEqual(expected_state_dict[k], v)
+            else:
+                self.assertTrue(torch.equal(expected_state_dict[k], v))
+        self.assertEqual(expected_state_dict.keys(), m_new.state_dict().keys())
         m_new.load_state_dict(state_dict)
         self.assertEqual(model.state_dict().keys(), m_new.state_dict().keys())
         for k in model.state_dict().keys():
@@ -445,26 +467,38 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
 
         # Make sure the model shapes are set correctly
         self.assertEqual(model.pyro_model.train_X.shape, torch.Size([n, d + 1]))
-        self.assertAllClose(model.pyro_model.train_X, train_X)
+        self.assertAllClose(train_X[:, :-1], model.pyro_model.train_X[:, :-1])
+        self.assertAllClose(
+            model.pyro_model.train_X[:, -1], expected_mapped_task_values
+        )
 
         # Put the model in eval mode with reset=True (reset should be ignored)
         trained_model = model.train(mode=False, reset=True)
         self.assertIs(trained_model, model)
-        self.assertAllClose(train_X, model.pyro_model.train_X)
+        self.assertAllClose(train_X[:, :-1], model.pyro_model.train_X[:, :-1])
+        self.assertAllClose(
+            model.pyro_model.train_X[:, -1], expected_mapped_task_values
+        )
         self.assertIsNotNone(model.mean_module)
         self.assertIsNotNone(model.covar_module)
         self.assertIsNotNone(model.likelihood)
         # Put the model in train mode, without resetting
         trained_model = model.train(reset=False)
         self.assertIs(trained_model, model)
-        self.assertAllClose(train_X, model.pyro_model.train_X)
+        self.assertAllClose(train_X[:, :-1], model.pyro_model.train_X[:, :-1])
+        self.assertAllClose(
+            model.pyro_model.train_X[:, -1], expected_mapped_task_values
+        )
         self.assertIsNotNone(model.mean_module)
         self.assertIsNotNone(model.covar_module)
         self.assertIsNotNone(model.likelihood)
         # Put the model in train mode, with resetting
         trained_model = model.train()
         self.assertIs(trained_model, model)
-        self.assertAllClose(train_X, model.pyro_model.train_X)
+        self.assertAllClose(train_X[:, :-1], model.pyro_model.train_X[:, :-1])
+        self.assertAllClose(
+            model.pyro_model.train_X[:, -1], expected_mapped_task_values
+        )
         self.assertIsNone(model.mean_module)
         self.assertIsNone(model.covar_module)
         self.assertIsNone(model.likelihood)
@@ -477,6 +511,32 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
 
     def test_fit_model_with_outcome_transform(self):
         self.test_fit_model(use_outcome_transform=True)
+
+    def test_fit_model_with_task_mapper(self) -> None:
+        dtype = torch.double
+        tkwargs = {"device": self.device, "dtype": dtype}
+        all_tasks = [0, 1, 2]
+        observed_task_values = [0, 2]
+        output_tasks = [2]
+        _, _, _, model = self._get_data_and_model(
+            infer_noise=True,
+            use_outcome_transform=True,
+            output_tasks=output_tasks,
+            observed_task_values=observed_task_values,
+            all_tasks=all_tasks,
+            validate_task_values=False,
+            **tkwargs,
+        )
+        self.assertTrue(
+            torch.equal(model._task_mapper, torch.tensor([0, 1, 1], **tkwargs))
+        )
+        self.test_fit_model(
+            use_outcome_transform=True,
+            all_tasks=all_tasks,
+            observed_task_values=observed_task_values,
+            output_tasks=output_tasks,
+            validate_task_values=False,
+        )
 
     def test_transforms(self, infer_noise: bool = False):
         tkwargs = {"device": self.device, "dtype": torch.double}

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -296,15 +296,28 @@ class TestMultiTaskGP(BotorchTestCase):
                 test_x_task = torch.zeros_like(test_x)
                 test_x_task[1, 0] = 2.0
                 test_x = torch.cat([test_x_task, test_x], dim=-1)
-                expected_task_mapper_non_nan = torch.tensor(
-                    [0.0, 1.0], dtype=dtype, device=self.device
+                expected_task_mapper = torch.tensor(
+                    [0.0, 0.0, 1.0], dtype=dtype, device=self.device
+                )
+                self.assertTrue(torch.equal(model._task_mapper, expected_task_mapper))
+                # Test making predictions for task without observations.
+                # These should be equivalent to predictions for the output task.
+                test_X_unobserved = torch.rand(1, 2, **tkwargs)
+                test_X_unobserved[0, 1] = 1.0
+                with torch.no_grad():
+                    posterior_unobserved = model.posterior(X=test_X_unobserved)
+                test_X_observed = torch.rand(1, 2, **tkwargs)
+                test_X_observed[0, 1] = 0.0
+                with torch.no_grad():
+                    posterior_observed = model.posterior(X=test_X_unobserved)
+                self.assertTrue(
+                    torch.allclose(posterior_unobserved.mean, posterior_observed.mean)
                 )
                 self.assertTrue(
-                    torch.equal(
-                        model._task_mapper[[0, 2]], expected_task_mapper_non_nan
+                    torch.allclose(
+                        posterior_unobserved.variance, posterior_observed.variance
                     )
                 )
-                self.assertTrue(torch.isnan(model._task_mapper[1]))
 
                 # test split inputs
                 _, task_idcs, _ = model._split_inputs(test_x)
@@ -424,9 +437,9 @@ class TestMultiTaskGP(BotorchTestCase):
         model = MultiTaskGP(
             train_X=train_X, train_Y=train_Y, task_feature=0, all_tasks=[0, 1, 2, 3]
         )
-        self.assertEqual(model.num_tasks, 4)
+        self.assertEqual(model.num_tasks, 2)
         # Check that IndexKernel knows of all tasks.
-        self.assertEqual(model.covar_module.kernels[1].raw_var.shape[-1], 4)
+        self.assertEqual(model.covar_module.kernels[1].raw_var.shape[-1], 2)
 
     def test_MultiTaskGP_construct_inputs(self) -> None:
         for dtype, fixed_noise, skip_task_features_in_datasets in zip(
@@ -489,6 +502,43 @@ class TestMultiTaskGP(BotorchTestCase):
             else:
                 self.assertNotIn("train_Yvar", data_dict)
             self.assertIsInstance(data_dict["task_covar_prior"], LKJCovariancePrior)
+
+    def test_validatation_of_task_values(self) -> None:
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        _, (train_X, train_Y, _) = gen_multi_task_dataset(**tkwargs)
+        model = MultiTaskGP(
+            train_X,
+            train_Y,
+            task_feature=0,
+            output_tasks=[1],
+            all_tasks=[0, 1, 2],
+            validate_task_values=False,
+        )
+        self.assertTrue(
+            torch.equal(model._task_mapper, torch.tensor([0, 1, 1], **tkwargs))
+        )
+        self.assertTrue(
+            torch.equal(
+                torch.tensor([1], **tkwargs),
+                model._map_tasks(task_values=torch.tensor([2], **tkwargs)),
+            )
+        )
+        model = MultiTaskGP(
+            train_X,
+            train_Y,
+            task_feature=0,
+            output_tasks=[1],
+            all_tasks=[0, 1, 2],
+            validate_task_values=True,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Received invalid raw task values. Expected raw value to be in"
+            r" \{0, 1\}, but got unexpected task"
+            r" values: \{2\}.",
+        ):
+            model._map_tasks(task_values=torch.tensor([2], **tkwargs))
 
 
 class TestKroneckerMultiTaskGP(BotorchTestCase):
@@ -693,19 +743,43 @@ class TestKroneckerMultiTaskGP(BotorchTestCase):
 class TestMultiTaskUtils(BotorchTestCase):
     def test_get_task_value_remapping(self) -> None:
         for dtype in (torch.float, torch.double):
-            task_values = torch.tensor([1, 3], dtype=torch.long, device=self.device)
-            expected_mapping_no_nan = torch.tensor(
-                [0.0, 1.0], dtype=dtype, device=self.device
+            observed_task_values = torch.tensor(
+                [1, 3], dtype=torch.long, device=self.device
             )
-            mapping = get_task_value_remapping(task_values, dtype)
-            self.assertTrue(torch.equal(mapping[[1, 3]], expected_mapping_no_nan))
-            self.assertTrue(torch.isnan(mapping[[0, 2]]).all())
+            expected_mapping = torch.tensor(
+                [0.0, 0.0, 0.0, 1.0, 0.0], dtype=dtype, device=self.device
+            )
+            all_task_values = torch.arange(5, dtype=torch.long, device=self.device)
+            mapping = get_task_value_remapping(
+                observed_task_values=observed_task_values,
+                all_task_values=all_task_values,
+                dtype=dtype,
+                default_task_value=1.0,
+            )
+            self.assertTrue(torch.equal(mapping, expected_mapping))
+            # test default_task_value that has not been observed
+            # and default_task_value=None
+            for default_task_value in (0.0, None):
+                mapping = get_task_value_remapping(
+                    observed_task_values=observed_task_values,
+                    all_task_values=all_task_values,
+                    dtype=dtype,
+                    default_task_value=default_task_value,
+                )
+                self.assertTrue(torch.equal(mapping[[1, 3]], expected_mapping[[1, 3]]))
+                self.assertTrue(torch.isnan(mapping[[0, 2, 4]]).all())
 
     def test_get_task_value_remapping_invalid_dtype(self) -> None:
-        task_values = torch.tensor([1, 3])
+        observed_task_values = torch.tensor([1, 3])
+        all_task_values = observed_task_values
         for dtype in (torch.int32, torch.long, torch.bool):
             with self.assertRaisesRegex(
                 ValueError,
                 f"dtype must be torch.float or torch.double, but got {dtype}.",
             ):
-                get_task_value_remapping(task_values, dtype)
+                get_task_value_remapping(
+                    observed_task_values=observed_task_values,
+                    all_task_values=all_task_values,
+                    dtype=dtype,
+                    default_task_value=None,
+                )


### PR DESCRIPTION
Summary:
Currently, cross-validation in Ax fails when using a MTGP if there are multiple metrics and only some metrics have been observed for some tasks. This is a modeling problem, since the model is a ModelListGP and not all MTGPs in the list are required to have the same tasks. Hence when you pass in a test input, the model errors out if there are not observations from that task in the training data.

This avoids the error by mapping (optionally) mapping unexpected tasks to the "target task". This does not change the default behavior. For cross-validation in Ax, predictions are discarded if there are no observations for a given (task, metric) pair.

This will still error out in Ax if data for the target trial is missing.

Differential Revision: D79812024


