### PR TITLE
Fix tutorials workflow git fetch failure

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -26,10 +26,10 @@ jobs:
     needs: tests-and-coverage
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Install uv
       uses: astral-sh/setup-uv@v5
-    - name: Fetch all history for all tags and branches
-      run: git fetch --prune --unshallow
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,8 +25,8 @@ jobs:
       UV_SYSTEM_PYTHON: 1
     steps:
     - uses: actions/checkout@v4
-    - name: Fetch all history for all tags and branches
-      run: git fetch --prune --unshallow
+      with:
+        fetch-depth: 0
     - name: Install uv
       uses: astral-sh/setup-uv@v5
     - name: Set up Python

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -29,6 +29,8 @@ jobs:
       UV_SYSTEM_PYTHON: 1
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Install uv
       uses: astral-sh/setup-uv@v5
     - if: ${{ !inputs.use_stable_pytorch_gpytorch }}
@@ -41,9 +43,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
-    - name: Fetch all history for all tags and branches
-      # We need to do this so setuptools_scm knows how to set the BoTorch version.
-      run: git fetch --prune --unshallow
     - if: ${{ !inputs.use_stable_pytorch_gpytorch }}
       name: Install latest PyTorch & GPyTorch
       run: |


### PR DESCRIPTION
Summary: The tutorials workflow was failing because `git fetch --prune --unshallow` could not authenticate with the HTTPS remote after `actions/checkout@v4` had completed. Instead, configure the checkout action to do a full clone directly by setting `fetch-depth: 0`, which uses the checkout action's own credentials. This is needed by `setuptools_scm` to determine the BoTorch version.

Differential Revision: D93482307


