### PR TITLE
Modernize type hints to Python 3.11+ syntax

### DIFF
--- a/botorch_community/acquisition/augmented_multisource.py
+++ b/botorch_community/acquisition/augmented_multisource.py
@@ -20,8 +20,6 @@ Contributor: andreaponti5
 
 from __future__ import annotations
 
-from typing import Dict, Optional, Tuple, Union
-
 import torch
 from botorch.acquisition import UpperConfidenceBound
 from botorch.acquisition.objective import PosteriorTransform
@@ -40,7 +38,7 @@ class AugmentedUpperConfidenceBound(UpperConfidenceBound):
 
     A modified version of the UCB for Multi Information Source, that consider
     the most optimistic improvement with respect to the best value observed so far.
-    The improvement is then penalized depending on source’s cost, and
+    The improvement is then penalized depending on source's cost, and
     the discrepancy between the GP associated to the source and the AGP.
 
     `AUCB(x, s, y^+) = ((mu(x) + sqrt(beta) * sigma(x)) - y^+)
@@ -53,10 +51,10 @@ class AugmentedUpperConfidenceBound(UpperConfidenceBound):
     def __init__(
         self,
         model: Model,
-        cost: Dict,
-        best_f: Union[float, Tensor],
-        beta: Union[float, Tensor],
-        posterior_transform: Optional[PosteriorTransform] = None,
+        cost: dict,
+        best_f: float | Tensor,
+        beta: float | Tensor,
+        posterior_transform: PosteriorTransform | None = None,
         maximize: bool = True,
     ) -> None:
         r"""Single-outcome Augmented Upper Confidence Bound.
@@ -123,7 +121,7 @@ class AugmentedUpperConfidenceBound(UpperConfidenceBound):
         model: ExactGP = None,
         compute_sigma: bool = True,
         min_var: float = 1e-12,
-    ) -> Tuple[Tensor, Optional[Tensor]]:
+    ) -> tuple[Tensor, Tensor | None]:
         r"""Computes the first and second moments of the model posterior.
 
         Args:

--- a/botorch_community/acquisition/hentropy_search.py
+++ b/botorch_community/acquisition/hentropy_search.py
@@ -29,7 +29,7 @@ Contributor: sangttruong, martinakaduc
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -46,9 +46,9 @@ from torch import Tensor
 
 
 def get_sampler_and_num_points(
-    sampler: Optional[MCSampler],
-    num_points: Optional[int],
-) -> Tuple[MCSampler, int]:
+    sampler: MCSampler | None,
+    num_points: int | None,
+) -> tuple[MCSampler, int]:
     r"""Make sure the sampler and num_points are consistent, if specified.
     If the sampler is not specified, construct one.
     """
@@ -70,11 +70,11 @@ class qHEntropySearch(MCAcquisitionFunction, OneShotAcquisitionFunction):
         self,
         model: Model,
         loss_function_class: nn.Module,
-        loss_function_hyperparameters: Dict[str, Any],
-        n_fantasy_at_design_pts: Optional[int] = 64,
-        n_fantasy_at_action_pts: Optional[int] = 64,
-        design_sampler: Optional[MCSampler] = None,
-        action_sampler: Optional[MCSampler] = None,
+        loss_function_hyperparameters: dict[str, Any],
+        n_fantasy_at_design_pts: int | None = 64,
+        n_fantasy_at_action_pts: int | None = 64,
+        design_sampler: MCSampler | None = None,
+        action_sampler: MCSampler | None = None,
     ) -> None:
         r"""Batch H-Entropy Search using one-shot optimization.
 

--- a/botorch_community/acquisition/input_constructors.py
+++ b/botorch_community/acquisition/input_constructors.py
@@ -13,7 +13,8 @@ Contributor: hvarfner (bayesian_active_learning, scorebo)
 
 from __future__ import annotations
 
-from typing import Any, Hashable, List, Optional, Tuple
+from collections.abc import Hashable
+from typing import Any
 
 import torch
 from botorch.acquisition.input_constructors import (
@@ -80,7 +81,7 @@ def construct_inputs_best_f(
 def construct_inputs_noisy(
     model: Model,
     posterior_transform: PosteriorTransform | None = None,
-    X_pending: Optional[Tensor] = None,
+    X_pending: Tensor | None = None,
 ) -> dict[str, Any]:
     r"""Construct kwargs for the acquisition functions requiring ``best_f``.
 
@@ -109,7 +110,7 @@ def construct_inputs_noisy(
 )
 def construct_inputs_BAL(
     model: Model,
-    X_pending: Optional[Tensor] = None,
+    X_pending: Tensor | None = None,
 ):
     inputs = {
         "model": model,
@@ -122,7 +123,7 @@ def construct_inputs_BAL(
 def construct_inputs_SAL(
     model: Model,
     distance_metric: str = "hellinger",
-    X_pending: Optional[Tensor] = None,
+    X_pending: Tensor | None = None,
 ):
     inputs = {
         "model": model,
@@ -135,11 +136,11 @@ def construct_inputs_SAL(
 @acqf_input_constructor(qSelfCorrectingBayesianOptimization)
 def construct_inputs_SCoreBO(
     model: Model,
-    bounds: List[Tuple[float, float]],
+    bounds: list[tuple[float, float]],
     num_optima: int = 8,
-    posterior_transform: Optional[ScalarizedPosteriorTransform] = None,
+    posterior_transform: ScalarizedPosteriorTransform | None = None,
     distance_metric: str = "hellinger",
-    X_pending: Optional[Tensor] = None,
+    X_pending: Tensor | None = None,
 ):
     dtype = model.train_targets.dtype
     # the number of optima are per model

--- a/botorch_community/acquisition/scorebo.py
+++ b/botorch_community/acquisition/scorebo.py
@@ -21,7 +21,6 @@ Contributor: hvarfner
 from __future__ import annotations
 
 import warnings
-from typing import Optional
 
 import torch
 from botorch import settings
@@ -52,10 +51,10 @@ class qSelfCorrectingBayesianOptimization(
         self,
         model: SaasFullyBayesianSingleTaskGP,
         optimal_outputs: Tensor,
-        optimal_inputs: Optional[Tensor] = None,
-        X_pending: Optional[Tensor] = None,
-        distance_metric: Optional[str] = "hellinger",
-        posterior_transform: Optional[ScalarizedPosteriorTransform] = None,
+        optimal_inputs: Tensor | None = None,
+        X_pending: Tensor | None = None,
+        distance_metric: str | None = "hellinger",
+        posterior_transform: ScalarizedPosteriorTransform | None = None,
     ) -> None:
         r"""Self-correcting Bayesian optimization [hvarfner2023scorebo]_ acquisition
         function. SCoreBO seeks to find accurate hyperparameters during the course

--- a/botorch_community/models/example.py
+++ b/botorch_community/models/example.py
@@ -16,8 +16,6 @@ References:
 Contributor: saitcakmak
 """
 
-from typing import Optional
-
 from botorch.models.gp_regression import SingleTaskGP
 from gpytorch.kernels import RBFKernel, ScaleKernel
 from torch import Tensor
@@ -25,7 +23,7 @@ from torch import Tensor
 
 class ExampleModel(SingleTaskGP):
     def __init__(
-        self, train_X: Tensor, train_Y: Tensor, train_Yvar: Optional[Tensor] = None
+        self, train_X: Tensor, train_Y: Tensor, train_Yvar: Tensor | None = None
     ) -> None:
         r"""Initialize the example model from [Example2024paper]_.
 

--- a/botorch_community/models/gp_regression_multisource.py
+++ b/botorch_community/models/gp_regression_multisource.py
@@ -21,7 +21,6 @@ Contributor: andreaponti5
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Optional
 
 import torch
 from botorch import fit_gpytorch_mll
@@ -41,7 +40,7 @@ def get_random_x_for_agp(
     n: int,
     bounds: Tensor,
     q: int,
-    seed: Optional[int] = None,
+    seed: int | None = None,
 ):
     r"""Draw qMC samples from the box defined by bounds.
     The function assures that at least one point belong to
@@ -91,13 +90,13 @@ class SingleTaskAugmentedGP(SingleTaskGP):
         self,
         train_X: Tensor,
         train_Y: Tensor,
-        train_Yvar: Optional[Tensor] = None,
+        train_Yvar: Tensor | None = None,
         m: int = 1,
-        likelihood: Optional[Likelihood] = None,
-        covar_module: Optional[Module] = None,
-        mean_module: Optional[Mean] = None,
-        outcome_transform: Optional[OutcomeTransform] = None,
-        input_transform: Optional[InputTransform] = None,
+        likelihood: Likelihood | None = None,
+        covar_module: Module | None = None,
+        mean_module: Mean | None = None,
+        outcome_transform: OutcomeTransform | None = None,
+        input_transform: InputTransform | None = None,
     ) -> None:
         r"""
         Args:
@@ -198,12 +197,12 @@ class SingleTaskAugmentedGP(SingleTaskGP):
         self,
         train_X: Tensor,
         train_Y: Tensor,
-        train_Yvar: Optional[Tensor] = None,
-        likelihood: Optional[Likelihood] = None,
-        covar_module: Optional[Module] = None,
-        mean_module: Optional[Mean] = None,
-        outcome_transform: Optional[OutcomeTransform] = None,
-        input_transform: Optional[InputTransform] = None,
+        train_Yvar: Tensor | None = None,
+        likelihood: Likelihood | None = None,
+        covar_module: Module | None = None,
+        mean_module: Mean | None = None,
+        outcome_transform: OutcomeTransform | None = None,
+        input_transform: InputTransform | None = None,
     ) -> SingleTaskGP:
         r"""Initialize and fit a Single Task GP model.
 

--- a/botorch_community/models/np_regression.py
+++ b/botorch_community/models/np_regression.py
@@ -17,7 +17,7 @@ References:
 Contributor: eibarolle
 """
 
-from typing import Callable, List, Optional, Tuple
+from collections.abc import Callable
 
 import torch
 import torch.nn as nn
@@ -37,9 +37,9 @@ class MLP(nn.Module):
         self,
         input_dim: int,
         output_dim: int,
-        hidden_dims: List[int],
+        hidden_dims: list[int],
         activation: Callable = nn.Sigmoid,
-        init_func: Optional[Callable] = nn.init.normal_,
+        init_func: Callable | None = nn.init.normal_,
     ) -> None:
         r"""
         A modular implementation of a Multilayer Perceptron (MLP).
@@ -81,9 +81,9 @@ class REncoder(nn.Module):
         self,
         input_dim: int,
         output_dim: int,
-        hidden_dims: List[int],
+        hidden_dims: list[int],
         activation: Callable = nn.Sigmoid,
-        init_func: Optional[Callable] = nn.init.normal_,
+        init_func: Callable | None = nn.init.normal_,
     ) -> None:
         r"""Encodes inputs of the form (x_i,y_i) into representations, r_i.
 
@@ -123,9 +123,9 @@ class ZEncoder(nn.Module):
         self,
         input_dim: int,
         output_dim: int,
-        hidden_dims: List[int],
+        hidden_dims: list[int],
         activation: Callable = nn.Sigmoid,
-        init_func: Optional[Callable] = nn.init.normal_,
+        init_func: Callable | None = nn.init.normal_,
     ) -> None:
         r"""Takes an r representation and produces the mean & standard
         deviation of the normally distributed function encoding, z.
@@ -175,9 +175,9 @@ class Decoder(torch.nn.Module):
         self,
         input_dim: int,
         output_dim: int,
-        hidden_dims: List[int],
+        hidden_dims: list[int],
         activation: Callable = nn.Sigmoid,
-        init_func: Optional[Callable] = nn.init.normal_,
+        init_func: Callable | None = nn.init.normal_,
     ) -> None:
         r"""Takes the x star points, along with a 'function encoding', z, and makes
         predictions.
@@ -227,16 +227,16 @@ class NeuralProcessModel(Model, GP):
         self,
         train_X: torch.Tensor,
         train_Y: torch.Tensor,
-        r_hidden_dims: List[int] | None = None,
-        z_hidden_dims: List[int] | None = None,
-        decoder_hidden_dims: List[int] | None = None,
+        r_hidden_dims: list[int] | None = None,
+        z_hidden_dims: list[int] | None = None,
+        decoder_hidden_dims: list[int] | None = None,
         x_dim: int = 2,
         y_dim: int = 1,
         r_dim: int = 64,
         z_dim: int = 8,
         n_context: int = 20,
         activation: Callable = nn.Sigmoid,
-        init_func: Optional[Callable] = torch.nn.init.normal_,
+        init_func: Callable | None = torch.nn.init.normal_,
         likelihood: Likelihood | None = None,
         input_transform: InputTransform | None = None,
     ) -> None:
@@ -305,7 +305,7 @@ class NeuralProcessModel(Model, GP):
 
     def data_to_z_params(
         self, x: torch.Tensor, y: torch.Tensor, r_dim: int = 0
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         r"""Compute latent parameters from inputs as a latent distribution.
 
         Args:
@@ -423,7 +423,7 @@ class NeuralProcessModel(Model, GP):
     def transform_inputs(
         self,
         X: torch.Tensor,
-        input_transform: Optional[Module] = None,
+        input_transform: Module | None = None,
     ) -> torch.Tensor:
         r"""Transform inputs.
 
@@ -476,7 +476,7 @@ class NeuralProcessModel(Model, GP):
 
     def random_split_context_target(
         self, x: torch.Tensor, y: torch.Tensor, n_context, axis: int = 0
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         r"""Helper function to split randomly into context and target.
 
         Args:

--- a/botorch_community/models/prior_fitted_network.py
+++ b/botorch_community/models/prior_fitted_network.py
@@ -13,7 +13,7 @@ For the latter to work ``pfns4bo`` must be installed.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from typing import Any
 
 import torch
 from botorch.acquisition.objective import PosteriorTransform
@@ -198,9 +198,9 @@ class PFNModel(Model):
     def posterior(
         self,
         X: Tensor,
-        output_indices: Optional[list[int]] = None,
-        observation_noise: Union[bool, Tensor] = False,
-        posterior_transform: Optional[PosteriorTransform] = None,
+        output_indices: list[int] | None = None,
+        observation_noise: bool | Tensor = False,
+        posterior_transform: PosteriorTransform | None = None,
         negate_train_ys: bool = False,
     ) -> BoundedRiemannPosterior:
         r"""Computes the posterior over model outputs at the provided points.
@@ -341,10 +341,10 @@ class PFNModelWithPendingPoints(PFNModel):
     def posterior(
         self,
         X: Tensor,
-        output_indices: Optional[list[int]] = None,
-        observation_noise: Union[bool, Tensor] = False,
-        posterior_transform: Optional[PosteriorTransform] = None,
-        pending_X: Optional[Tensor] = None,
+        output_indices: list[int] | None = None,
+        observation_noise: bool | Tensor = False,
+        posterior_transform: PosteriorTransform | None = None,
+        pending_X: Tensor | None = None,
         negate_train_ys: bool = False,
     ) -> BoundedRiemannPosterior:
         r"""Computes the posterior over model outputs at the provided points.
@@ -429,10 +429,10 @@ class MultivariatePFNModel(PFNModel):
     def posterior(
         self,
         X: Tensor,
-        output_indices: Optional[list[int]] = None,
-        observation_noise: Union[bool, Tensor] = False,
-        posterior_transform: Optional[PosteriorTransform] = None,
-    ) -> Union[BoundedRiemannPosterior, MultivariateRiemannPosterior]:
+        output_indices: list[int] | None = None,
+        observation_noise: bool | Tensor = False,
+        posterior_transform: PosteriorTransform | None = None,
+    ) -> BoundedRiemannPosterior | MultivariateRiemannPosterior:
         """Computes the posterior over model outputs at the provided points.
 
         Will produce a MultivariateRiemannPosterior that fits a joint structure

--- a/botorch_community/models/utils/prior_fitted_network.py
+++ b/botorch_community/models/utils/prior_fitted_network.py
@@ -8,7 +8,6 @@ import gzip
 import io
 import os
 from enum import Enum
-from typing import Optional
 
 from botorch.logging import logger
 
@@ -46,8 +45,8 @@ class ModelPaths(Enum):
 
 def download_model(
     model_path: str | ModelPaths,
-    proxies: Optional[dict[str, str]] = None,
-    cache_dir: Optional[str] = None,
+    proxies: dict[str, str] | None = None,
+    cache_dir: str | None = None,
 ) -> nn.Module:
     """Download and load PFN model weights from a URL.
 

--- a/botorch_community/models/vbll_helper.py
+++ b/botorch_community/models/vbll_helper.py
@@ -12,8 +12,8 @@ Paper: "Variational Bayesian Last Layers" by Harrison et al., ICLR 2024
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 import numpy as np
 import torch

--- a/botorch_community/posteriors/riemann.py
+++ b/botorch_community/posteriors/riemann.py
@@ -10,7 +10,7 @@ Abstract base module for all botorch posteriors.
 
 from __future__ import annotations
 
-from typing import Callable, Optional, Union
+from collections.abc import Callable
 
 import torch
 from botorch.posteriors.posterior import Posterior
@@ -69,7 +69,7 @@ class BoundedRiemannPosterior(Posterior):
 
     def rsample(
         self,
-        sample_shape: Optional[torch.Size] = None,
+        sample_shape: torch.Size | None = None,
     ) -> Tensor:
         r"""Sample from the posterior (with gradients).
 
@@ -169,7 +169,7 @@ class BoundedRiemannPosterior(Posterior):
 
     def icdf(
         self,
-        value: Union[float, Tensor],
+        value: float | Tensor,
     ) -> Tensor:
         r"""Inverse cdf (with gradients).
         Use value to get the index of the bucket that contains the value


### PR DESCRIPTION
Summary:
This commit modernizes all type hints in botorch_community to use Python 3.11+
native syntax instead of importing from the typing module:

Changes made:
- Replace `Optional[X]` with `X | None`
- Replace `Union[X, Y]` with `X | Y`
- Replace `List[X]` with `list[X]`
- Replace `Dict[X, Y]` with `dict[X, Y]`
- Replace `Tuple[X, Y]` with `tuple[X, Y]`
- Import `Callable`, `Hashable` from `collections.abc` instead of `typing`

Files modified:
- botorch_community/acquisition/augmented_multisource.py
- botorch_community/acquisition/hentropy_search.py
- botorch_community/acquisition/input_constructors.py
- botorch_community/acquisition/scorebo.py
- botorch_community/models/example.py
- botorch_community/models/gp_regression_multisource.py
- botorch_community/models/np_regression.py
- botorch_community/models/prior_fitted_network.py
- botorch_community/models/vbll_helper.py
- botorch_community/models/utils/prior_fitted_network.py
- botorch_community/posteriors/riemann.py

Reviewed By: hvarfner

Differential Revision: D91641967


