### PR TITLE
Fix KernelEvaluationMap.num_outputs using wrong dimension

### DIFF
--- a/botorch/sampling/pathwise/features/maps.py
+++ b/botorch/sampling/pathwise/features/maps.py
@@ -66,10 +66,10 @@ class KernelEvaluationMap(FeatureMap):
     @property
     def num_outputs(self) -> int:
         if self.output_transform is None:
-            return self.points.shape[-1]
+            return self.points.shape[-2]
 
         canary = torch.empty(
-            1, self.points.shape[-1], device=self.points.device, dtype=self.points.dtype
+            1, self.points.shape[-2], device=self.points.device, dtype=self.points.dtype
         )
         return self.output_transform(canary).shape[-1]
 


### PR DESCRIPTION
Summary:
`KernelEvaluationMap.num_outputs` used `self.points.shape[-1]` (the feature dimension `d`) instead of `self.points.shape[-2]` (the number of points). Since the `forward` method computes `kernel(x, self.points)`, which returns a tensor of shape `... x q x n_points`, the number of outputs should be `n_points = self.points.shape[-2]`, not the input feature dimension.

The canary tensor for the `output_transform` branch was also using the wrong dimension, and has been corrected.

Differential Revision: D92863437


