### PR TITLE
Non-uniform model weights in EnsembleModel & EnsemblePosterior

### DIFF
--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -24,6 +24,19 @@ from torch import Tensor
 class EnsembleModel(Model, ABC):
     """Abstract base class for ensemble models."""
 
+    def __init__(self, weights: Tensor | None = None):
+        """Initialize the ensemble model.
+
+        Args:
+            weights: Optional weights for the ensemble members.
+                If None, the model weights will default to uniform in the
+                corresponding mixture posterior.
+        """
+        super().__init__()
+        # buffer `weights` is generally a name occupied by another module,
+        # so we have to be more specific here
+        self.ensemble_weights = weights
+
     @abstractmethod
     def forward(self, X: Tensor) -> Tensor:
         r"""Compute the (ensemble) model output at X.
@@ -82,7 +95,7 @@ class EnsembleModel(Model, ABC):
             values, _ = self.outcome_transform.untransform(values, X=X)
         if output_indices is not None:
             values = values[..., output_indices]
-        posterior = EnsemblePosterior(values=values)
+        posterior = EnsemblePosterior(values=values, weights=self.ensemble_weights)
         if posterior_transform is not None:
             return posterior_transform(posterior)
         else:

--- a/botorch/posteriors/ensemble.py
+++ b/botorch/posteriors/ensemble.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import torch
 from botorch.posteriors.posterior import Posterior
 from torch import Tensor
+from torch.distributions.multinomial import Multinomial
 
 
 class EnsemblePosterior(Posterior):
@@ -20,16 +21,23 @@ class EnsemblePosterior(Posterior):
     eagerly a finite number of samples per X value as for example a deep ensemble
     or a random forest."""
 
-    def __init__(self, values: Tensor) -> None:
+    def __init__(self, values: Tensor, weights: Tensor | None = None) -> None:
         r"""
         Args:
             values: Values of the samples produced by this posterior as
                 a `(b) x s x q x m` tensor where `m` is the output size of the
                 model and `s` is the ensemble size.
+            weights: Optional weights for the ensemble members as a tensor of shape
+                `(s,)`. If None, uses uniform weights.
         """
         if values.ndim < 3:
             raise ValueError("Values has to be at least three-dimensional.")
         self.values = values
+        self._weights = weights.to(values) if weights is not None else None
+        # Pre-compute normalized weights and mixture properties for efficiency
+        self._mixture_dims = list(range(self.values.ndim - 2))
+        self._normalized_weights = self._compute_normalized_weights()
+        self._normalized_mixture_weights = self._compute_normalized_mixture_weights()
 
     @property
     def ensemble_size(self) -> int:
@@ -37,10 +45,59 @@ class EnsemblePosterior(Posterior):
         return self.values.shape[-3]
 
     @property
