### PR TITLE
Set default cache_root based on whether the model supports it

### DIFF
--- a/botorch/acquisition/cached_cholesky.py
+++ b/botorch/acquisition/cached_cholesky.py
@@ -71,7 +71,7 @@ class CachedCholeskyMCSamplerMixin(MCSamplerMixin):
     def __init__(
         self,
         model: Model,
-        cache_root: bool = False,
+        cache_root: bool | None = None,
         sampler: MCSampler | None = None,
     ) -> None:
         r"""Set class attributes and perform compatibility checks.
@@ -79,11 +79,14 @@ class CachedCholeskyMCSamplerMixin(MCSamplerMixin):
         Args:
             model: A model.
             cache_root: A boolean indicating whether to cache the Cholesky.
-                This might be overridden in the model is not compatible.
+                If None, will be set to True if the model supports it and False
+                otherwise.
             sampler: An optional MCSampler object.
         """
         MCSamplerMixin.__init__(self, sampler=sampler)
-        if cache_root and not supports_cache_root(model):
+        if cache_root is None:
+            cache_root = supports_cache_root(model)
+        elif cache_root and not supports_cache_root(model):
             warnings.warn(
                 _get_cache_root_not_supported_message(type(model)),
                 RuntimeWarning,

--- a/botorch/acquisition/factory.py
+++ b/botorch/acquisition/factory.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import torch
-
 from botorch.acquisition import logei, monte_carlo
 from botorch.acquisition.multi_objective import (
     logei as moo_logei,
@@ -46,7 +45,7 @@ def get_acquisition_function(
     tau: float = 1e-3,
     prune_baseline: bool = True,
     marginalize_dim: int | None = None,
-    cache_root: bool = True,
+    cache_root: bool | None = None,
     beta: float | None = None,
     ref_point: None | list[float] | Tensor = None,
     Y: Tensor | None = None,

--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -33,7 +33,6 @@ from botorch.acquisition.analytic import (
 from botorch.acquisition.bayesian_active_learning import (
     qBayesianActiveLearningByDisagreement,
 )
-from botorch.acquisition.cached_cholesky import supports_cache_root
 from botorch.acquisition.cost_aware import InverseCostWeightedUtility
 from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
 from botorch.acquisition.joint_entropy_search import qJointEntropySearch
@@ -711,7 +710,7 @@ def construct_inputs_qNEI(
     sampler: MCSampler | None = None,
     X_baseline: Tensor | None = None,
     prune_baseline: bool | None = True,
-    cache_root: bool | None = True,
+    cache_root: bool | None = None,
     constraints: list[Callable[[Tensor], Tensor]] | None = None,
     eta: Tensor | float = 1e-3,
 ) -> dict[str, Any]:
@@ -735,6 +734,10 @@ def construct_inputs_qNEI(
         prune_baseline: If True, remove points in `X_baseline` that are
             highly unlikely to be the best point. This can significantly
             improve performance and is generally recommended.
+        cache_root: A boolean indicating whether to cache the root
+            decomposition over `X_baseline` and use low-rank updates.
+            If None, will be set to True if the model supports it and False
+            otherwise.
         constraints: A list of constraint callables which map a Tensor of posterior
             samples of dimension `sample_shape x batch-shape x q x m`-dim to a
             `sample_shape x batch-shape x q`-dim Tensor. The associated constraints
@@ -825,8 +828,6 @@ def construct_inputs_qLogNEI(
     Returns:
         A dict mapping kwarg names of the constructor to values.
     """
-    if cache_root is None:
-        cache_root = supports_cache_root(model)
     return {
         **construct_inputs_qNEI(
             model=model,
@@ -1135,7 +1136,7 @@ def construct_inputs_qNEHVI(
     cache_pending: bool = True,
     max_iep: int = 0,
     incremental_nehvi: bool = True,
-    cache_root: bool = True,
+    cache_root: bool | None = None,
 ) -> dict[str, Any]:
     r"""Construct kwargs for `qNoisyExpectedHypervolumeImprovement`'s constructor."""
     if X_baseline is None:
@@ -1207,7 +1208,7 @@ def construct_inputs_qLogNEHVI(
     cache_pending: bool = True,
     max_iep: int = 0,
     incremental_nehvi: bool = True,
-    cache_root: bool = True,
+    cache_root: bool | None = None,
     tau_relu: float = TAU_RELU,
     tau_max: float = TAU_MAX,
 ) -> dict[str, Any]:
@@ -1250,7 +1251,7 @@ def construct_inputs_qLogNParEGO(
     sampler: MCSampler | None = None,
     X_baseline: Tensor | None = None,
     prune_baseline: bool | None = True,
-    cache_root: bool | None = True,
+    cache_root: bool | None = None,
     constraints: list[Callable[[Tensor], Tensor]] | None = None,
     eta: Tensor | float = 1e-3,
     fat: bool = True,

--- a/botorch/acquisition/logei.py
+++ b/botorch/acquisition/logei.py
@@ -277,7 +277,7 @@ class qLogNoisyExpectedImprovement(
         eta: Tensor | float = 1e-3,
         fat: bool = True,
         prune_baseline: bool = True,
-        cache_root: bool = True,
+        cache_root: bool | None = None,
         tau_max: float = TAU_MAX,
         tau_relu: float = TAU_RELU,
         marginalize_dim: int | None = None,
@@ -387,7 +387,7 @@ class qLogNoisyExpectedImprovement(
         sampler: MCSampler | None = None,
         objective: MCAcquisitionObjective | None = None,
         posterior_transform: PosteriorTransform | None = None,
-        cache_root: bool = True,
+        cache_root: bool | None = None,
     ) -> None:
         CachedCholeskyMCSamplerMixin.__init__(
             self, model=model, cache_root=cache_root, sampler=sampler

--- a/botorch/acquisition/monte_carlo.py
+++ b/botorch/acquisition/monte_carlo.py
@@ -454,7 +454,7 @@ class qNoisyExpectedImprovement(
         posterior_transform: PosteriorTransform | None = None,
         X_pending: Tensor | None = None,
         prune_baseline: bool = True,
-        cache_root: bool = True,
+        cache_root: bool | None = None,
         constraints: list[Callable[[Tensor], Tensor]] | None = None,
         eta: Tensor | float = 1e-3,
         marginalize_dim: int | None = None,

--- a/botorch/acquisition/multi_objective/logei.py
+++ b/botorch/acquisition/multi_objective/logei.py
@@ -337,7 +337,7 @@ class qLogNoisyExpectedHypervolumeImprovement(
         cache_pending: bool = True,
         max_iep: int = 0,
         incremental_nehvi: bool = True,
-        cache_root: bool = True,
+        cache_root: bool | None = None,
         tau_relu: float = TAU_RELU,
         tau_max: float = 1e-3,  # TAU_MAX,
         fat: bool = True,

--- a/botorch/acquisition/multi_objective/monte_carlo.py
+++ b/botorch/acquisition/multi_objective/monte_carlo.py
@@ -249,7 +249,7 @@ class qNoisyExpectedHypervolumeImprovement(
         cache_pending: bool = True,
         max_iep: int = 0,
         incremental_nehvi: bool = True,
-        cache_root: bool = True,
+        cache_root: bool | None = None,
         marginalize_dim: int | None = None,
     ) -> None:
         r"""q-Noisy Expected Hypervolume Improvement supporting m>=2 outcomes.

--- a/botorch/acquisition/multi_objective/parego.py
+++ b/botorch/acquisition/multi_objective/parego.py
@@ -32,7 +32,7 @@ class qLogNParEGO(qLogNoisyExpectedImprovement, MultiObjectiveMCAcquisitionFunct
         eta: Tensor | float = 1e-3,
         fat: bool = True,
         prune_baseline: bool = False,
-        cache_root: bool = True,
+        cache_root: bool | None = None,
         tau_relu: float = TAU_RELU,
         tau_max: float = TAU_MAX,
         incremental: bool = True,

--- a/botorch/utils/multi_objective/hypervolume.py
+++ b/botorch/utils/multi_objective/hypervolume.py
@@ -522,7 +522,7 @@ class NoisyExpectedHypervolumeMixin(CachedCholeskyMCSamplerMixin):
         cache_pending: bool = True,
         max_iep: int = 0,
         incremental_nehvi: bool = True,
-        cache_root: bool = True,
+        cache_root: bool | None = None,
         marginalize_dim: int | None = None,
     ):
         """Initialize a mixin that contains functions for the batched Pareto-frontier

--- a/test/acquisition/test_factory.py
+++ b/test/acquisition/test_factory.py
@@ -308,7 +308,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
         self.assertEqual(sampler.sample_shape, torch.Size([self.mc_samples]))
         self.assertEqual(sampler.seed, 1)
         self.assertEqual(kwargs["marginalize_dim"], 0)
-        self.assertEqual(kwargs["cache_root"], True)
+        self.assertIsNone(kwargs["cache_root"])
         # test with cache_root = False
         acqf = get_acquisition_function(
             acquisition_function_name=acqf_name,
@@ -358,7 +358,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
             X_pending=self.X_pending,
             prune_baseline=True,
             marginalize_dim=0,
-            cache_root=True,
+            cache_root=None,
             constraints=constraints,
             eta=eta,
         )
@@ -639,7 +639,7 @@ class TestGetAcquisitionFunction(BotorchTestCase):
             alpha=0.0,
             X_pending=self.X_pending,
             marginalize_dim=None,
-            cache_root=True,
+            cache_root=None,
         )
         args, kwargs = mock_acqf.call_args
         self.assertEqual(args, ())

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -1313,7 +1313,7 @@ class TestMultiObjectiveAcquisitionFunctionInputConstructors(
         self.assertTrue(kwargs["cache_pending"])
         self.assertEqual(kwargs["max_iep"], 0)
         self.assertTrue(kwargs["incremental_nehvi"])
-        self.assertTrue(kwargs["cache_root"])
+        self.assertIsNone(kwargs["cache_root"])
 
         if acqf_class == qLogNoisyExpectedHypervolumeImprovement:
             self.assertEqual(kwargs["tau_relu"], TAU_RELU)


### PR DESCRIPTION
Summary: The current default of True leads to a lot of unnecessary warnings with multi task models. By setting it based on whether the model supports it, we can avoid these warnings.

Reviewed By: SebastianAment

Differential Revision: D86460922


