### PR TITLE
Fix lint issues: C420, B026, LICENSELINT

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -1351,7 +1351,7 @@ def construct_inputs_mf_base(
 ) -> dict[str, Any]:
     r"""Construct kwargs for a multifidelity acquisition function's constructor."""
     if fidelity_weights is None:
-        fidelity_weights = {f: 1.0 for f in target_fidelities}
+        fidelity_weights = dict.fromkeys(target_fidelities, 1.0)
 
     if set(target_fidelities) != set(fidelity_weights):
         raise RuntimeError(

--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -113,7 +113,7 @@ class ApproximateGPyTorchModel(GPyTorchModel):
         super().__init__()
 
         self.model = (
-            _SingleTaskVariationalGP(num_outputs=num_outputs, *args, **kwargs)
+            _SingleTaskVariationalGP(*args, num_outputs=num_outputs, **kwargs)
             if model is None
             else model
         )

--- a/botorch/optim/batched_lbfgs_b.py
+++ b/botorch/optim/batched_lbfgs_b.py
@@ -1,5 +1,6 @@
 # noqa
 # flake8: noqa
+# @lint-ignore-every LICENSELINT
 """
 This is a port of the L-BFGS-B implementation from SciPy s.t. it supports batched
 evaluations. That is, the objective function's output value (and its gradient)
@@ -15,32 +16,32 @@ ported from FORTRAN to C, we handle the API changes, though, and are
 compatible with both.
 """
 
-## License for the Python wrapper
-## ==============================
+# License for the Python wrapper
+# ==============================
 
-## Heavily modified to allow batched optimization by Samuel Müller (2025) <sammuller@meta.com>
+# Heavily modified to allow batched optimization by Samuel Müller (2025) <sammuller@meta.com>
 
-## Copyright (c) 2004 David M. Cooke <cookedm@physics.mcmaster.ca>
+# Copyright (c) 2004 David M. Cooke <cookedm@physics.mcmaster.ca>
 
-## Permission is hereby granted, free of charge, to any person obtaining a
-## copy of this software and associated documentation files (the "Software"),
-## to deal in the Software without restriction, including without limitation
-## the rights to use, copy, modify, merge, publish, distribute, sublicense,
-## and/or sell copies of the Software, and to permit persons to whom the
-## Software is furnished to do so, subject to the following conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
 
-## The above copyright notice and this permission notice shall be included in
-## all copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 
-## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-## AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-## LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-## FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-## DEALINGS IN THE SOFTWARE.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
 
-## Modifications by Travis Oliphant and Enthought, Inc. for inclusion in SciPy
+# Modifications by Travis Oliphant and Enthought, Inc. for inclusion in SciPy
 
 import typing as tp
 


### PR DESCRIPTION
Summary:
This commit fixes three lint issues identified in the botorch codebase:

1. **C420** in `input_constructors.py`: Changed dict comprehension to use `dict.fromkeys()` for creating a dictionary with uniform values.

2. **B026** in `approximate_gp.py`: Reordered function arguments to put `*args` before the keyword argument `num_outputs=num_outputs`. The star-arg unpacking was incorrectly placed after a keyword argument.

3. **LICENSELINT** in `batched_lbfgs_b.py`: Added `lint-ignore-every LICENSELINT` to suppress the third-party license detection warning. This file contains legitimately modified third-party code (from SciPy) with its MIT license preserved, and the lint warning is a false positive since this is correctly licensed third-party code that's been modified for Meta's use.

Reviewed By: hvarfner

Differential Revision: D91641964


