### PR TITLE
Update deploy_on_release.yml to trigger when a draft release is published

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -2,7 +2,7 @@ name: Deploy On Release
 
 on:
   release:
-    types: [created]
+    types: [created, published]
   workflow_dispatch:
 
 


### PR DESCRIPTION
The current "created" condition only triggers if we create a non-draft release. If a draft release is created and later published, we need an additional "published" condition for the workflow to trigger.