### PR TITLE
Test python 3.14 in CI

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: "3.14"
     - name: Install dependencies
       run: |
         uv pip install .[test]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: "3.14"
     - name: Install dependencies
       run: |
         uv pip install git+https://github.com/cornellius-gp/linear_operator.git

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: uv pip install pre-commit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: "3.14"
     - name: Install dependencies
       run: |
         uv pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: "3.14"
     - if: ${{ !inputs.new_version }}
       name: Install latest GPyTorch and Linear Operator
       run: |

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
     env:
       # `uv pip ...` requires venv by default. This skips that requirement.
       UV_SYSTEM_PYTHON: 1

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -35,7 +35,7 @@ jobs:
       name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: "3.14"
     - if: ${{ inputs.use_stable_pytorch_gpytorch }}
       name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14"]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
     env:
       # `uv pip ...` requires venv by default. This skips that requirement.
       UV_SYSTEM_PYTHON: 1
@@ -36,8 +36,8 @@ jobs:
       run: |
         # Extract minimum versions from pyproject.toml
         min_torch_version=$(grep '"torch>=' pyproject.toml | sed 's/.*"torch>=\([^"]*\)".*/\1/')
-        # The earliest PyTorch version on Python 3.13 available for all OS is 2.6.0.
-        min_torch_version="$(if ${{ matrix.python-version == '3.13' }}; then echo "2.6.0"; else echo "${min_torch_version}"; fi)"
+        # The earliest PyTorch version on Python 3.14 available for all OS is 2.9.0.
+        min_torch_version="$(if ${{ matrix.python-version == '3.14' }}; then echo "2.9.0"; else echo "${min_torch_version}"; fi)"
         min_gpytorch_version=$(grep '"gpytorch>=' pyproject.toml | sed 's/.*"gpytorch>=\([^"]*\)".*/\1/')
         min_linear_operator_version=$(grep '"linear_operator>=' pyproject.toml | sed 's/.*"linear_operator>=\([^"]*\)".*/\1/')
         uv pip install "numpy<2"  # Numpy >2.0 is not compatible with PyTorch <2.2.


### PR DESCRIPTION
Replaces Python 3.13 with 3.14 in GHA workflows.

Test plan:
- Tests / lint / docs / tutorials run by default
- Nightly cron: https://github.com/meta-pytorch/botorch/actions/runs/20855619905
- Test against stable: https://github.com/meta-pytorch/botorch/actions/runs/20855645235