### PR TITLE
Fix two bugs in safe_math.py

### DIFF
--- a/botorch/utils/safe_math.py
+++ b/botorch/utils/safe_math.py
@@ -58,7 +58,7 @@ def sub(a: Tensor, b: Tensor) -> Tensor:
 
 def div(a: Tensor, b: Tensor) -> Tensor:
     _0, _1 = get_constants_like(values=(0, 1), ref=a)
-    case = ((a == _0) & (b == _0)) | (a.isinf() & a.isinf())
+    case = ((a == _0) & (b == _0)) | (a.isinf() & b.isinf())
     return torch.where(case, torch.where(a != b, -_1, _1), a / torch.where(case, _1, b))
 
 
@@ -385,6 +385,10 @@ def fatmaximum(
         tau: Temperature parameter controlling the smoothness of the approximation. A
             smaller tau corresponds to a tighter approximation that leads to a sharper
             objective landscape that might be more difficult to optimize.
+        alpha: The exponent of the asymptotic power decay of the approximation. The
+            default value is 2. Higher alpha parameters make the function behave more
+            similarly to the standard logsumexp approximation to the max, so it is
+            recommended to keep this value low or moderate, e.g. < 10.
 
     Returns:
         A smooth approximation of torch.maximum(a, b).
@@ -394,6 +398,7 @@ def fatmaximum(
         dim=-1,
         keepdim=False,
         tau=tau,
+        alpha=alpha,
     )
 
 
@@ -408,6 +413,10 @@ def fatminimum(
         tau: Temperature parameter controlling the smoothness of the approximation. A
             smaller tau corresponds to a tighter approximation that leads to a sharper
             objective landscape that might be more difficult to optimize.
+        alpha: The exponent of the asymptotic power decay of the approximation. The
+            default value is 2. Higher alpha parameters make the function behave more
+            similarly to the standard logsumexp approximation to the max, so it is
+            recommended to keep this value low or moderate, e.g. < 10.
 
     Returns:
         A smooth approximation of torch.minimum(a, b).

--- a/test/utils/test_safe_math.py
+++ b/test/utils/test_safe_math.py
@@ -239,6 +239,21 @@ class TestSafeDiv(
                     self.assertEqual(a.grad, 1 / b)
                     self.assertEqual(b.grad, -a * b**-2)
 
+    def test_inf_div_finite(self):
+        """Test that div(inf, finite) returns inf, not 1."""
+        for dtype in (torch.float32, torch.float64):
+            for _a, _b in [(INF, 2.0), (-INF, 2.0), (INF, -2.0), (-INF, -2.0)]:
+                a = torch.tensor(
+                    _a, dtype=dtype, requires_grad=True, device=self.device
+                )
+                b = torch.tensor(
+                    _b, dtype=dtype, requires_grad=True, device=self.device
+                )
+                out = self.safe_op(a, b)
+                # inf / finite should return inf with the correct sign
+                expected = torch.tensor(_a / _b, dtype=dtype, device=self.device)
+                self.assertEqual(out, expected)
+
 
 class TestLogMeanExp(BotorchTestCase):
     def test_log_mean_exp(self):
@@ -434,8 +449,22 @@ class TestSmoothNonLinearities(BotorchTestCase):
             tau = 1e-2
             self.assertAllClose(fatmaximum(x, y, tau=tau), x.maximum(y), atol=tau)
 
+            # testing fatmaximum with custom alpha
+            alpha_default = fatmaximum(x, y, tau=tau)
+            alpha_custom = fatmaximum(x, y, tau=tau, alpha=5.0)
+            # different alpha should produce different results
+            self.assertFalse(torch.allclose(alpha_default, alpha_custom))
+            # but both should still approximate the true maximum
+            self.assertAllClose(alpha_custom, x.maximum(y), atol=tau)
+
             # testing fatminimum
             self.assertAllClose(fatminimum(x, y, tau=tau), x.minimum(y), atol=tau)
+
+            # testing fatminimum with custom alpha
+            alpha_default = fatminimum(x, y, tau=tau)
+            alpha_custom = fatminimum(x, y, tau=tau, alpha=5.0)
+            self.assertFalse(torch.allclose(alpha_default, alpha_custom))
+            self.assertAllClose(alpha_custom, x.minimum(y), atol=tau)
 
             # testing fatmoid
             X = torch.arange(-a, a, step=2 * a / n, requires_grad=True, **tkwargs)


### PR DESCRIPTION
Summary:
1. **`div()` copy-paste bug:** The condition `a.isinf() & a.isinf()` redundantly checks if `a` is infinite twice. This should be `a.isinf() & b.isinf()` to handle the `inf/inf` special case, analogous to how `sub()` handles it. Without this fix, `div(inf, finite_value)` incorrectly returns `1` or `-1` instead of `inf` or `-inf`.

2. **`fatmaximum()` silently ignores `alpha` parameter:** The function accepts `alpha` as a parameter but never passes it to the underlying `fatmax()` call. Users who explicitly set `alpha` get silently incorrect results. The fix passes `alpha` through to `fatmax`. Since `fatminimum` delegates to `fatmaximum`, it is also fixed transitively.

Differential Revision: D92863366


