### PR TITLE
log values for HVKG using LogEHVI

### DIFF
--- a/botorch/acquisition/cost_aware.py
+++ b/botorch/acquisition/cost_aware.py
@@ -11,7 +11,6 @@ To be used in a context where there is an objective/cost tradeoff.
 
 from __future__ import annotations
 
-import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 
@@ -21,7 +20,6 @@ from botorch.acquisition.objective import (
     IdentityMCObjective,
     MCAcquisitionObjective,
 )
-from botorch.exceptions.warnings import CostAwareWarning
 from botorch.models.deterministic import DeterministicModel
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.sampling.base import MCSampler
@@ -112,7 +110,7 @@ class InverseCostWeightedUtility(CostAwareUtility):
         cost_model: DeterministicModel | GPyTorchModel,
         use_mean: bool = True,
         cost_objective: MCAcquisitionObjective | None = None,
-        min_cost: float = 1e-2,
+        log: bool = False,
     ) -> None:
         r"""Cost-aware utility that weights increase in utility by inverse cost.
         For negative increases in utility, the utility is instead scaled by the
@@ -130,7 +128,8 @@ class InverseCostWeightedUtility(CostAwareUtility):
                 un-transform predictions/samples of a cost model fit on the
                 log-transformed cost (often done to ensure non-negativity). If the
                 cost model is multi-output, then by default this will sum the cost
-                across outputs.
+                across outputs. NOTE: Keep in mind that cost_objective must output
+                strictly positive values; forward will raise a ValueError otherwise.
             min_cost: A value used to clamp the cost samples so that they are not
                 too close to zero, which may cause numerical issues.
         Returns:
@@ -147,7 +146,7 @@ class InverseCostWeightedUtility(CostAwareUtility):
         self.cost_model = cost_model
         self.cost_objective: MCAcquisitionObjective = cost_objective
         self._use_mean = use_mean
-        self._min_cost = min_cost
+        self._log = log
 
     def forward(
         self,
@@ -202,18 +201,21 @@ class InverseCostWeightedUtility(CostAwareUtility):
             cost = none_throws(sampler)(cost_posterior)
         cost = self.cost_objective(cost)
 
-        # Ensure non-negativity of the cost
-        if torch.any(cost < -1e-7):
-            warnings.warn(
-                "Encountered negative cost values in InverseCostWeightedUtility",
-                CostAwareWarning,
-                stacklevel=2,
+        # Ensure that costs are positive
+        if not torch.all(cost > 0.0):
+            raise ValueError(
+                "Costs must be strictly positive. Consider clamping cost_objective."
             )
-        # clamp (away from zero) and sum cost across elements of the q-batch -
-        # this will be of shape `num_fantasies x batch_shape` or `batch_shape`
-        cost = cost.clamp_min(self._min_cost).sum(dim=-1)
+
+        # sum costs along q-batch
+        cost = cost.sum(dim=-1)
 
         # compute and return the ratio on the sample level - If `use_mean=True`
         # this operation involves broadcasting the cost across fantasies.
-        # We multiply by the cost if the deltas are <= 0, see discussion #2914
-        return torch.where(deltas > 0, deltas / cost, deltas * cost)
+        if self._log:
+            # if _log is True then input deltas are in log space
+            # so original deltas cannot be <= 0
+            return deltas - torch.log(cost)
+        else:
+            # We multiply by the cost if the deltas are <= 0, see discussion #2914
+            return torch.where(deltas > 0, deltas / cost, deltas * cost)

--- a/botorch/acquisition/multi_objective/hypervolume_knowledge_gradient.py
+++ b/botorch/acquisition/multi_objective/hypervolume_knowledge_gradient.py
@@ -32,11 +32,12 @@ from botorch.acquisition.cost_aware import CostAwareUtility
 from botorch.acquisition.decoupled import DecoupledAcquisitionFunction
 from botorch.acquisition.knowledge_gradient import ProjectedAcquisitionFunction
 from botorch.acquisition.multi_objective.base import MultiObjectiveMCAcquisitionFunction
+from botorch.acquisition.multi_objective.logei import qLogExpectedHypervolumeImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
     qExpectedHypervolumeImprovement,
 )
 from botorch.acquisition.multi_objective.objective import MCMultiOutputObjective
-from botorch.exceptions.errors import UnsupportedError
+from botorch.exceptions.errors import BotorchError, UnsupportedError
 from botorch.exceptions.warnings import NumericsWarning
 from botorch.models.deterministic import PosteriorMeanModel
 from botorch.models.model import Model
@@ -47,6 +48,7 @@ from botorch.sampling.stochastic_samplers import StochasticSampler
 from botorch.utils.multi_objective.box_decompositions.non_dominated import (
     FastNondominatedPartitioning,
 )
+from botorch.utils.safe_math import logdiffexp, logmeanexp
 from botorch.utils.transforms import (
     average_over_ensemble_models,
     match_batch_shape,
@@ -91,6 +93,7 @@ class qHypervolumeKnowledgeGradient(
         current_value: Tensor | None = None,
         use_posterior_mean: bool = True,
         cost_aware_utility: CostAwareUtility | None = None,
+        log: bool = False,
     ) -> None:
         r"""q-Hypervolume Knowledge Gradient.
 
