### PR TITLE
fix: correct typo 'occurences' in docstring

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -1448,7 +1448,7 @@ def _filter_infeasible(
 
 
 def _filter_invalid(X: Tensor, X_avoid: Tensor) -> Tensor:
-    """Remove all occurences of ``X_avoid`` from ``X``."""
+    """Remove all occurrences of ``X_avoid`` from ``X``."""
     return X[~(X == X_avoid.unsqueeze(-2)).all(dim=-1).any(dim=-2)]
 
 


### PR DESCRIPTION
Corrected a minor typo in the `_filter_invalid` function docstring:

- `occurences` → `occurrences`

No functional changes.