### PR TITLE
Remove_outcome_transform=Standardize for SingleTaskGP [botorch tests]

### DIFF
--- a/botorch/cross_validation.py
+++ b/botorch/cross_validation.py
@@ -154,9 +154,6 @@ def batch_cross_validation(
         >>> train_Y = torch.rand_like(train_X)
         >>> cv_folds = gen_loo_cv_folds(train_X, train_Y)
         >>> input_transform = Normalize(d=train_X.shape[-1])
-        >>> outcome_transform = Standardize(
-        ...     m=train_Y.shape[-1], batch_shape=cv_folds.train_Y.shape[:-2]
-        ... )
         >>>
         >>> cv_results = batch_cross_validation(
         ...    model_cls=SingleTaskGP,
@@ -164,7 +161,6 @@ def batch_cross_validation(
         ...    cv_folds=cv_folds,
         ...    model_init_kwargs={
         ...        "input_transform": input_transform,
-        ...        "outcome_transform": outcome_transform,
         ...    },
         ... )
     """

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -41,7 +41,6 @@ from botorch.models import (
 )
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.transforms.input import InputPerturbation
-from botorch.models.transforms.outcome import Standardize
 from botorch.posteriors.posterior_list import PosteriorList
 from botorch.posteriors.transformed import TransformedPosterior
 from botorch.sampling.list_sampler import ListSampler
@@ -1718,9 +1717,7 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             with self.subTest(acqf_class.__name__):
                 train_x = torch.rand(3, 2, dtype=torch.float64)
                 train_y = torch.randn(3, 2, dtype=torch.float64)
-                model = SingleTaskGP(
-                    train_x, train_y, outcome_transform=Standardize(m=2)
-                )
+                model = SingleTaskGP(train_x, train_y)
                 with catch_warnings():
                     simplefilter("ignore", category=NumericsWarning)
                     acqf = acqf_class(

--- a/test/models/test_model_list_gp_regression.py
+++ b/test/models/test_model_list_gp_regression.py
@@ -562,9 +562,10 @@ class TestModelListGP(BotorchTestCase):
                 Y = torch.cat([Y1, Y2], dim=-1)
                 target_x = torch.tensor([[0.5]], **tkwargs)
 
+                # Default behavior is to Standardize outcomes
                 model_with_transform = ModelListGP(
-                    SingleTaskGP(X, Y1, outcome_transform=Standardize(m=1)),
-                    SingleTaskGP(X, Y2, outcome_transform=Standardize(m=1)),
+                    SingleTaskGP(X, Y1),
+                    SingleTaskGP(X, Y2),
                 )
                 outcome_transform = Standardize(m=2)
                 y_standardized, _ = outcome_transform(Y)
@@ -682,8 +683,8 @@ class TestModelListGP(BotorchTestCase):
                 yvar = torch.full_like(Y, 1e-4)
                 yvar2 = 2 * yvar
                 model = ModelListGP(
-                    SingleTaskGP(X, Y, yvar, outcome_transform=Standardize(m=1)),
-                    SingleTaskGP(X, Y2, yvar2, outcome_transform=Standardize(m=1)),
+                    SingleTaskGP(X, Y, yvar),
+                    SingleTaskGP(X, Y2, yvar2),
                 )
                 # test exceptions
                 eval_mask = torch.zeros(

--- a/test/models/test_relevance_pursuit.py
+++ b/test/models/test_relevance_pursuit.py
@@ -34,7 +34,6 @@ from botorch.models.robust_relevance_pursuit_model import (
     RobustRelevancePursuitSingleTaskGP,
 )
 from botorch.models.transforms.input import Normalize
-from botorch.models.transforms.outcome import Standardize
 from botorch.test_functions.base import constant_outlier_generator, CorruptedTestProblem
 
 from botorch.test_functions.synthetic import Ackley
@@ -122,7 +121,6 @@ class TestRobustGP(BotorchTestCase):
             mean_module=ZeroMean(),
             covar_module=kernel,
             input_transform=Normalize(d=X.shape[-1]),
-            outcome_transform=Standardize(m=Y.shape[-1]),
             likelihood=likelihood,
         )
         model.to(dtype=X.dtype, device=self.device)

--- a/test/optim/closures/test_model_closures.py
+++ b/test/optim/closures/test_model_closures.py
@@ -10,7 +10,6 @@ from math import pi
 import torch
 from botorch.models import ModelListGP, SingleTaskGP
 from botorch.models.transforms.input import Normalize
-from botorch.models.transforms.outcome import Standardize
 from botorch.optim.closures.model_closures import (
     get_loss_closure,
     get_loss_closure_with_grads,
@@ -63,7 +62,6 @@ def _get_mlls(
         train_X=train_X,
         train_Y=train_Y,
         input_transform=Normalize(d=1),
-        outcome_transform=Standardize(m=1),
     )
     if wrap_likelihood:
         model.likelihood = WrapperLikelihood(model.likelihood)

--- a/test/optim/test_fit.py
+++ b/test/optim/test_fit.py
@@ -13,7 +13,6 @@ import torch
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.models import SingleTaskGP
 from botorch.models.transforms.input import Normalize
-from botorch.models.transforms.outcome import Standardize
 from botorch.optim import core, fit
 from botorch.optim.core import OptimizationResult, OptimizationStatus
 from botorch.utils.context_managers import module_rollback_ctx, TensorCheckpoint
@@ -41,7 +40,6 @@ class TestFitGPyTorchMLLScipy(BotorchTestCase):
             train_X=train_X,
             train_Y=train_Y,
             input_transform=Normalize(d=1),
-            outcome_transform=Standardize(m=1),
         )
         self.mlls[SingleTaskGP, 1] = ExactMarginalLogLikelihood(model.likelihood, model)
 
@@ -188,7 +186,6 @@ class TestFitGPyTorchMLLTorch(BotorchTestCase):
             train_X=train_X,
             train_Y=train_Y,
             input_transform=Normalize(d=1),
-            outcome_transform=Standardize(m=1),
         )
         self.mlls[SingleTaskGP, 1] = ExactMarginalLogLikelihood(model.likelihood, model)
 

--- a/test/sampling/pathwise/test_utils.py
+++ b/test/sampling/pathwise/test_utils.py
@@ -64,7 +64,6 @@ class TestGetters(BotorchTestCase):
                     train_X=train_X,
                     train_Y=train_Y[:, :num_outputs],
                     input_transform=Normalize(d=2),
-                    outcome_transform=Standardize(m=num_outputs),
                 )
             )
 

--- a/test/test_cross_validation.py
+++ b/test/test_cross_validation.py
@@ -14,7 +14,6 @@ from botorch.exceptions.warnings import OptimizationWarning
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.multitask import MultiTaskGP
 from botorch.models.transforms.input import Normalize
-from botorch.models.transforms.outcome import Standardize
 from botorch.utils.testing import BotorchTestCase, get_random_data
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 
@@ -73,9 +72,6 @@ class TestFitBatchCrossValidation(BotorchTestCase):
                 self.assertIs(cv_folds.train_X.dtype, dtype)
 
             input_transform = Normalize(d=train_X.shape[-1])
-            outcome_transform = Standardize(
-                m=m, batch_shape=torch.Size([*batch_shape, n])
-            )
 
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=OptimizationWarning)
@@ -86,7 +82,6 @@ class TestFitBatchCrossValidation(BotorchTestCase):
                     fit_args={"optimizer_kwargs": {"options": {"maxiter": 1}}},
                     model_init_kwargs={
                         "input_transform": input_transform,
-                        "outcome_transform": outcome_transform,
                     },
                 )
             with self.subTest(

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -90,7 +90,6 @@ class TestFitAPI(BotorchTestCase):
                 train_X=train_X,
                 train_Y=train_Y,
                 input_transform=Normalize(d=1),
-                outcome_transform=Standardize(m=1),
             )
             self.mll = ExactMarginalLogLikelihood(model.likelihood, model)
 
@@ -137,7 +136,6 @@ class TestFitFallback(BotorchTestCase):
                     train_Y=train_Y,
                     train_Yvar=torch.full_like(train_Y, 0.1) if fixed_noise else None,
                     input_transform=Normalize(d=1),
-                    outcome_transform=Standardize(m=output_dim),
                 )
                 self.assertIsInstance(model.covar_module, RBFKernel)
 


### PR DESCRIPTION
Summary: SingleTaskGP standardizes outcomes by default; updated botorch tests to remove redundant standardizations

Differential Revision: D80032173


