### PR TITLE
Upgrade Docusaurus to 3.8.1-canary-6401

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -11,12 +11,13 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.8.1",
-    "@docusaurus/types": "3.8.1"
+    "@docusaurus/module-type-aliases": "3.8.1-canary-6401",
+    "@docusaurus/types": "3.8.1-canary-6401"
   },
+  "//": "TODO: T239136996 Unpin Docusaurus canary after 3.8.2 or 3.9 is released",
   "dependencies": {
-    "@docusaurus/core": "^3.8.1",
-    "@docusaurus/preset-classic": "^3.8.1",
+    "@docusaurus/core": "^3.8.1-canary-6401",
+    "@docusaurus/preset-classic": "^3.8.1-canary-6401",
     "bl": "^6.0.0",
     "clsx": "^1.1.1",
     "plotly.js": "^2.8.1",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1485,7 +1485,7 @@
     webpack "^5.95.0"
     webpackbar "^6.0.1"
 
-"@docusaurus/core@3.8.1", "@docusaurus/core@^3.8.1":
+"@docusaurus/core@3.8.1", "@docusaurus/core@^3.8.1-canary-6401":
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.8.1.tgz#c22e47c16a22cb7d245306c64bc54083838ff3db"
   integrity sha512-ENB01IyQSqI2FLtOzqSI3qxG2B/jP4gQPahl2C3XReiLebcVh5B5cB9KYFvdoOqOWPyr5gXK4sjgTKv7peXCrA==
@@ -1587,6 +1587,19 @@
   integrity sha512-6xhvAJiXzsaq3JdosS7wbRt/PwEPWHr9eM4YNYqVlbgG1hSK3uQDXTVvQktasp3VO6BmfYWPozueLWuj4gB+vg==
   dependencies:
     "@docusaurus/types" "3.8.1"
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    "@types/react-router-config" "*"
+    "@types/react-router-dom" "*"
+    react-helmet-async "npm:@slorber/react-helmet-async@1.3.0"
+    react-loadable "npm:@docusaurus/react-loadable@6.0.0"
+
+"@docusaurus/module-type-aliases@3.8.1-canary-6401":
+  version "3.8.1-canary-6401"
+  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.1-canary-6401.tgz#7a7be188191a591ced856cfd947bfe429d3b4385"
+  integrity sha512-Umdri8Qo2Wf9+K+oPVSdzBF7JhCEhwsILtaroCNJSkLocV16anAMRh8Jtw4d9s3h4nxL4g9dOyK/Jk0uPrk+tg==
+  dependencies:
+    "@docusaurus/types" "3.8.1-canary-6401"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -1739,7 +1752,7 @@
     tslib "^2.6.0"
     webpack "^5.88.1"
 
-"@docusaurus/preset-classic@^3.8.1":
+"@docusaurus/preset-classic@^3.8.1-canary-6401":
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-3.8.1.tgz#bb79fd12f3211363720c569a526c7e24d3aa966b"
   integrity sha512-yJSjYNHXD8POMGc2mKQuj3ApPrN+eG0rO1UPgSx7jySpYU+n4WjBikbrA2ue5ad9A7aouEtMWUoiSRXTH/g7KQ==
@@ -1847,6 +1860,22 @@
   dependencies:
     "@mdx-js/mdx" "^3.0.0"
     "@types/history" "^4.7.11"
+    "@types/react" "*"
+    commander "^5.1.0"
+    joi "^17.9.2"
+    react-helmet-async "npm:@slorber/react-helmet-async@1.3.0"
+    utility-types "^3.10.0"
+    webpack "^5.95.0"
+    webpack-merge "^5.9.0"
+
+"@docusaurus/types@3.8.1-canary-6401":
+  version "3.8.1-canary-6401"
+  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.8.1-canary-6401.tgz#4109898ca79c7ad5f9a049ba383b71b431d59397"
+  integrity sha512-igR/CgXfL8Fgk4so9uuMPX021bX1hdmr9EGt4RqlNYt5FcruzxKcsIWcnKYxQlh4sJOgUaG8iq6qcJUeGvWsOA==
+  dependencies:
+    "@mdx-js/mdx" "^3.0.0"
+    "@types/history" "^4.7.11"
+    "@types/mdast" "^4.0.2"
     "@types/react" "*"
     commander "^5.1.0"
     joi "^17.9.2"


### PR DESCRIPTION
Summary:
We recently noticed that the copy feature on our website codeblocks were excluding indentation.  There's a github issue on the docusaurus repo tracking this https://github.com/facebook/docusaurus/issues/11414 with a fix that was just merged today https://github.com/facebook/docusaurus/pull/11422.

To avoid waiting until their next release we have two options:

1. update our website package.json to use a docusaurus canary until they release 3.9

2. swizzle the relevant docusaurus code and fix it ourselves using their
well documented api. There's an example of another project replacing this same logic that we can use. Though it will become unnecessary once docusaurus 3.9 releases

We're going with option (1) here and upgrading Docusaurus to version 3.8.1-canary-6401 across Ax and BoTorch. The docusaurus team releases canaries regularly and are what they use to build their website. https://docusaurus.io/community/canary

Differential Revision: D83068096


