### PR TITLE
Migrate typing imports to collections.abc

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -12,9 +12,9 @@ from __future__ import annotations
 
 import time
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import partial
-from typing import Any, Mapping, NoReturn
+from typing import Any, NoReturn
 
 import numpy as np
 import numpy.typing as npt

--- a/botorch/models/gpytorch.py
+++ b/botorch/models/gpytorch.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 import itertools
 import warnings
 from abc import ABC
+from collections.abc import Mapping
 from copy import deepcopy
-from typing import Any, Mapping, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import torch
 from botorch.acquisition.objective import PosteriorTransform

--- a/botorch/models/map_saas.py
+++ b/botorch/models/map_saas.py
@@ -11,7 +11,8 @@ References
     Optimization with Natural Simplicity and Interpretability. ArXiv, 2026.
 """
 
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 import torch
 from botorch.acquisition.objective import PosteriorTransform

--- a/botorch/optim/optimize_mixed.py
+++ b/botorch/optim/optimize_mixed.py
@@ -8,8 +8,8 @@ import dataclasses
 import itertools
 import random
 import warnings
-from collections.abc import Mapping, Sequence
-from typing import Any, Callable
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
 
 import torch
 from botorch.acquisition import AcquisitionFunction

--- a/botorch/optim/utils/acquisition_utils.py
+++ b/botorch/optim/utils/acquisition_utils.py
@@ -8,7 +8,7 @@ r"""Utilities for maximizing acquisition functions."""
 
 from __future__ import annotations
 
-from typing import Mapping
+from collections.abc import Mapping
 from warnings import warn
 
 import torch

--- a/botorch/test_functions/base.py
+++ b/botorch/test_functions/base.py
@@ -11,7 +11,8 @@ Base class for test functions for optimization benchmarks.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, Iterator, Protocol
+from collections.abc import Iterable, Iterator
+from typing import Any, Protocol
 
 import torch
 from botorch.exceptions.errors import InputDataError, UnsupportedError

--- a/botorch/test_utils/mock.py
+++ b/botorch/test_utils/mock.py
@@ -11,10 +11,10 @@ Utilities for speeding up optimization in tests.
 
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager, ExitStack
 from functools import wraps
-from typing import Any, Callable
+from typing import Any
 from unittest import mock
 
 from botorch.optim.batched_lbfgs_b import fmin_l_bfgs_b_batched

--- a/botorch/utils/multi_objective/optimize.py
+++ b/botorch/utils/multi_objective/optimize.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import torch

--- a/botorch/utils/testing.py
+++ b/botorch/utils/testing.py
@@ -10,9 +10,9 @@ import math
 import warnings
 from abc import abstractmethod
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from itertools import product
-from typing import Any, Callable
+from typing import Any
 from unittest import mock, TestCase
 from warnings import warn
 


### PR DESCRIPTION
Summary:
Python 3.11+ allows using `collections.abc` types directly in type hints
(Callable, Mapping, Iterable, Iterator, Sequence) instead of importing
them from the `typing` module. This is the preferred approach.

Files updated:
- botorch/generation/gen.py (Mapping)
- botorch/models/gpytorch.py (Mapping)
- botorch/models/map_saas.py (Mapping)
- botorch/optim/optimize_mixed.py (Callable)
- botorch/optim/utils/acquisition_utils.py (Mapping)
- botorch/utils/testing.py (Callable)
- botorch/test_utils/mock.py (Callable)
- botorch/test_functions/base.py (Iterable, Iterator)
- botorch/utils/multi_objective/optimize.py (Callable)

Reviewed By: hvarfner

Differential Revision: D91641966


