### PR TITLE
Replace deprecated torch.inverse/torch.det with torch.linalg equivalents

### DIFF
--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -371,7 +371,7 @@ class qMaxValueEntropy(MaxValueBase, MCSamplerMixin):
         # s_m x batch_shape x num_fantasies x (m) x (1 + num_trace) x (1 + num_trace)
         L = psd_safe_cholesky(variance_m)
         temp_term = torch.cholesky_solve(covar_mM.unsqueeze(-1), L).transpose(-2, -1)
-        # equivalent to torch.matmul(covar_mM.unsqueeze(-2), torch.inverse(variance_m))
+        # equivalent to covar_mM.unsqueeze(-2) @ torch.linalg.inv(variance_m)
         # batch_shape x num_fantasies (m) x 1 x (1 + num_trace_observations)
 
         mean_pt1 = torch.matmul(temp_term, (samples_m - mean_m).unsqueeze(-1))

--- a/botorch/acquisition/multi_objective/predictive_entropy_search.py
+++ b/botorch/acquisition/multi_objective/predictive_entropy_search.py
@@ -720,7 +720,7 @@ def _update_omega(
     identity = torch.diag_embed(torch.ones(cov_fX_fS.shape[:-1], **tkwargs))
     # remove the Pareto diagonal
     cov_fX_fS = _replace_pareto_diagonal(cov_fX_fS + jitter * identity)
-    nat_cov_fX_fS = torch.inverse(cov_fX_fS)
+    nat_cov_fX_fS = torch.linalg.inv(cov_fX_fS)
     nat_mean_fX_fS = torch.einsum("...ij,...j->...i", nat_cov_fX_fS, mean_fX_fS)
 
     ###############################################################################
@@ -735,7 +735,7 @@ def _update_omega(
     # remove the Pareto diagonal
     cav_nat_cov_f = _replace_pareto_diagonal(cav_nat_cov_f)
     identity = torch.diag_embed(torch.ones(cav_nat_cov_f.shape[:-1], **tkwargs))
-    cav_cov_f = torch.inverse(cav_nat_cov_f + jitter * identity)
+    cav_cov_f = torch.linalg.inv(cav_nat_cov_f + jitter * identity)
 
     cav_mean_f = torch.einsum("...ij,...j->...i", cav_cov_f, cav_nat_mean_f)
 
@@ -818,7 +818,7 @@ def _update_omega(
     cav_updated_cov_f = _replace_pareto_diagonal(cav_updated_cov_f)
 
     identity = torch.diag_embed(torch.ones(cav_updated_cov_f.shape[:-1], **tkwargs))
-    cav_updated_nat_cov_f = torch.inverse(cav_updated_cov_f + jitter * identity)
+    cav_updated_nat_cov_f = torch.linalg.inv(cav_updated_cov_f + jitter * identity)
 
     cav_updated_nat_mean_f = torch.einsum(
         "...ij,...j->...i", cav_updated_nat_cov_f, cav_updated_mean_f
@@ -830,7 +830,7 @@ def _update_omega(
 
     # it is also possible to calculate the update directly as in the original paper:
     # identity = torch.diag_embed(torch.ones(cav_d2logZ_dm2.shape[:-1], **tkwargs))
-    # denominator = torch.inverse(cav_cov_f @ cav_d2logZ_dm2 + identity)
+    # denominator = torch.linalg.inv(cav_cov_f @ cav_d2logZ_dm2 + identity)
     # omega_f_nat_cov_new = - cav_d2logZ_dm2 @ denominator
     # omega_f_nat_mean_new = torch.einsum(
     #     '...ij,...j->...i', denominator,

--- a/botorch/utils/sampling.py
+++ b/botorch/utils/sampling.py
@@ -795,7 +795,9 @@ class DelaunayPolytopeSampler(PolytopeSampler):
             polytopes = torch.from_numpy(
                 np.array([delaunay.points[s] for s in delaunay.simplices]),
             ).to(self.A)
-            volumes = torch.stack([torch.det(p[1:] - p[0]).abs() for p in polytopes])
+            volumes = torch.stack(
+                [torch.linalg.det(p[1:] - p[0]).abs() for p in polytopes]
+            )
             self._polytopes = polytopes
             self._p = volumes / volumes.sum()
 

--- a/botorch_community/models/vbll_helper.py
+++ b/botorch_community/models/vbll_helper.py
@@ -295,9 +295,14 @@ class DenseNormalPrec(torch.distributions.MultivariateNormal):
 
     @property
     def trace_covariance(self):
-        return (
-            (torch.inverse(self.tril) ** 2).sum(-1).sum(-1)
-        )  # compute as frob norm squared
+        # Compute ||L^{-1}||_F^2 via triangular solve instead of full inverse.
+        Eye = torch.eye(
+            self.tril.shape[-1],
+            device=self.tril.device,
+            dtype=self.tril.dtype,
+        )
+        L_inv = torch.linalg.solve_triangular(self.tril, Eye, upper=False)
+        return (L_inv**2).sum(-1).sum(-1)
 
     def covariance_weighted_inner_prod(self, b, reduce_dim=True):
         assert b.shape[-1] == 1

--- a/botorch_community/utils/stat_dist.py
+++ b/botorch_community/utils/stat_dist.py
@@ -21,19 +21,19 @@ def mvn_kl_divergence(
     Args:
         p_mean: A ``batch_shape x dist_shape x 1``-dim Tensor of means of
             the first distribution.
-        q_mean: A ``batch_shape x dist_shape x dist_shape``-dim Tensor of
-            covariances of the first distribution,  where the covariances
+        p_covar: A ``batch_shape x dist_shape x dist_shape``-dim Tensor of
+            covariances of the first distribution, where the covariances
             are (optionally) in the q-batch dim.
-        p_mean: A ``batch_shape x dist_shape x 1``-dim Tensor of means of
+        q_mean: A ``batch_shape x dist_shape x 1``-dim Tensor of means of
             the second distribution.
-        q_mean: A ``batch_shape x dist_shape x dist_shape``-dim Tensor of
+        q_covar: A ``batch_shape x dist_shape x dist_shape``-dim Tensor of
             covariances of the second distribution where the covariances
             are (optionally) in the q-batch dim.
     Returns:
         A tensor of shape ``batch_shape x dist_shape`` denoting the KL-divergence
         between the multivariate Gaussian distributions p and q.
     """
-    p_inv_covar = torch.inverse(p_covar)
+    p_inv_covar = torch.linalg.inv(p_covar)
     mean_diff = p_mean - q_mean
     kl_first_term = torch.diagonal(
         torch.matmul(p_inv_covar, q_covar), dim1=-2, dim2=-1
@@ -53,17 +53,17 @@ def mvn_hellinger_distance(
     Args:
         p_mean: A ``batch_shape x dist_shape x 1``-dim Tensor of means of
             the first distribution.
-        q_mean: A ``batch_shape x dist_shape x dist_shape``-dim Tensor of
-            covariances of the first distribution,  where the covariances
+        p_covar: A ``batch_shape x dist_shape x dist_shape``-dim Tensor of
+            covariances of the first distribution, where the covariances
             are (optionally) in the q-batch dim.
-        p_mean: A ``batch_shape x dist_shape x 1``-dim Tensor of means of
+        q_mean: A ``batch_shape x dist_shape x 1``-dim Tensor of means of
             the second distribution.
-        q_mean: A ``batch_shape x dist_shape x dist_shape``-dim Tensor of
+        q_covar: A ``batch_shape x dist_shape x dist_shape``-dim Tensor of
             covariances of the second distribution where the covariances
             are (optionally) in the q-batch dim.
     Returns:
-        A tensor of shape ``batch_shape x dist_shape`` denoting the KL-divergence
-        between the multivariate Gaussian distributions p and q.
+        A tensor of shape ``batch_shape x dist_shape`` denoting the Hellinger
+        distance between the multivariate Gaussian distributions p and q.
     """
     p_logdet = torch.logdet(p_covar).unsqueeze(-1)
     q_logdet = torch.logdet(q_covar).unsqueeze(-1)
@@ -71,7 +71,6 @@ def mvn_hellinger_distance(
 
     # we need to re-use the cholesky decomp, so we compute it once here
     L_avg = torch.linalg.cholesky(avg_covar)
-    L_inv = torch.inverse(L_avg)
 
     # removes one dimension, which needs to be recouped
     pq_logdet = (
@@ -82,7 +81,9 @@ def mvn_hellinger_distance(
     base_logterm = 0.25 * (p_logdet + q_logdet) - 0.5 * pq_logdet
 
     mean_diff = p_mean - q_mean
-    L_mean_diff = torch.matmul(L_inv, mean_diff)
+    # Use solve_triangular instead of computing the full inverse of L_avg,
+    # since we only need L_avg^{-1} @ mean_diff. This is O(n^2) vs O(n^3).
+    L_mean_diff = torch.linalg.solve_triangular(L_avg, mean_diff, upper=False)
     exp_logterm = -0.125 * torch.matmul(L_mean_diff.transpose(-2, -1), L_mean_diff)
     sq_hdist = 1 - (base_logterm + exp_logterm.squeeze(-1)).exp()
     return sq_hdist.clamp_min(0.0).sqrt()


### PR DESCRIPTION
Summary:
Replace deprecated PyTorch functions with their modern `torch.linalg` equivalents:
- `torch.inverse` → `torch.linalg.inv` (6 code sites + 2 comments)
- `torch.det` → `torch.linalg.det` (1 code site)

Files changed:
- `predictive_entropy_search.py`: 3 `torch.inverse` code calls + 1 comment
- `stat_dist.py`: 2 `torch.inverse` code calls
- `vbll_helper.py`: 1 `torch.inverse` code call
- `max_value_entropy_search.py`: 1 `torch.inverse` comment
- `sampling.py`: 1 `torch.det` code call

Differential Revision: D95102837