+    def mixture_size(self) -> int:
+        r"""The total number of elements in the mixture dimensions"""
+        return self.values.shape[:-2].numel()
+
+    def _compute_normalized_weights(self) -> Tensor:
+        r"""Compute and cache normalized weights."""
+        if self._weights is not None:
+            return self._weights / self._weights.sum(dim=-1, keepdim=True)
+        else:
+            return (
+                torch.ones(
+                    self.ensemble_size,
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+                / self.ensemble_size
+            )
+
+    def _compute_normalized_mixture_weights(self) -> Tensor:
+        r"""Compute and cache normalized mixture weights."""
+        if self._weights is not None:
+            unnorm_weights = self._weights.expand(self.values.shape[:-2])
+            return unnorm_weights / unnorm_weights.sum(
+                dim=self._mixture_dims, keepdim=True
+            )
+        else:
+            return (
+                torch.ones(
+                    self.values.shape[:-2],
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+                / self.mixture_size
+            )
+
+    @property
     def weights(self) -> Tensor:
         r"""The weights of the individual models in the ensemble.
-        Equally weighted by default."""
-        return torch.ones(self.ensemble_size) / self.ensemble_size
+        uniformly weighted by default."""
+        return self._normalized_weights
+
+    @property
+    def mixture_weights(self) -> Tensor:
+        r"""The weights of the individual models in the ensemble.
+        uniformly weighted by default, and normalized over ensemble and
+        batch dimensions of the model."""
+        return self._normalized_mixture_weights
+
+    @property
+    def mixture_dims(self) -> list[int]:
+        r"""The mixture dimensions of the posterior. For ensemble posteriors,
+        this includes all dimensions except the last two (query points and outputs)."""
+        return self._mixture_dims
 
     @property
     def device(self) -> torch.device:
@@ -55,17 +112,60 @@ class EnsemblePosterior(Posterior):
     @property
     def mean(self) -> Tensor:
         r"""The mean of the posterior as a `(b) x n x m`-dim Tensor."""
-        return self.values.mean(dim=-3)
+        # Weighted average across ensemble dimension
+        return (self.values * self.weights[..., None, None]).sum(dim=-3)
 
     @property
     def variance(self) -> Tensor:
         r"""The variance of the posterior as a `(b) x n x m`-dim Tensor.
 
-        Computed as the sample variance across the ensemble outputs.
+        Computed as the weighted sample variance across the ensemble outputs.
+
+        This treats weights as probability weights (normalized to sum to 1) and
+        computes the unbiased weighted sample variance using the formula:
+        Var = Σ(w_i * (x_i - μ)²) / (1 - Σw_i²)
+        where the sum over w_i² is taken over the ensemble dimension only.
+        Source: https://en.wikipedia.org/wiki/Weighted_arithmetic_mean under
+        "Reliability Weights".
         """
         if self.ensemble_size == 1:
             return torch.zeros_like(self.values.squeeze(-3))
-        return self.values.var(dim=-3)
+
+        # Add dimensions for query points and outputs to enable broadcasting
+        weights = self.weights[..., None, None]
+        squared_deviations = (self.values - self.mean.unsqueeze(-3)) ** 2
+        return (weights * squared_deviations).sum(dim=-3) / (1 - (weights**2).sum())
+
+    @property
+    def mixture_mean(self) -> Tensor:
+        r"""The mixture mean of the posterior as a `(b) x n x m`-dim Tensor.
+
+        Computed as the weighted average across the ensemble outputs.
+        """
+        return (self.values * self.mixture_weights[..., None, None]).sum(
+            dim=self.mixture_dims
+        )
+
+    @property
+    def mixture_variance(self) -> Tensor:
+        r"""The mixture variance of the posterior as a `(b) x n x m`-dim Tensor.
+
+        Computed as the weighted sample variance across the ensemble outputs.
+
+        This treats weights as probability weights (normalized to sum to 1) and
+        computes the unbiased weighted sample variance using the formula:
+        Var = Σ(w_i * (x_i - μ)²) / (1 - Σw_i²) where w_i is normalized over the
+        entire mixture, and the sum over w_i² is taken over all mixture dimensions.
+        Source: https://en.wikipedia.org/wiki/Weighted_arithmetic_mean under
+        "Reliability Weights".
+        """
+
+        # Add dimensions for query points and outputs to enable broadcasting
+        weights = self.mixture_weights[..., None, None]
+        squared_deviations = (self.values - self.mixture_mean.unsqueeze(-3)) ** 2
+        return (weights * squared_deviations).sum(dim=self.mixture_dims) / (
+            1 - (weights**2).sum()
+        )
 
     def _extended_shape(
         self,
@@ -75,6 +175,10 @@ class EnsemblePosterior(Posterior):
         the given `sample_shape`.
         """
         return sample_shape + self.values.shape[:-3] + self.values.shape[-2:]
+
+    @property
+    def batch_shape(self) -> torch.Size:
+        return self.values.shape[:-3]
 
     def rsample(
         self,
@@ -94,17 +198,26 @@ class EnsemblePosterior(Posterior):
             Samples from the posterior, a tensor of shape
             `self._extended_shape(sample_shape=sample_shape)`.
         """
-        if sample_shape is None:
+        if sample_shape is None or len(sample_shape) == 0:
             sample_shape = torch.Size([1])
-        # get indices as base_samples
-        base_samples = (
-            torch.multinomial(
-                self.weights,
-                num_samples=sample_shape.numel(),
-                replacement=True,
+
+        # NOTE This occasionally happens in Hypervolume evals when there
+        # are no points which improve over the reference point. In this case, we
+        # create a posterior for all the points which improve over the reference,
+        # which is an empty set.
+        if self.values.numel() == 0:
+            return torch.empty(
+                *self._extended_shape(sample_shape=sample_shape),
+                device=self.device,
+                dtype=self.dtype,
             )
-            .reshape(sample_shape)
-            .to(device=self.device)
+
+        base_samples = (
+            Multinomial(
+                probs=self.mixture_weights,
+            )
+            .sample(sample_shape=sample_shape)
+            .argmax(dim=-1)
         )
         return self.rsample_from_base_samples(
             sample_shape=sample_shape, base_samples=base_samples
@@ -132,9 +245,31 @@ class EnsemblePosterior(Posterior):
             Samples from the posterior, a tensor of shape
             `self._extended_shape(sample_shape=sample_shape)`.
         """
-        if base_samples.shape != sample_shape:
-            raise ValueError("Base samples do not match sample shape.")
-        # move sample axis to front
-        values = self.values.movedim(-3, 0)
-        # sample from the first dimension of values
-        return values[base_samples, ...]
+        # Check that the first dimensions of base_samples match sample_shape
+        if base_samples.shape != sample_shape + self.batch_shape:
+            raise ValueError(
+                f"Sample_shape={sample_shape + self.batch_shape} does not match "
+                f"the leading dimensions of base_samples.shape={base_samples.shape}."
+            )
+
+        if self.batch_shape:
+            # Values is always going to be 4-dimensional with this reshape,
+            # even if we have more than one batch dimension
+            values = self.values.reshape(
+                ((self.batch_shape.numel(),) + self.values.shape[-3:])
+            )
+
+            # Collapse the base samples to enable index selecting along the
+            # ensemble dim (dim -3)
+            batch_numel = self.batch_shape.numel()
+            collapsed_base_samples = base_samples.reshape(sample_shape + (batch_numel,))
+
+            # First dimension is just 1, 2, 3, ..., batch_shape.numel() -1 to flatten
+            # the first dimension and extract one index
+
+            # second dimension extracts the ensemble member, for each element in the
+            # entire batch shape
+            return values[torch.arange(batch_numel), collapsed_base_samples].reshape(
+                self._extended_shape(sample_shape=sample_shape)
+            )
+        return self.values[base_samples]

--- a/test/models/test_ensemble.py
+++ b/test/models/test_ensemble.py
@@ -12,9 +12,9 @@ from botorch.utils.testing import BotorchTestCase
 class DummyEnsembleModel(EnsembleModel):
     r"""A dummy ensemble model."""
 
-    def __init__(self):
+    def __init__(self, weights=None):
         r"""Init model."""
-        super().__init__()
+        super().__init__(weights=weights)
         self._num_outputs = 2
         self.a = torch.rand(4, 3, 2)
 
@@ -35,3 +35,19 @@ class TestEnsembleModels(BotorchTestCase):
             X = torch.randn(*shape)
             p = e.posterior(X)
             self.assertEqual(p.ensemble_size, 4)
+
+    def test_EnsembleModel_weights(self):
+        """Test that weights are properly passed from EnsembleModel to
+        EnsemblePosterior."""
+        custom_weights = torch.tensor([0.4, 0.3, 0.2, 0.1])
+        e = DummyEnsembleModel(weights=custom_weights)
+
+        # Test weights are correctly passed through
+        X = torch.randn(5, 3)
+        p = e.posterior(X)
+        self.assertAllClose(p.weights, custom_weights)
+
+        # Test with batch dimensions - weights should remain 1-dimensional
+        X_batch = torch.randn(2, 5, 3)  # batch_shape = (2,)
+        p_batch = e.posterior(X_batch)
+        self.assertAllClose(p_batch.weights, custom_weights)

--- a/test/posteriors/test_ensemble.py
+++ b/test/posteriors/test_ensemble.py
@@ -16,7 +16,8 @@ class TestEnsemblePosterior(BotorchTestCase):
         for shape, dtype in itertools.product(
             ((5, 2), (5, 1)), (torch.float, torch.double)
         ):
-            values = torch.randn(*shape, device=self.device, dtype=dtype)
+            tkwargs = {"device": self.device, "dtype": dtype}
+            values = torch.randn(*shape, **tkwargs)
             with self.assertRaisesRegex(
                 ValueError,
                 "Values has to be at least three-dimensional",
@@ -27,7 +28,8 @@ class TestEnsemblePosterior(BotorchTestCase):
         for shape, dtype in itertools.product(
             ((1, 3, 2), (2, 1, 3, 2)), (torch.float, torch.double)
         ):
-            values = torch.randn(*shape, device=self.device, dtype=dtype)
+            tkwargs = {"device": self.device, "dtype": dtype}
+            values = torch.randn(*shape, **tkwargs)
             p = EnsemblePosterior(values)
             self.assertEqual(p.ensemble_size, 1)
             self.assertEqual(p.device.type, self.device.type)
@@ -36,7 +38,7 @@ class TestEnsemblePosterior(BotorchTestCase):
                 p._extended_shape(torch.Size((1,))),
                 torch.Size((1, 3, 2)) if len(shape) == 3 else torch.Size((1, 2, 3, 2)),
             )
-            self.assertEqual(p.weights, torch.ones(1))
+            self.assertEqual(p.weights, torch.ones(1, **tkwargs))
             with self.assertRaises(NotImplementedError):
                 p.base_sample_shape
             self.assertTrue(torch.equal(p.mean, values.squeeze(-3)))
@@ -53,17 +55,22 @@ class TestEnsemblePosterior(BotorchTestCase):
         for shape, dtype in itertools.product(
             ((16, 5, 2), (2, 16, 5, 2)), (torch.float, torch.double)
         ):
-            values = torch.randn(*shape, device=self.device, dtype=dtype)
+            tkwargs = {"device": self.device, "dtype": dtype}
+            values = torch.randn(*shape, **tkwargs)
             p = EnsemblePosterior(values)
             self.assertEqual(p.device.type, self.device.type)
             self.assertEqual(p.dtype, dtype)
             self.assertEqual(p.ensemble_size, 16)
+            self.assertEqual(
+                p.batch_shape, torch.Size([]) if len(shape) == 3 else torch.Size([2])
+            )
             self.assertAllClose(
-                p.weights, torch.tensor([1.0 / p.ensemble_size] * p.ensemble_size)
+                p.weights,
+                torch.tensor([1.0 / p.ensemble_size] * p.ensemble_size).to(p.values),
             )
             # test mean and variance
             self.assertTrue(torch.equal(p.mean, values.mean(dim=-3)))
-            self.assertTrue(torch.equal(p.variance, values.var(dim=-3)))
+            self.assertTrue(torch.allclose(p.variance, values.var(dim=-3)))
             # test extended shape
             self.assertEqual(
                 p._extended_shape(torch.Size((128,))),
@@ -73,19 +80,114 @@ class TestEnsemblePosterior(BotorchTestCase):
                     else torch.Size((128, 2, 5, 2))
                 ),
             )
+            # test mixture_mean and mixture_variance
+            expected_mixture_mean = values.mean(dim=list(range(values.ndim - 2)))
+            expected_mixture_var = values.var(dim=list(range(values.ndim - 2)))
+            self.assertAllClose(p.mixture_mean, expected_mixture_mean)
+            self.assertAllClose(p.mixture_variance, expected_mixture_var)
             # test rsample
-            samples = p.rsample(torch.Size((1024,)))
-            self.assertEqual(samples.shape, p._extended_shape(torch.Size((1024,))))
-            # test rsample from base samples
-            # test that produced samples are correct
-            samples = p.rsample_from_base_samples(
-                sample_shape=torch.Size((16,)), base_samples=torch.arange(16)
-            )
-            self.assertEqual(samples.shape, p._extended_shape(torch.Size((16,))))
-            self.assertAllClose(p.mean, samples.mean(dim=0), rtol=1e-04, atol=1e-06)
-            self.assertAllClose(p.variance, samples.var(dim=0), rtol=1e-04, atol=1e-06)
+            samples = p.rsample(torch.Size((4096,)))
+            self.assertEqual(samples.shape, p._extended_shape(torch.Size((4096,))))
+
+            self.assertAllClose(p.mean, samples.mean(dim=0), rtol=1e-01, atol=1e-01)
+            self.assertAllClose(p.variance, samples.var(dim=0), rtol=1e-01, atol=1e-01)
             # test error on base_samples, sample_shape mismatch
             with self.assertRaises(ValueError):
                 p.rsample_from_base_samples(
-                    sample_shape=torch.Size((17,)), base_samples=torch.arange(16)
+                    sample_shape=torch.Size((17,)),
+                    base_samples=torch.arange(
+                        16,
+                        **tkwargs,
+                    ).expand(*shape[:-2]),
                 )
+            # test zero batch shape tensor - should return an empty second dimension
+            empty_values = torch.empty((0, 1, 5, 2), **tkwargs)
+            p_empty = EnsemblePosterior(empty_values)
+            empty_samples = p_empty.rsample(torch.Size([4]))
+            self.assertEqual(empty_samples.shape, torch.Size([4, 0, 5, 2]))
+
+    def test_EnsemblePosterior_weighted(self):
+        """Test that weighted mean and variance calculations work correctly."""
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            # Test case 1: No batch dimensions, shape (3, 2, 1)
+            values = torch.tensor(
+                [[[1.0], [2.0]], [[3.0], [4.0]], [[5.0], [6.0]]], **tkwargs
+            )
+            norm_weights = torch.tensor([0.5, 0.5, 0.0], **tkwargs)
+            p = EnsemblePosterior(values, weights=norm_weights)
+
+            expected_mean = torch.tensor([[2.0], [3.0]], **tkwargs)  # weighted means
+            expected_variance = torch.tensor(
+                [[2.0], [2.0]], **tkwargs
+            )  # weighted variances
+            self.assertAllClose(p.mean, expected_mean)
+            self.assertAllClose(p.weights, norm_weights)
+
+            # test for unnormalized weights
+            weights = torch.tensor([3.0, 3.0, 0.0], **tkwargs)
+            p = EnsemblePosterior(values, weights=weights)
+            self.assertAllClose(p.weights, norm_weights)
+            self.assertAllClose(p.mean, expected_mean)
+            self.assertAllClose(p.variance, expected_variance)
+            #  With batch dimensions, shape (2, 3, 2, 1)
+            batch_values = torch.tensor(
+                [
+                    [[[1.0], [2.0]], [[3.0], [6.0]], [[5.0], [6.0]]],
+                    [[[2.0], [4.0]], [[4.0], [8.0]], [[6.0], [7.0]]],
+                ],
+                **tkwargs,
+            )
+            p_batch = EnsemblePosterior(batch_values, weights=weights)
+            # Weights should remain 1-dimensional regardless of batch dimensions
+
+            self.assertAllClose(p_batch.weights, norm_weights)
+            self.assertAllClose(p_batch.mixture_weights, norm_weights.repeat(2, 1) / 2)
+
+            # batch size 2, so the mixture weights should be halved
+            # Check that mean calculation works with batch dimensions
+            # bottom row is 1 larger everywhere than the top row, so results
+            # should be too.
+            expected_batch_mean = torch.tensor(
+                [[[2.0], [4.0]], [[3.0], [6.0]]], **tkwargs
+            )
+            expected_batch_variance = torch.tensor(
+                [[[2.0], [8.0]], [[2.0], [8.0]]], **tkwargs
+            )
+            self.assertAllClose(p_batch.mean, expected_batch_mean)
+            self.assertAllClose(p_batch.variance, expected_batch_variance)
+            # Test mixture_mean and mixture_variance
+            expected_mixture_mean = batch_values[:, :-1].mean(
+                dim=(0, 1)
+            )  # Mean across batch and ensemble dims
+            expected_mixture_var = batch_values[:, :-1].var(
+                dim=(0, 1)
+            )  # Variance across batch and ensemble dims
+            self.assertAllClose(p_batch.mixture_mean, expected_mixture_mean)
+            self.assertAllClose(p_batch.mixture_variance, expected_mixture_var)
+
+            # Test unnormalized 2-dimensional batch weights
+            weights_2d = torch.tensor([[3.0, 3.0, 0.0], [6.0, 6.0, 0.0]], **tkwargs)
+            p_2d = EnsemblePosterior(batch_values, weights=weights_2d)
+            expected_norm_2d = torch.tensor(
+                [[0.5, 0.5, 0.0], [0.5, 0.5, 0.0]], **tkwargs
+            )
+            self.assertAllClose(p_2d.weights, expected_norm_2d)
+
+    def test_EnsembleModel_weighted_rsample(self):
+        """Test that weighted rsample works correctly. All negative `batch_values`
+        have zero weight, so all samples should be positive."""
+        batch_values = torch.tensor(
+            [
+                [[[1.0], [2.0]], [[3.0], [6.0]], [[-5.0], [-6.0]], [[-5.0], [-16.0]]],
+                [[[1.0], [2.0]], [[-3.0], [-6.0]], [[5.0], [6.0]], [[-5.0], [-16.0]]],
+                [[[2.0], [4.0]], [[-4.0], [-8.0]], [[-6.0], [-7.0]], [[6.0], [17.0]]],
+            ]
+        )
+        weights_2d = torch.tensor(
+            [[3.0, 3.0, 0.0, 0.0], [3.0, 0.0, 5.0, 0.0], [6.0, 0.0, 0.0, 60.0]]
+        )
+        p_2d = EnsemblePosterior(batch_values, weights=weights_2d)
+        samples = p_2d.rsample(torch.Size([10]))
+        self.assertEqual(samples.shape, torch.Size([10, 3, 2, 1]))
+        self.assertTrue((samples >= 0).all())

--- a/test/sampling/test_index_sampler.py
+++ b/test/sampling/test_index_sampler.py
@@ -16,6 +16,7 @@ class TestIndexSampler(BotorchTestCase):
         posterior = EnsemblePosterior(
             values=torch.randn(torch.Size((50, 16, 1, 1))).to(self.device)
         )
+        posterior_batch_shape = posterior.batch_shape
         sampler = IndexSampler(sample_shape=torch.Size((128,)))
         samples = sampler(posterior)
         self.assertTrue(samples.shape == torch.Size((128, 50, 1, 1)))
@@ -28,7 +29,12 @@ class TestIndexSampler(BotorchTestCase):
         sampler = IndexSampler(sample_shape=torch.Size((4, 128)), seed=42)
         self.assertTrue(sampler.base_samples is None)
         sampler._construct_base_samples(posterior=posterior)
-        self.assertTrue(sampler.base_samples.shape == torch.Size((4, 128)))
+        (
+            self.assertTrue(
+                sampler.base_samples.shape
+                == (torch.Size((4, 128))) + posterior_batch_shape
+            )
+        )
         self.assertTrue(
             sampler.base_samples.device.type
             == posterior.device.type


### PR DESCRIPTION
Summary:
Adds support for non-uniform model weights in EnsembleModel & EnsemblePosterior

Why bother?
- Setting weights to be non-uniform for `MatheronPathModel` (e.g., [0, 0, 0, 1]) for different models in an ensemble (e.g. a `FullyBayesianSingleTaskGP`) allows the drawing of function samples from fully Bayesian Models.

Indended use in benchmarking.

Differential Revision: D80728012


