### PR TITLE
Fix-docstring-eubo

### DIFF
--- a/botorch/acquisition/preference.py
+++ b/botorch/acquisition/preference.py
@@ -104,8 +104,8 @@ class AnalyticExpectedUtilityOfBestOption(AnalyticAcquisitionFunction):
         ):
             raise UnsupportedError(
                 f"{self.__class__.__name__} only support q=2 or q=1"
-f"{self.__class__.__name__} only supports q=2 (no previous
-"winner specified) or q=1 (previous winner specified)."
+                f"{self.__class__.__name__} only supports q=2 (no previous
+                "winner specified) or q=1 (previous winner specified)."
             )
 
         Y = X if self.outcome_model is None else self.outcome_model(X)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

Fix the AnalyticEUBO docstring: the expected q value was flipped relative to the actual runtime check.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?
Yes.

## Test Plan
Not run (docstring-only change).

## Related PRs
N/A
