### PR TITLE
Replace Union/Optional with modern X | Y / X | None syntax

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable, Hashable, Iterable, Sequence
-from typing import Any, TypeVar, Union
+from typing import Any, TypeVar
 
 import torch
 from botorch.acquisition.acquisition import AcquisitionFunction
@@ -118,19 +118,19 @@ from torch import Tensor
 ACQF_INPUT_CONSTRUCTOR_REGISTRY = {}
 
 T = TypeVar("T")
-MaybeDict = Union[T, dict[Hashable, T]]
-TOptimizeObjectiveKwargs = Union[
-    None,
-    MCAcquisitionObjective,
-    PosteriorTransform,
-    tuple[Tensor, Tensor],
-    dict[int, float],
-    bool,
-    int,
-    dict[str, Any],
-    Callable[[Tensor], Tensor],
-    Tensor,
-]
+MaybeDict = T | dict[Hashable, T]
+TOptimizeObjectiveKwargs = (
+    None
+    | MCAcquisitionObjective
+    | PosteriorTransform
+    | tuple[Tensor, Tensor]
+    | dict[int, float]
+    | bool
+    | int
+    | dict[str, Any]
+    | Callable[[Tensor], Tensor]
+    | Tensor
+)
 
 
 def _field_is_shared(

--- a/botorch/models/relevance_pursuit.py
+++ b/botorch/models/relevance_pursuit.py
@@ -22,7 +22,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from copy import copy, deepcopy
 from functools import partial
-from typing import Any, cast, Optional
+from typing import Any, cast
 from warnings import warn
 
 import torch
@@ -468,7 +468,7 @@ def forward_relevance_pursuit(
     optimizer: Callable | None = None,
     closure_kwargs: dict[str, Any] | None = None,
     optimizer_kwargs: dict[str, Any] | None = None,
-) -> tuple[RelevancePursuitMixin, Optional[list[Model]]]:
+) -> tuple[RelevancePursuitMixin, list[Model] | None]:
     """Forward Relevance Pursuit.
 
     NOTE: For the robust ``SparseOutlierNoise`` model of
@@ -584,7 +584,7 @@ def backward_relevance_pursuit(
     optimizer: Callable | None = None,
     closure_kwargs: dict[str, Any] | None = None,
     optimizer_kwargs: dict[str, Any] | None = None,
-) -> tuple[RelevancePursuitMixin, Optional[list[Model]]]:
+) -> tuple[RelevancePursuitMixin, list[Model] | None]:
     """Backward Relevance Pursuit.
 
     NOTE: For the robust ``SparseOutlierNoise`` model of

--- a/botorch/models/robust_relevance_pursuit_model.py
+++ b/botorch/models/robust_relevance_pursuit_model.py
@@ -33,7 +33,8 @@ to do two distinct operations in the context of the robust model:
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Mapping, Optional, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
 
 import torch
 from botorch.exceptions.errors import UnsupportedError
