### PR TITLE
Exclude test_community from built package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ recursive-exclude docs *
 recursive-exclude scripts *
 recursive-exclude sphinx *
 recursive-exclude test *
+recursive-exclude test_community *
 recursive-exclude tutorials *
 recursive-exclude website *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,8 @@ Homepage = "https://botorch.org"
 Documentation = "https://botorch.org"
 Repository = "https://github.com/meta-pytorch/botorch"
 
-[tool.setuptools.packages]
-find = {exclude = ["test", "test.*"]}
+[tool.setuptools]
+packages.find.exclude = ["test", "test.*", "test_community.*"]
 
 [tool.setuptools_scm]
 local_scheme = "node-and-date"


### PR DESCRIPTION
We're already excluding the `test` folder, let's do the same for `test_community`

Tested locally via `python -m build --sdist --wheel`