### PR TITLE
Expand Self usage for better fluent APIs

### DIFF
--- a/botorch/models/model.py
+++ b/botorch/models/model.py
@@ -243,12 +243,12 @@ class Model(Module, ABC):
             self.set_train_data(self._original_train_inputs, strict=False)
             self._has_transformed_inputs = False
 
-    def eval(self) -> Model:
+    def eval(self) -> Self:
         r"""Puts the model in ``eval`` mode and sets the transformed inputs."""
         self._set_transformed_inputs()
         return super().eval()
 
-    def train(self, mode: bool = True) -> Model:
+    def train(self, mode: bool = True) -> Self:
         r"""Put the model in ``train`` mode. Reverts to the original inputs if
         in ``train`` mode (``mode=True``) or sets transformed inputs if in
         ``eval`` mode (``mode=False``).

--- a/botorch/models/relevance_pursuit.py
+++ b/botorch/models/relevance_pursuit.py
@@ -22,7 +22,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from copy import copy, deepcopy
 from functools import partial
-from typing import Any, cast
+from typing import Any, cast, Self
 from warnings import warn
 
 import torch
@@ -117,7 +117,7 @@ class RelevancePursuitMixin(ABC):
         device = self.sparse_parameter.device
         return torch.arange(self.dim, device=device)[~self.is_active]
 
-    def to_sparse(self) -> RelevancePursuitMixin:
+    def to_sparse(self) -> Self:
         """Converts the sparse parameter to its sparse (< dim) representation.
 
         Returns:
@@ -130,7 +130,7 @@ class RelevancePursuitMixin(ABC):
             self._is_sparse = True
         return self
 
-    def to_dense(self) -> RelevancePursuitMixin:
+    def to_dense(self) -> Self:
         """Converts the sparse parameter to its dense, length-``dim`` representation.
 
         Returns:
@@ -157,7 +157,7 @@ class RelevancePursuitMixin(ABC):
             self._is_sparse = False
         return self
 
-    def expand_support(self, indices: list[int]) -> RelevancePursuitMixin:
+    def expand_support(self, indices: list[int]) -> Self:
         """Expands the support by a number of indices.
 
         Args:
@@ -186,7 +186,7 @@ class RelevancePursuitMixin(ABC):
             )
         return self
 
-    def contract_support(self, indices: list[int]) -> RelevancePursuitMixin:
+    def contract_support(self, indices: list[int]) -> Self:
         """Contracts the support by a number of indices.
 
         Args:
@@ -216,7 +216,7 @@ class RelevancePursuitMixin(ABC):
         return self
 
     # support initialization helpers
-    def full_support(self) -> RelevancePursuitMixin:
+    def full_support(self) -> Self:
         """Initializes the RelevancePursuitMixin with a full, size-``dim`` support.
 
         Returns:
@@ -226,7 +226,7 @@ class RelevancePursuitMixin(ABC):
         self.to_dense()  # no reason to be sparse with full support
         return self
 
-    def remove_support(self) -> RelevancePursuitMixin:
+    def remove_support(self) -> Self:
         """Initializes the RelevancePursuitMixin with an empty, size-zero support.
 
         Returns:

--- a/botorch/models/robust_relevance_pursuit_model.py
+++ b/botorch/models/robust_relevance_pursuit_model.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any
+from typing import Any, Self
 
 import torch
 from botorch.exceptions.errors import UnsupportedError
@@ -140,7 +140,7 @@ class RobustRelevancePursuitMixin(ABC):
             A standard model.
         """
 
-    def load_standard_model(self, standard_model: Model) -> RobustRelevancePursuitMixin:
+    def load_standard_model(self, standard_model: Model) -> Self:
         """Loads the state dict of a model into the ``RobustRelevancePursuitMixin``.
 
         Args:


### PR DESCRIPTION
Summary:
Replace explicit class return types with `Self` for methods that return
`self`, enabling better type inference for subclasses.

Files updated:
- botorch/models/relevance_pursuit.py
  - RelevancePursuitMixin: to_sparse, to_dense, expand_support, contract_support,
    full_support, remove_support now return Self
- botorch/models/robust_relevance_pursuit_model.py
  - RobustRelevancePursuitMixin.load_standard_model now returns Self
- botorch/models/model.py
  - Model.eval, Model.train now return Self

Reviewed By: hvarfner

Differential Revision: D91641969


