### PR TITLE
Rename docusaurus-versions branch to gh-pages

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: 'docusaurus-versions' # release branch
+        ref: 'gh-pages' # release branch
         fetch-depth: 0
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -92,7 +92,7 @@ jobs:
 
         git add versioned_docs/ versioned_sidebars/ versions.json
         git commit -m "Create version ${{ inputs.new_version }} of site in Docusaurus"
-        git push --force origin HEAD:docusaurus-versions
+        git push --force origin HEAD:gh-pages
     - name: Build website
       run: |
         bash scripts/build_docs.sh -b


### PR DESCRIPTION
Summary:
# Context

We commit docusaurus version to a dedicated `docusaurus-versions` branch because we want this to be an automated process and our GHA workflows cannot commit to the protected `main` branch.

# Problem

There was a recent change to OSS that now enforces the "Meta CLA Check" on all branches including our `docusaurus-versions` branch. This has resulted in our deploy workflows failing on the website versioning step.

- botorch: https://github.com/pytorch/botorch/actions/runs/16760443248/job/47456054783
- ax: https://github.com/facebook/Ax/actions/runs/16917549143/job/47935175650

The OSS team made an exemption to this CLA enforcement specifically for the `gh-pages` branch (D79653219) as that is the default branch name for GitHub Pages deployment, but this has not yet saved us since we already migrated to the preferred solution of [deploying using GitHub Actions](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages#deploying-github-pages-artifacts).

# Solution

Instead of reverting to the old way of deploying, here we rename the `docusaurus-versions` branch to `gh-pages` so we can continue automating the versioning process while making use of the CLA exemption that has been created for the `gh-pages` branch.


# Considerations

Even if we use the `gh-pages` branch name we are very much still using the newer github actions deployment method.

The `gh-pages` branch traditionally contains the final website build that gets directly deployed. In our case we are instead storing our entire project and website source in the branch, ephemerally building the website, and deploying the output build as an artifact.

If we were to change our github pages repo settings to directly deploy the `gh-pages` branch  that would not work as it is not the final website build. This is controlled in the settings here:  {F1981144462}

This hybrid solution is a bit of a hack, there's more context and ongoing discussion in this workplace post: https://fb.workplace.com/groups/osssupport/permalink/29118198351135403/



# Post-land

After landing this we will need to rename the branches in Github for both the ax and botorch repos. Something like


```bash
> git checkout docusaurus-versions && git branch -m gh-pages
```

Reviewed By: zpao, saitcakmak

Differential Revision: D80110693


