### PR TITLE
Support inequality constraints in optimize_with_nsgaii (#3220)

### DIFF
--- a/botorch/utils/multi_objective/optimize.py
+++ b/botorch/utils/multi_objective/optimize.py
@@ -90,6 +90,7 @@ try:
             ref_point: Tensor | None = None,
             objective: MCMultiOutputObjective | None = None,
             constraints: list[Callable[[Tensor], Tensor]] | None = None,
+            inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
         ) -> None:
             """PyMOO problem for optimizing the model posterior mean using NSGA-II.
 
@@ -120,10 +121,17 @@ try:
                     ``sample_shape x batch-shape x q x m`` to a Tensor of dimension
                     ``sample_shape x batch-shape x q``, where negative values imply
                     feasibility.
+                inequality_constraints: A list of tuples (indices, coefficients, rhs),
+                    representing inequality constraints of the form
+                    ``sum_i (X[indices[i]] * coefficients[i]) >= rhs``. These are
+                    parameter-space constraints (as opposed to outcome-space
+                    constraints).
             """
             num_constraints = 0 if constraints is None else len(constraints)
             if ref_point is not None:
                 num_constraints += ref_point.shape[0]
+            if inequality_constraints is not None:
+                num_constraints += len(inequality_constraints)
             super().__init__(
                 n_var=n_var,
                 n_obj=n_obj,
@@ -138,6 +146,7 @@ try:
                 IdentityMCMultiOutputObjective() if objective is None else objective
             )
             self.botorch_constraints = constraints
+            self.botorch_inequality_constraints = inequality_constraints
             self.torch_dtype = dtype
             self.torch_device = device
 
@@ -165,6 +174,26 @@ try:
                     )
                 else:
                     constraint_vals = ref_constraints
+            # Handle parameter-space inequality constraints
+            # These are of the form sum_i (X[indices[i]] * coefficients[i]) >= rhs
+            # PyMOO expects constraints in the form G(x) <= 0, so we transform:
+            # sum_i (X[indices[i]] * coefficients[i]) >= rhs
+            # => rhs - sum_i (X[indices[i]] * coefficients[i]) <= 0
+            if self.botorch_inequality_constraints is not None:
+                ineq_constraint_vals = []
+                for indices, coefficients, rhs in self.botorch_inequality_constraints:
+                    # X is (pop_size, n_var), indices is (num_terms,)
+                    # Extract relevant columns and compute linear combination
+                    lhs = (X[:, indices] * coefficients).sum(dim=-1)
+                    # Transform to G(x) <= 0 form: rhs - lhs <= 0
+                    ineq_constraint_vals.append(rhs - lhs)
+                ineq_constraints = torch.stack(ineq_constraint_vals, dim=-1)
+                if constraint_vals is not None:
+                    constraint_vals = torch.cat(
+                        [constraint_vals, ineq_constraints], dim=-1
+                    )
+                else:
+                    constraint_vals = ineq_constraints
             if constraint_vals is not None:
                 out["G"] = constraint_vals.cpu().numpy()
 
@@ -176,6 +205,7 @@ try:
         ref_point: list[float] | Tensor | None = None,
         objective: MCMultiOutputObjective | None = None,
         constraints: list[Callable[[Tensor], Tensor]] | None = None,
+        inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
         population_size: int = 250,
         max_gen: int | None = None,
         seed: int | None = None,
@@ -206,6 +236,11 @@ try:
                 ``sample_shape x batch-shape x q x m`` to a Tensor of dimension
                 ``sample_shape x batch-shape x q``, where negative values imply
                 feasibility.
+            inequality_constraints: A list of tuples (indices, coefficients, rhs),
+                representing inequality constraints of the form
+                ``sum_i (X[indices[i]] * coefficients[i]) >= rhs``. These are
+                parameter-space constraints (as opposed to outcome-space
+                constraints).
             population_size: the population size for NSGA-II.
             max_gen: The number of iterations for NSGA-II. If None, this uses the
                 default termination condition in pymoo for NSGA-II.
