### PR TITLE
Modernize dataclasses with slots=True and kw_only=True

### DIFF
--- a/botorch/generation/utils.py
+++ b/botorch/generation/utils.py
@@ -52,7 +52,7 @@ def _flip_sub_unique(x: Tensor, k: int) -> Tensor:
     return x[idcs[: len(out)]]
 
 
-@dataclass(frozen=True, repr=False, eq=False)
+@dataclass(frozen=True, repr=False, eq=False, slots=True)
 class _NoFixedFeatures:
     """
     Dataclass to store the objects after removing fixed features.

--- a/botorch/optim/core.py
+++ b/botorch/optim/core.py
@@ -47,7 +47,7 @@ class OptimizationStatus(int, Enum):
     STOPPED = auto()  # stopped due to user provided criterion
 
 
-@dataclass
+@dataclass(slots=True)
 class OptimizationResult:
     step: int
     fval: float | int

--- a/botorch/optim/homotopy.py
+++ b/botorch/optim/homotopy.py
@@ -79,7 +79,7 @@ class LogLinearHomotopySchedule(FixedHomotopySchedule):
         )
 
 
-@dataclass
+@dataclass(slots=True)
 class HomotopyParameter:
     r"""Homotopy parameter.
 

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -60,7 +60,7 @@ INIT_OPTION_KEYS = {
 }
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class OptimizeAcqfInputs:
     """
     Container for inputs to ``optimize_acqf``.

--- a/botorch/utils/containers.py
+++ b/botorch/utils/containers.py
@@ -24,9 +24,6 @@ class BotorchContainer(ABC):
     returned by its ``__call__`` method. Said tensor is expected to consist of
     one or more "events" (e.g. data points or feature vectors), whose shape is
     given by the required ``event_shape`` field.
-
-    Notice: Once version 3.10 becomes standard, this class should
-    be reworked to take advantage of dataclasses' ``kw_only`` flag.
     """
 
     event_shape: Size
@@ -65,7 +62,7 @@ class BotorchContainer(ABC):
         raise AttributeError("Missing required field `event_shape`.")
 
 
-@dataclass(eq=False)
+@dataclass(eq=False, slots=True, kw_only=True)
 class DenseContainer(BotorchContainer):
     r"""Basic representation of data stored as a dense Tensor."""
 
@@ -96,7 +93,7 @@ class DenseContainer(BotorchContainer):
         return self.values.dtype
 
     def _validate(self) -> None:
