### PR TITLE
Clean up get_constants_like usage in botorch/utils/probability

### DIFF
--- a/botorch/utils/probability/truncated_multivariate_normal.py
+++ b/botorch/utils/probability/truncated_multivariate_normal.py
@@ -11,7 +11,6 @@ from collections.abc import Sequence
 import torch
 from botorch.utils.probability.lin_ess import LinearEllipticalSliceSampler
 from botorch.utils.probability.mvnxpb import MVNXPB
-from botorch.utils.probability.utils import get_constants_like
 from torch import Tensor
 from torch.distributions.multivariate_normal import MultivariateNormal
 
@@ -68,7 +67,7 @@ class TruncatedMultivariateNormal(MultivariateNormal):
 
     def log_prob(self, value: Tensor) -> Tensor:
         r"""Approximates the true log probability."""
-        neg_inf = get_constants_like(-float("inf"), value)
+        neg_inf = float("-inf")
         inbounds = torch.logical_and(
             (self.bounds[..., 0] < value).all(-1),
             (self.bounds[..., 1] > value).all(-1),


### PR DESCRIPTION
Summary:
These reduce readability of the code and do not seem to offer any meaningful runtime benefits (see profiling notebooks linked in T250904629, which shows comparable runtimes on both CPU and GPU).

This diff removes get_constants_like and replaces all usage with native int/floats.

Differential Revision: D90393039