@@ -273,7 +274,7 @@ def _fit_rrp(
     closure: Callable[[], tuple[Tensor, Sequence[Tensor | None]]] | None = None,
     optimizer: Callable | None = None,
     closure_kwargs: dict[str, Any] | None = None,
-    optimizer_kwargs: Optional[Mapping[str, Any]] = None,
+    optimizer_kwargs: Mapping[str, Any] | None = None,
 ) -> MarginalLogLikelihood:
     """Fits a RobustRelevancePursuitGP model using the given marginal likelihood.
 

--- a/botorch/optim/batched_lbfgs_b.py
+++ b/botorch/optim/batched_lbfgs_b.py
@@ -635,8 +635,8 @@ def _minimize_lbfgsb(
 
 # extra helper function
 def translate_bounds_for_lbfgsb(
-    lower_bounds: tp.Union[tp.Sequence[tp.Optional[float]], float, None],
-    upper_bounds: tp.Union[tp.Sequence[tp.Optional[float]], float, None],
+    lower_bounds: tp.Sequence[float | None] | float | None,
+    upper_bounds: tp.Sequence[float | None] | float | None,
     num_features: int,
     q: int,
 ):

--- a/botorch/optim/fit.py
+++ b/botorch/optim/fit.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from functools import partial
-from typing import Any, Optional
+from typing import Any
 from warnings import warn
 
 from botorch.exceptions.warnings import OptimizationWarning
@@ -32,13 +32,13 @@ from torch.optim.adam import Adam
 from torch.optim.lr_scheduler import _LRScheduler
 from torch.optim.optimizer import Optimizer
 
-TBoundsDict = dict[str, tuple[Optional[float], Optional[float]]]
+TBoundsDict = dict[str, tuple[float | None, float | None]]
 TScipyObjective = Callable[
     [ndarray, MarginalLogLikelihood, dict[str, TorchAttr]], tuple[float, ndarray]
 ]
 TModToArray = Callable[
-    [Module, Optional[TBoundsDict], Optional[set[str]]],
-    tuple[ndarray, dict[str, TorchAttr], Optional[ndarray]],
+    [Module, TBoundsDict | None, set[str] | None],
+    tuple[ndarray, dict[str, TorchAttr], ndarray | None],
 ]
 TArrayToMod = Callable[[Module, ndarray, dict[str, TorchAttr]], Module]
 

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable
-from typing import Optional, Union
 
 import torch
 from botorch.acquisition import analytic, monte_carlo, multi_objective
@@ -55,18 +54,17 @@ from torch.quasirandom import SobolEngine
 
 TGenInitialConditions = Callable[
     [
-        # reasoning behind this annotation: contravariance
         qKnowledgeGradient,
         Tensor,
         int,
         int,
         int,
-        Optional[dict[int, float]],
-        Optional[dict[str, Union[bool, float, int]]],
-        Optional[list[tuple[Tensor, Tensor, float]]],
-        Optional[list[tuple[Tensor, Tensor, float]]],
+        dict[int, float] | None,
+        dict[str, bool | float | int] | None,
+        list[tuple[Tensor, Tensor, float]] | None,
+        list[tuple[Tensor, Tensor, float]] | None,
     ],
-    Optional[Tensor],
+    Tensor | None,
 ]
 
 

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial
-from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -24,7 +23,7 @@ from torch import Tensor
 
 
 ScipyConstraintDict = dict[
-    str, Union[str, Callable[[np.ndarray], float], Callable[[np.ndarray], np.ndarray]]
+    str, str | Callable[[np.ndarray], float] | Callable[[np.ndarray], np.ndarray]
 ]
 
 

--- a/botorch/sampling/pathwise/utils.py
+++ b/botorch/sampling/pathwise/utils.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
-from typing import Any, overload, Union
+from typing import Any, overload
 
 import torch
 from botorch.models.approximate_gp import SingleTaskVariationalGP
@@ -22,8 +22,8 @@ from gpytorch.kernels.kernel import Kernel
 from torch import LongTensor, Tensor
 from torch.nn import Module, ModuleList
 
-TInputTransform = Union[InputTransform, Callable[[Tensor], Tensor]]
-TOutputTransform = Union[OutcomeTransform, Callable[[Tensor], Tensor]]
+TInputTransform = InputTransform | Callable[[Tensor], Tensor]
+TOutputTransform = OutcomeTransform | Callable[[Tensor], Tensor]
 GetTrainInputs = Dispatcher("get_train_inputs")
 GetTrainTargets = Dispatcher("get_train_targets")
 


### PR DESCRIPTION
Summary:
Modernize type hints to use Python 3.11+ union syntax:
- Replace `Union[X, Y]` with `X | Y`
- Replace `Optional[X]` with `X | None`

This is part of a larger effort to leverage Python 3.11+ features in botorch.

Files updated:
- botorch/optim/fit.py
- botorch/optim/initializers.py
- botorch/optim/parameter_constraints.py
- botorch/optim/batched_lbfgs_b.py
- botorch/acquisition/input_constructors.py
- botorch/models/relevance_pursuit.py
- botorch/models/robust_relevance_pursuit_model.py
- botorch/sampling/pathwise/utils.py

Reviewed By: hvarfner

Differential Revision: D91641968


