### PR TITLE
Remove a leftover docstring note

### DIFF
--- a/botorch/optim/optimize_mixed.py
+++ b/botorch/optim/optimize_mixed.py
@@ -860,8 +860,6 @@ def optimize_acqf_mixed_alternating(
     discrete/categorical local search and continuous optimization via (L-BFGS)
     is performed for a fixed number of iterations.
 
-    NOTE: This method assumes that all categorical variables are
-    integer valued.
     The discrete dimensions that have more than
     `options.get("max_discrete_values", MAX_DISCRETE_VALUES)` values will
     be optimized using continuous relaxation.


### PR DESCRIPTION
Summary: `optimize_acqf_mixed_alternating` now supports non-integer discrete and categorical variables. Remove the legacy comment.

Reviewed By: saitcakmak

Differential Revision: D81944645


