### PR TITLE
Links to Active Learning Papers

### DIFF
--- a/botorch/acquisition/active_learning.py
+++ b/botorch/acquisition/active_learning.py
@@ -8,20 +8,20 @@ r"""
 Active learning acquisition functions.
 
 .. [Seo2014activedata]
-    S. Seo, M. Wallat, T. Graepel, and K. Obermayer. [Gaussian process regression:
-    Active data selection and test point rejection]
-    (https://ieeexplore.ieee.org/document/861310).
+    S. Seo, M. Wallat, T. Graepel, and K. Obermayer. `Gaussian process regression:
+    Active data selection and test point rejection.
+    <https://ieeexplore.ieee.org/document/861310>`_
     IJCNN 2000.
 
 .. [Chen2014seqexpdesign]
-    X. Chen and Q. Zhou. [Sequential experimental designs for stochastic kriging.]
-    (https://ieeexplore.ieee.org/document/7020209)
+    X. Chen and Q. Zhou. `Sequential experimental designs for stochastic kriging.
+    <https://ieeexplore.ieee.org/document/7020209>`_
     Winter Simulation Conference 2014.
 
 .. [Binois2017repexp]
-    M. Binois, J. Huang, R. B. Gramacy, and M. Ludkovski. [Replication or
-    exploration? Sequential design for stochastic simulation experiments.]
-    (https://arxiv.org/abs/1710.03206)
+    M. Binois, J. Huang, R. B. Gramacy, and M. Ludkovski. `Replication or
+    exploration? Sequential design for stochastic simulation experiments.
+    <https://arxiv.org/abs/1710.03206>`_
     ArXiv 2017.
 """
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

I was looking up papers referenced in the active learning acqfs and thought it could be useful to have the links directly in, then the next does not need to search for them again. 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Just docs, I hope they build and look correct as I am not 100% sure how they are displayed in the API references if put in as I did ... let's see ;)

