### PR TITLE
Allow PosteriorTransform API to optionally accept features X

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -1745,7 +1745,7 @@ def get_best_f_analytic(
     )
 
     if posterior_transform is not None:
-        return posterior_transform.evaluate(Y).max(-1).values
+        return posterior_transform.evaluate(Y=Y, X=None).max(-1).values
     if Y.shape[-1] > 1:
         raise NotImplementedError(
             "Analytic acquisition functions currently only work with "
@@ -1801,7 +1801,7 @@ def get_best_f_mc(
         # retain the original tensor dimension since objective expects explicit
         # output dimension.
         Y_dim = Y.dim()
-        Y = posterior_transform.evaluate(Y)
+        Y = posterior_transform.evaluate(Y=Y, X=X_baseline)
         if Y.dim() < Y_dim:
             Y = Y.unsqueeze(-1)
     if objective is None:

--- a/botorch/acquisition/joint_entropy_search.py
+++ b/botorch/acquisition/joint_entropy_search.py
@@ -114,7 +114,7 @@ class qJointEntropySearch(AcquisitionFunction, MCSamplerMixin):
         self.optimal_inputs = optimal_inputs.unsqueeze(-2)
         self.optimal_outputs = optimal_outputs.unsqueeze(-2)
         self.optimal_output_values = (
-            posterior_transform.evaluate(self.optimal_outputs).unsqueeze(-1)
+            posterior_transform.evaluate(Y=self.optimal_outputs, X=None).unsqueeze(-1)
             if posterior_transform
             else self.optimal_outputs
         )

--- a/botorch/acquisition/thompson_sampling.py
+++ b/botorch/acquisition/thompson_sampling.py
@@ -148,7 +148,9 @@ class PathwiseThompsonSampling(AcquisitionFunction):
         posterior_values = self.select_from_ensemble_models(values=posterior_values)
 
         if self.posterior_transform:
-            posterior_values = self.posterior_transform.evaluate(posterior_values)
+            posterior_values = self.posterior_transform.evaluate(
+                Y=posterior_values, X=X
+            )
         # objective removes the `m` dimension
         objective_values = self.objective(posterior_values)  # batch_shape x q
         return objective_values

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -174,7 +174,7 @@ class ApproximateGPyTorchModel(GPyTorchModel):
         if hasattr(self, "outcome_transform"):
             posterior = self.outcome_transform.untransform_posterior(posterior, X=X)
         if posterior_transform is not None:
-            posterior = posterior_transform(posterior)
+            posterior = posterior_transform(posterior=posterior, X=X)
         return posterior
 
     def forward(self, X) -> MultivariateNormal:

--- a/botorch/models/ensemble.py
+++ b/botorch/models/ensemble.py
@@ -97,6 +97,6 @@ class EnsembleModel(Model, ABC):
             values = values[..., output_indices]
         posterior = EnsemblePosterior(values=values, weights=self.ensemble_weights)
         if posterior_transform is not None:
-            return posterior_transform(posterior)
+            return posterior_transform(posterior=posterior, X=X)
         else:
             return posterior

--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -203,7 +203,7 @@ class GPyTorchModel(Model, ABC):
         if hasattr(self, "outcome_transform"):
             posterior = self.outcome_transform.untransform_posterior(posterior, X=X)
         if posterior_transform is not None:
-            return posterior_transform(posterior)
+            return posterior_transform(posterior=posterior, X=X)
         return posterior
 
     def condition_on_observations(
@@ -593,7 +593,7 @@ class BatchedMultiOutputGPyTorchModel(GPyTorchModel):
         if hasattr(self, "outcome_transform"):
             posterior = self.outcome_transform.untransform_posterior(posterior, X=X)
         if posterior_transform is not None:
-            return posterior_transform(posterior)
+            return posterior_transform(posterior=posterior, X=X)
         return posterior
 
     # pyre-ignore[14]: Inconsistent override. Could not find parameter `noise`.
@@ -864,7 +864,7 @@ class ModelListGPyTorchModel(ModelList, GPyTorchModel, ABC):
             else:
                 posterior = GPyTorchPosterior(distribution=mvn)
         if posterior_transform is not None:
-            return posterior_transform(posterior)
+            return posterior_transform(posterior=posterior, X=X)
         return posterior
 
     def condition_on_observations(self, X: Tensor, Y: Tensor, **kwargs: Any) -> Model:
@@ -1084,7 +1084,7 @@ class MultiTaskGPyTorchModel(GPyTorchModel, ABC):
         if hasattr(self, "outcome_transform"):
             posterior = self.outcome_transform.untransform_posterior(posterior, X=X)
         if posterior_transform is not None:
-            return posterior_transform(posterior)
+            return posterior_transform(posterior=posterior, X=X)
         return posterior
 
     def subset_output(self, idcs: list[int]) -> MultiTaskGPyTorchModel:

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -434,7 +434,7 @@ class ModelList(Model):
                 respective model in the `ModelList`.
         """
         if idcs is None:
-            return {i: None for i in range(len(self.models))}
+            return dict.fromkeys(range(len(self.models)))
         output_sizes = [model.num_outputs for model in self.models]
         cum_output_sizes = np.cumsum(output_sizes)
         idcs = [idx % cum_output_sizes[-1] for idx in idcs]
@@ -498,7 +498,7 @@ class ModelList(Model):
             )
         posterior = PosteriorList(*posteriors)
         if posterior_transform is not None:
-            posterior = posterior_transform(posterior)
+            posterior = posterior_transform(posterior=posterior, X=X)
         return posterior
 
     @property

--- a/botorch/models/pairwise_gp.py
+++ b/botorch/models/pairwise_gp.py
@@ -1098,7 +1098,7 @@ class PairwiseGP(Model, GP, FantasizeMixin):
         post = self(X)
         posterior = GPyTorchPosterior(post)
         if posterior_transform is not None:
-            return posterior_transform(posterior)
+            return posterior_transform(posterior=posterior, X=X)
         return posterior
 
     def condition_on_observations(self, X: Tensor, Y: Tensor) -> Model:

--- a/botorch/utils/test_helpers.py
+++ b/botorch/utils/test_helpers.py
@@ -25,6 +25,7 @@ from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.transforms.outcome import Standardize
 from botorch.models.utils import add_output_dim
 from botorch.models.utils.assorted import fantasize
+from botorch.posteriors.posterior import Posterior
 from botorch.posteriors.torch import TorchPosterior
 from botorch.utils.datasets import MultiTaskDataset, SupervisedDataset
 from gpytorch.distributions.multivariate_normal import MultivariateNormal
@@ -301,11 +302,11 @@ def get_pvar_expected(
 class DummyNonScalarizingPosteriorTransform(PosteriorTransform):
     scalarize = False
 
-    def evaluate(self, Y):
-        pass  # pragma: no cover
+    def evaluate(self, Y: Tensor, X: Tensor | None = None) -> Tensor:
+        return Y  # pragma: no cover
 
-    def forward(self, posterior):
-        pass  # pragma: no cover
+    def forward(self, posterior: Posterior, X: Tensor | None = None) -> Posterior:
+        return posterior  # pragma: no cover
 
 
 class SimpleGPyTorchModel(GPyTorchModel, ExactGP, FantasizeMixin):

--- a/botorch_community/acquisition/scorebo.py
+++ b/botorch_community/acquisition/scorebo.py
@@ -78,7 +78,7 @@ class qSelfCorrectingBayesianOptimization(
         # to get num_optima x num_gps unique GPs
         self.optimal_outputs = optimal_outputs.unsqueeze(-2)
         self.optimal_output_values = (
-            posterior_transform.evaluate(self.optimal_outputs).unsqueeze(-1)
+            posterior_transform.evaluate(Y=self.optimal_outputs, X=None).unsqueeze(-1)
             if posterior_transform
             else self.optimal_outputs
         )

--- a/botorch_community/models/np_regression.py
+++ b/botorch_community/models/np_regression.py
@@ -410,7 +410,7 @@ class NeuralProcessModel(Model, GP):
         mvn = MultivariateNormal(mean, covariance)
         posterior = GPyTorchPosterior(mvn)
         if posterior_transform is not None:
-            posterior = posterior_transform(posterior)
+            posterior = posterior_transform(posterior=posterior, X=X)
         return posterior
 
     def transform_inputs(

--- a/test/acquisition/multi_objective/test_base.py
+++ b/test/acquisition/multi_objective/test_base.py
@@ -13,13 +13,12 @@ from botorch.acquisition.multi_objective.objective import (
     IdentityMCMultiOutputObjective,
     MCMultiOutputObjective,
 )
-from botorch.acquisition.objective import IdentityMCObjective, PosteriorTransform
+from botorch.acquisition.objective import IdentityMCObjective
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.transforms.input import InputPerturbation
-from botorch.posteriors import GPyTorchPosterior
 from botorch.sampling.normal import SobolQMCNormalSampler
+from botorch.utils.test_helpers import DummyNonScalarizingPosteriorTransform
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
-from torch import Tensor
 
 
 class DummyMultiObjectiveAnalyticAcquisitionFunction(
@@ -31,14 +30,6 @@ class DummyMultiObjectiveAnalyticAcquisitionFunction(
 
 class DummyMultiObjectiveMCAcquisitionFunction(MultiObjectiveMCAcquisitionFunction):
     def forward(self, X):
-        pass
-
-
-class DummyPosteriorTransform(PosteriorTransform):
-    def evaluate(self, Y: Tensor) -> Tensor:
-        pass
-
-    def forward(self, posterior: GPyTorchPosterior) -> GPyTorchPosterior:
         pass
 
 
@@ -63,7 +54,7 @@ class TestBaseMultiObjectiveAcquisitionFunctions(BotorchTestCase):
         acqf = DummyMultiObjectiveAnalyticAcquisitionFunction(model=mm)
         self.assertTrue(acqf.posterior_transform is None)  # is None by default
         # test custom init
-        posterior_transform = DummyPosteriorTransform()
+        posterior_transform = DummyNonScalarizingPosteriorTransform()
         acqf = DummyMultiObjectiveAnalyticAcquisitionFunction(
             model=mm, posterior_transform=posterior_transform
         )

--- a/test/acquisition/test_logei.py
+++ b/test/acquisition/test_logei.py
@@ -32,12 +32,10 @@ from botorch.acquisition.monte_carlo import (
 from botorch.acquisition.multi_objective.logei import (
     qLogNoisyExpectedHypervolumeImprovement,
 )
-
 from botorch.acquisition.objective import (
     ConstrainedMCObjective,
     GenericMCObjective,
     IdentityMCObjective,
-    PosteriorTransform,
     ScalarizedPosteriorTransform,
 )
 from botorch.acquisition.utils import prune_inferior_points
@@ -47,6 +45,7 @@ from botorch.models import ModelListGP, SingleTaskGP
 from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.low_rank import sample_cached_cholesky
 from botorch.utils.objective import compute_smoothed_feasibility_indicator
+from botorch.utils.test_helpers import DummyNonScalarizingPosteriorTransform
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
 from botorch.utils.transforms import standardize
 from torch import Tensor
@@ -63,16 +62,6 @@ def feasible_con(samples: Tensor) -> Tensor:
 class DummyLogImprovementAcquisitionFunction(LogImprovementMCAcquisitionFunction):
     def _sample_forward(self, X):
         pass
-
-
-class DummyNonScalarizingPosteriorTransform(PosteriorTransform):
-    scalarize = False
-
-    def evaluate(self, Y):
-        pass  # pragma: no cover
-
-    def forward(self, posterior):
-        pass  # pragma: no cover
 
 
 class TestLogImprovementAcquisitionFunction(BotorchTestCase):

--- a/test/models/test_higher_order_gp.py
+++ b/test/models/test_higher_order_gp.py
@@ -8,7 +8,6 @@ import itertools
 from unittest import mock
 
 import torch
-from botorch.acquisition.objective import PosteriorTransform
 from botorch.models import HigherOrderGP
 from botorch.models.higher_order_gp import FlattenedStandardize
 from botorch.models.transforms.input import Normalize
@@ -16,19 +15,12 @@ from botorch.models.transforms.outcome import Standardize
 from botorch.optim.fit import fit_gpytorch_mll_torch
 from botorch.posteriors import GPyTorchPosterior, TransformedPosterior
 from botorch.sampling import IIDNormalSampler
+from botorch.utils.test_helpers import DummyNonScalarizingPosteriorTransform
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.kernels import RBFKernel
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.mlls import ExactMarginalLogLikelihood
 from gpytorch.settings import max_cholesky_size, skip_posterior_variances
-
-
-class DummyPosteriorTransform(PosteriorTransform):
-    def evaluate(self, Y):
-        return Y
-
-    def forward(self, posterior):
-        return posterior
 
 
 class TestHigherOrderGP(BotorchTestCase):
@@ -103,7 +95,8 @@ class TestHigherOrderGP(BotorchTestCase):
                     # test that a posterior transform raises an error
                     with self.assertRaises(NotImplementedError):
                         self.model.posterior(
-                            test_x, posterior_transform=DummyPosteriorTransform()
+                            test_x,
+                            posterior_transform=DummyNonScalarizingPosteriorTransform(),
                         )
 
                     # test the posterior works with observation noise

--- a/test/models/test_model.py
+++ b/test/models/test_model.py
@@ -15,7 +15,7 @@ from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.posteriors.posterior_list import PosteriorList
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
-from torch import rand
+from torch import rand, Tensor
 
 
 class NotSoAbstractBaseModel(Model):
@@ -47,10 +47,12 @@ class GenericDeterministicModelWithBatchShape(GenericDeterministicModel):
 
 
 class DummyPosteriorTransform(PosteriorTransform):
-    def evaluate(self, Y):
+    def evaluate(self, Y: Tensor, X: Tensor | None = None) -> Tensor:
         return 2 * Y + 1
 
-    def forward(self, posterior):
+    def forward(
+        self, posterior: PosteriorList, X: Tensor | None = None
+    ) -> PosteriorList:
         return PosteriorList(
             *[
                 EnsemblePosterior(2 * p.mean.unsqueeze(0) + 1)

--- a/test_community/models/test_np_regression.py
+++ b/test_community/models/test_np_regression.py
@@ -1,16 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import torch
 from botorch.models.transforms.input import Normalize
 from botorch.posteriors import GPyTorchPosterior
+from botorch.utils.test_helpers import DummyNonScalarizingPosteriorTransform
 from botorch_community.models.np_regression import NeuralProcessModel
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-
-class Identity:
-    def __call__(self, posterior):
-        return posterior
 
 
 class TestNeuralProcessModel(unittest.TestCase):
@@ -109,7 +110,9 @@ class TestNeuralProcessModel(unittest.TestCase):
         self.initialize()
         self.model(self.model.train_X, self.model.train_Y)
         identity_posterior = self.model.posterior(
-            self.model.train_X, observation_noise=True, posterior_transform=Identity()
+            self.model.train_X,
+            observation_noise=True,
+            posterior_transform=DummyNonScalarizingPosteriorTransform(),
         )
         posterior = self.model.posterior(self.model.train_X, observation_noise=True)
         self.assertIsInstance(identity_posterior, GPyTorchPosterior)


### PR DESCRIPTION
Summary:
This change updates the `PosteriorTransform` API to optionally accept features `X` in addition to the values `Y` (for `evaluate()`) or posterior (for `forward()`).

This aligns `PosteriorTransform` with `MCAcquisitionObjective`, which already accepts `X` to enable input-dependent objectives. The change enables use cases where posterior transformations need to depend on the input features explicitly.

Updates all posterior transform classes and callsites to accept / pass in X along with the posterior

Resolves https://github.com/pytorch/botorch/issues/1548

Differential Revision: D89930506


