### PR TITLE
Preserving train inputs and targets through transforms

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -33,7 +33,6 @@ from botorch.sampling.base import MCSampler
 from botorch.sampling.list_sampler import ListSampler
 from botorch.utils.containers import BotorchContainer
 from botorch.utils.datasets import SupervisedDataset
-from botorch.utils.transforms import is_fully_bayesian
 from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
 from torch import Tensor
 from torch.nn import Module, ModuleDict, ModuleList
@@ -578,18 +577,19 @@ class ModelList(Model):
         return transformed_X_list
 
     def load_state_dict(
-        self, state_dict: Mapping[str, Any], strict: bool = True
+        self,
+        state_dict: Mapping[str, Any],
+        strict: bool = True,
+        keep_transforms: bool = True,
     ) -> None:
         """Initialize the fully Bayesian models before loading the state dict."""
         for i, m in enumerate(self.models):
-            if is_fully_bayesian(m):
-                filtered_dict = {
-                    k.replace(f"models.{i}.", ""): v
-                    for k, v in state_dict.items()
-                    if k.startswith(f"models.{i}.")
-                }
-                m.load_state_dict(filtered_dict)
-        super().load_state_dict(state_dict=state_dict, strict=strict)
+            filtered_dict = {
+                k.replace(f"models.{i}.", ""): v
+                for k, v in state_dict.items()
+                if k.startswith(f"models.{i}.")
+            }
+            m.load_state_dict(filtered_dict, strict=strict)
 
     def fantasize(
         self,

--- a/botorch/models/utils/__init__.py
+++ b/botorch/models/utils/__init__.py
@@ -12,10 +12,12 @@ from botorch.models.utils.assorted import (
     check_standardization,
     consolidate_duplicates,
     detect_duplicates,
+    extract_targets_and_noise_single_output,
     fantasize,
     gpt_posterior_settings,
     mod_batch_shape,
     multioutput_to_batch_mode_transform,
+    restore_targets_and_noise_single_output,
     validate_input_scaling,
 )
 
@@ -33,4 +35,6 @@ __all__ = [
     "validate_input_scaling",
     "detect_duplicates",
     "consolidate_duplicates",
+    "extract_targets_and_noise_single_output",
+    "restore_targets_and_noise_single_output",
 ]


### PR DESCRIPTION
Summary:
This PR preserves botorch transforms (specifically outcome_transforms, like Standardize) through state_dict loading. The fix also ensures that train_targets of a Leave-one-out model with outcome transforms will, in the default case, have the same targets as a base model, minus the point left out.


__Longer explanation:__
Transforms, and specifically learnable output transforms like Standardize, will currently:
a. Learn the parameters at initialization of the GP
b. Transform the train_Ys to the normalized space

Then, when we load a state dict, we will:
a. Impose new standardization parameters on already standardized data
b. Potentially make the transforms re-learnable, nullifying the change made by the state dict

This has undesired consequences for cross-validation, as all cross-validated models will effectively have different training data. In essence, _we don't simply leave one point out, but instead we leave one out and re-standardize_. When we have outliers in the data, this will lead to substantially different predictions when the outlier is left out, since the outlier will substantially impact the outcome transform parameters.

TODO: 
- Account for non-invertible transforms

Differential Revision: D84571407


