### PR TITLE
Migrate typing_extensions.Self to typing.Self

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import copy
 import warnings
+from typing import Self
 
 import torch
 from botorch.acquisition.objective import PosteriorTransform
@@ -67,7 +68,6 @@ from gpytorch.variational import (
 )
 from torch import Tensor
 from torch.nn import Module
-from typing_extensions import Self
 
 
 TRANSFORM_WARNING = (

--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -16,7 +16,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Mapping
-from typing import Any, TYPE_CHECKING
+from typing import Any, Self, TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -36,7 +36,6 @@ from botorch.utils.datasets import SupervisedDataset
 from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
 from torch import Tensor
 from torch.nn import Module, ModuleDict, ModuleList
-from typing_extensions import Self
 
 if TYPE_CHECKING:
     from botorch.acquisition.objective import PosteriorTransform  # pragma: no cover


### PR DESCRIPTION
Summary:
Python 3.11 added `Self` to the standard `typing` module, so we no longer
need to import it from `typing_extensions`.

Files updated:
- botorch/models/model.py
- botorch/models/approximate_gp.py

Reviewed By: hvarfner

Differential Revision: D91641970


