### PR TITLE
Make `d` and `target_fidelities` required in `project_to_target_fidelity`

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -1374,7 +1374,7 @@ def construct_inputs_mf_base(
             num_trace_obs=num_trace_observations,
         ),
         "project": lambda X: project_to_target_fidelity(
-            X=X, target_fidelities=target_fidelities
+            X=X, target_fidelities=target_fidelities, d=X.shape[-1]
         ),
     }
 

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -1679,7 +1679,11 @@ class TestKGandESAcquisitionFunctionInputConstructors(InputConstructorBaseTestCa
             self.assertTrue(
                 torch.equal(
                     kwargs["project"](X),
-                    project_to_target_fidelity(X, target_fidelities=target_fidelities),
+                    project_to_target_fidelity(
+                        X,
+                        target_fidelities=target_fidelities,
+                        d=X.shape[-1],
+                    ),
                 )
             )
 

--- a/tutorials/discrete_multi_fidelity_bo/discrete_multi_fidelity_bo.ipynb
+++ b/tutorials/discrete_multi_fidelity_bo/discrete_multi_fidelity_bo.ipynb
@@ -297,7 +297,7 @@
     "\n",
     "\n",
     "def project(X):\n",
-    "    return project_to_target_fidelity(X=X, target_fidelities=target_fidelities)\n",
+    "    return project_to_target_fidelity(X=X, target_fidelities=target_fidelities, d=7)\n",
     "\n",
     "\n",
     "def get_mfkg(model):\n",

--- a/tutorials/multi_fidelity_bo/multi_fidelity_bo.ipynb
+++ b/tutorials/multi_fidelity_bo/multi_fidelity_bo.ipynb
@@ -293,7 +293,7 @@
     "\n",
     "\n",
     "def project(X):\n",
-    "    return project_to_target_fidelity(X=X, target_fidelities=target_fidelities)\n",
+    "    return project_to_target_fidelity(X=X, target_fidelities=target_fidelities, d=7)\n",
     "\n",
     "\n",
     "def get_mfkg(model):\n",


### PR DESCRIPTION
Summary:
`project_to_target_fidelity` previously had optional `d` and
`target_fidelities` arguments with defaults that led to silent bugs:

- When `d` was not provided, it was inferred as `X.shape[-1]`. If `X`
  didn't actually contain fidelity dims, positive fidelity indices became
  no-ops and negative indices silently overwrote the wrong columns.
- When `target_fidelities` was not provided, it defaulted to `{-1: 1.0}`,
  which could silently do the wrong thing when combined with the inferred
  `d`.

This diff makes both `d` and `target_fidelities` required arguments,
eliminating all ambiguity. It also adds bounds validation: after
normalizing negative indices, all resolved indices must fall within
`[0, d)`.

All callers are updated to pass `d` explicitly. Callers that receive `X`
with fidelity dims at call time pass `d=X.shape[-1]`.

Also fixes a duplicated/garbled sentence in the docstring.

Differential Revision: D94156594


