### PR TITLE
Update optimize_acqf_homotopy and refactor mixed optimizer dispatch

### DIFF
--- a/botorch/optim/optimize_homotopy.py
+++ b/botorch/optim/optimize_homotopy.py
@@ -5,7 +5,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
+from itertools import product
 from typing import Any
 
 import torch
@@ -14,6 +15,10 @@ from botorch.generation.gen import TGenCandidates
 from botorch.optim.homotopy import Homotopy
 from botorch.optim.initializers import TGenInitialConditions
 from botorch.optim.optimize import optimize_acqf, optimize_acqf_mixed
+from botorch.optim.optimize_mixed import (
+    optimize_acqf_mixed_alternating,
+    should_use_mixed_alternating_optimizer,
+)
 from torch import Tensor
 
 
@@ -64,7 +69,9 @@ def optimize_acqf_homotopy(
     inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
     equality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
     nonlinear_inequality_constraints: list[tuple[Callable, bool]] | None = None,
-    fixed_features_list: list[dict[int, float]] | None = None,
+    fixed_features: dict[int, float] | None = None,
+    discrete_dims: Mapping[int, Sequence[float]] | None = None,
+    cat_dims: Mapping[int, Sequence[float]] | None = None,
     post_processing_func: Callable[[Tensor], Tensor] | None = None,
     batch_initial_conditions: Tensor | None = None,
     gen_candidates: TGenCandidates | None = None,
@@ -124,10 +131,19 @@ def optimize_acqf_homotopy(
             Using non-linear inequality constraints also requires that ``batch_limit``
             is set to 1, which will be done automatically if not specified in
             ``options``.
-        fixed_features_list: A list of maps ``{feature_index: value}``. The i-th
-            item represents the fixed_feature for the i-th optimization. If
-            ``fixed_features_list`` is provided, ``optimize_acqf_mixed`` is invoked.
-            All indices (``feature_index``) should be non-negative.
+        fixed_features: A map ``{feature_index: value}`` for features that should
+            be fixed to a particular value during generation. Used with
+            ``optimize_acqf`` or ``optimize_acqf_mixed_alternating``.
+        discrete_dims: A dictionary mapping indices of discrete and binary
+            dimensions to a list of allowed values for that dimension. If provided
+            along with ``cat_dims``, the optimizer is chosen based on the number
+            of discrete combinations: ``optimize_acqf_mixed_alternating`` is used
+            if there are more than 10 combinations, otherwise ``optimize_acqf_mixed``
+            is used.
+        cat_dims: A dictionary mapping indices of categorical dimensions
+            to a list of allowed values for that dimension. If provided
+            along with ``discrete_dims``, the optimizer is chosen based on the
+            number of discrete combinations (see ``discrete_dims``).
         post_processing_func: A function that post-processes an optimization
             result appropriately (i.e., according to ``round-trip``
             transformations).
@@ -151,27 +167,69 @@ def optimize_acqf_homotopy(
         ic_gen_kwargs: Additional keyword arguments passed to function specified by
             ``ic_generator``
     """
-    shared_optimize_acqf_kwargs = {
-        "num_restarts": num_restarts,
-        "inequality_constraints": inequality_constraints,
-        "equality_constraints": equality_constraints,
-        "nonlinear_inequality_constraints": nonlinear_inequality_constraints,
-        "return_best_only": False,  # False to make n_restarts persist through homotopy.
-        "gen_candidates": gen_candidates,
-        "ic_generator": ic_generator,
-        "timeout_sec": timeout_sec,
-        "retry_on_optimization_warning": retry_on_optimization_warning,
-        **ic_gen_kwargs,
-    }
+    # Determine which optimization function to use based on the arguments.
+    # This logic uses the shared `should_use_mixed_alternating_optimizer` utility
+    # which is also used by `determine_optimizer` in Ax.
+    use_mixed_alternating = should_use_mixed_alternating_optimizer(
+        discrete_dims=discrete_dims,
+        cat_dims=cat_dims,
+    )
 
-    if fixed_features_list and len(fixed_features_list) > 1:
+    if use_mixed_alternating:
+        # Use optimize_acqf_mixed_alternating for mixed discrete/continuous problems
+        # with many discrete combinations.
+        optimization_fn = optimize_acqf_mixed_alternating
+        shared_optimize_acqf_kwargs = {
+            "num_restarts": num_restarts,
+            "inequality_constraints": inequality_constraints,
+            "equality_constraints": equality_constraints,
+            "discrete_dims": discrete_dims,
+            "cat_dims": cat_dims,
+            "fixed_features": fixed_features,
+        }
+        fixed_features_kwargs = {}
+    elif discrete_dims is not None or cat_dims is not None:
+        # Use optimize_acqf_mixed for mixed problems with few discrete combinations.
+        # Build fixed_features_list from discrete_dims and cat_dims.
+
+        all_discrete_dims = {**(discrete_dims or {}), **(cat_dims or {})}
+        dim_indices = sorted(all_discrete_dims.keys())
+        value_lists = [all_discrete_dims[idx] for idx in dim_indices]
+        fixed_features_list = [
+            dict(zip(dim_indices, combo)) for combo in product(*value_lists)
+        ]
         optimization_fn = optimize_acqf_mixed
+        shared_optimize_acqf_kwargs = {
+            "num_restarts": num_restarts,
+            "inequality_constraints": inequality_constraints,
+            "equality_constraints": equality_constraints,
+            "nonlinear_inequality_constraints": nonlinear_inequality_constraints,
+            "return_best_only": False,  # to make n_restarts persist through homotopy.
+            "gen_candidates": gen_candidates,
+            "ic_generator": ic_generator,
+            "timeout_sec": timeout_sec,
+            "retry_on_optimization_warning": retry_on_optimization_warning,
+            **ic_gen_kwargs,
+        }
         fixed_features_kwargs = {"fixed_features_list": fixed_features_list}
     else:
         optimization_fn = optimize_acqf
-        fixed_features_kwargs = {
-            "fixed_features": fixed_features_list[0] if fixed_features_list else None
+        shared_optimize_acqf_kwargs = {
+            "num_restarts": num_restarts,
+            "inequality_constraints": inequality_constraints,
+            "equality_constraints": equality_constraints,
+            "nonlinear_inequality_constraints": nonlinear_inequality_constraints,
+            "return_best_only": False,  # to make n_restarts persist through homotopy.
+            "gen_candidates": gen_candidates,
+            "ic_generator": ic_generator,
+            "timeout_sec": timeout_sec,
+            "retry_on_optimization_warning": retry_on_optimization_warning,
+            **ic_gen_kwargs,
         }
+        if fixed_features is not None:
+            fixed_features_kwargs = {"fixed_features": fixed_features}
+        else:
+            fixed_features_kwargs = {}
 
     candidate_list, acq_value_list = [], []
     if q > 1:
@@ -183,16 +241,34 @@ def optimize_acqf_homotopy(
         homotopy.restart()
 
         while not homotopy.should_stop:
-            candidates, acq_values = optimization_fn(
-                acq_function=acq_function,
-                bounds=bounds,
-                q=1,
-                options=options,
-                batch_initial_conditions=candidates,
-                raw_samples=q_raw_samples,
-                **fixed_features_kwargs,
-                **shared_optimize_acqf_kwargs,
-            )
+            if use_mixed_alternating:
+                # optimize_acqf_mixed_alternating handles its own initialization
+                # and always returns best only, so we get shape (1, d).
+                candidates, acq_values = optimization_fn(
+                    acq_function=acq_function,
+                    bounds=bounds,
+                    q=1,
+                    options=options,
+                    raw_samples=q_raw_samples or raw_samples,
+                    post_processing_func=post_processing_func,
+                    **fixed_features_kwargs,
+                    **shared_optimize_acqf_kwargs,
+                )
+                # Reshape to (1, 1, d) to match optimize_acqf output shape and
+                # ensure acq_values is 1-d for prune_candidates.
+                candidates = candidates.unsqueeze(0)
+                acq_values = acq_values.view(-1)
+            else:
+                candidates, acq_values = optimization_fn(
+                    acq_function=acq_function,
+                    bounds=bounds,
+                    q=1,
+                    options=options,
+                    batch_initial_conditions=candidates,
+                    raw_samples=q_raw_samples,
+                    **fixed_features_kwargs,
+                    **shared_optimize_acqf_kwargs,
+                )
 
             homotopy.step()
 
@@ -208,19 +284,36 @@ def optimize_acqf_homotopy(
             ).unsqueeze(1)
 
         # Optimize one more time with the final options
-        candidates, acq_values = optimization_fn(
-            acq_function=acq_function,
-            bounds=bounds,
-            q=1,
-            options=final_options,
-            raw_samples=q_raw_samples,
-            batch_initial_conditions=candidates,
-            **fixed_features_kwargs,
-            **shared_optimize_acqf_kwargs,
-        )
+        if use_mixed_alternating:
+            candidates, acq_values = optimization_fn(
+                acq_function=acq_function,
+                bounds=bounds,
+                q=1,
+                options=final_options,
+                raw_samples=raw_samples,
+                post_processing_func=post_processing_func,
+                **fixed_features_kwargs,
+                **shared_optimize_acqf_kwargs,
+            )
+            # Reshape to (1, 1, d) to match optimize_acqf output shape.
+            candidates = candidates.unsqueeze(0)
+            acq_values = acq_values.view(-1)
+        else:
+            candidates, acq_values = optimization_fn(
+                acq_function=acq_function,
+                bounds=bounds,
+                q=1,
+                options=final_options,
+                raw_samples=q_raw_samples,
+                batch_initial_conditions=candidates,
+                **fixed_features_kwargs,
+                **shared_optimize_acqf_kwargs,
+            )
 
         # Post-process the candidates and grab the best candidate
-        if post_processing_func is not None:
+        # Note: post_processing_func is already applied within
+        # optimize_acqf_mixed_alternating, so we skip it here in that case.
+        if post_processing_func is not None and not use_mixed_alternating:
             candidates = post_processing_func(candidates)
             acq_values = acq_function(candidates)
 

--- a/test/optim/test_homotopy.py
+++ b/test/optim/test_homotopy.py
@@ -17,6 +17,7 @@ from botorch.optim.homotopy import (
     LogLinearHomotopySchedule,
 )
 from botorch.optim.optimize_homotopy import optimize_acqf_homotopy, prune_candidates
+from botorch.optim.optimize_mixed import should_use_mixed_alternating_optimizer
 from botorch.utils.testing import BotorchTestCase
 from torch.nn import Parameter
 
@@ -126,24 +127,10 @@ class TestHomotopy(BotorchTestCase):
         self.assertEqual(candidate, torch.zeros(1, **tkwargs))
         self.assertEqual(acqf_val, 5 * torch.ones(1, **tkwargs))
 
-        # test fixed feature list
-        fixed_features_list = [{0: 1.0}, {1: 3.0}]
+        # With q > 1.
         model = GenericDeterministicModel(
             f=lambda x: 5 - (x - p).sum(dim=-1, keepdims=True) ** 2
         )
-        acqf = PosteriorMean(model=model)
-        candidate, acqf_val = optimize_acqf_homotopy(
-            q=1,
-            acq_function=acqf,
-            bounds=torch.tensor([[-10, -10, -10], [5, 5, 5]], **tkwargs),
-            homotopy=Homotopy(homotopy_parameters=[hp]),
-            num_restarts=2,
-            raw_samples=16,
-            fixed_features_list=fixed_features_list,
-        )
-        self.assertEqual(candidate[0, 0], torch.tensor(1, **tkwargs))
-
-        # With q > 1.
         acqf = qExpectedImprovement(model=model, best_f=0.0)
         candidate, acqf_val = optimize_acqf_homotopy(
             q=3,
@@ -152,7 +139,7 @@ class TestHomotopy(BotorchTestCase):
             homotopy=Homotopy(homotopy_parameters=[hp]),
             num_restarts=2,
             raw_samples=16,
-            fixed_features_list=[{0: 1.0}],
+            fixed_features={0: 1.0},
         )
         self.assertEqual(candidate.shape, torch.Size([3, 2]))
         self.assertEqual(acqf_val.shape, torch.Size([3]))
@@ -244,3 +231,171 @@ class TestHomotopy(BotorchTestCase):
                 prune_candidates_mock.call_args_list[i][1]["candidates"].shape,
                 torch.Size([1, 1]),
             )
+
+    def test_optimize_acqf_homotopy_discrete_dims(self):
+        """Test optimize_acqf_homotopy with discrete_dims and cat_dims."""
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        p = Parameter(-2 * torch.ones(1, **tkwargs))
+        hp = HomotopyParameter(
+            parameter=p,
+            schedule=LinearHomotopySchedule(start=4, end=0, num_steps=3),
+        )
+        model = GenericDeterministicModel(
+            f=lambda x: 5 - (x - p).sum(dim=-1, keepdims=True) ** 2
+        )
+        acqf = PosteriorMean(model=model)
+
+        # Test with few discrete combinations (<=10) -> should use optimize_acqf_mixed
+        # 2 * 2 = 4 combinations
+        discrete_dims = {0: [0.0, 1.0]}
+        cat_dims = {1: [0.0, 1.0]}
+        candidate, acqf_val = optimize_acqf_homotopy(
+            q=1,
+            acq_function=acqf,
+            bounds=torch.tensor([[0, 0, -10], [1, 1, 5]], **tkwargs),
+            homotopy=Homotopy(homotopy_parameters=[hp]),
+            num_restarts=2,
+            raw_samples=16,
+            discrete_dims=discrete_dims,
+            cat_dims=cat_dims,
+        )
+        self.assertEqual(candidate.shape, torch.Size([1, 3]))
+        self.assertEqual(acqf_val.shape, torch.Size([1]))
+        # The discrete dimensions should be in the allowed values
+        self.assertIn(candidate[0, 0].item(), [0.0, 1.0])
+        self.assertIn(candidate[0, 1].item(), [0.0, 1.0])
+
+    def test_optimize_acqf_homotopy_discrete_dims_many_combos(self):
+        """Test with many discrete combinations (>10) -> uses mixed_alternating."""
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        p = Parameter(-2 * torch.ones(1, **tkwargs))
+        hp = HomotopyParameter(
+            parameter=p,
+            schedule=LinearHomotopySchedule(start=4, end=0, num_steps=3),
+        )
+        model = GenericDeterministicModel(
+            f=lambda x: 5 - (x - p).sum(dim=-1, keepdims=True) ** 2
+        )
+        acqf = PosteriorMean(model=model)
+
+        # Test with many discrete combinations (>10) -> uses
+        # optimize_acqf_mixed_alternating
+        # 4 * 4 = 16 combinations
+        discrete_dims = {0: [0.0, 1.0, 2.0, 3.0], 1: [0.0, 1.0, 2.0, 3.0]}
+        candidate, acqf_val = optimize_acqf_homotopy(
+            q=1,
+            acq_function=acqf,
+            bounds=torch.tensor([[0, 0, -10], [3, 3, 5]], **tkwargs),
+            homotopy=Homotopy(homotopy_parameters=[hp]),
+            num_restarts=2,
+            raw_samples=16,
+            discrete_dims=discrete_dims,
+        )
+        self.assertEqual(candidate.shape, torch.Size([1, 3]))
+        self.assertEqual(acqf_val.shape, torch.Size([1]))
+        # The discrete dimensions should be in the allowed values
+        self.assertIn(candidate[0, 0].item(), [0.0, 1.0, 2.0, 3.0])
+        self.assertIn(candidate[0, 1].item(), [0.0, 1.0, 2.0, 3.0])
+
+    @mock.patch(
+        "botorch.optim.optimize_homotopy.optimize_acqf_mixed_alternating",
+        wraps=None,
+    )
+    @mock.patch(
+        "botorch.optim.optimize_homotopy.optimize_acqf_mixed",
+        wraps=None,
+    )
+    def test_optimize_acqf_homotopy_dispatch_logic(
+        self, mock_mixed, mock_mixed_alternating
+    ):
+        """Test that the correct optimizer is dispatched based on number of combos."""
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        p = Parameter(-2 * torch.ones(1, **tkwargs))
+        hp = HomotopyParameter(
+            parameter=p,
+            schedule=LinearHomotopySchedule(start=1, end=0, num_steps=1),
+        )
+        model = GenericDeterministicModel(
+            f=lambda x: 5 - (x - p).sum(dim=-1, keepdims=True) ** 2
+        )
+        acqf = PosteriorMean(model=model)
+
+        # Mock return values
+        mock_candidates = torch.zeros(1, 3, **tkwargs)
+        mock_acq_values = torch.zeros(1, **tkwargs)
+        mock_mixed.return_value = (mock_candidates.unsqueeze(0), mock_acq_values)
+        mock_mixed_alternating.return_value = (mock_candidates, mock_acq_values)
+
+        # Test with few combinations (<=10) -> should call optimize_acqf_mixed
+        discrete_dims = {0: [0.0, 1.0]}  # 2 combinations
+        optimize_acqf_homotopy(
+            q=1,
+            acq_function=acqf,
+            bounds=torch.tensor([[0, 0, -10], [1, 1, 5]], **tkwargs),
+            homotopy=Homotopy(homotopy_parameters=[hp]),
+            num_restarts=2,
+            raw_samples=16,
+            discrete_dims=discrete_dims,
+        )
+        self.assertTrue(mock_mixed.called)
+        self.assertFalse(mock_mixed_alternating.called)
+
+        # Reset mocks
+        mock_mixed.reset_mock()
+        mock_mixed_alternating.reset_mock()
+        hp = HomotopyParameter(
+            parameter=p,
+            schedule=LinearHomotopySchedule(start=1, end=0, num_steps=1),
+        )
+
+        # Test with many combinations (>10) -> should call
+        # optimize_acqf_mixed_alternating
+        discrete_dims = {0: [0.0, 1.0, 2.0, 3.0], 1: [0.0, 1.0, 2.0, 3.0]}  # 16 combos
+        optimize_acqf_homotopy(
+            q=1,
+            acq_function=acqf,
+            bounds=torch.tensor([[0, 0, -10], [3, 3, 5]], **tkwargs),
+            homotopy=Homotopy(homotopy_parameters=[hp]),
+            num_restarts=2,
+            raw_samples=16,
+            discrete_dims=discrete_dims,
+        )
+        self.assertTrue(mock_mixed_alternating.called)
+        self.assertFalse(mock_mixed.called)
+
+    def test_should_use_mixed_alternating_optimizer(self):
+        """Test the shared utility function for determining optimizer dispatch."""
+        # Test with no discrete dims -> should return False
+        self.assertFalse(should_use_mixed_alternating_optimizer())
+        self.assertFalse(
+            should_use_mixed_alternating_optimizer(discrete_dims=None, cat_dims=None)
+        )
+
+        # Test with few combinations (<=10) -> should return False
+        self.assertFalse(
+            should_use_mixed_alternating_optimizer(discrete_dims={0: [0.0, 1.0]})
+        )
+        self.assertFalse(
+            should_use_mixed_alternating_optimizer(
+                discrete_dims={0: [0.0, 1.0]}, cat_dims={1: [0.0, 1.0]}
+            )
+        )  # 2 * 2 = 4 combinations
+        self.assertFalse(
+            should_use_mixed_alternating_optimizer(
+                discrete_dims={0: [0.0, 1.0, 2.0, 3.0, 4.0]},
+                cat_dims={1: [0.0, 1.0]},
+            )
+        )  # 5 * 2 = 10 combinations (boundary)
+
+        # Test with many combinations (>10) -> should return True
+        self.assertTrue(
+            should_use_mixed_alternating_optimizer(
+                discrete_dims={0: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]},
+                cat_dims={1: [0.0, 1.0]},
+            )
+        )  # 6 * 2 = 12 combinations
+        self.assertTrue(
+            should_use_mixed_alternating_optimizer(
+                discrete_dims={0: [0.0, 1.0, 2.0, 3.0], 1: [0.0, 1.0, 2.0, 3.0]}
+            )
+        )  # 4 * 4 = 16 combinations


### PR DESCRIPTION
Summary: see title. This refactors dispatch to mixed optimizers into a shared utility for botorch and ax. This also cleans up optimize_acqf_homotopy by removing fixed_features_list and leveraging the new dispatch util. This adds support for using optimize_acqf_mixed_alternating.

Reviewed By: bletham

Differential Revision: D91913317


