### PR TITLE
Remove deprecated APIs for v0.17

### DIFF
--- a/botorch/acquisition/multi_objective/__init__.py
+++ b/botorch/acquisition/multi_objective/__init__.py
@@ -17,9 +17,6 @@ from botorch.acquisition.multi_objective.logei import (
     qLogExpectedHypervolumeImprovement,
     qLogNoisyExpectedHypervolumeImprovement,
 )
-from botorch.acquisition.multi_objective.max_value_entropy_search import (
-    qMultiObjectiveMaxValueEntropy,
-)
 from botorch.acquisition.multi_objective.monte_carlo import (
     qExpectedHypervolumeImprovement,
     qNoisyExpectedHypervolumeImprovement,
@@ -50,7 +47,6 @@ __all__ = [
     "qLogExpectedHypervolumeImprovement",
     "qLogNoisyExpectedHypervolumeImprovement",
     "qMultiFidelityHypervolumeKnowledgeGradient",
-    "qMultiObjectiveMaxValueEntropy",
     "qNoisyExpectedHypervolumeImprovement",
     "WeightedMCMultiOutputObjective",
 ]

--- a/botorch/acquisition/multi_objective/max_value_entropy_search.py
+++ b/botorch/acquisition/multi_objective/max_value_entropy_search.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 from math import pi
 
 import torch
-from botorch.acquisition.max_value_entropy_search import qMaxValueEntropy
-from botorch.acquisition.multi_objective.base import MultiObjectiveMCAcquisitionFunction
 from botorch.acquisition.multi_objective.joint_entropy_search import (
     LowerBoundMultiObjectiveEntropySearch,
 )
@@ -27,25 +25,6 @@ from botorch.utils.transforms import (
     t_batch_mode_transform,
 )
 from torch import Tensor
-
-
-# Can be removed in version 0.15.0, or potentially sooner because the code has
-# already been raising deprecation warnings for a long time
-class qMultiObjectiveMaxValueEntropy(
-    qMaxValueEntropy, MultiObjectiveMCAcquisitionFunction
-):
-    r"""The acquisition function for MESMO.
-
-    This is no longer available. We recommend
-    ``qLowerBoundMultiObjectiveMaxValueEntropySearch`` as a replacement.
-    """
-
-    def __init__(self, *args, **kwargs) -> None:
-        """Multi-objective max-value entropy search acquisition function."""
-        raise NotImplementedError(
-            "qMultiObjectiveMaxValueEntropy is no longer available. We suggest "
-            "qLowerBoundMultiObjectiveMaxValueEntropySearch as a replacement."
-        )
 
 
 class qLowerBoundMultiObjectiveMaxValueEntropySearch(

--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -8,7 +8,6 @@ r"""Model fitting routines."""
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from functools import partial
@@ -21,12 +20,9 @@ from botorch.exceptions.warnings import OptimizationWarning
 from botorch.logging import logger
 from botorch.models import SingleTaskGP
 from botorch.models.approximate_gp import ApproximateGPyTorchModel
-from botorch.models.fully_bayesian import (
-    AbstractFullyBayesianSingleTaskGP,
-    SaasFullyBayesianSingleTaskGP,
-)
+from botorch.models.fully_bayesian import AbstractFullyBayesianSingleTaskGP
 from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
-from botorch.models.map_saas import EnsembleMapSaasSingleTaskGP, get_map_saas_model
+from botorch.models.map_saas import get_map_saas_model
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
@@ -44,7 +40,6 @@ from botorch.utils.context_managers import (
     TensorCheckpoint,
 )
 from botorch.utils.dispatcher import Dispatcher, type_bypassing_encoder
-from botorch.utils.types import _DefaultType, DEFAULT
 from gpytorch.likelihoods import Likelihood
 from gpytorch.mlls._approximate_mll import _ApproximateMarginalLogLikelihood
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
@@ -434,56 +429,6 @@ def get_fitted_map_saas_model(
         ),
         outcome_transform=outcome_transform,
         tau=tau,
-    )
-    mll = ExactMarginalLogLikelihood(model=model, likelihood=model.likelihood)
-    fit_gpytorch_mll(mll, optimizer_kwargs=optimizer_kwargs)
-    return model
-
-
-def get_fitted_map_saas_ensemble(
-    train_X: Tensor,
-    train_Y: Tensor,
-    train_Yvar: Tensor | None = None,
-    input_transform: InputTransform | None = None,
-    outcome_transform: OutcomeTransform | _DefaultType | None = DEFAULT,
-    taus: Tensor | list[float] | None = None,
-    num_taus: int = 4,
-    optimizer_kwargs: dict[str, Any] | None = None,
-) -> SaasFullyBayesianSingleTaskGP:
-    """Get a fitted SAAS ensemble using several different tau values.
-
-    DEPRECATED: Please use ``EnsembleMapSaasSingleTaskGP`` directly!
-
-    Args:
-        train_X: Tensor of shape ``n x d`` with training inputs.
-        train_Y: Tensor of shape ``n x 1`` with training targets.
-        train_Yvar: Optional tensor of shape ``n x 1`` with observed noise,
-            inferred if None.
-        input_transform: An optional input transform.
-        outcome_transform: An optional outcome transform.
-        taus: Global shrinkage values to use. If None, we sample ``num_taus`` values
-            from an HC(0.1) distribution.
-        num_taus: Optional argument for how many taus to sample.
-        optimizer_kwargs: A dict of options for the optimizer passed
-            to fit_gpytorch_mll.
-
-    Returns:
-        A fitted EnsembleMapSaasSingleTaskGP with a Matern kernel.
-    """
-    warnings.warn(
-        "get_fitted_map_saas_ensemble is deprecated and will be removed in v0.17. "
-        "Please use EnsembleMapSaasSingleTaskGP instead!",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    model = EnsembleMapSaasSingleTaskGP(
-        train_X=train_X,
-        train_Y=train_Y,
-        train_Yvar=train_Yvar,
-        num_taus=num_taus,
-        taus=taus,
-        input_transform=input_transform,
-        outcome_transform=outcome_transform,
     )
     mll = ExactMarginalLogLikelihood(model=model, likelihood=model.likelihood)
     fit_gpytorch_mll(mll, optimizer_kwargs=optimizer_kwargs)

--- a/botorch/models/gp_regression.py
+++ b/botorch/models/gp_regression.py
@@ -29,8 +29,6 @@ use a multi-task model like ``MultiTaskGP``.
 
 from __future__ import annotations
 
-import warnings
-
 import torch
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
 from botorch.models.model import FantasizeMixin
@@ -41,8 +39,6 @@ from botorch.models.utils.gpytorch_modules import (
     get_covar_module_with_dim_scaled_prior,
     get_gaussian_likelihood_with_lognormal_prior,
 )
-from botorch.utils.containers import BotorchContainer
-from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.types import _DefaultType, DEFAULT
 from gpytorch.distributions.multivariate_normal import MultivariateNormal
 from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
@@ -209,32 +205,6 @@ class SingleTaskGP(BatchedMultiOutputGPyTorchModel, ExactGP, FantasizeMixin):
         if input_transform is not None:
             self.input_transform = input_transform
         self.to(train_X)
-
-    @classmethod
-    def construct_inputs(
-        cls, training_data: SupervisedDataset, *, task_feature: int | None = None
-    ) -> dict[str, BotorchContainer | Tensor]:
-        r"""Construct ``SingleTaskGP`` keyword arguments from a ``SupervisedDataset``.
-
-        Args:
-            training_data: A ``SupervisedDataset``, with attributes ``train_X``,
-                ``train_Y``, and, optionally, ``train_Yvar``.
-            task_feature: Deprecated and allowed only for backward
-                compatibility; ignored.
-
-        Returns:
-            A dict of keyword arguments that can be used to initialize a
-            ``SingleTaskGP``, with keys ``train_X``, ``train_Y``, and,
-            optionally, ``train_Yvar``.
-        """
-        if task_feature is not None:
-            warnings.warn(
-                "`task_feature` is deprecated and will be ignored. In the "
-                "future, this will be an error.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        return super().construct_inputs(training_data=training_data)
 
     def forward(self, x: Tensor) -> MultivariateNormal:
         if self.training:

--- a/botorch/optim/optimize_homotopy.py
+++ b/botorch/optim/optimize_homotopy.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable
 from typing import Any
 
@@ -65,7 +64,6 @@ def optimize_acqf_homotopy(
     inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
     equality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
     nonlinear_inequality_constraints: list[tuple[Callable, bool]] | None = None,
-    fixed_features: dict[int, float] | None = None,
     fixed_features_list: list[dict[int, float]] | None = None,
     post_processing_func: Callable[[Tensor], Tensor] | None = None,
     batch_initial_conditions: Tensor | None = None,
@@ -126,8 +124,6 @@ def optimize_acqf_homotopy(
             Using non-linear inequality constraints also requires that ``batch_limit``
             is set to 1, which will be done automatically if not specified in
             ``options``.
-        fixed_features: A map ``{feature_index: value}`` for features that
-            should be fixed to a particular value during generation.
         fixed_features_list: A list of maps ``{feature_index: value}``. The i-th
             item represents the fixed_feature for the i-th optimization. If
             ``fixed_features_list`` is provided, ``optimize_acqf_mixed`` is invoked.
@@ -155,22 +151,6 @@ def optimize_acqf_homotopy(
         ic_gen_kwargs: Additional keyword arguments passed to function specified by
             ``ic_generator``
     """
-    if fixed_features and fixed_features_list:
-        raise ValueError(
-            "Either `fixed_feature` or `fixed_features_list` can be provided, not both."
-        )
-
-    if fixed_features:
-        message = (
-            "The `fixed_features` argument is deprecated, "
-            "use `fixed_features_list` instead."
-        )
-        warnings.warn(
-            message,
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
     shared_optimize_acqf_kwargs = {
         "num_restarts": num_restarts,
         "inequality_constraints": inequality_constraints,
@@ -190,9 +170,7 @@ def optimize_acqf_homotopy(
     else:
         optimization_fn = optimize_acqf
         fixed_features_kwargs = {
-            "fixed_features": fixed_features_list[0]
-            if fixed_features_list
-            else fixed_features
+            "fixed_features": fixed_features_list[0] if fixed_features_list else None
         }
 
     candidate_list, acq_value_list = [], []

--- a/botorch/posteriors/__init__.py
+++ b/botorch/posteriors/__init__.py
@@ -4,10 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from botorch.posteriors.fully_bayesian import (
-    FullyBayesianPosterior,
-    GaussianMixturePosterior,
-)
+from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.higher_order import HigherOrderGPPosterior
 from botorch.posteriors.multitask import MultitaskGPPosterior
@@ -18,7 +15,6 @@ from botorch.posteriors.transformed import TransformedPosterior
 
 __all__ = [
     "GaussianMixturePosterior",
-    "FullyBayesianPosterior",
     "GPyTorchPosterior",
     "HigherOrderGPPosterior",
     "MultitaskGPPosterior",

--- a/botorch/posteriors/fully_bayesian.py
+++ b/botorch/posteriors/fully_bayesian.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from warnings import warn
 
 import torch
 from botorch.posteriors.gpytorch import GPyTorchPosterior
@@ -156,16 +155,3 @@ class GaussianMixturePosterior(GPyTorchPosterior):
         candidate produces same value regardless of its position on the t-batch.
         """
         return (0, -2) if self._is_mt else (0, -1)
-
-
-class FullyBayesianPosterior(GaussianMixturePosterior):
-    """For backwards compatibility."""
-
-    def __init__(self, distribution: MultivariateNormal) -> None:
-        """DEPRECATED."""
-        warn(
-            "`FullyBayesianPosterior` is marked for deprecation, consider using "
-            "`GaussianMixturePosterior` instead.",
-            DeprecationWarning,
-        )
-        super().__init__(distribution=distribution)

--- a/test/acquisition/multi_objective/test_max_value_entropy_search.py
+++ b/test/acquisition/multi_objective/test_max_value_entropy_search.py
@@ -9,7 +9,6 @@ from itertools import product
 import torch
 from botorch.acquisition.multi_objective.max_value_entropy_search import (
     qLowerBoundMultiObjectiveMaxValueEntropySearch,
-    qMultiObjectiveMaxValueEntropy,
 )
 from botorch.acquisition.multi_objective.utils import compute_sample_box_decomposition
 from botorch.models.model_list_gp_regression import ModelListGP
@@ -27,13 +26,6 @@ def dummy_sample_pareto_frontiers(model):
         dtype=m.train_inputs[0].dtype,
         device=m.train_inputs[0].device,
     )
-
-
-# TODO: remove all references
-class TestMultiObjectiveMaxValueEntropy(BotorchTestCase):
-    def test_multi_objective_max_value_entropy(self) -> None:
-        with self.assertRaisesRegex(NotImplementedError, "no longer available"):
-            qMultiObjectiveMaxValueEntropy()
 
 
 class TestQLowerBoundMultiObjectiveMaxValueEntropySearch(BotorchTestCase):

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -55,11 +55,7 @@ from botorch.models.fully_bayesian import (
 )
 from botorch.models.transforms import Normalize, Standardize
 from botorch.models.transforms.input import ChainedInputTransform, Warp
-from botorch.posteriors.fully_bayesian import (
-    batched_bisect,
-    FullyBayesianPosterior,
-    GaussianMixturePosterior,
-)
+from botorch.posteriors.fully_bayesian import batched_bisect, GaussianMixturePosterior
 from botorch.sampling.get_sampler import get_sampler
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.multi_objective.box_decompositions.non_dominated import (
@@ -1082,17 +1078,6 @@ class TestSaasFullyBayesianSingleTaskGP(BotorchTestCase):
                 self.assertAllClose(
                     dist.cdf(x), q * torch.ones(1, 5, 1, **tkwargs), atol=1e-4
                 )
-
-    def test_deprecated_posterior(self) -> None:
-        mean = torch.randn(1, 5)
-        variance = torch.rand(1, 5)
-        covar = torch.diag_embed(variance)
-        mvn = MultivariateNormal(mean, to_linear_operator(covar))
-        with self.assertWarnsRegex(
-            DeprecationWarning, "`FullyBayesianPosterior` is marked for deprecation"
-        ):
-            posterior = FullyBayesianPosterior(distribution=mvn)
-        self.assertIsInstance(posterior, GaussianMixturePosterior)
 
     def test_predict_in_train_mode(self) -> None:
         torch.manual_seed(16)

--- a/test/models/test_gp_regression.py
+++ b/test/models/test_gp_regression.py
@@ -445,24 +445,6 @@ class TestGPRegressionBase(BotorchTestCase):
 class TestSingleTaskGP(TestGPRegressionBase):
     model_class = SingleTaskGP
 
-    def test_construct_inputs_task_feature_deprecated(self) -> None:
-        model, model_kwargs = self._get_model_and_data(
-            batch_shape=torch.Size([]),
-            m=1,
-            device=self.device,
-            dtype=torch.double,
-        )
-        X = model_kwargs["train_X"]
-        Y = model_kwargs["train_Y"]
-        training_data = SupervisedDataset(
-            X,
-            Y,
-            feature_names=[f"x{i}" for i in range(X.shape[-1])],
-            outcome_names=["y"],
-        )
-        with self.assertWarnsRegex(DeprecationWarning, "`task_feature` is deprecated"):
-            model.construct_inputs(training_data, task_feature=0)
-
 
 class TestSingleTaskGPFixedNoise(TestSingleTaskGP):
     def _get_model_and_data(

--- a/test/models/test_map_saas.py
+++ b/test/models/test_map_saas.py
@@ -14,11 +14,7 @@ from unittest import mock
 
 import torch
 from botorch.exceptions import UnsupportedError
-from botorch.fit import (
-    fit_gpytorch_mll,
-    get_fitted_map_saas_ensemble,
-    get_fitted_map_saas_model,
-)
+from botorch.fit import fit_gpytorch_mll, get_fitted_map_saas_model
 from botorch.models import SingleTaskGP
 from botorch.models.map_saas import (
     add_saas_prior,
@@ -297,24 +293,6 @@ class TestMapSaas(BotorchTestCase):
             loss = -mll(model(*train_inputs), train_targets).item()
             # longer running optimization should have smaller loss than the shorter one
             self.assertTrue(loss < loss_short)
-
-    def test_get_saas_ensemble(self) -> None:
-        train_X, train_Y, _ = self._get_data_hardcoded(device=self.device)
-        with (
-            self.assertWarnsRegex(DeprecationWarning, "EnsembleMapSaasSingleTaskGP"),
-            mock.patch("botorch.fit.fit_gpytorch_mll") as mock_fit,
-        ):
-            model = get_fitted_map_saas_ensemble(
-                train_X=train_X,
-                train_Y=train_Y,
-                input_transform=Normalize(d=train_X.shape[-1]),
-                outcome_transform=Standardize(m=1, batch_shape=torch.Size([4])),
-                optimizer_kwargs={"options": {"maxiter": 3}},
-            )
-        self.assertEqual(
-            mock_fit.call_args.kwargs["optimizer_kwargs"], {"options": {"maxiter": 3}}
-        )
-        self.assertIsInstance(model, EnsembleMapSaasSingleTaskGP)
 
     def test_input_transform_in_train(self) -> None:
         train_X, train_Y, test_X = self._get_data()

--- a/test/optim/test_homotopy.py
+++ b/test/optim/test_homotopy.py
@@ -126,60 +126,12 @@ class TestHomotopy(BotorchTestCase):
         self.assertEqual(candidate, torch.zeros(1, **tkwargs))
         self.assertEqual(acqf_val, 5 * torch.ones(1, **tkwargs))
 
-        # test fixed feature
-        fixed_features = {0: 1.0}
-        model = GenericDeterministicModel(
-            f=lambda x: 5 - (x - p).sum(dim=-1, keepdims=True) ** 2
-        )
-        acqf = PosteriorMean(model=model)
-        # test raise warning on using ``fixed_features`` argument
-        message = (
-            "The `fixed_features` argument is deprecated, "
-            "use `fixed_features_list` instead."
-        )
-        with self.assertWarnsRegex(DeprecationWarning, message):
-            optimize_acqf_homotopy(
-                q=1,
-                acq_function=acqf,
-                bounds=torch.tensor([[-10, -10], [5, 5]]).to(**tkwargs),
-                homotopy=Homotopy(homotopy_parameters=[hp]),
-                num_restarts=2,
-                raw_samples=16,
-                fixed_features=fixed_features,
-            )
-
-        candidate, acqf_val = optimize_acqf_homotopy(
-            q=1,
-            acq_function=acqf,
-            bounds=torch.tensor([[-10, -10], [5, 5]], **tkwargs),
-            homotopy=Homotopy(homotopy_parameters=[hp]),
-            num_restarts=2,
-            raw_samples=16,
-            fixed_features_list=[fixed_features],
-        )
-        self.assertEqual(candidate[0, 0], torch.tensor(1, **tkwargs))
-
         # test fixed feature list
         fixed_features_list = [{0: 1.0}, {1: 3.0}]
         model = GenericDeterministicModel(
             f=lambda x: 5 - (x - p).sum(dim=-1, keepdims=True) ** 2
         )
         acqf = PosteriorMean(model=model)
-        # test raise error when fixed_features and fixed_features_list are both provided
-        with self.assertRaisesRegex(
-            ValueError,
-            "Either `fixed_feature` or `fixed_features_list` can be provided",
-        ):
-            optimize_acqf_homotopy(
-                q=1,
-                acq_function=acqf,
-                bounds=torch.tensor([[-10, -10, -10], [5, 5, 5]], **tkwargs),
-                homotopy=Homotopy(homotopy_parameters=[hp]),
-                num_restarts=2,
-                raw_samples=16,
-                fixed_features_list=fixed_features_list,
-                fixed_features=fixed_features,
-            )
         candidate, acqf_val = optimize_acqf_homotopy(
             q=1,
             acq_function=acqf,
@@ -200,7 +152,7 @@ class TestHomotopy(BotorchTestCase):
             homotopy=Homotopy(homotopy_parameters=[hp]),
             num_restarts=2,
             raw_samples=16,
-            fixed_features_list=[fixed_features],
+            fixed_features_list=[{0: 1.0}],
         )
         self.assertEqual(candidate.shape, torch.Size([3, 2]))
         self.assertEqual(acqf_val.shape, torch.Size([3]))


### PR DESCRIPTION
Summary:
Remove deprecated APIs that were marked for removal by v0.17 or have been deprecated for a significant period of time:

1. `get_fitted_map_saas_ensemble` from `botorch/fit.py` - explicitly marked for v0.17 removal
2. `qMultiObjectiveMaxValueEntropy` from multi-objective acquisition functions - marked for v0.15 removal (overdue)
3. `FullyBayesianPosterior` from posteriors - deprecated since November 2023 (~7 versions)
4. `task_feature` parameter from `SingleTaskGP.construct_inputs` - deprecated since April 2024 (~5 versions). The method reduces to a super call after this, so it is fully removed.
5. `fixed_features` argument from `optimize_acqf_homotopy` - deprecated since December 2024 (~2 versions)

Note: The `maxiter` option deprecation in `botorch/optim/core.py` was NOT removed as it was only added ~2 months ago in v0.16.1.

Differential Revision: D90519310