@@ -133,6 +136,9 @@ class qHypervolumeKnowledgeGradient(
                 [Daulton2023hvkg]_ for details.
             cost_aware_utility: A CostAwareUtility specifying the cost function for
                 evaluating the `X` on the objectives indicated by `evaluation_mask`.
+            log: If True, then returns the log of the HVKG value. If True, then it
+                expects current_value to be in log-space and cost_aware_utility to
+                output log utilities.
         """
         if sampler is None:
             # base samples should be fixed for joint optimization over X, X_fantasies
@@ -169,6 +175,8 @@ class qHypervolumeKnowledgeGradient(
         self.use_posterior_mean = use_posterior_mean
         self.cost_aware_utility = cost_aware_utility
         self._cost_sampler = None
+
+        self._log = log
 
     @property
     def cost_sampler(self):
@@ -242,6 +250,7 @@ class qHypervolumeKnowledgeGradient(
             objective=self.objective,
             sampler=self.inner_sampler,
             use_posterior_mean=self.use_posterior_mean,
+            log=self._log,
         )
 
         # make sure to propagate gradients to the fantasy model train inputs
@@ -259,9 +268,23 @@ class qHypervolumeKnowledgeGradient(
             values = value_function(X=X_fantasies.reshape(shape))  # num_fantasies x b
 
         if self.current_value is not None:
-            values = values - self.current_value
+            if self._log:
+                values = logdiffexp(self.current_value, values)
+            else:
+                values = values - self.current_value
 
         if self.cost_aware_utility is not None:
+            if self._log:
+                # check whether cost_aware_utility has a _log flag
+                # raises an error if it does not or if _log is False
+                if (
+                    not hasattr(self.cost_aware_utility, "_log")
+                    or not self.cost_aware_utility._log
+                ):
+                    raise BotorchError(
+                        "Cost-aware HVKG has _log=True and requires cost_aware_utility"
+                        "to output log utilities."
+                    )
             values = self.cost_aware_utility(
                 # exclude pending points
                 X=X_actual[..., :q, :],
@@ -271,7 +294,10 @@ class qHypervolumeKnowledgeGradient(
             )
 
         # return average over the fantasy samples
-        return values.mean(dim=0)
+        if self._log:
+            return logmeanexp(values, dim=0)
+        else:
+            return values.mean(dim=0)
 
     def get_augmented_q_batch_size(self, q: int) -> int:
         r"""Get augmented q batch size for one-shot optimization.
@@ -329,6 +355,7 @@ class qMultiFidelityHypervolumeKnowledgeGradient(qHypervolumeKnowledgeGradient):
         valfunc_cls: type[AcquisitionFunction] | None = None,
         valfunc_argfac: Callable[[Model], dict[str, Any]] | None = None,
         use_posterior_mean: bool = True,
+        log: bool = False,
         **kwargs: Any,
     ) -> None:
         r"""Multi-Fidelity q-Knowledge Gradient (one-shot optimization).
@@ -376,6 +403,9 @@ class qMultiFidelityHypervolumeKnowledgeGradient(qHypervolumeKnowledgeGradient):
             valfunc_argfac: An argument factory, i.e. callable that maps a `Model`
                 to a dictionary of kwargs for the terminal value function (e.g.
                 `best_f` for `ExpectedImprovement`).
+            log: If True, then returns the log of the HVKG value. If True, then it
+                expects current_value to be in log-space and cost_aware_utility to
+                output log utilities.
         """
 
         super().__init__(
@@ -392,6 +422,7 @@ class qMultiFidelityHypervolumeKnowledgeGradient(qHypervolumeKnowledgeGradient):
             current_value=current_value,
             use_posterior_mean=use_posterior_mean,
             cost_aware_utility=cost_aware_utility,
+            log=log,
         )
         self.project = project
         if kwargs.get("expand") is not None:
