### PR TITLE
Project candidate_set in MF-MES init and add multi-fidelity model tests

### DIFF
--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -671,9 +671,13 @@ class qMultiFidelityMaxValueEntropy(qMaxValueEntropy):
 
         Args:
             model: A fitted single-outcome model.
-            candidate_set: A ``n x d`` Tensor including ``n`` candidate points to
-                discretize the design space, which will be used to sample the
-                max values from their posteriors.
+            candidate_set: A ``n x d`` or ``n x (d + s)`` Tensor including ``n``
+                candidate points to discretize the design space, which will be
+                used to sample the max values from their posteriors. ``s`` is the
+                number of fidelity dimensions. The ``project`` callable is applied
+                to the candidate set before use, so if it handles inserting fidelity
+                dimensions (e.g., ``project_to_target_fidelity`` with ``d``
+                specified), ``candidate_set`` can omit them.
             cost_aware_utility: A CostAwareUtility computing the cost-transformed
                 utility from a candidate set and samples of increases in utility.
             num_fantasies: Number of fantasies to generate. The higher this
@@ -694,12 +698,19 @@ class qMultiFidelityMaxValueEntropy(qMaxValueEntropy):
             project: A callable mapping a ``batch_shape x q x d`` tensor of design
                 points to a tensor of the same shape projected to the desired
                 target set (e.g. the target fidelities in case of multi-fidelity
-                optimization).
+                optimization). This is also applied to the candidate set during
+                initialization.
             expand: A callable mapping a ``batch_shape x q x d`` input tensor to
                 a ``batch_shape x (q + q_e)' x d``-dim output tensor, where the
                 ``q_e`` additional points in each q-batch correspond to
                 additional ("trace") observations.
         """
+        # Project candidate_set to target fidelity before passing to super.
+        # This ensures candidate_set has the right dimensions for concatenation
+        # with train_inputs in MaxValueBase.__init__, and also allows
+        # candidate_set to omit fidelity dimensions if project handles
+        # inserting them (e.g., project_to_target_fidelity with d specified).
+        candidate_set = project(candidate_set)
         super().__init__(
             model=model,
             candidate_set=candidate_set,
@@ -822,9 +833,13 @@ class qMultiFidelityLowerBoundMaxValueEntropy(qMultiFidelityMaxValueEntropy):
 
         Args:
             model: A fitted single-outcome model.
-            candidate_set: A ``n x d`` Tensor including ``n`` candidate points to
-                discretize the design space, which will be used to sample the
-                max values from their posteriors.
+            candidate_set: A ``n x d`` or ``n x (d + s)`` Tensor including ``n``
+                candidate points to discretize the design space, which will be
+                used to sample the max values from their posteriors. ``s`` is the
+                number of fidelity dimensions. The ``project`` callable is applied
+                to the candidate set before use, so if it handles inserting fidelity
+                dimensions (e.g., ``project_to_target_fidelity`` with ``d``
+                specified), ``candidate_set`` can omit them.
             cost_aware_utility: A CostAwareUtility computing the cost-transformed
                 utility from a candidate set and samples of increases in utility.
             num_fantasies: Number of fantasies to generate. The higher this

--- a/test/acquisition/test_max_value_entropy_search.py
+++ b/test/acquisition/test_max_value_entropy_search.py
@@ -18,8 +18,11 @@ from botorch.acquisition.max_value_entropy_search import (
     qMultiFidelityMaxValueEntropy,
 )
 from botorch.acquisition.objective import ScalarizedPosteriorTransform
+from botorch.acquisition.utils import project_to_target_fidelity
 from botorch.exceptions.errors import UnsupportedError
+from botorch.models.cost import AffineFidelityCostModel
 from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.sampling.normal import SobolQMCNormalSampler
 from botorch.utils.testing import BotorchTestCase
@@ -213,6 +216,7 @@ class TestMaxValueEntropySearch(BotorchTestCase):
     def test_q_multi_fidelity_max_value_entropy(
         self, acqf_class=qMultiFidelityMaxValueEntropy
     ):
+        is_mes = acqf_class is qMultiFidelityMaxValueEntropy
         for dtype in (torch.float, torch.double):
             torch.manual_seed(7)
             model = SingleTaskGP(
@@ -255,7 +259,7 @@ class TestMaxValueEntropySearch(BotorchTestCase):
                 )
 
             # Test with expand.
-            if acqf_class is qMultiFidelityMaxValueEntropy:
+            if is_mes:
                 qMF_MVE = acqf_class(
                     model=model,
                     candidate_set=candidate_set,
@@ -272,6 +276,113 @@ class TestMaxValueEntropySearch(BotorchTestCase):
                         num_mv_samples=5,
                         expand=lambda X: X.repeat(1, 2, 1),
                     )
+
+            # Test candidate_set dimension mismatch with MF model.
+            torch.manual_seed(7)
+            train_x = torch.rand(10, 3, device=self.device, dtype=dtype)
+            train_fidelity = torch.ones(10, 1, device=self.device, dtype=dtype)
+            train_x_full = torch.cat((train_x, train_fidelity), dim=1)
+            train_y = torch.rand(10, 1, device=self.device, dtype=dtype)
+            mf_model = SingleTaskMultiFidelityGP(
+                train_X=train_x_full,
+                train_Y=train_y,
+                data_fidelities=[3],
+            )
+            candidate_set_wrong_dim = torch.rand(
+                100, 3, device=self.device, dtype=dtype
+            )
+            with self.assertRaisesRegex(RuntimeError, "Sizes of tensors must match"):
+                acqf_class(
+                    model=mf_model,
+                    candidate_set=candidate_set_wrong_dim,
+                    num_mv_samples=5,
+                )
+
+            # Test with SingleTaskMultiFidelityGP models.
+            # MES produces NaN with torch.float for MF GP models due to
+            # numerical issues in _compute_information_gain. GIBBON does not.
+            if is_mes and dtype == torch.float:
+                continue
+
+            # Configs: (d, fidelity_dims, iteration_fidelity)
+            mf_configs = [
+                (3, [3], None),  # single fidelity dim
+                (2, [3], 2),  # iteration + data fidelity dims
+            ]
+            for d, fidelity_dims, iteration_fidelity in mf_configs:
+                torch.manual_seed(7)
+                n_fidelity = len(fidelity_dims) + (iteration_fidelity is not None)
+                d_full = d + n_fidelity
+                train_x = torch.rand(16, d, device=self.device, dtype=dtype)
+                fidelity_cols = [
+                    torch.tensor([0.5, 0.75, 1.0], device=self.device, dtype=dtype)[
+                        torch.randint(3, (16, 1))
+                    ]
+                    for _ in range(n_fidelity)
+                ]
+                train_x_full = torch.cat([train_x] + fidelity_cols, dim=1)
+                train_y = torch.rand(16, 1, device=self.device, dtype=dtype)
+
+                mf_model = SingleTaskMultiFidelityGP(
+                    train_X=train_x_full,
+                    train_Y=train_y,
+                    data_fidelities=fidelity_dims,
+                    iteration_fidelity=iteration_fidelity,
+                )
+
+                all_fidelity_dims = sorted(
+                    fidelity_dims + ([iteration_fidelity] if iteration_fidelity else [])
+                )
+                target_fidelities = dict.fromkeys(all_fidelity_dims, 1.0)
+
+                def project(X, tf=target_fidelities, _d=d_full):
+                    return project_to_target_fidelity(X=X, target_fidelities=tf, d=_d)
+
+                cost_model = AffineFidelityCostModel(
+                    fidelity_weights={all_fidelity_dims[0]: 1.0}, fixed_cost=0.25
+                )
+                cost_aware_utility = InverseCostWeightedUtility(cost_model=cost_model)
+
+                mf_candidate_set = torch.rand(
+                    50, d_full, device=self.device, dtype=dtype
+                )
+                for dim in all_fidelity_dims:
+                    mf_candidate_set[..., dim] = 1.0
+
+                qMF_MVE = acqf_class(
+                    model=mf_model,
+                    candidate_set=mf_candidate_set,
+                    num_mv_samples=5,
+                    project=project,
+                    cost_aware_utility=cost_aware_utility,
+                )
+                self.assertEqual(qMF_MVE.posterior_max_values.shape, torch.Size([5, 1]))
+
+                X = torch.rand(3, 1, d_full, device=self.device, dtype=dtype)
+                for dim in all_fidelity_dims:
+                    X[..., dim] = 0.5
+                acq_values = qMF_MVE(X)
+                self.assertEqual(acq_values.shape, torch.Size([3]))
+                self.assertTrue(torch.isfinite(acq_values).all())
+
+                # Test with candidate_set of size n x d (without fidelity dims).
+                # project should insert fidelity dims automatically.
+                mf_candidate_set_no_fidelity = torch.rand(
+                    50, d, device=self.device, dtype=dtype
+                )
+                qMF_MVE_no_f = acqf_class(
+                    model=mf_model,
+                    candidate_set=mf_candidate_set_no_fidelity,
+                    num_mv_samples=5,
+                    project=project,
+                    cost_aware_utility=cost_aware_utility,
+                )
+                self.assertEqual(
+                    qMF_MVE_no_f.posterior_max_values.shape, torch.Size([5, 1])
+                )
+                acq_values_no_f = qMF_MVE_no_f(X)
+                self.assertEqual(acq_values_no_f.shape, torch.Size([3]))
+                self.assertTrue(torch.isfinite(acq_values_no_f).all())
 
     def test_q_multi_fidelity_lower_bound_max_value_entropy(self):
         # Same test as for MF-MES since GIBBON only changes in the way it computes the


### PR DESCRIPTION
Summary:
Apply `project` to `candidate_set` in `qMultiFidelityMaxValueEntropy.__init__`
before passing it to `super().__init__`. This allows `candidate_set` to be
either `n x d` (without fidelity dims) or `n x (d + s)` (with fidelity dims),
since `project_to_target_fidelity` can insert fidelity dimensions when `d` is
specified. Previously, `candidate_set` was required to include fidelity
dimensions to avoid a shape mismatch when concatenated with `train_inputs`.

Also add test cases using `SingleTaskMultiFidelityGP` to validate correct
behavior with multi-fidelity models, including:
- Single and multiple fidelity dimensions
- `candidate_set` without fidelity dimensions (n x d)
- Dimension mismatch error when `project` is the default identity

Update docstrings for both `qMultiFidelityMaxValueEntropy` and
`qMultiFidelityLowerBoundMaxValueEntropy` to reflect the new flexibility.

Differential Revision: D94167671


