### PR TITLE
Update deploy_on_release.yml to only run when a release is published

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -2,7 +2,7 @@ name: Deploy On Release
 
 on:
   release:
-    types: [created, published]
+    types: [published]
   workflow_dispatch:
 
 


### PR DESCRIPTION
Looks like releasing directly without first creating a draft release triggers on both "created" and "published". Since "published" also covers publishing a draft release, it should be the only rule we need.