### PR TITLE
Update posterior_transform call in qJointEntropySearch

### DIFF
--- a/botorch/acquisition/joint_entropy_search.py
+++ b/botorch/acquisition/joint_entropy_search.py
@@ -114,7 +114,9 @@ class qJointEntropySearch(AcquisitionFunction, MCSamplerMixin):
         self.optimal_inputs = optimal_inputs.unsqueeze(-2)
         self.optimal_outputs = optimal_outputs.unsqueeze(-2)
         self.optimal_output_values = (
-            posterior_transform.evaluate(Y=self.optimal_outputs, X=None).unsqueeze(-1)
+            posterior_transform.evaluate(
+                Y=self.optimal_outputs, X=self.optimal_inputs
+            ).unsqueeze(-1)
             if posterior_transform
             else self.optimal_outputs
         )


### PR DESCRIPTION
Summary:
Optimal inputs is the X corresponding to optimal outputs here, so we should pass that in.

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: Balandat

Differential Revision: D90083032


