### PR TITLE
Fix optimize_acqf_mixed_alternating initialization with categorical features

### DIFF
--- a/botorch/optim/optimize_mixed.py
+++ b/botorch/optim/optimize_mixed.py
@@ -614,6 +614,7 @@ def generate_starting_points(
 
     # For each discrete dimension, map to the nearest allowed value
     x_init_candts = round_discrete_dims(X=x_init_candts, discrete_dims=discrete_dims)
+    x_init_candts = round_discrete_dims(X=x_init_candts, discrete_dims=cat_dims)
     x_init_candts = fix_features(
         X=x_init_candts,
         fixed_features=opt_inputs.fixed_features,

--- a/test/optim/test_optimize_mixed.py
+++ b/test/optim/test_optimize_mixed.py
@@ -1216,10 +1216,15 @@ class TestOptimizeAcqfMixed(BotorchTestCase):
                     options={"batch_limit": 2, "init_batch_limit": 2},
                 ),
                 discrete_dims=discrete_dims,
-                cat_dims={},
+                cat_dims=cat_dims,
                 cont_dims=torch.tensor(cont_dims, device=self.device),
             )
         self.assertEqual(candidates.shape, torch.Size([4, dim]))
+        # Check that the candidates are rounded to discrete / categorical values.
+        self.assertAllClose(
+            candidates,
+            round_discrete_dims(X=candidates, discrete_dims=discrete_dims | cat_dims),
+        )
 
         # Test with fixed features and constraints. Using both discrete and continuous.
         constraint = (  # X[..., 0] + X[..., 1] >= 1.


### PR DESCRIPTION
Summary: `generate_starting_points` wasn't rounding the categorical dimensions, which leads to errors down the line.

Differential Revision: D80547764


