### PR TITLE
Remove outcome_transform=Standardize to SingleTaskGP [botorch]

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -1078,13 +1078,12 @@ class PosteriorStandardDeviation(AnalyticAcquisitionFunction):
         >>> import torch
         >>> from botorch.models.gp_regression import SingleTaskGP
         >>> from botorch.models.transforms.input import Normalize
-        >>> from botorch.models.transforms.outcome import Standardize
         >>>
         >>> # Set up a model
         >>> train_X = torch.rand(20, 2, dtype=torch.float64)
         >>> train_Y = torch.sin(train_X).sum(dim=1, keepdim=True)
         >>> model = SingleTaskGP(
-        ...     train_X, train_Y, outcome_transform=Standardize(m=1),
+        ...     train_X, train_Y,
         ...     input_transform=Normalize(d=2),
         ... )
         >>> # Now set up the acquisition function

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -41,7 +41,6 @@ from botorch.models import (
 )
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.transforms.input import InputPerturbation
-from botorch.models.transforms.outcome import Standardize
 from botorch.posteriors.posterior_list import PosteriorList
 from botorch.posteriors.transformed import TransformedPosterior
 from botorch.sampling.list_sampler import ListSampler
@@ -1718,9 +1717,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             with self.subTest(acqf_class.__name__):
                 train_x = torch.rand(3, 2, dtype=torch.float64)
                 train_y = torch.randn(3, 2, dtype=torch.float64)
-                model = SingleTaskGP(
-                    train_x, train_y, outcome_transform=Standardize(m=2)
-                )
+                model = SingleTaskGP(train_x, train_y)
                 with catch_warnings():
                     simplefilter("ignore", category=NumericsWarning)
                     acqf = acqf_class(

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -562,9 +562,10 @@ class TestModelListGP(BotorchTestCase):
                 Y = torch.cat([Y1, Y2], dim=-1)
                 target_x = torch.tensor([[0.5]], **tkwargs)
 
+                # Default behavior is to Standardize outcomes
                 model_with_transform = ModelListGP(
-                    SingleTaskGP(X, Y1, outcome_transform=Standardize(m=1)),
-                    SingleTaskGP(X, Y2, outcome_transform=Standardize(m=1)),
+                    SingleTaskGP(X, Y1),
+                    SingleTaskGP(X, Y2),
                 )
                 outcome_transform = Standardize(m=2)
                 y_standardized, _ = outcome_transform(Y)
@@ -682,8 +683,8 @@ class TestModelListGP(BotorchTestCase):
                 yvar = torch.full_like(Y, 1e-4)
                 yvar2 = 2 * yvar
                 model = ModelListGP(
-                    SingleTaskGP(X, Y, yvar, outcome_transform=Standardize(m=1)),
-                    SingleTaskGP(X, Y2, yvar2, outcome_transform=Standardize(m=1)),
+                    SingleTaskGP(X, Y, yvar),
+                    SingleTaskGP(X, Y2, yvar2),
                 )
                 # test exceptions
                 eval_mask = torch.zeros(

--- a/test/models/test_relevance_pursuit.py
+++ b/test/models/test_relevance_pursuit.py
@@ -34,7 +34,6 @@ from botorch.models.robust_relevance_pursuit_model import (
     RobustRelevancePursuitSingleTaskGP,
 )
 from botorch.models.transforms.input import Normalize
-from botorch.models.transforms.outcome import Standardize
 from botorch.test_functions.base import constant_outlier_generator, CorruptedTestProblem
 
 from botorch.test_functions.synthetic import Ackley
@@ -122,7 +121,6 @@ class TestRobustGP(BotorchTestCase):
             mean_module=ZeroMean(),
             covar_module=kernel,
             input_transform=Normalize(d=X.shape[-1]),
-            outcome_transform=Standardize(m=Y.shape[-1]),
             likelihood=likelihood,
         )
         model.to(dtype=X.dtype, device=self.device)

--- a/test/optim/closures/test_model_closures.py
+++ b/test/optim/closures/test_model_closures.py
@@ -10,7 +10,6 @@ from math import pi
 import torch
 from botorch.models import ModelListGP, SingleTaskGP
 from botorch.models.transforms.input import Normalize
-from botorch.models.transforms.outcome import Standardize
 from botorch.optim.closures.model_closures import (
     get_loss_closure,
     get_loss_closure_with_grads,
@@ -63,7 +62,6 @@ def _get_mlls(
         train_X=train_X,
         train_Y=train_Y,
         input_transform=Normalize(d=1),
-        outcome_transform=Standardize(m=1),
     )
     if wrap_likelihood:
         model.likelihood = WrapperLikelihood(model.likelihood)

--- a/test/optim/test_fit.py
+++ b/test/optim/test_fit.py
@@ -13,7 +13,6 @@ import torch
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.models import SingleTaskGP
 from botorch.models.transforms.input import Normalize
-from botorch.models.transforms.outcome import Standardize
 from botorch.optim import core, fit
 from botorch.optim.core import OptimizationResult, OptimizationStatus
 from botorch.utils.context_managers import module_rollback_ctx, TensorCheckpoint
@@ -41,7 +40,6 @@ class TestFitGPyTorchMLLScipy(BotorchTestCase):
             train_X=train_X,
             train_Y=train_Y,
             input_transform=Normalize(d=1),
-            outcome_transform=Standardize(m=1),
         )
         self.mlls[SingleTaskGP, 1] = ExactMarginalLogLikelihood(model.likelihood, model)
 
@@ -188,7 +186,6 @@ class TestFitGPyTorchMLLTorch(BotorchTestCase):
             train_X=train_X,
             train_Y=train_Y,
             input_transform=Normalize(d=1),
-            outcome_transform=Standardize(m=1),
         )
         self.mlls[SingleTaskGP, 1] = ExactMarginalLogLikelihood(model.likelihood, model)
 

--- a/test/sampling/pathwise/test_utils.py
+++ b/test/sampling/pathwise/test_utils.py
@@ -64,7 +64,6 @@ class TestGetters(BotorchTestCase):
                     train_X=train_X,
                     train_Y=train_Y[:, :num_outputs],
                     input_transform=Normalize(d=2),
-                    outcome_transform=Standardize(m=num_outputs),
                 )
             )
 

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -90,7 +90,6 @@ class TestFitAPI(BotorchTestCase):
                 train_X=train_X,
                 train_Y=train_Y,
                 input_transform=Normalize(d=1),
-                outcome_transform=Standardize(m=1),
             )
             self.mll = ExactMarginalLogLikelihood(model.likelihood, model)
 
@@ -137,7 +136,6 @@ class TestFitFallback(BotorchTestCase):
                     train_Y=train_Y,
                     train_Yvar=torch.full_like(train_Y, 0.1) if fixed_noise else None,
                     input_transform=Normalize(d=1),
-                    outcome_transform=Standardize(m=output_dim),
                 )
                 self.assertIsInstance(model.covar_module, RBFKernel)
 


### PR DESCRIPTION
Summary: Removing outcome_transform = Standardize for SingleTaskGP

Differential Revision: D80022407


