### PR TITLE
use parallel lbfgs for fitting batched multi-output models

### DIFF
--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -178,9 +178,12 @@ def _fit_fallback(
     ckpt_nograd: dict[str, TensorCheckpoint] = None  # pyre-ignore [9]
     ckpt: dict[str, TensorCheckpoint] = None  # pyre-ignore [9]
 
-    # Build closure
+    # Build closure. When no closure is provided and no closure_kwargs are
+    # needed, pass closure=None through to the optimizer so that it can use
+    # its own internal dispatch (e.g. batched independent fitting in
+    # fit_gpytorch_mll_scipy).
     mll.train()
-    if closure is None:
+    if closure is None and closure_kwargs is not None:
         closure = get_loss_closure_with_grads(
             mll, parameters=get_parameters(mll, requires_grad=True)
         )

--- a/botorch/optim/closures/__init__.py
+++ b/botorch/optim/closures/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from botorch.optim.closures.core import (
+    BatchedNDarrayOptimizationClosure,
     ForwardBackwardClosure,
     NdarrayOptimizationClosure,
 )
@@ -15,6 +16,7 @@ from botorch.optim.closures.model_closures import (
 
 
 __all__ = [
+    "BatchedNDarrayOptimizationClosure",
     "ForwardBackwardClosure",
     "get_loss_closure",
     "get_loss_closure_with_grads",

--- a/botorch/optim/fit.py
+++ b/botorch/optim/fit.py
@@ -56,6 +56,14 @@ def fit_gpytorch_mll_scipy(
 ) -> OptimizationResult:
     r"""Generic scipy.optimize-based fitting routine for GPyTorch MLLs.
 
+    For ``BatchedMultiOutputGPyTorchModel`` instances with a non-trivial
+    ``_aug_batch_shape`` (e.g., multi-output ``SingleTaskGP`` or
+    ``EnsembleMapSaasSingleTaskGP``), this automatically runs
+    ``fmin_l_bfgs_b_batched`` to optimize each batch element's
+    hyperparameters independently. This converts the single
+    high-dimensional optimization problem into multiple lower-dimensional
+    problems that are easier to solve.
+
     The model and likelihood in mll must already be in train mode.
 
     Args:
@@ -67,18 +75,40 @@ def fit_gpytorch_mll_scipy(
         closure: Callable that returns a tensor and an iterable of gradient
             tensors. Responsible for setting the ``grad`` attributes of
             ``parameters``. If no closure is provided, one will be obtained
-            by calling ``get_loss_closure_with_grads``.
+            by calling ``get_loss_closure_with_grads``. When no closure is
+            provided and the model is a batched multi-output model, batched
+            independent fitting is used automatically.
         closure_kwargs: Keyword arguments passed to ``closure``.
         method: Solver type, passed along to scipy.optimize.minimize.
-        options: Dictionary of solver options, passed along to scipy.optimize.minimize.
+        options: Dictionary of solver options, passed along to
+            scipy.optimize.minimize or ``fmin_l_bfgs_b_batched``.
         callback: Optional callback taking ``parameters`` and an
             ``OptimizationResult`` as its sole arguments.
         timeout_sec: Timeout in seconds after which to terminate the fitting loop
-            (note that timing out can result in bad fits!).
+            (note that timing out can result in bad fits!). Not currently
+            supported for batched independent fitting.
 
     Returns:
         The final OptimizationResult.
     """
+    # Avoid circular import: models.gpytorch imports from optim.
+    from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
+
+    model = mll.model
+    if (
+        closure is None
+        and isinstance(model, BatchedMultiOutputGPyTorchModel)
+        and model._aug_batch_shape.numel() > 1
+    ):
+        return _fit_gpytorch_mll_scipy_independent(
+            mll=mll,
+            parameters=parameters,
+            bounds=bounds,
+            options=options,
+            callback=callback,
+            timeout_sec=timeout_sec,
+        )
+
     # Resolve ``parameters`` and update default bounds
     _parameters, _bounds = get_parameters_and_bounds(mll)
     bounds = _bounds if bounds is None else {**_bounds, **bounds}
@@ -175,4 +205,137 @@ def fit_gpytorch_mll_torch(
         stopping_criterion=stopping_criterion,
         callback=callback,
         timeout_sec=timeout_sec,
+    )
+
+
+def _fit_gpytorch_mll_scipy_independent(
+    mll: MarginalLogLikelihood,
+    parameters: dict[str, Tensor] | None = None,
+    bounds: dict[str, tuple[float | None, float | None]] | None = None,
+    options: dict[str, Any] | None = None,
+    callback: Callable[[dict[str, Tensor], OptimizationResult], None] | None = None,
+    timeout_sec: float | None = None,
+) -> OptimizationResult:
+    r"""Fit a batched model by independently optimizing each batch element's
+    hyperparameters using parallel L-BFGS-B.
+
+    This is an internal helper called by ``fit_gpytorch_mll_scipy`` when the
+    model is a ``BatchedMultiOutputGPyTorchModel`` with a non-trivial
+    ``_aug_batch_shape``.
+
+    Args:
+        mll: MarginalLogLikelihood to be maximized.
+        parameters: Optional dictionary of parameters to be optimized.
+        bounds: A dictionary of user-specified bounds for ``parameters``.
+        options: Dictionary of solver options passed to
+            ``fmin_l_bfgs_b_batched`` (e.g., ``maxiter``, ``pgtol``).
+        callback: Optional callback passed to ``fmin_l_bfgs_b_batched``.
+        timeout_sec: Timeout in seconds. Not currently supported for batched
+            fitting; a warning is issued if provided.
+
+    Returns:
+        The final OptimizationResult. The ``fval`` field contains the sum of
+        per-batch-element negative MLL values.
+    """
+    if timeout_sec is not None:
+        warn(
+            "timeout_sec is not supported for batched independent fitting "
+            "and will be ignored.",
+            OptimizationWarning,
+            stacklevel=2,
+        )
+
+    # Avoid circular imports: closures and batched_lbfgs_b import from optim.
+    from botorch.optim.batched_lbfgs_b import fmin_l_bfgs_b_batched
+    from botorch.optim.closures import (
+        BatchedNDarrayOptimizationClosure,
+        get_loss_closure,
+    )
+    from botorch.optim.utils.numpy_utils import get_per_element_bounds
+
+    # Resolve parameters and bounds
+    _parameters, _bounds = get_parameters_and_bounds(mll)
+    bounds = _bounds if bounds is None else {**_bounds, **bounds}
+    if parameters is None:
+        parameters = {n: p for n, p in _parameters.items() if p.requires_grad}
+
+    batch_shape = mll.model._aug_batch_shape
+
+    # Build forward closure (returns per-batch neg MLL, NOT summed)
+    forward = get_loss_closure(mll)
+
+    # Build batched closure
+    batched_closure = BatchedNDarrayOptimizationClosure(
+        forward=forward,
+        parameters=parameters,
+        batch_shape=batch_shape,
+    )
+
+    # Extract per-element bounds
+    bounds_np = get_per_element_bounds(parameters, bounds, batch_shape)
+
+    # Get initial state
+    x0 = batched_closure.state  # (batch_size, per_element_size)
+
+    # Resolve options for fmin_l_bfgs_b_batched
+    _recognized_options = {
+        "gtol",
+        "maxiter",
+        "maxcor",
+        "ftol",
+        "pgtol",
+        "maxls",
+        "factr",
+    }
+    lbfgsb_options: dict[str, Any] = {}
+    if options is not None:
+        # Map scipy-style option names to fmin_l_bfgs_b_batched kwargs
+        for key, value in options.items():
+            if key == "gtol":
+                lbfgsb_options["pgtol"] = value
+            elif key in ("maxiter", "maxcor", "ftol", "pgtol", "maxls", "factr"):
+                lbfgsb_options[key] = value
+        unrecognized = set(options.keys()) - _recognized_options
+        if unrecognized:
+            warn(
+                f"Unrecognized options for batched independent fitting "
+                f"will be ignored: {sorted(unrecognized)}.",
+                OptimizationWarning,
+                stacklevel=2,
+            )
+
+    # Run batched L-BFGS-B
+    xs, fs, results = fmin_l_bfgs_b_batched(
+        func=batched_closure,
+        x0=x0,
+        bounds=bounds_np,
+        pass_batch_indices=True,
+        callback=callback,
+        **lbfgsb_options,
+    )
+
+    # Write optimal state back to model parameters
+    batched_closure.state = xs
+
+    # Determine overall status from individual results
+    all_success = all(r.get("success", False) for r in results)
+    max_nit = max(r.get("nit", 0) for r in results)
+
+    if all_success:
+        status = OptimizationStatus.SUCCESS
+    else:
+        # Check if any hit maxiter
+        any_maxiter = any(r.get("warnflag", 0) == 1 for r in results)
+        status = (
+            OptimizationStatus.STOPPED if any_maxiter else OptimizationStatus.FAILURE
+        )
+
+    return OptimizationResult(
+        fval=float(fs.sum()),
+        step=max_nit,
+        status=status,
+        message=(
+            f"Batched L-BFGS-B: {sum(r.get('success', False) for r in results)}"
+            f"/{len(results)} outputs converged."
+        ),
     )

--- a/botorch/optim/utils/numpy_utils.py
+++ b/botorch/optim/utils/numpy_utils.py
@@ -95,3 +95,46 @@ def get_bounds_as_ndarray(
     if np.isinf(out).all():
         out = None
     return out
+
+
+def get_per_element_bounds(
+    parameters: dict[str, Tensor],
+    bounds: dict[str, tuple[float | Tensor | None, float | Tensor | None]],
+    batch_shape: torch.Size,
+) -> npt.NDArray | None:
+    r"""Convert bounds to an ndarray for a single batch element's parameters.
+
+    For batched models where all batch elements share the same parameter
+    constraints, this extracts bounds for one element's worth of parameters.
+
+    Args:
+        parameters: A dictionary of batched parameter tensors, each with shape
+            ``(*batch_shape, *trailing_shape)``.
+        bounds: A dictionary of (optional) lower and upper bounds.
+        batch_shape: The batch shape shared by all parameters.
+
+    Returns:
+        An ndarray of shape ``(per_element_size, 2)`` or None if all bounds
+        are infinite.
+    """
+    inf = float("inf")
+    batch_size = max(int(torch.Size(batch_shape).numel()), 1)
+    per_element_size = sum(param.numel() // batch_size for param in parameters.values())
+    out = np.full((per_element_size, 2), (-inf, inf))
+    index = 0
+    for name, param in parameters.items():
+        size = param.numel() // batch_size
+        if name in bounds:
+            lower, upper = bounds[name]
+            lower = -inf if lower is None else lower
+            upper = inf if upper is None else upper
+            if isinstance(lower, Tensor):
+                lower = lower.cpu().numpy()
+            if isinstance(upper, Tensor):
+                upper = upper.cpu().numpy()
+            out[index : index + size, 0] = lower
+            out[index : index + size, 1] = upper
+        index += size
+    if np.isinf(out).all():
+        return None
+    return out

--- a/botorch/test_utils/mock.py
+++ b/botorch/test_utils/mock.py
@@ -81,6 +81,17 @@ def mock_optimize_context_manager(
             )
         )
 
+        # Works when calling ``fit_gpytorch_mll_scipy`` for batched multi-output
+        # models (e.g., ``EnsembleMapSaasSingleTaskGP``) which use independent
+        # fitting via ``fmin_l_bfgs_b_batched``. The function is imported locally
+        # inside ``_fit_independent_models``, so we mock at the definition location.
+        mock_fit_independent = es.enter_context(
+            mock.patch(
+                "botorch.optim.batched_lbfgs_b.fmin_l_bfgs_b_batched",
+                wraps=two_iteration_fast_minimize,
+            )
+        )
+
         # Similarly, works when calling a function defined in
         # ``optim.core``, such as ``scipy_minimize`` and ``torch_minimize``.
         mock_fit = es.enter_context(
@@ -124,6 +135,7 @@ def mock_optimize_context_manager(
             mock_generation,
             mock_generation_fast,
             mock_fit,
+            mock_fit_independent,
             mock_gen_ics,
             mock_gen_os_ics,
         ]

--- a/test/optim/test_fit.py
+++ b/test/optim/test_fit.py
@@ -9,6 +9,7 @@ import re
 from unittest.mock import MagicMock, patch
 from warnings import catch_warnings
 
+import numpy as np
 import torch
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.models import SingleTaskGP
@@ -235,3 +236,278 @@ class TestFitGPyTorchMLLTorch(BotorchTestCase):
                     mll, closure=mock_closure, closure_kwargs={"ab": "cd"}
                 )
             mock_closure.assert_called_once_with(ab="cd")
+
+
+class TestFitGPyTorchMLLScipyIndependent(BotorchTestCase):
+    """Tests for the batched independent fitting path of fit_gpytorch_mll_scipy."""
+
+    def test_dispatches_to_independent_for_multi_output(self):
+        """Verify that fit_gpytorch_mll_scipy dispatches to
+        _fit_gpytorch_mll_scipy_independent when using a batched
+        multi-output model (aug_batch_shape.numel() > 1)."""
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 2, dtype=torch.double)
+            train_Y = torch.rand(10, 3, dtype=torch.double)  # 3 outputs
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+
+        with patch(
+            "botorch.optim.fit._fit_gpytorch_mll_scipy_independent"
+        ) as mock_independent:
+            mock_independent.return_value = OptimizationResult(
+                fval=0.0, step=1, status=OptimizationStatus.SUCCESS
+            )
+            fit.fit_gpytorch_mll_scipy(mll)
+            mock_independent.assert_called_once()
+
+    def test_dispatches_to_independent_for_ensemble_model(self):
+        """Verify that fit_gpytorch_mll_scipy dispatches to
+        _fit_gpytorch_mll_scipy_independent when using an ensemble
+        model (aug_batch_shape.numel() > 1)."""
+        from botorch.models.map_saas import EnsembleMapSaasSingleTaskGP
+
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 3, dtype=torch.double)
+            train_Y = torch.rand(10, 1, dtype=torch.double)
+        model = EnsembleMapSaasSingleTaskGP(train_X, train_Y, num_taus=3)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+
+        with patch(
+            "botorch.optim.fit._fit_gpytorch_mll_scipy_independent"
+        ) as mock_independent:
+            mock_independent.return_value = OptimizationResult(
+                fval=0.0, step=1, status=OptimizationStatus.SUCCESS
+            )
+            fit.fit_gpytorch_mll_scipy(mll)
+            mock_independent.assert_called_once()
+
+    def test_does_not_dispatch_to_independent_for_single_output(self):
+        """Verify that fit_gpytorch_mll_scipy does NOT dispatch to
+        _fit_gpytorch_mll_scipy_independent for single-output models."""
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 2, dtype=torch.double)
+            train_Y = torch.rand(10, 1, dtype=torch.double)  # single output
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+
+        with patch(
+            "botorch.optim.fit._fit_gpytorch_mll_scipy_independent"
+        ) as mock_independent:
+            # The standard path should be used, not the independent path
+            fit.fit_gpytorch_mll_scipy(mll, options={"maxiter": 2})
+            mock_independent.assert_not_called()
+
+    def test_does_not_dispatch_to_independent_when_closure_provided(self):
+        """Verify that fit_gpytorch_mll_scipy does NOT dispatch to
+        _fit_gpytorch_mll_scipy_independent when a custom closure is provided,
+        even for multi-output models."""
+        from botorch.optim.closures import get_loss_closure_with_grads
+        from botorch.optim.utils import get_parameters
+
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 2, dtype=torch.double)
+            train_Y = torch.rand(10, 3, dtype=torch.double)  # multi-output
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+
+        closure = get_loss_closure_with_grads(
+            mll, parameters=get_parameters(mll, requires_grad=True)
+        )
+
+        with patch(
+            "botorch.optim.fit._fit_gpytorch_mll_scipy_independent"
+        ) as mock_independent:
+            fit.fit_gpytorch_mll_scipy(mll, closure=closure, options={"maxiter": 2})
+            mock_independent.assert_not_called()
+
+    def test_multi_output(self):
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 2, dtype=torch.double)
+            train_Y = torch.rand(10, 3, dtype=torch.double)
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+        result = fit.fit_gpytorch_mll_scipy(mll)
+        self.assertIsInstance(result, OptimizationResult)
+        self.assertEqual(result.status, OptimizationStatus.SUCCESS)
+        # Verify model can produce predictions after fitting.
+        model.eval()
+        test_X = torch.rand(3, 2, dtype=torch.double)
+        posterior = model.posterior(test_X)
+        self.assertEqual(posterior.mean.shape, torch.Size([3, 3]))
+
+    def test_single_output_fallback(self):
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 2, dtype=torch.double)
+            train_Y = torch.rand(10, 1, dtype=torch.double)
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+        result = fit.fit_gpytorch_mll_scipy(mll, options={"maxiter": 2})
+        self.assertIsInstance(result, OptimizationResult)
+
+    def test_with_fit_gpytorch_mll(self):
+        from botorch.fit import fit_gpytorch_mll
+
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 2, dtype=torch.double)
+            train_Y = torch.rand(10, 2, dtype=torch.double)
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        with catch_warnings(record=True):
+            fit_gpytorch_mll(
+                mll,
+                optimizer_kwargs={"options": {"maxiter": 2}},
+                max_attempts=1,
+            )
+        self.assertFalse(model.training)
+
+    def test_callback_passed_through(self):
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(5, 2, dtype=torch.double)
+            train_Y = torch.rand(5, 2, dtype=torch.double)
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+
+        callback_called = []
+
+        def my_callback(*args, **kwargs):
+            callback_called.append(True)
+
+        fit.fit_gpytorch_mll_scipy(
+            mll,
+            callback=my_callback,
+            options={"maxiter": 1},
+        )
+        self.assertTrue(len(callback_called) > 0)
+
+    def test_ensemble_model(self):
+        from botorch.models.map_saas import EnsembleMapSaasSingleTaskGP
+
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 3, dtype=torch.double)
+            train_Y = torch.rand(10, 1, dtype=torch.double)
+        model = EnsembleMapSaasSingleTaskGP(train_X, train_Y, num_taus=3)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+        result = fit.fit_gpytorch_mll_scipy(mll, options={"maxiter": 3})
+        self.assertIsInstance(result, OptimizationResult)
+        # Verify the model can produce predictions.
+        model.eval()
+        test_X = torch.rand(4, 3, dtype=torch.double)
+        posterior = model.posterior(test_X)
+        self.assertEqual(posterior.mean.shape, torch.Size([3, 4, 1]))
+
+    def test_timeout_sec_warning(self):
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(5, 2, dtype=torch.double)
+            train_Y = torch.rand(5, 2, dtype=torch.double)
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+        with self.assertWarns(OptimizationWarning):
+            fit.fit_gpytorch_mll_scipy(
+                mll,
+                timeout_sec=60.0,
+                options={"maxiter": 1},
+            )
+
+    def test_gtol_option_mapping(self):
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 2, dtype=torch.double)
+            train_Y = torch.rand(10, 2, dtype=torch.double)
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+        # gtol should be mapped to pgtol for fmin_l_bfgs_b_batched
+        result = fit.fit_gpytorch_mll_scipy(
+            mll,
+            options={"gtol": 1e-3, "maxiter": 2},
+        )
+        self.assertIsInstance(result, OptimizationResult)
+
+    def test_unrecognized_options_warning(self):
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(5, 2, dtype=torch.double)
+            train_Y = torch.rand(5, 2, dtype=torch.double)
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+        with self.assertWarns(OptimizationWarning):
+            fit.fit_gpytorch_mll_scipy(
+                mll,
+                options={"maxiter": 1, "disp": True, "unknown_opt": 42},
+            )
+
+    def test_stopped_status(self):
+        """Test STOPPED status when some outputs hit maxiter (warnflag=1)."""
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 2, dtype=torch.double)
+            train_Y = torch.rand(10, 2, dtype=torch.double)
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+
+        def mock_fmin(func, x0, bounds, **kwargs):
+            return (
+                x0,
+                np.zeros(x0.shape[0]),
+                [
+                    {"success": False, "nit": 1, "warnflag": 1}
+                    for _ in range(x0.shape[0])
+                ],
+            )
+
+        with patch(
+            "botorch.optim.batched_lbfgs_b.fmin_l_bfgs_b_batched",
+            side_effect=mock_fmin,
+        ):
+            result = fit.fit_gpytorch_mll_scipy(mll)
+
+        self.assertEqual(result.status, OptimizationStatus.STOPPED)
+
+    def test_failure_status(self):
+        """Test FAILURE status when outputs fail without hitting maxiter."""
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 2, dtype=torch.double)
+            train_Y = torch.rand(10, 2, dtype=torch.double)
+        model = SingleTaskGP(train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        mll.train()
+
+        def mock_fmin(func, x0, bounds, **kwargs):
+            return (
+                x0,
+                np.zeros(x0.shape[0]),
+                [
+                    {"success": False, "nit": 1, "warnflag": 2}
+                    for _ in range(x0.shape[0])
+                ],
+            )
+
+        with patch(
+            "botorch.optim.batched_lbfgs_b.fmin_l_bfgs_b_batched",
+            side_effect=mock_fmin,
+        ):
+            result = fit.fit_gpytorch_mll_scipy(mll)
+
+        self.assertEqual(result.status, OptimizationStatus.FAILURE)

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -464,3 +464,115 @@ class TestFitFallbackApproximate(BotorchTestCase):
                 closure=self.closure,
                 data_loader=self.data_loader,
             )
