### PR TITLE
batched NEI w/ PFNs, enable more styles in botorch pfns

### DIFF
--- a/botorch_community/acquisition/input_constructors.py
+++ b/botorch_community/acquisition/input_constructors.py
@@ -37,6 +37,7 @@ from botorch_community.acquisition.bayesian_active_learning import (
 
 from botorch_community.acquisition.discretized import (
     DiscretizedExpectedImprovement,
+    DiscretizedNoisyExpectedImprovement,
     DiscretizedProbabilityOfImprovement,
 )
 from botorch_community.acquisition.scorebo import qSelfCorrectingBayesianOptimization
@@ -75,6 +76,33 @@ def construct_inputs_best_f(
         "model": model,
         "posterior_transform": posterior_transform,
         "best_f": best_f,
+    }
+
+
+@acqf_input_constructor(DiscretizedNoisyExpectedImprovement)
+def construct_inputs_noisy(
+    model: Model,
+    posterior_transform: PosteriorTransform | None = None,
+    X_pending: Optional[Tensor] = None,
+) -> dict[str, Any]:
+    r"""Construct kwargs for the acquisition functions requiring `best_f`.
+
+    Args:
+        model: The model to be used in the acquisition function.
+        best_f: Threshold above (or below) which improvement is defined.
+        posterior_transform: The posterior transform to be used in the
+            acquisition function.
+        X_pending: Points already tried, but not yet included in the
+            training data.
+
+
+    Returns:
+        A dict mapping kwarg names of the constructor to values.
+    """
+    return {
+        "model": model,
+        "posterior_transform": posterior_transform,
+        "X_pending": X_pending,
     }
 
 

--- a/test_community/acquisition/test_input_constructors.py
+++ b/test_community/acquisition/test_input_constructors.py
@@ -18,6 +18,7 @@ from botorch_community.acquisition.bayesian_active_learning import (
 )
 from botorch_community.acquisition.discretized import (
     DiscretizedExpectedImprovement,
+    DiscretizedNoisyExpectedImprovement,
     DiscretizedProbabilityOfImprovement,
 )
 from botorch_community.acquisition.scorebo import qSelfCorrectingBayesianOptimization
@@ -86,6 +87,25 @@ class TestAnalyticalAcquisitionFunctionInputConstructors(InputConstructorBaseTes
                 self.assertEqual(kwargs["best_f"], 0.1)
                 acqf = acqf_cls(**kwargs)
                 self.assertIs(acqf.model, mock_model)
+
+    def test_construct_inputs_noisy(self) -> None:
+        c = get_acqf_input_constructor(DiscretizedNoisyExpectedImprovement)
+        mock_model = self.mock_model
+        X_pending = torch.rand(2, 2)
+
+        kwargs = c(model=mock_model)
+        self.assertIs(kwargs["model"], mock_model)
+        self.assertIsNone(kwargs["posterior_transform"])
+        self.assertIsNone(kwargs["X_pending"])
+        acqf = DiscretizedNoisyExpectedImprovement(**kwargs)
+        self.assertIs(acqf.model, mock_model)
+
+        kwargs = c(model=mock_model, X_pending=X_pending)
+        self.assertIs(kwargs["model"], mock_model)
+        self.assertIsNone(kwargs["posterior_transform"])
+        self.assertTrue(torch.equal(kwargs["X_pending"], X_pending))
+        acqf = DiscretizedNoisyExpectedImprovement(**kwargs)
+        self.assertIs(acqf.model, mock_model)
 
 
 class TestFullyBayesianAcquisitionFunctionInputConstructors(


### PR DESCRIPTION
Summary:
2 Things:

- Allows training (with path_stgp.py) and evaluating models with unknown y's in their context s.t. one can amortize batched BO
- Allows passing styles that are not hyperparameters.

Reviewed By: bletham

Differential Revision: D88383475


