### PR TITLE
Use logsumexp for numerically stable mixture entropy in BALD

### DIFF
--- a/botorch/acquisition/bayesian_active_learning.py
+++ b/botorch/acquisition/bayesian_active_learning.py
@@ -20,8 +20,10 @@ References
 
 from __future__ import annotations
 
+import math
 import warnings
 
+import torch
 from botorch.acquisition.acquisition import AcquisitionFunction, MCSamplerMixin
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.models import ModelListGP
@@ -143,14 +145,19 @@ class qBayesianActiveLearningByDisagreement(
         # avg the probs over models in the mixture - dim (-2) will be broadcasted
         # with the num_models of the posterior --> querying all samples on all models
         # posterior.mvn takes q-dimensional input by default, which removes the q-dim
-        # component_sample_probs: num_models x num_samples x batch_shape x num_models
-        component_sample_probs = posterior.mvn.log_prob(prev_samples).exp()
+        # component_sample_log_probs:
+        #   num_models x num_samples x batch_shape x num_models
+        component_sample_log_probs = posterior.mvn.log_prob(prev_samples)
 
-        # average over mixture components
-        mixture_sample_probs = component_sample_probs.mean(dim=-1, keepdim=True)
+        # average over mixture components in log-space for numerical stability:
+        # log(mean(exp(x))) = logsumexp(x, dim) - log(N)
+        n_components = component_sample_log_probs.shape[-1]
+        mixture_sample_log_probs = torch.logsumexp(
+            component_sample_log_probs, dim=-1, keepdim=True
+        ) - math.log(n_components)
 
         # this is the average over the model and sample dim
-        prev_entropy = -mixture_sample_probs.log().mean(dim=[0, 1])
+        prev_entropy = -mixture_sample_log_probs.mean(dim=[0, 1])
 
         # the posterior entropy is an average entropy over gaussians, so no mixture
         post_entropy = -posterior.mvn.log_prob(samples.squeeze(-1)).mean(0)

--- a/botorch_community/acquisition/bayesian_active_learning.py
+++ b/botorch_community/acquisition/bayesian_active_learning.py
@@ -321,13 +321,17 @@ class qConditionalHyperparameterInformationGain(
         )
         samples = self.get_posterior_samples(conditional_posterior)
         prev_samples = samples.unsqueeze(0).transpose(0, MCMC_DIM).squeeze(-1)
-        component_sample_probs = conditional_posterior.mvn.log_prob(prev_samples).exp()
+        component_sample_log_probs = conditional_posterior.mvn.log_prob(prev_samples)
 
-        # average over mixture components
-        mixture_sample_probs = component_sample_probs.mean(dim=-1, keepdim=True)
+        # average over mixture components in log-space for numerical stability:
+        # log(mean(exp(x))) = logsumexp(x, dim) - log(N)
+        n_components = component_sample_log_probs.shape[-1]
+        mixture_sample_log_probs = torch.logsumexp(
+            component_sample_log_probs, dim=-1, keepdim=True
+        ) - math.log(n_components)
 
         # this is the average over the model and sample dim
-        prev_entropy = -mixture_sample_probs.log().mean(dim=[0, 1])
+        prev_entropy = -mixture_sample_log_probs.mean(dim=[0, 1])
 
         # the posterior entropy is an average entropy over gaussians, so no mixture
         post_entropy = -conditional_posterior.mvn.log_prob(samples.squeeze(-1)).mean(0)


### PR DESCRIPTION
Summary:
The BALD acquisition function and its community variant (`qConditionalHyperparameterInformationGain`) computed mixture log-probabilities via an exp-log round-trip:

```python
component_sample_probs = log_prob(samples).exp()
mixture_sample_probs = component_sample_probs.mean(dim=-1)
entropy = -mixture_sample_probs.log().mean(...)
```

This `log(mean(exp(log_prob)))` pattern risks numerical underflow/overflow when log-probabilities are very large or very small. Replace with the numerically stable `logsumexp`:

```python
log_mixture_probs = logsumexp(log_probs, dim=-1) - log(N)
entropy = -log_mixture_probs.mean(...)
```

This stays entirely in log-space, avoiding the exp-log round-trip.

Reviewed By: hvarfner

Differential Revision: D95400826