@@ -465,6 +496,7 @@ class qMultiFidelityHypervolumeKnowledgeGradient(qHypervolumeKnowledgeGradient):
             valfunc_cls=self.valfunc_cls,
             valfunc_argfac=self.valfunc_argfac,
             use_posterior_mean=self.use_posterior_mean,
+            log=self._log,
         )
 
         # make sure to propagate gradients to the fantasy model train inputs
@@ -481,9 +513,24 @@ class qMultiFidelityHypervolumeKnowledgeGradient(qHypervolumeKnowledgeGradient):
             )
             values = value_function(X=X_fantasies.reshape(shape))  # num_fantasies x b
         if self.current_value is not None:
-            values = values - self.current_value
+            if self._log:
+                # Assumes current value is in log-space
+                values = logdiffexp(self.current_value, values)
+            else:
+                values = values - self.current_value
 
         if self.cost_aware_utility is not None:
+            if self._log:
+                # check whether cost_aware_utility has a _log flag
+                # raises an error if it does not or if _log is False
+                if (
+                    not hasattr(self.cost_aware_utility, "_log")
+                    or not self.cost_aware_utility._log
+                ):
+                    raise BotorchError(
+                        "Cost-aware HVKG has _log=True and requires cost_aware_utility"
+                        "to output log utilities."
+                    )
             values = self.cost_aware_utility(
                 # exclude pending points
                 X=X_actual[..., :q, :],
@@ -493,7 +540,7 @@ class qMultiFidelityHypervolumeKnowledgeGradient(qHypervolumeKnowledgeGradient):
             )
 
         # return average over the fantasy samples