@@ -273,6 +308,7 @@ try:
                     ref_point=ref_point,
                     objective=objective,
                     constraints=constraints,
+                    inequality_constraints=inequality_constraints,
                     **tkwargs,
                 )
                 pop_size = max(population_size, q) if q is not None else population_size

--- a/test/utils/multi_objective/test_optimize.py
+++ b/test/utils/multi_objective/test_optimize.py
@@ -402,3 +402,82 @@ class TestOptimizeWithNSGAII(BotorchTestCase):
                 torch.allclose(pareto_Y, expected_Y, atol=1e-6),
                 "Y values should be re-evaluated with objective after post-processing",
             )
+
+    def _test_nsgaii_with_inequality_constraints(
+        self,
+        ref_point: list[float] | None = None,
+    ) -> None:
+        """Helper to test optimize_with_nsgaii with inequality constraints.
+
+        Args:
+            ref_point: Optional reference point. When provided, tests the code path
+                where inequality constraints are concatenated with ref_point
+                constraints.
+        """
+        from botorch.utils.multi_objective.optimize import optimize_with_nsgaii
+
+        tkwargs = {"device": self.device}
+        for dtype in (torch.float, torch.double):
+            tkwargs["dtype"] = dtype
+            dim = 6
+            num_objectives = 2
+            prob = DTLZ2(dim=dim, num_objectives=num_objectives, negate=True).to(
+                **tkwargs
+            )
+
+            model = GenericDeterministicModel(f=prob, num_outputs=2)
+            acqf = MultiOutputPosteriorMean(model=model)
+            bounds = torch.zeros(2, dim, **tkwargs)
+            bounds[1] = 1
+
+            # Define inequality constraint: x[0] + x[1] >= 1.0
+            inequality_constraints = [
+                (
+                    torch.tensor([0, 1], dtype=torch.long),
+                    torch.tensor([1.0, 1.0], **tkwargs),
+                    1.0,
+                )
+            ]
+
+            pareto_X, pareto_Y = optimize_with_nsgaii(
+                acq_function=acqf,
+                bounds=bounds,
+                q=5,
+                num_objectives=num_objectives,
+                max_gen=10,
+                population_size=50,
+                inequality_constraints=inequality_constraints,
+                ref_point=ref_point,
+            )
+
+            # Verify all solutions satisfy the constraint: x[0] + x[1] >= 1.0
+            constraint_values = pareto_X[:, 0] + pareto_X[:, 1]
+            self.assertTrue(
+                (constraint_values >= 1.0 - 1e-6).all(),
+                f"Constraint x[0] + x[1] >= 1.0 violated. Values: {constraint_values}",
+            )
+
+            # Verify solutions dominate the reference point if provided
+            if ref_point is not None:
+                self.assertTrue(
+                    (pareto_Y > torch.tensor(ref_point, **tkwargs)).all(),
+                    "All Pareto-optimal solutions should dominate the reference point",
+                )
+
+            # Verify Y values match the model output
+            expected_Y = prob(pareto_X)
+            self.assertTrue(torch.allclose(pareto_Y, expected_Y, atol=1e-6))
+
+    @skip_if_import_error
+    def test_optimize_with_nsgaii_inequality_constraints(self) -> None:
+        """Test that optimize_with_nsgaii respects inequality constraints."""
+        self._test_nsgaii_with_inequality_constraints()
+
+    @skip_if_import_error
+    def test_optimize_with_nsgaii_inequality_constraints_with_ref_point(self) -> None:
+        """Test inequality constraints combined with ref_point.
+
+        This test ensures the code path where inequality constraints are
+        concatenated with existing constraint values (from ref_point) is covered.
+        """
+        self._test_nsgaii_with_inequality_constraints(ref_point=[-2.0, -2.0])


### PR DESCRIPTION
Summary:

Adds support for inequality constraints in `optimize_with_nsgaii`. These were previously not passed down from Ax as they were not supported, which could result in invalid candidates. The diff leverages the existing constraint functionality in PyMoo to add support for constraints.

Reviewed By: sdaulton

Differential Revision: D95296285


