### PR TITLE
Fix numerical precision in MultivariateNormalQMCEngine eigendecomposition for CUDA

### DIFF
--- a/botorch/sampling/qmc.py
+++ b/botorch/sampling/qmc.py
@@ -146,7 +146,9 @@ class MultivariateNormalQMCEngine:
             tol = 1e-8 if eigval.dtype == torch.double else 1e-6
             if torch.any(eigval < -tol):
                 raise ValueError("Covariance matrix not PSD.")
-            eigval_root = eigval.clamp_min(0.0).sqrt()
+            eigval_root = torch.where(
+                eigval > tol, eigval, torch.zeros_like(eigval)
+            ).sqrt()
             self._corr_matrix = (eigvec * eigval_root).transpose(-1, -2)
 
     def draw(self, n: int = 1, out: Tensor | None = None) -> Tensor | None:


### PR DESCRIPTION
Summary:
In `MultivariateNormalQMCEngine.__init__`, when the Cholesky decomposition fails (for PSD but not PD matrices), the eigendecomposition fallback path uses `eigval.clamp_min(0.0).sqrt()` to compute the correlation matrix. This only clamps negative eigenvalues to zero, but leaves small positive eigenvalues (numerically zero) untouched.

On CUDA with float32, eigenvalues that should be exactly 0 (for degenerate covariance matrices) can be computed as small positive values (~1e-7). After taking the square root (~3e-4) and multiplying through the matrix, this introduces errors large enough to break exact linear relationships (like X + Y = Z in the degenerate test case).

The fix uses the already-defined tolerance `tol` (1e-6 for float32, 1e-8 for float64) to zero out eigenvalues below the threshold, consistent with how the same tolerance is used to check for negative eigenvalues. This ensures that numerically-zero eigenvalues in degenerate covariance matrices are treated as exactly zero.

Fixes T258699315.

Reviewed By: saitcakmak

Differential Revision: D95818000


