### PR TITLE
Add retries to `optimize_with_nsgaii`

### DIFF
--- a/botorch/utils/multi_objective/optimize.py
+++ b/botorch/utils/multi_objective/optimize.py
@@ -130,7 +130,7 @@ try:
         max_gen: int | None = None,
         seed: int | None = None,
         fixed_features: dict[int, float] | None = None,
-        num_retries: int = 1,
+        max_attempts: int = 2,
     ) -> tuple[Tensor, Tensor]:
         """Optimize the posterior mean via NSGA-II, returning the Pareto set and front.
 
@@ -162,8 +162,8 @@ try:
             fixed_features: A map `{feature_index: value}` for features that
                 should be fixed to a particular value during generation. All indices
                 should be non-negative.
-            num_retries: The number of times to retry the optimization if it fails
-                (usually due to NSGA-II failing to find a feasible point).
+            max_attempts: The total number of times to run the optimization if it
+                fails (usually due to NSGA-II failing to find a feasible point).
 
         Returns:
             A two-element tuple containing the pareto set X and pareto frontier Y.
@@ -207,15 +207,15 @@ try:
             return res
 
         # run optimization with retries in case NSGA-II fails to find a feasible point
-        for i in range(num_retries + 1):
+        for i in range(1, max_attempts + 1):
             res = _opt_with_nsgaii()
             if res.X is not None:
                 break
-            if i == num_retries:
+            if i == max_attempts:
                 raise RuntimeError(
-                    "NSGA-II failed to find a feasible point after "
-                    f"{num_retries} retries. Consider relaxing the constraints "
-                    "or increasing the population size."
+                    f"NSGA-II failed to find a feasible point after {max_attempts} "
+                    f"attempts. Consider relaxing the constraints or increasing "
+                    "the population size."
                 )
         X = torch.tensor(res.X, **tkwargs)
 

--- a/test/utils/multi_objective/test_optimize.py
+++ b/test/utils/multi_objective/test_optimize.py
@@ -183,8 +183,24 @@ class TestOptimizeWithNSGAII(BotorchTestCase):
                     num_objectives=num_objectives,
                     max_gen=2,
                     q=3,
-                    num_retries=2,
+                    max_attempts=3,
                 )
                 self.assertEqual(mock_minimize.call_count, 3)
             self.assertTrue(torch.equal(pareto_X, X))
             self.assertTrue(torch.equal(pareto_Y, -F))
+
+            with patch(
+                "botorch.utils.multi_objective.optimize.minimize",
+                side_effect=[Mock(X=None, F=None), Mock(X=None, F=None)],
+            ) as mock_minimize:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "NSGA-II failed to find a feasible point after 2 attempts",
+                ):
+                    optimize_with_nsgaii(
+                        acq_function=acqf,
+                        bounds=bounds,
+                        num_objectives=num_objectives,
+                        max_gen=2,
+                        q=3,
+                    )


### PR DESCRIPTION
It may happen that NSGA-II does not find any feasible solutions, in which case it will return `None` as the results `X` attribute. This breaks the current code with a `TypeError`. This also led to flaky unit tests, see e.g. here; https://github.com/meta-pytorch/botorch/actions/runs/20408594090/job/58641991612

This PR adds a `max_attempts` input to `optimize_with_nsgaii` to increase robustness. This should fix the flaky unit tests.