-        super()._validate()
+        BotorchContainer._validate(self)
         for a, b in zip(reversed(self.event_shape), reversed(self.values.shape)):
             if a != b:
                 raise ValueError(
@@ -108,7 +105,7 @@ class DenseContainer(BotorchContainer):
         return dataclasses.replace(self)
 
 
-@dataclass(eq=False)
+@dataclass(eq=False, slots=True, kw_only=True)
 class SliceContainer(BotorchContainer):
     r"""Represent data points formed by concatenating (n-1)-dimensional slices
     taken from the leading dimension of an n-dimensional source tensor."""
@@ -141,7 +138,7 @@ class SliceContainer(BotorchContainer):
         return self.values.dtype
 
     def _validate(self) -> None:
-        super()._validate()
+        BotorchContainer._validate(self)
         values = self.values
         indices = self.indices
         assert indices.ndim > 1

--- a/botorch/utils/probability/linalg.py
+++ b/botorch/utils/probability/linalg.py
@@ -71,7 +71,7 @@ def augment_cholesky(
     return block_matrix_concat(blocks=([pad(Laa, (0, n))], [Lba, Lbb]))
 
 
-@dataclass
+@dataclass(slots=True)
 class PivotedCholesky:
     step: int
     tril: Tensor

--- a/test/models/test_pairwise_gp.py
+++ b/test/models/test_pairwise_gp.py
@@ -80,7 +80,9 @@ class TestPairwiseGP(BotorchTestCase):
         datapoints = torch.rand(3, 2)
         indices = torch.tensor([[0, 1], [1, 2]], dtype=torch.long)
         event_shape = torch.Size([2 * datapoints.shape[-1]])
-        dataset_X = SliceContainer(datapoints, indices, event_shape=event_shape)
+        dataset_X = SliceContainer(
+            values=datapoints, indices=indices, event_shape=event_shape
+        )
         dataset_Y = torch.tensor([[0, 1], [1, 0]]).expand(indices.shape)
         dataset = RankingDataset(
             X=dataset_X, Y=dataset_Y, feature_names=["a", "b"], outcome_names=["y"]

--- a/test/utils/test_containers.py
+++ b/test/utils/test_containers.py
@@ -78,8 +78,11 @@ class TestContainers(BotorchTestCase):
             self.assertEqual(X.shape, values.shape)
 
             # Test ``__eq__``
-            self.assertEqual(X, DenseContainer(values, event_shape))
-            self.assertNotEqual(X, DenseContainer(torch.rand_like(values), event_shape))
+            self.assertEqual(X, DenseContainer(values=values, event_shape=event_shape))
+            self.assertNotEqual(
+                X,
+                DenseContainer(values=torch.rand_like(values), event_shape=event_shape),
+            )
 
             # Test ``__call__``
             self.assertTrue(X().equal(values))
@@ -105,15 +108,27 @@ class TestContainers(BotorchTestCase):
                     )
 
                 # Test some basic propeties
-                groups = SliceContainer(vals, indices, event_shape=event_shape)
+                groups = SliceContainer(
+                    values=vals, indices=indices, event_shape=event_shape
+                )
                 self.assertEqual(groups.device, vals.device)
                 self.assertEqual(groups.dtype, vals.dtype)
                 self.assertEqual(groups.shape, groups().shape)
 
                 # Test ``__eq__``
-                self.assertEqual(groups, SliceContainer(vals, indices, event_shape))
+                self.assertEqual(
+                    groups,
+                    SliceContainer(
+                        values=vals, indices=indices, event_shape=event_shape
+                    ),
+                )
                 self.assertNotEqual(
-                    groups, SliceContainer(torch.rand_like(vals), indices, event_shape)
+                    groups,
+                    SliceContainer(
+                        values=torch.rand_like(vals),
+                        indices=indices,
+                        event_shape=event_shape,
+                    ),
                 )
 
                 # Test ``__call__``

--- a/test/utils/test_datasets.py
+++ b/test/utils/test_datasets.py
@@ -122,8 +122,8 @@ class TestDatasets(BotorchTestCase):
         self.assertTrue(torch.equal(dataset.group_indices, group_indices))
 
         dataset2 = SupervisedDataset(
-            X=DenseContainer(X, X.shape[-1:]),
-            Y=DenseContainer(Y, Y.shape[-1:]),
+            X=DenseContainer(values=X, event_shape=X.shape[-1:]),
+            Y=DenseContainer(values=Y, event_shape=Y.shape[-1:]),
             feature_names=feature_names,
             outcome_names=outcome_names,
             group_indices=group_indices,
@@ -177,7 +177,7 @@ class TestDatasets(BotorchTestCase):
         dataset = SupervisedDataset(
             X=X,
             Y=Y,
-            Yvar=DenseContainer(Y, Y.shape[-1:]),
+            Yvar=DenseContainer(values=Y, event_shape=Y.shape[-1:]),
             feature_names=feature_names,
             outcome_names=outcome_names,
         )
@@ -204,7 +204,7 @@ class TestDatasets(BotorchTestCase):
                 X_val = rand(16, 2)
                 X_idx = stack([randperm(len(X_val))[:3] for _ in range(1)])
                 X = SliceContainer(
-                    X_val, X_idx, event_shape=Size([3 * X_val.shape[-1]])
+                    values=X_val, indices=X_idx, event_shape=Size([3 * X_val.shape[-1]])
                 )
                 dataset = RankingDataset(
                     X=X,
@@ -281,7 +281,9 @@ class TestDatasets(BotorchTestCase):
         # Test ``_validate``
         X_val = rand(16, 2)
         X_idx = stack([randperm(len(X_val))[:3] for _ in range(1)])
-        X = SliceContainer(X_val, X_idx, event_shape=Size([3 * X_val.shape[-1]]))
+        X = SliceContainer(
+            values=X_val, indices=X_idx, event_shape=Size([3 * X_val.shape[-1]])
+        )
         feature_names = ["x1", "x2"]
         outcome_names = ["ranking indices"]
 


### PR DESCRIPTION
Summary:
This commit modernizes all dataclass definitions in botorch to use Python 3.11+
features:

- Added `slots=True` to all dataclasses for memory efficiency
- Added `kw_only=True` to dataclasses where appropriate:
   - DenseContainer and SliceContainer: Per the existing TODO comment
     recommending this for Python 3.10+
   - OptimizeAcqfInputs: Has many fields making keyword-only cleane

Reviewed By: hvarfner

Differential Revision: D91641965


