### PR TITLE
Resolve numpy_utils warnings

### DIFF
--- a/botorch/optim/utils/numpy_utils.py
+++ b/botorch/optim/utils/numpy_utils.py
@@ -85,9 +85,9 @@ def get_bounds_as_ndarray(
             lower = -inf if lower is None else lower
             upper = inf if upper is None else upper
             if isinstance(lower, Tensor):
-                lower = lower.cpu()
+                lower = lower.cpu().numpy()
             if isinstance(upper, Tensor):
-                upper = upper.cpu()
+                upper = upper.cpu().numpy()
             out[index : index + size, 0] = lower
             out[index : index + size, 1] = upper
         index = index + size


### PR DESCRIPTION
Summary:
Numpy doesn't like assigning a torch.Tensor to a numpy array, so let's do that conversion explicity.

This resolves **a ton** of warnings of the form:
```
[W 250925 11:18:45 numpy_utils:91] __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword
```

Reviewed By: Balandat

Differential Revision: D83269102


