### PR TITLE
Fix the shape of NoisyExpectedHypervolumeMixin._initial_hvs

### DIFF
--- a/botorch/utils/multi_objective/hypervolume.py
+++ b/botorch/utils/multi_objective/hypervolume.py
@@ -658,9 +658,9 @@ class NoisyExpectedHypervolumeMixin(CachedCholeskyMCSamplerMixin):
         r"""Compute hypervolume dominated by f(X_baseline) under each sample.
 
         Args:
-            obj: A `sample_shape x batch_shape x n x m`-dim tensor of samples
+            obj: A `(sample_shape * batch_shape) x n x m`-dim tensor of samples
                 of objectives.
-            feas: `sample_shape x batch_shape x n`-dim tensor of samples
+            feas: `(sample_shape * batch_shape) x n`-dim tensor of samples
                 of feasibility indicators.
         """
         initial_hvs = []
@@ -676,7 +676,7 @@ class NoisyExpectedHypervolumeMixin(CachedCholeskyMCSamplerMixin):
         self.register_buffer(
             "_initial_hvs",
             torch.tensor(initial_hvs, dtype=obj.dtype, device=obj.device).view(
-                self._batch_sample_shape, *obj.shape[-2:]
+                self._batch_sample_shape
             ),
         )
 

--- a/test/acquisition/multi_objective/test_monte_carlo.py
+++ b/test/acquisition/multi_objective/test_monte_carlo.py
@@ -1013,6 +1013,9 @@ class TestQNoisyExpectedHypervolumeImprovement(BotorchTestCase):
             # test _initial_hvs
             if not incremental_nehvi:
                 self.assertTrue(hasattr(acqf, "_initial_hvs"))
+                # test that _initial_hvs has the correct shape
+                self.assertEqual(acqf._initial_hvs.shape, acqf._batch_sample_shape)
+                # test that _initial_hvs contains the correct hypervolume values
                 self.assertTrue(torch.equal(acqf._initial_hvs, initial_hv.view(-1)))
             # test forward
             X_test = torch.rand(1, 1, dtype=dtype, device=self.device)


### PR DESCRIPTION
In `_compute_initial_hvs`, we have a `flat_batch x n x m` shaped `obj`, which leads to a `flat_batch` length list of `initial_hvs`. The subsequent `view` operation is supposed to be `self._batch_sample_shape` (unflattened. versison of `flat_batch`) for the shapes to match. Not sure how this didn't error out before.