### PR TITLE
Update documentation and error handling for inter-point constraints

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -1055,6 +1055,9 @@ def optimize_acqf_mixed(
     For q > 1 this function always performs sequential greedy optimization (with
     proper conditioning on generated candidates).
 
+    NOTE: This method does not support the kind of "inter-point constraints" that
+    are supported by `optimize_acqf()`.
+
     Args:
         acq_function: An AcquisitionFunction
         bounds: A `2 x d` tensor of lower and upper bounds for each column of `X`
@@ -1076,19 +1079,8 @@ def optimize_acqf_mixed(
             `\sum_i (X[indices[i]] * coefficients[i]) = rhs`
         nonlinear_inequality_constraints: A list of tuples representing the nonlinear
             inequality constraints. The first element in the tuple is a callable
-            representing a constraint of the form `callable(x) >= 0`. In case of an
-            intra-point constraint, `callable()`takes in an one-dimensional tensor of
-            shape `d` and returns a scalar. In case of an inter-point constraint,
-            `callable()` takes a two dimensional tensor of shape `q x d` and again
-            returns a scalar. The second element is a boolean, indicating if it is an
-            intra-point or inter-point constraint (`True` for intra-point. `False` for
-            inter-point). For more information on intra-point vs inter-point
-            constraints, see the docstring of the `inequality_constraints` argument to
-            `optimize_acqf()`. The constraints will later be passed to the scipy
-            solver. You need to pass in `batch_initial_conditions` in this case.
-            Using non-linear inequality constraints also requires that `batch_limit`
-            is set to 1, which will be done automatically if not specified in
-            `options`.
+            representing a constraint of the form `callable(x) >= 0`. The `callable()`
+            takes in an one-dimensional tensor of shape `d` and returns a scalar.
         post_processing_func: A function that post-processes an optimization
             result appropriately (i.e., according to `round-trip`
             transformations).
@@ -1123,6 +1115,27 @@ def optimize_acqf_mixed(
         - a tensor of associated acquisition values of dim `num_restarts`
             if `return_best_only=False` else a scalar acquisition value.
     """
+    const_err_message = (
+        "Inter-point constraints are not supported for sequential optimization. "
+        "But the {}th {} constraint is defined as inter-point."
+    )
+    # Check for existence of inter-point constraints
+    # Code adapted from _validate_sequential_inputs
+    if inequality_constraints is not None:
+        for i, constraint in enumerate(inequality_constraints):
+            if len(constraint[0].shape) > 1:
+                raise UnsupportedError(const_err_message.format(i, "linear inequality"))
+    if equality_constraints is not None:
+        for i, constraint in enumerate(equality_constraints):
+            if len(constraint[0].shape) > 1:
+                raise UnsupportedError(const_err_message.format(i, "linear equality"))
+    if nonlinear_inequality_constraints is not None:
+        for i, (_, intra_point) in enumerate(nonlinear_inequality_constraints):
+            if not intra_point:
+                raise UnsupportedError(
+                    const_err_message.format(i, "non-linear inequality")
+                )
+
     if not return_best_only and q > 1:
         raise NotImplementedError("`return_best_only=False` is only supported for q=1.")
 
@@ -1283,8 +1296,7 @@ def optimize_acqf_discrete(
     """
     if isinstance(acq_function, OneShotAcquisitionFunction):
         raise UnsupportedError(
-            "Discrete optimization is not supported for"
-            "one-shot acquisition functions."
+            "Discrete optimization is not supported forone-shot acquisition functions."
         )
     if X_avoid is not None and unique:
         choices = _filter_invalid(X=choices, X_avoid=X_avoid)


### PR DESCRIPTION
## Motivation

This PR improves the documentation and error handling when attempting to use inter-point constraints within `optimize_acqf_mixed` which is not supported. It implements the solution to #2996 discussed in this issue.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I verified my code by ensuring that the example posted in #2996 raises an error message. I did not add any tests, but would be happy to turn that example into a dedicated test if being pointed to the correct place for doing so.

## Related PRs

None.
