### PR TITLE
Replace deprecated torch.jit.trace with torch.compile

### DIFF
--- a/test/models/test_gpytorch.py
+++ b/test/models/test_gpytorch.py
@@ -466,8 +466,9 @@ class TestBatchedMultiOutputGPyTorchModel(BotorchTestCase):
         with torch.no_grad(), trace_mode():
             X_test = torch.rand(3, 1, **tkwargs)
             wrapped_model(X_test)  # Compute caches
-            traced_model = torch.jit.trace(wrapped_model, X_test)
-            mean, std = traced_model(X_test)
+            # Use torch.compile instead of deprecated torch.jit.trace
+            compiled_model = torch.compile(wrapped_model)
+            mean, std = compiled_model(X_test)
             self.assertEqual(mean.shape, torch.Size([3, 2]))
 
 


### PR DESCRIPTION
Summary:
PyTorch is deprecating `torch.jit.trace` in favor of `torch.compile` for model optimization. Update the test in `test_gpytorch.py` to use the recommended `torch.compile` API instead.

This change aligns with PyTorch's direction toward TorchDynamo-based compilation and ensures the test remains compatible with future PyTorch versions.

Differential Revision: D91187729


