### PR TITLE
Fix copy-paste docstring errors in acquisition functions

### DIFF
--- a/botorch/acquisition/analytic.py
+++ b/botorch/acquisition/analytic.py
@@ -144,7 +144,7 @@ class LogProbabilityOfImprovement(AnalyticAcquisitionFunction):
         posterior_transform: PosteriorTransform | None = None,
         maximize: bool = True,
     ):
-        r"""Single-outcome Probability of Improvement.
+        r"""Single-outcome Log Probability of Improvement.
 
         Args:
             model: A fitted single-outcome model.
@@ -1121,7 +1121,7 @@ class PosteriorStandardDeviation(AnalyticAcquisitionFunction):
         posterior_transform: PosteriorTransform | None = None,
         maximize: bool = True,
     ) -> None:
-        r"""Single-outcome Posterior Mean.
+        r"""Single-outcome Posterior Standard Deviation.
 
         Args:
             model: A fitted single-outcome GP model (must be in batch mode if
@@ -1148,7 +1148,7 @@ class PosteriorStandardDeviation(AnalyticAcquisitionFunction):
                 design points.
 
         Returns:
-            A ``(b1 x ... bk)``-dim tensor of Posterior Mean values at
+            A ``(b1 x ... bk)``-dim tensor of Posterior Standard Deviation values at
                 the given design points ``X``.
         """
         _, std = self._mean_and_sigma(X)

--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -602,7 +602,7 @@ def construct_inputs_qLogEI(
     tau_max: float = TAU_MAX,
     tau_relu: float = TAU_RELU,
 ) -> dict[str, Any]:
-    r"""Construct kwargs for the ``qExpectedImprovement`` constructor.
+    r"""Construct kwargs for the ``qLogExpectedImprovement`` constructor.
 
     Args:
         model: The model to be used in the acquisition function.
@@ -662,7 +662,7 @@ def construct_inputs_LogPF(
     fat: bool = True,
     tau_max: float = TAU_MAX,
 ) -> dict[str, Any]:
-    r"""Construct kwargs for the ``qExpectedImprovement`` constructor.
+    r"""Construct kwargs for the ``qLogProbabilityOfFeasibility`` constructor.
 
     Args:
         model: The model to be used in the acquisition function.
@@ -1258,7 +1258,7 @@ def construct_inputs_qLogNParEGO(
     tau_max: float = TAU_MAX,
     tau_relu: float = TAU_RELU,
 ):
-    r"""Construct kwargs for the ``qLogNoisyExpectedImprovement`` constructor.
+    r"""Construct kwargs for the ``qLogNParEGO`` constructor.
 
     Args:
         model: The model to be used in the acquisition function.

--- a/botorch/acquisition/multi_objective/logei.py
+++ b/botorch/acquisition/multi_objective/logei.py
@@ -352,7 +352,9 @@ class qLogNoisyExpectedHypervolumeImprovement(
         Example:
             >>> model = SingleTaskGP(train_X, train_Y)
             >>> ref_point = [0.0, 0.0]
-            >>> qNEHVI = qNoisyExpectedHypervolumeImprovement(model, ref_point, train_X)
+            >>> qNEHVI = qLogNoisyExpectedHypervolumeImprovement(
+            ...     model, ref_point, train_X
+            ... )
             >>> qnehvi = qNEHVI(test_X)
 
         Args:


### PR DESCRIPTION
Summary:
Fix six copy-paste docstring errors across acquisition function files:

1. `PosteriorStandardDeviation.__init__` and `forward` docstrings said "Posterior Mean" instead of "Posterior Standard Deviation".
2. `LogProbabilityOfImprovement.__init__` said "Probability of Improvement" instead of "Log Probability of Improvement".
3. `construct_inputs_qLogEI` referenced `qExpectedImprovement` instead of `qLogExpectedImprovement`.
4. `construct_inputs_LogPF` referenced `qExpectedImprovement` instead of `qLogProbabilityOfFeasibility`.
5. `construct_inputs_qLogNParEGO` referenced `qLogNoisyExpectedImprovement` instead of `qLogNParEGO`.
6. `qLogNoisyExpectedHypervolumeImprovement.__init__` example used `qNoisyExpectedHypervolumeImprovement` instead of the correct class name.

Differential Revision: D92863327


