### PR TITLE
Add task-level means to SaasFullyBayesianMultiTaskGP

### DIFF
--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -32,6 +32,8 @@ from gpytorch.kernels import MaternKernel
 from gpytorch.kernels.index_kernel import IndexKernel
 from gpytorch.kernels.kernel import Kernel
 from gpytorch.likelihoods.likelihood import Likelihood
+from gpytorch.means import MultitaskMean
+from gpytorch.means.constant_mean import ConstantMean
 from gpytorch.means.mean import Mean
 from torch import Tensor
 from torch.nn.parameter import Parameter
@@ -93,6 +95,19 @@ class MultitaskSaasPyroModel(SaasPyroModel):
         # assume there is one column for task feature
         self.ard_num_dims = self.train_X.shape[-1] - 1
 
+    def sample_mean(self, **tkwargs: Any) -> Tensor:
+        r"""Sample per-task mean constants.
+
+        Returns a vector of shape ``(num_tasks,)`` with one mean per task.
+        """
+        return pyro.sample(
+            "mean",
+            pyro.distributions.Normal(
+                torch.tensor(0.0, **tkwargs),
+                torch.tensor(1.0, **tkwargs),
+            ).expand(torch.Size([self.num_tasks])),
+        )
+
     def sample(self) -> None:
         r"""Sample from the SAAS model.
 
@@ -124,7 +139,7 @@ class MultitaskSaasPyroModel(SaasPyroModel):
         pyro.sample(
             "Y",
             pyro.distributions.MultivariateNormal(
-                loc=mean.view(-1).expand(self.train_X.shape[0]),
+                loc=mean[task_indices],
                 covariance_matrix=K,
             ),
             obs=self.train_Y.squeeze(-1),
@@ -158,9 +173,28 @@ class MultitaskSaasPyroModel(SaasPyroModel):
         num_mcmc_samples = len(mcmc_samples["mean"])
         batch_shape = torch.Size([num_mcmc_samples])
 
-        mean_module, data_covar_module, likelihood, _ = super().load_mcmc_samples(
-            mcmc_samples=mcmc_samples
+        # Pass a dummy scalar mean to the parent so it can construct covar/likelihood.
+        # We replace the mean_module with a MultitaskMean below.
+        parent_mcmc_samples = {
+            **mcmc_samples,
+            "mean": mcmc_samples["mean"][:, 0],
+        }
+        _, data_covar_module, likelihood, _ = super().load_mcmc_samples(
+            mcmc_samples=parent_mcmc_samples
         )
+
+        # Construct a MultitaskMean with per-task constants from MCMC samples.
+        mean_module = MultitaskMean(
+            base_means=ConstantMean(batch_shape=batch_shape),
+            num_tasks=self.num_tasks,
+        ).to(**tkwargs)
+        # mcmc_samples["mean"] has shape (num_mcmc_samples, num_tasks)
+        for i in range(self.num_tasks):
+            mean_module.base_means[i].constant.data = reshape_and_detach(
+                target=mean_module.base_means[i].constant.data,
+                new_value=mcmc_samples["mean"][:, i],
+            )
+
         data_indices = torch.arange(self.train_X.shape[-1] - 1)
         data_indices[self.task_feature :] += 1  # exclude task feature
 
@@ -463,13 +497,13 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
             raise NotImplementedError(  # pragma: no cover
                 "load_state_dict only works for MultitaskSaasPyroModel"
             )
-        raw_mean = state_dict["mean_module.raw_constant"]
+        raw_mean = state_dict["mean_module.base_means.0.raw_constant"]
         num_mcmc_samples = len(raw_mean)
         dim = self.pyro_model.train_X.shape[-1] - 1  # Removing 1 for the task feature.
         tkwargs = {"device": raw_mean.device, "dtype": raw_mean.dtype}
         # Load some dummy samples
         mcmc_samples = {
-            "mean": torch.ones(num_mcmc_samples, **tkwargs),
+            "mean": torch.ones(num_mcmc_samples, self.num_tasks, **tkwargs),
             "lengthscale": torch.ones(num_mcmc_samples, dim, **tkwargs),
             "outputscale": torch.ones(num_mcmc_samples, **tkwargs),
             "task_lengthscale": torch.ones(num_mcmc_samples, self._rank, **tkwargs),

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -110,9 +110,11 @@ def _compute_multitask_mean(
         # according to task_idcs.
         x_mean = torch.cat([x_before, x_after], dim=-1)
         mean_x = mean_module(x_mean)
-        # Extract the appropriate task mean for each point
+        # Extract the appropriate task mean for each point.
+        # Expand task_idcs to match mean_x batch dimensions (e.g. MCMC samples).
+        gather_idcs = task_idcs.long().expand(mean_x.shape[:-1] + task_idcs.shape[-1:])
         # mean_x has shape ``batch_shape x n`` after the gather
-        mean_x = mean_x.gather(-1, task_idcs.long()).squeeze(-1)
+        mean_x = mean_x.gather(-1, gather_idcs).squeeze(-1)
     else:
         # For non-MultitaskMean, include task indices in the input
         x_mean = torch.cat([x_before, task_idcs, x_after], dim=-1)


### PR DESCRIPTION
Summary:
Backlog task: T201650561 


Update MultitaskSaasPyroModel and SaasFullyBayesianMultiTaskGP to support per-task mean constants via MultitaskMean, instead of a single shared scalar mean. This aligns the fully Bayesian multi-task GP with the non-Bayesian MultiTaskGP, which already defaults to per-task means.

Differential Revision: D92836605


