### PR TITLE
Update scipy version checks to allow scipy 1.17

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -506,9 +506,7 @@ def get_reasons_against_fast_path(
         why_not_fast_path.append(f"timeout_sec={timeout_sec}, it needs to be None")
     if not check_scipy_version_at_least(
         minor=SCIPY_MIN_VERSION
-    ) or check_scipy_version_at_least(
-        minor=SCIPY_UNTESTED_VERSION
-    ):  # pragma: no cover
+    ) or check_scipy_version_at_least(minor=SCIPY_UNTESTED_VERSION):  # pragma: no cover
         # In SciPy 1.15.0, the fortran implementation of L-BFGS-B was
         # translated to C changing its interface slightly.
         # Additionally, we don't know what the future might hold in scipy,


### PR DESCRIPTION
Updates scipy version checks to allow 1.17 for parallel lbfgsb implementation. 

Test plan:
Updated the version checks and ran the units. 