### PR TITLE
`KroneckerMultiTaskGP.posterior` transforms inputs twice

### DIFF
--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -687,7 +687,7 @@ class KroneckerMultiTaskGP(ExactGP, GPyTorchModel, FantasizeMixin):
             )
 
         X = self.transform_inputs(X)
-        train_x = self.transform_inputs(self.train_inputs[0])
+        train_x = self.train_inputs[0]
 
         # construct Ktt
         task_covar = self._task_covar_matrix


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

`self.eval()` is called at the start of `KroneckerMultiTaskGP.posterior`, which transforms `self.train_inputs`.

The inputs are then incorrectly transformed again.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Not written unit tests yet, but this demonstrates the issue:

```python
import torch
from botorch.models.multitask import KroneckerMultiTaskGP
from botorch.models.transforms import Normalize, Standardize
from gpytorch.mlls import ExactMarginalLogLikelihood
from botorch.fit import fit_gpytorch_mll
from plotly.subplots import make_subplots

n_inputs = 1
n_outputs = 2
n_train = 2
n_test = 100
device = torch.device("cuda")

torch.manual_seed(42)
train_x = torch.rand(n_train, n_inputs, dtype=torch.float64, device=device)
train_y = torch.randn(n_train, n_outputs, dtype=torch.float64, device=device)
test_x = torch.linspace(-1, 2, n_test, dtype=torch.float64, device=device)[:, None, None]

model = KroneckerMultiTaskGP(
    train_x, 
    train_y, 
    input_transform=Normalize(n_inputs),  # Comment this out to avoid the bug
    outcome_transform=Standardize(n_outputs),
)

with torch.no_grad():
    posterior_q = model.posterior(test_x)

fig = make_subplots(rows=2)
fig.add_scatter(x=train_x[:, 0].cpu().numpy(), y=train_y[:, 0].cpu().numpy(), mode="markers", showlegend=False, row=1, col=1)
fig.add_scatter(x=train_x[:, 0].cpu().numpy(), y=train_y[:, 1].cpu().numpy(), mode="markers", showlegend=False, row=2, col=1)
fig.add_scatter(x=test_x[:, 0, 0].cpu().numpy(), y=posterior_q.mean[:, 0, 0].cpu().numpy(), showlegend=False, row=1, col=1)
fig.add_scatter(x=test_x[:, 0, 0].cpu().numpy(), y=posterior_q.mean[:, 0, 1].cpu().numpy(), showlegend=False, row=2, col=1)
```

With the input transform:
<img width="739" height="327" alt="image" src="https://github.com/user-attachments/assets/5e8caa96-e7db-4428-ac8a-eb89e80fd695" />

Without the input transform:
<img width="745" height="336" alt="image" src="https://github.com/user-attachments/assets/00a7655f-b8c5-43be-8752-0e3235f093d9" />


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/meta-pytorch/botorch, and link to your PR here.)
