### PR TITLE
condition_on_observations does not apply input transforms

### DIFF
--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -242,8 +242,8 @@ class GPyTorchModel(Model, ABC):
             >>> new_Y = torch.sin(new_X[:, :1]) + torch.cos(new_X[:, 1:])
             >>> model = model.condition_on_observations(X=new_X, Y=new_Y)
         """
+        X = self.transform_inputs(X)
         Yvar = noise
-
         if hasattr(self, "outcome_transform"):
             # pass the transformed data to get_fantasy_model below
             # (unless we've already trasnformed if BatchedMultiOutputGPyTorchModel)

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -379,7 +379,7 @@ class FantasizeMixin(ABC):
             if observation_noise is not None:
                 kwargs["noise"] = observation_noise.expand(Y.shape[1:])
             return self.condition_on_observations(
-                X=self.transform_inputs(X),
+                X=X,
                 Y=Y,
                 **kwargs,
             )
@@ -395,9 +395,7 @@ class FantasizeMixin(ABC):
             Y_fantasized = sampler(post_X)  # num_fantasies x batch_shape x n' x m
             if observation_noise is not None:
                 kwargs["noise"] = observation_noise.expand(Y_fantasized.shape[1:])
-            return self.condition_on_observations(
-                X=self.transform_inputs(X), Y=Y_fantasized, **kwargs
-            )
+            return self.condition_on_observations(X=X, Y=Y_fantasized, **kwargs)
 
 
 class ModelList(Model):


### PR DESCRIPTION
Summary:
Fixes OSS-reported issues in the interaction between condition_on_observations and input transforms, as input transforms are generally bypassed when using the method.

Moreover, it can't be trialed in Ax without this fix.

Differential Revision: D80813693


