### PR TITLE
Add multi-task support to the PyroModel base class

### DIFF
--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -86,6 +86,9 @@ class CustomPyroModel(PyroModel):
     def load_mcmc_samples(self, mcmc_samples) -> None:
         pass
 
+    def get_dummy_mcmc_samples(self, num_mcmc_samples, **tkwargs):
+        return {}
+
 
 class TestPyroModelPriorMode(BotorchTestCase):
     """Tests for the _prior_mode attribute and sample_observations method."""


### PR DESCRIPTION
Summary: Generalize `PyroModel` with an `is_multitask` kwarg (following the `use_input_warping` pattern) so that any PyroModel subclass can sample and load multi-task components. This eliminates the need for a separate `MultitaskSaasPyroModel` by moving task kernel sampling, latent feature handling, and multi-task `load_mcmc_samples` logic into reusable base class methods. `MultitaskSaasPyroModel` becomes a thin backward-compatible alias.

Differential Revision: D92844567