+
+
+class TestFitIndependent(BotorchTestCase):
+    """End-to-end integration tests for fit_gpytorch_mll with batched
+    independent fitting via fit_gpytorch_mll_scipy."""
+
+    def test_multi_output_independent_fitting(self):
+        """Fit a multi-output SingleTaskGP using independent per-output
+        optimization via fit_gpytorch_mll."""
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.linspace(0, 1, 10, dtype=torch.double).unsqueeze(-1)
+            train_F = torch.cat(
+                [torch.sin(2 * math.pi * train_X), torch.cos(2 * math.pi * train_X)],
+                dim=-1,
+            )
+            train_Y = train_F + 0.1 * torch.randn_like(train_F)
+
+        model = SingleTaskGP(train_X=train_X, train_Y=train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+
+        # Store initial parameter values.
+        initial_params = {
+            n: p.clone() for n, p in mll.named_parameters() if p.requires_grad
+        }
+
+        with catch_warnings(record=True):
+            fit_gpytorch_mll(
+                mll,
+                max_attempts=1,
+            )
+
+        # Model should be in eval mode after fitting.
+        self.assertFalse(model.training)
+
+        # At least some parameters should have changed.
+        any_changed = False
+        for n, p in mll.named_parameters():
+            if p.requires_grad and not p.equal(initial_params[n]):
+                any_changed = True
+                break
+        self.assertTrue(any_changed, "No parameters changed during fitting.")
+
+        # Verify predictions work.
+        test_X = torch.rand(5, 1, dtype=torch.double)
+        posterior = model.posterior(test_X)
+        self.assertEqual(posterior.mean.shape, torch.Size([5, 2]))
+        self.assertEqual(posterior.variance.shape, torch.Size([5, 2]))
+
+    def test_multi_output_with_transforms(self):
+        """Fit a multi-output model with input and outcome transforms."""
+        with torch.random.fork_rng():
+            torch.manual_seed(42)
+            train_X = torch.rand(15, 2, dtype=torch.double)
+            train_Y = torch.rand(15, 3, dtype=torch.double)
+
+        model = SingleTaskGP(
+            train_X=train_X,
+            train_Y=train_Y,
+            input_transform=Normalize(d=2),
+            outcome_transform=Standardize(m=3),
+        )
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+
+        with catch_warnings(record=True):
+            fit_gpytorch_mll(
+                mll,
+                max_attempts=1,
+            )
+
+        self.assertFalse(model.training)
+        test_X = torch.rand(4, 2, dtype=torch.double)
+        posterior = model.posterior(test_X)
+        self.assertEqual(posterior.mean.shape, torch.Size([4, 3]))
+
+    def test_ensemble_model(self):
+        """Fit an EnsembleMapSaasSingleTaskGP using independent per-ensemble-member
+        optimization via fit_gpytorch_mll."""
+        from botorch.models.map_saas import EnsembleMapSaasSingleTaskGP
+
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            train_X = torch.rand(10, 3, dtype=torch.double)
+            train_Y = torch.rand(10, 1, dtype=torch.double)
+
+        model = EnsembleMapSaasSingleTaskGP(
+            train_X=train_X, train_Y=train_Y, num_taus=3
+        )
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+
+        initial_params = {
+            n: p.clone() for n, p in mll.named_parameters() if p.requires_grad
+        }
+
+        with catch_warnings(record=True):
+            fit_gpytorch_mll(
+                mll,
+                max_attempts=1,
+            )
+
+        self.assertFalse(model.training)
+
+        any_changed = False
+        for n, p in mll.named_parameters():
+            if p.requires_grad and not p.equal(initial_params[n]):
+                any_changed = True
+                break
+        self.assertTrue(any_changed, "No parameters changed during fitting.")
+
+        test_X = torch.rand(5, 3, dtype=torch.double)
+        posterior = model.posterior(test_X)
+        self.assertEqual(posterior.mean.shape, torch.Size([3, 5, 1]))


### PR DESCRIPTION
Summary: Uses the parallel l-bfgs-b implementation for fitting batched models (multi-output and ensemble map saas), which each batch is an independent model. This results in significant speedups, and avoids having to split/reconstruct the model (as with the old converters).

Differential Revision: D94397395


