### PR TITLE
KroneckerMultiTaskGP doesn't clear caches correctly

### DIFF
--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -883,7 +883,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
 
     def train(self, val=True, *args, **kwargs):
         if val:
-            fixed_cache_names = ["data_data_roots", "train_full_covar", "task_root"]
+            fixed_cache_names = ["predictive_mean_cache", "train_full_covar"]
             for name in fixed_cache_names:
                 try:
                     pop_from_cache(self, name)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

When training a `KroneckerMultiTaskGP`, adding a validation callback to `fit_gpytorch_mll` (calling `model.eval(); model.posterior(test_x); model.train()`) results in nonsensical results due to the caches not being correctly cleared. In particular, the analytical mean is incorrect.

It would probably be even safer to use `gpytorch.utils.memoize.clear_cache_hook`, as I assume the root cause of this issue is that `data_data_roots` and `task_root` were removed and `predictive_mean_cache` was added, but this method was never updated.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

No unit test added yet; maybe could check that the cache is empty after calling `model.eval()`?

```python
import torch
from botorch.models.multitask import KroneckerMultiTaskGP
from botorch.models.transforms import Normalize, Standardize
from gpytorch.mlls import ExactMarginalLogLikelihood
from botorch.fit import fit_gpytorch_mll
from plotly.subplots import make_subplots

n_inputs = 1
n_outputs = 2
n_train = 128
n_test = 1
device = torch.device("cuda")

torch.manual_seed(42)
train_x = torch.rand(n_train, n_inputs, dtype=torch.float64, device=device)
train_y = torch.hstack([train_x, -train_x])
test_x = torch.ones(n_test, 1, n_inputs, dtype=torch.float64, device=device)

model = KroneckerMultiTaskGP(
    train_x, 
    train_y, 
    input_transform=Normalize(n_inputs),
    outcome_transform=Standardize(n_outputs),
)

mll = ExactMarginalLogLikelihood(model.likelihood, model)

def callback(*args, **kwargs):
    with torch.no_grad():
        model.eval()
        _ = model.posterior(test_x).mean.detach()
        model.train()

fit_gpytorch_mll(
    mll, 
    options={"maxiter": 5},
    optimizer_kwargs={"callback": callback},
)

posterior_q = model.posterior(test_x)
mean = posterior_q.mean.detach().cpu().numpy()
samples = posterior_q.sample(torch.Size([256])).detach().cpu().numpy()

fig = make_subplots()
fig.add_histogram(
    x=samples[:, 0, 0, 0],
    name="Samples",
    showlegend=True,
)
fig.add_vline(
    x=mean[0, 0, 0], 
    line_color="red", 
    showlegend=True, 
    name="Analytic mean",
)
```

Before:
<img width="873" height="325" alt="image" src="https://github.com/user-attachments/assets/b02f112f-5698-4a26-a700-004a29b73751" />


After:
<img width="874" height="320" alt="image" src="https://github.com/user-attachments/assets/5a7cfa8f-011d-40b5-b44e-6c937d981fbd" />


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/meta-pytorch/botorch, and link to your PR here.)
