### PR TITLE
Use python 3.10 in tutorial tests against stable

### DIFF
--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -31,10 +31,16 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install uv
       uses: astral-sh/setup-uv@v5
-    - name: Set up Python
+    - if: ${{ !inputs.use_stable_pytorch_gpytorch }}
+      name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: "3.13"
+    - if: ${{ inputs.use_stable_pytorch_gpytorch }}
+      name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
     - name: Fetch all history for all tags and branches
       # We need to do this so setuptools_scm knows how to set the BoTorch version.
       run: git fetch --prune --unshallow


### PR DESCRIPTION
Without this, we run into the following error when testing the notebooks against the stable versions:
```
  × No solution found when resolving dependencies:
  ╰─▶ Because torch==2.0.1 has no wheels with a matching Python ABI tag
      (e.g., `cp313`) and you require torch==2.0.1, we can conclude that your
      requirements are unsatisfiable.

      hint: You require CPython 3.13 (`cp313`), but we only found wheels for
      `torch` (v2.0.1) with the following Python ABI tags: `cp38`, `cp39`,
      `cp310`, `cp311`
```
