### PR TITLE
Fixed tutorial link in "getting_started.mdx"

### DIFF
--- a/docs/getting_started.mdx
+++ b/docs/getting_started.mdx
@@ -88,7 +88,7 @@ Here's a quick run down of the main components of a Bayesian Optimization loop.
 ## Tutorials
 
 Our Jupyter notebook tutorials help you get off the ground with BoTorch.
-View and download them [here](https://botorch.org/docs/tutorials/).
+View and download them [here](tutorials/index.mdx).
 
 
 ## API Reference


### PR DESCRIPTION
The link was broken, so I updated it, it works now.

<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

The link didn't work for the tutorial section, so I fixed it

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

If you click the link, it goes to the page

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