-        return values.mean(dim=0)
+        return logmeanexp(values, dim=0) if self._log else values.mean(dim=0)
 
 
 def _get_hv_value_function(
@@ -505,6 +552,7 @@ def _get_hv_value_function(
     valfunc_cls: type[AcquisitionFunction] | None = None,
     valfunc_argfac: Callable[[Model], dict[str, Any]] | None = None,
     use_posterior_mean: bool = False,
+    log: bool = False,
 ) -> AcquisitionFunction:
     r"""Construct value function (i.e. inner acquisition function).
     This is a method for computing hypervolume.
@@ -518,7 +566,13 @@ def _get_hv_value_function(
             action="ignore",
             category=NumericsWarning,
         )
-        base_value_function = qExpectedHypervolumeImprovement(
+
+        base_value_function_class = (
+            qLogExpectedHypervolumeImprovement
+            if log
+            else qExpectedHypervolumeImprovement
+        )
+        base_value_function = base_value_function_class(
             model=model,
             ref_point=ref_point,
             partitioning=FastNondominatedPartitioning(

--- a/test/acquisition/multi_objective/test_hypervolume_knowledge_gradient.py
+++ b/test/acquisition/multi_objective/test_hypervolume_knowledge_gradient.py
@@ -11,7 +11,10 @@ from unittest import mock
 import numpy as np
 
 import torch
-from botorch.acquisition.cost_aware import InverseCostWeightedUtility
+from botorch.acquisition.cost_aware import (
+    GenericCostAwareUtility,
+    InverseCostWeightedUtility,
+)
 from botorch.acquisition.multi_objective.hypervolume_knowledge_gradient import (
     _get_hv_value_function,
     _split_hvkg_fantasy_points,
@@ -22,7 +25,7 @@ from botorch.acquisition.multi_objective.objective import (
     GenericMCMultiOutputObjective,
     IdentityMCMultiOutputObjective,
 )
-from botorch.exceptions.errors import UnsupportedError
+from botorch.exceptions.errors import BotorchError, UnsupportedError
 from botorch.exceptions.warnings import NumericsWarning
 from botorch.models.deterministic import GenericDeterministicModel
 from botorch.models.gp_regression import SingleTaskGP
@@ -171,9 +174,10 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
     def test_evaluate_q_hvkg(self):
         tkwargs = {"device": self.device}
         num_pareto = 3
-        for dtype, acqf_class in product(
+        for dtype, acqf_class, log_ehvi in product(
             (torch.float, torch.double),
             (qHypervolumeKnowledgeGradient, qMultiFidelityHypervolumeKnowledgeGradient),
+            (False, True),
         ):
             tkwargs["dtype"] = dtype
             # basic test
@@ -194,28 +198,32 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
 
             with mock.patch.object(
                 ModelListGP, "fantasize", return_value=mfm
-            ) as patch_f:
-                with mock.patch(NO, new_callable=mock.PropertyMock) as mock_num_outputs:
-                    mock_num_outputs.return_value = 2
-
-                    qHVKG = acqf_class(
-                        model=model,
-                        num_fantasies=n_f,
-                        ref_point=ref_point,
-                        num_pareto=num_pareto,
-                        **mf_kwargs,
-                    )
-                    X = torch.rand(n_f * num_pareto + 1, 1, **tkwargs)
-                    val = qHVKG(X)
-                    patch_f.assert_called_once()
-                    cargs, ckwargs = patch_f.call_args
-                    self.assertEqual(ckwargs["X"].shape, torch.Size([1, 1, 1]))
+            ) as patch_f, mock.patch(
+                NO, new_callable=mock.PropertyMock
+            ) as mock_num_outputs:
+                mock_num_outputs.return_value = 2
+                qHVKG = acqf_class(
+                    model=model,
+                    num_fantasies=n_f,
+                    ref_point=ref_point,
+                    num_pareto=num_pareto,
+                    log=log_ehvi,
+                    **mf_kwargs,
+                )
+                X = torch.rand(n_f * num_pareto + 1, 1, **tkwargs)
+                val = qHVKG(X)
+                patch_f.assert_called_once()
+                cargs, ckwargs = patch_f.call_args
+                self.assertEqual(ckwargs["X"].shape, torch.Size([1, 1, 1]))
             expected_hv = (
                 DominatedPartitioning(Y=mean.squeeze(1), ref_point=ref_point)
                 .compute_hypervolume()
                 .mean()
             )
-            self.assertAllClose(val.item(), expected_hv.item(), atol=1e-4)
+            if log_ehvi:
+                self.assertAllClose(val.exp().item(), expected_hv.item(), rtol=1e-2)
+            else:
+                self.assertAllClose(val.item(), expected_hv.item(), atol=1e-4)
             self.assertTrue(
                 torch.equal(qHVKG.extract_candidates(X), X[..., : -n_f * num_pareto, :])
             )
@@ -228,20 +236,22 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
             X = torch.rand(b, n_f * num_pareto + 1, 1, **tkwargs)
             with mock.patch.object(
                 ModelListGP, "fantasize", return_value=mfm
-            ) as patch_f:
-                with mock.patch(NO, new_callable=mock.PropertyMock) as mock_num_outputs:
-                    mock_num_outputs.return_value = 2
-                    qHVKG = acqf_class(
-                        model=model,
-                        num_fantasies=n_f,
-                        ref_point=ref_point,
-                        num_pareto=num_pareto,
-                        **mf_kwargs,
-                    )
-                    val = qHVKG(X)
-                    patch_f.assert_called_once()
-                    cargs, ckwargs = patch_f.call_args
-                    self.assertEqual(ckwargs["X"].shape, torch.Size([b, 1, 1]))
+            ) as patch_f, mock.patch(
+                NO, new_callable=mock.PropertyMock
+            ) as mock_num_outputs:
+                mock_num_outputs.return_value = 2
+                qHVKG = acqf_class(
+                    model=model,
+                    num_fantasies=n_f,
+                    ref_point=ref_point,
+                    num_pareto=num_pareto,
+                    log=log_ehvi,
+                    **mf_kwargs,
+                )
+                val = qHVKG(X)
+                patch_f.assert_called_once()
+                cargs, ckwargs = patch_f.call_args
+                self.assertEqual(ckwargs["X"].shape, torch.Size([b, 1, 1]))
             expected_hv = (
                 DominatedPartitioning(
                     Y=mean.view(-1, num_pareto, 2), ref_point=ref_point
@@ -250,7 +260,10 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
                 .view(n_f, b)
                 .mean(dim=0)
             )
-            self.assertAllClose(val, expected_hv, atol=1e-4)
+            if log_ehvi:
+                self.assertAllClose(val.exp(), expected_hv, rtol=1e-2)
+            else:
+                self.assertAllClose(val, expected_hv, atol=1e-4)
             self.assertTrue(
                 torch.equal(qHVKG.extract_candidates(X), X[..., : -n_f * num_pareto, :])
             )
@@ -263,38 +276,46 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
             mean = torch.rand(n_f, 1, num_pareto, 2, **tkwargs)
             variance = torch.rand(n_f, 1, num_pareto, 2, **tkwargs)
             mfm = MockModel(MockPosterior(mean=mean, variance=variance))
-            current_value = torch.tensor(0.0, **tkwargs)
             X = torch.rand(n_f * num_pareto + 1, 1, **tkwargs)
+            current_value = torch.tensor(0.01, **tkwargs)
+            # if log flag is on, current_value is expected to be in log space
+            input_current_value = (
+                torch.log(current_value) if log_ehvi else current_value
+            )
+            # if log flag is on, the cost_aware_utility should be in log space
             cost_aware_utility = InverseCostWeightedUtility(
-                cost_model=GenericDeterministicModel(cost_fn, num_outputs=2)
+                cost_model=GenericDeterministicModel(cost_fn, num_outputs=2),
+                log=log_ehvi,
             )
             with mock.patch.object(
                 ModelListGP, "fantasize", return_value=mfm
-            ) as patch_f:
-                with mock.patch(NO, new_callable=mock.PropertyMock) as mock_num_outputs:
-                    mock_num_outputs.return_value = 2
-                    qHVKG = acqf_class(
-                        model=model,
-                        num_fantasies=n_f,
-                        X_pending=X_pending,
-                        X_pending_evaluation_mask=X_pending_evaluation_mask,
-                        X_evaluation_mask=X_evaluation_mask,
-                        current_value=current_value,
-                        ref_point=ref_point,
-                        num_pareto=num_pareto,
-                        cost_aware_utility=cost_aware_utility,
-                        **mf_kwargs,
-                    )
-                    val = qHVKG(X)
-                    patch_f.assert_called_once()
-                    expected_eval_mask = torch.cat(
-                        [X_evaluation_mask, X_pending_evaluation_mask], dim=0
-                    )
-                    cargs, ckwargs = patch_f.call_args
-                    self.assertEqual(ckwargs["X"].shape, torch.Size([1, 3, 1]))
-                    self.assertTrue(
-                        torch.equal(ckwargs["evaluation_mask"], expected_eval_mask)
-                    )
+            ) as patch_f, mock.patch(
+                NO, new_callable=mock.PropertyMock
+            ) as mock_num_outputs:
+                mock_num_outputs.return_value = 2
+                qHVKG = acqf_class(
+                    model=model,
+                    num_fantasies=n_f,
+                    X_pending=X_pending,
+                    X_pending_evaluation_mask=X_pending_evaluation_mask,
+                    X_evaluation_mask=X_evaluation_mask,
+                    current_value=input_current_value,
+                    ref_point=ref_point,
+                    num_pareto=num_pareto,
+                    cost_aware_utility=cost_aware_utility,
+                    log=log_ehvi,
+                    **mf_kwargs,
+                )
+                val = qHVKG(X)
+                patch_f.assert_called_once()
+                expected_eval_mask = torch.cat(
+                    [X_evaluation_mask, X_pending_evaluation_mask], dim=0
+                )
+                cargs, ckwargs = patch_f.call_args
+                self.assertEqual(ckwargs["X"].shape, torch.Size([1, 3, 1]))
+                self.assertTrue(
+                    torch.equal(ckwargs["evaluation_mask"], expected_eval_mask)
+                )
             expected_hv = (
                 DominatedPartitioning(Y=mean.squeeze(1), ref_point=ref_point)
                 .compute_hypervolume()
@@ -302,17 +323,83 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
             )
             # divide by 3 because the cost is 3 per design
             expected = (expected_hv.mean() - current_value).item() / 3
-            self.assertAllClose(val.item(), expected, atol=1e-4)
+            if log_ehvi:
+                self.assertAllClose(
+                    val.exp().item(),
+                    expected,
+                    rtol=1e-2,
+                )
+            else:
+                self.assertAllClose(val.item(), expected, atol=1e-4)
             self.assertTrue(
                 torch.equal(qHVKG.extract_candidates(X), X[..., : -n_f * num_pareto, :])
             )
+
+            # test that it raises an error if cost_aware_utility is not Logged
+            if log_ehvi:
+                cost_aware_utility = InverseCostWeightedUtility(
+                    cost_model=GenericDeterministicModel(cost_fn, num_outputs=2),
+                    log=False,
+                )
+                with mock.patch.object(
+                    ModelListGP, "fantasize", return_value=mfm
+                ) as patch_f, mock.patch(
+                    NO, new_callable=mock.PropertyMock
+                ) as mock_num_outputs:
+                    mock_num_outputs.return_value = 2
+                    qHVKG = acqf_class(
+                        model=model,
+                        num_fantasies=n_f,
+                        current_value=input_current_value,
+                        ref_point=ref_point,
+                        num_pareto=num_pareto,
+                        cost_aware_utility=cost_aware_utility,
+                        log=log_ehvi,
+                        **mf_kwargs,
+                    )
+                    # raises error when log=False
+                    with self.assertRaisesRegex(
+                        BotorchError,
+                        "Cost-aware HVKG has _log=True and requires cost_aware_utility"
+                        "to output log utilities.",
+                    ):
+                        val = qHVKG(X)
+
+                # check log is not a class attribute of cost_aware_utility
+                # Generic cost aware utility does not have a log flag
+                cost_aware_utility = GenericCostAwareUtility(
+                    cost=GenericDeterministicModel(cost_fn, num_outputs=2),
+                )
+                with mock.patch.object(
+                    ModelListGP, "fantasize", return_value=mfm
+                ) as patch_f, mock.patch(
+                    NO, new_callable=mock.PropertyMock
+                ) as mock_num_outputs:
+                    mock_num_outputs.return_value = 2
+                    qHVKG = acqf_class(
+                        model=model,
+                        num_fantasies=n_f,
+                        current_value=input_current_value,
+                        ref_point=ref_point,
+                        num_pareto=num_pareto,
+                        cost_aware_utility=cost_aware_utility,
+                        log=log_ehvi,
+                        **mf_kwargs,
+                    )
+                    # raises error when log is not a class variable
+                    with self.assertRaisesRegex(
+                        BotorchError,
+                        "Cost-aware HVKG has _log=True and requires cost_aware_utility"
+                        "to output log utilities.",
+                    ):
+                        val = qHVKG(X)
 
             # test mfkg
             if acqf_class == qMultiFidelityHypervolumeKnowledgeGradient:
                 mean = torch.rand(n_f, 1, num_pareto, 2, **tkwargs)
                 variance = torch.rand(n_f, 1, num_pareto, 2, **tkwargs)
                 mfm = MockModel(MockPosterior(mean=mean, variance=variance))
-                current_value = torch.rand(1, **tkwargs)
+                current_value = torch.rand(1, **tkwargs) if not log_ehvi else None
                 X = torch.rand(n_f * num_pareto + 1, 1, **tkwargs)
                 with mock.patch(
                     "botorch.acquisition.multi_objective."
@@ -321,23 +408,23 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
                 ) as mock_get_value_func:
                     with mock.patch.object(
                         ModelListGP, "fantasize", return_value=mfm
-                    ) as patch_f:
-                        with mock.patch(
-                            NO, new_callable=mock.PropertyMock
-                        ) as mock_num_outputs:
-                            mock_num_outputs.return_value = 2
-                            qHVKG = acqf_class(
-                                model=model,
-                                num_fantasies=n_f,
-                                current_value=current_value,
-                                ref_point=ref_point,
-                                num_pareto=num_pareto,
-                                **mf_kwargs,
-                            )
-                            val = qHVKG(X)
-                            self.assertIsNotNone(
-                                mock_get_value_func.call_args_list[0][1]["project"]
-                            )
+                    ) as patch_f, mock.patch(
+                        NO, new_callable=mock.PropertyMock
+                    ) as mock_num_outputs:
+                        mock_num_outputs.return_value = 2
+                        qHVKG = acqf_class(
+                            model=model,
+                            num_fantasies=n_f,
+                            current_value=current_value,
+                            ref_point=ref_point,
+                            num_pareto=num_pareto,
+                            log=log_ehvi,
+                            **mf_kwargs,
+                        )
+                        val = qHVKG(X)
+                        self.assertIsNotNone(
+                            mock_get_value_func.call_args_list[0][1]["project"]
+                        )
 
             # test objective (inner MC sampling)
             mean = torch.rand(n_f, 1, num_pareto, 3, **tkwargs)
@@ -379,6 +466,7 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
                             ref_point=ref_point,
                             num_pareto=num_pareto,
                             use_posterior_mean=use_posterior_mean,
+                            log=log_ehvi,
                             **mf_kwargs,
                         )
                         val = qHVKG(X)
@@ -407,10 +495,14 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
                                 for obj in objs
                             ]
                         )
-                    self.assertAllClose(val.item(), expected_hv, atol=1e-4)
+                    if log_ehvi:
+                        self.assertAllClose(val.exp().item(), expected_hv, rtol=1e-2)
+                    else:
+                        self.assertAllClose(val.item(), expected_hv, atol=1e-4)
                     self.assertTrue(
                         torch.equal(
-                            qHVKG.extract_candidates(X), X[..., : -n_f * num_pareto, :]
+                            qHVKG.extract_candidates(X),
+                            X[..., : -n_f * num_pareto, :],
                         )
                     )
 


### PR DESCRIPTION
Summary:
HKVG to output log values when _log=True using the LogEHVI value function.

Also adds a _log flag to InverseCostWeightedUtility to output utilities in log-space.

if _log=True, it assumes that
* current_value is in log-space
* cost_aware_utility outputs in log-space (raises an error if cost_aware_utility does not have a _log flag or if its _log=False).

Note that InverseCostWeightedUtility does a logarithmic transform for the inputted costs; assumes that inputted costs are in the original space. This is so that one does not need to make any direct modification to the cost fn, and because InverseCostWeightedUtility already does some pre-processing to the costs (e.g. clipping).

tldr: HKVG assumes all of its inputs are logged, but InverseCostWeightedUtility does not.

Rollback Plan:

Differential Revision: D80263869


