### PR TITLE
Check shape of state dict when comparing input transforms

### DIFF
--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -42,6 +42,13 @@ from torch.nn import Module, ModuleDict
 from torch.nn.functional import one_hot
 
 
+def _allclose(input: Tensor, other: Tensor) -> bool:
+    """Check if `input` and `other` are the same shape, and satisfy `torch.allclose`."""
+    if input.shape != other.shape:
+        return False
+    return torch.allclose(input, other)
+
+
 class InputTransform(Module, ABC):
     r"""Abstract base class for input transforms.
 
@@ -124,7 +131,7 @@ class InputTransform(Module, ABC):
             and (self.transform_on_eval == other.transform_on_eval)
             and (self.transform_on_fantasize == other.transform_on_fantasize)
             and all(
-                torch.allclose(v, other_state_dict[k].to(v))
+                _allclose(v, other_state_dict[k].to(v))
                 for k, v in self.state_dict().items()
             )
         )

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -400,7 +400,9 @@ class TestInputTransforms(BotorchTestCase):
                 self.assertTrue(nlz6.equals(nlz8))
                 nlz9 = Normalize(d=3, batch_shape=batch_shape, indices=[0, 1])
                 nlz10 = Normalize(d=3, batch_shape=batch_shape, indices=[0, 2])
+                nlz11 = Normalize(d=3, batch_shape=batch_shape, indices=[0, 1, 2])
                 self.assertFalse(nlz9.equals(nlz10))
+                self.assertFalse(nlz9.equals(nlz11))
 
                 # test with grad
                 nlz = Normalize(d=1)


### PR DESCRIPTION
## Motivation

See #3050 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

I have added an additional test case to `test/models/transforms/test_input.py`. Without the changes in this PR, the new test case would fail with a runtime error, as described in #3050. The test now correctly passes.