### PR TITLE
Enable eval of empty MTGP

### DIFF
--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -529,6 +529,8 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
         self.assertTrue(
             torch.equal(model._task_mapper, torch.tensor([0, 1, 1], **tkwargs))
         )
+        # Verify the pyro_model has the correct number of tasks (3, not 2)
+        self.assertEqual(model.pyro_model.num_tasks, 3)
         self.test_fit_model(
             use_outcome_transform=True,
             all_tasks=all_tasks,


### PR DESCRIPTION
Summary:
Permits an MTGP to predict on an unobserved task, addressing these issues:
https://github.com/meta-pytorch/botorch/issues/2360
https://github.com/meta-pytorch/botorch/issues/3085

To do this, we assume that the unobserved task is maximally correlated with the target tasks (equally with each, by averaging the elements). Exact heuristic on correlation is definitely up for discussion, but this seems like a decent default assumption.

Will come in handy for TL initialization.

Differential Revision: D90769576


