### PR TITLE
PFN changes to enable PFNs in new MAST FBFlow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "pytest-cov",
     "requests",
     "pymoo",
+    "pfns"
 ]
 
 dev = [


### PR DESCRIPTION
Summary:
To get PFNs to work in the new MAST PFN flow, I have changed a few dependencies, added dependencies, fixed device handling.

I needed to overwrite `construct_inputs` and get errors in changing the signature. I don't feel like this should be an issue, so I added an ignore statement.


To really enable them, one also needs the next two commits in this stack.

Differential Revision: D80944578


