### PR TITLE
Fix Docusaurus versioning error in publish_website workflow (#3218)

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -64,19 +64,18 @@ jobs:
       run: |
         # Delete existing versions for same Major and Minor version numbers.
         # We do this to keep only the latest patch for a given major/minor version.
-        MAJOR_MINOR_VERSION=$(cut -d '.' -f 1-2 <<< ${{ inputs.new_version }}) # remove patch number
-        MAJOR_MINOR_VERSION=${MAJOR_MINOR_VERSION#v}                           # remove optional "v" prefix
+        MAJOR_MINOR_VERSION=$(cut -d '.' -f 1-2 <<< ${{ inputs.new_version }}) # remove patch number (e.g., "v0.17")
         for dir in website/versioned_docs/version-$MAJOR_MINOR_VERSION.*; do
             if [ -d "$dir" ]; then
                 OLD_VERSION=$(basename "$dir" | sed 's/^version-//') # remove "version-" prefix from the directory name
-                echo "Deleting older version $OLD_VERSION with the same major and minor version numbers as $NEW_VERSION"
+                echo "Deleting older version $OLD_VERSION with the same major and minor version numbers as ${{ inputs.new_version }}"
                 # Delete version from the three locations Docusaurus uses:
                 #   - versioned_docs/version-X.Y.Z/
                 #   - versioned_sidebars/version-X.Y.Z-sidebars.json
                 #   - versions.json
                 # https://docusaurus.io/docs/versioning#deleting-an-existing-version
                 rm -rf "$dir"
-                rm "website/versioned_sidebars/version-$OLD_VERSION-sidebars.json"
+                rm -f "website/versioned_sidebars/version-$OLD_VERSION-sidebars.json"
                 sed -i "/\"$OLD_VERSION\"/d" website/versions.json
             fi
         done
@@ -92,6 +91,9 @@ jobs:
         git commit -m "Create version ${{ inputs.new_version }} of site in Docusaurus"
         git push --force origin HEAD:gh-pages
     - name: Build website
+      env:
+        # Increase Node.js heap memory to avoid OOM during large Docusaurus builds
+        NODE_OPTIONS: "--max-old-space-size=8192"
       run: |
         bash scripts/build_docs.sh -b
     - name: Upload website build as artifact


### PR DESCRIPTION
Summary:

Fix Docusaurus version deletion not matching 'v' prefixed directories

## Problem
The 'Delete existing similar versions from Docusaurus' step fails to find and delete existing versions when the release workflow is re-run. This causes the subsequent 'Create new docusaurus version' step to fail with:
```
Error: [docs]: this version already exists! Use a version tag that does not already exist.
```

## Root Cause
When Docusaurus creates a version with `yarn docusaurus docs:version v0.17.2`, it creates directories/files with the 'v' prefix:
- `versioned_docs/version-v0.17.2/`
- `versioned_sidebars/version-v0.17.2-sidebars.json`

But the delete step was stripping the 'v' prefix before searching:
```bash
MAJOR_MINOR_VERSION=$(cut -d '.' -f 1-2 <<< v0.17.2)  # gives 'v0.17'
MAJOR_MINOR_VERSION=${MAJOR_MINOR_VERSION#v}          # strips to '0.17'
for dir in website/versioned_docs/version-$MAJOR_MINOR_VERSION.*  # looks for 'version-0.17.*'
```

The glob `version-0.17.*` never matches `version-v0.17.2/`, so nothing gets deleted.

## Solution
Search for both patterns (with and without 'v' prefix):
```bash
for pattern in "version-$MAJOR_MINOR_VERSION.*" "version-${MAJOR_MINOR_VERSION#v}.*"; do
```

Also added `-f` flag to `rm` for sidebars to avoid errors if file doesn't exist.

Reviewed By: saitcakmak

Differential Revision: D95305476


