### PR TITLE
Add `ref_point` to MOO input constructors

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -12,6 +12,7 @@ constructors programmatically from a consistent input format.
 from __future__ import annotations
 
 import inspect
+import warnings
 from collections.abc import Callable, Hashable, Iterable, Sequence
 from typing import Any, TypeVar
 
@@ -223,6 +224,9 @@ def allow_only_specific_variable_kwargs(f: Callable[..., T]) -> Callable[..., T]
         # Objective thresholds are needed for defining hypervolumes in
         # multi-objective optimization.
         "objective_thresholds",
+        # ref_point is the new preferred way to pass reference points
+        # for multi-objective optimization.
+        "ref_point",
         # Used in input constructors for some lookahead acquisition functions
         # such as qKnowledgeGradient.
         "bounds",
@@ -985,14 +989,19 @@ def _get_sampler(mc_samples: int, qmc: bool) -> MCSampler:
 def construct_inputs_EHVI(
     model: Model,
     training_data: MaybeDict[SupervisedDataset],
-    objective_thresholds: Tensor,
+    objective_thresholds: Tensor | None = None,
     posterior_transform: PosteriorTransform | None = None,
     constraints: list[Callable[[Tensor], Tensor]] | None = None,
     alpha: float | None = None,
     Y_pmean: Tensor | None = None,
+    ref_point: Tensor | None = None,
 ) -> dict[str, Any]:
     r"""Construct kwargs for ``ExpectedHypervolumeImprovement`` constructor."""
-    num_objectives = objective_thresholds.shape[0]
+    ref_point = _get_ref_point(
+        objective_thresholds=objective_thresholds,
+        ref_point=ref_point,
+    )
+    num_objectives = ref_point.shape[0]
     if constraints is not None:
         raise NotImplementedError("EHVI does not yet support outcome constraints.")
 
@@ -1016,19 +1025,19 @@ def construct_inputs_EHVI(
             Y_pmean = model.posterior(X).mean
     if alpha > 0:
         partitioning = NondominatedPartitioning(
-            ref_point=objective_thresholds,
+            ref_point=ref_point,
             Y=Y_pmean,
             alpha=alpha,
         )
     else:
         partitioning = FastNondominatedPartitioning(
-            ref_point=objective_thresholds,
+            ref_point=ref_point,
             Y=Y_pmean,
         )
 
     kwargs = {
         "model": model,
-        "ref_point": objective_thresholds,
+        "ref_point": ref_point,
         "partitioning": partitioning,
     }
     if posterior_transform is not None:
@@ -1042,7 +1051,7 @@ def construct_inputs_EHVI(
 def construct_inputs_qEHVI(
     model: Model,
     training_data: MaybeDict[SupervisedDataset],
-    objective_thresholds: Tensor,
+    objective_thresholds: Tensor | None = None,
     objective: MCMultiOutputObjective | None = None,
     constraints: list[Callable[[Tensor], Tensor]] | None = None,
     alpha: float | None = None,
@@ -1051,6 +1060,7 @@ def construct_inputs_qEHVI(
     eta: float = 1e-3,
     mc_samples: int = 128,
     qmc: bool = True,
+    ref_point: Tensor | None = None,
 ) -> dict[str, Any]:
     r"""
     Construct kwargs for ``qExpectedHypervolumeImprovement`` and
@@ -1072,7 +1082,12 @@ def construct_inputs_qEHVI(
         feas = torch.stack([c(Y_pmean) <= 0 for c in constraints], dim=-1).all(dim=-1)
         Y_pmean = Y_pmean[feas]
 
-    num_objectives = objective_thresholds.shape[0]
+    ref_point = _get_ref_point(
+        objective_thresholds=objective_thresholds,
+        objective=objective,
+        ref_point=ref_point,
+    )
+    num_objectives = ref_point.shape[0]
 
     alpha = (
         get_default_partitioning_alpha(num_objectives=num_objectives)
@@ -1081,13 +1096,10 @@ def construct_inputs_qEHVI(
     )
 
     if objective is None:
-        ref_point = objective_thresholds
         Y = Y_pmean
     elif isinstance(objective, RiskMeasureMCObjective):
-        ref_point = objective.preprocessing_function(objective_thresholds)
         Y = objective.preprocessing_function(Y_pmean)
     else:
-        ref_point = objective(objective_thresholds)
         Y = objective(Y_pmean)
 
     if alpha > 0:
@@ -1121,7 +1133,7 @@ def construct_inputs_qEHVI(
 def construct_inputs_qNEHVI(
     model: Model,
     training_data: MaybeDict[SupervisedDataset],
-    objective_thresholds: Tensor,
+    objective_thresholds: Tensor | None = None,
     objective: MCMultiOutputObjective | None = None,
     X_baseline: Tensor | None = None,
     constraints: list[Callable[[Tensor], Tensor]] | None = None,
@@ -1137,6 +1149,7 @@ def construct_inputs_qNEHVI(
     max_iep: int = 0,
     incremental_nehvi: bool = True,
     cache_root: bool | None = None,
+    ref_point: Tensor | None = None,
 ) -> dict[str, Any]:
     r"""Construct kwargs for ``qNoisyExpectedHypervolumeImprovement``'s constructor."""
     if X_baseline is None:
@@ -1161,12 +1174,13 @@ def construct_inputs_qNEHVI(
     if sampler is None and isinstance(model, GPyTorchModel):
         sampler = _get_sampler(mc_samples=mc_samples, qmc=qmc)
 
-    if isinstance(objective, RiskMeasureMCObjective):
-        ref_point = objective.preprocessing_function(objective_thresholds)
-    else:
-        ref_point = objective(objective_thresholds)
+    ref_point = _get_ref_point(
+        objective_thresholds=objective_thresholds,
+        objective=objective,
+        ref_point=ref_point,
+    )
 
-    num_objectives = objective_thresholds[~torch.isnan(objective_thresholds)].shape[0]
+    num_objectives = ref_point[~torch.isnan(ref_point)].shape[0]
     if alpha is None:
         alpha = get_default_partitioning_alpha(num_objectives=num_objectives)
 
@@ -1193,7 +1207,7 @@ def construct_inputs_qNEHVI(
 def construct_inputs_qLogNEHVI(
     model: Model,
     training_data: MaybeDict[SupervisedDataset],
-    objective_thresholds: Tensor,
+    objective_thresholds: Tensor | None = None,
     objective: MCMultiOutputObjective | None = None,
     X_baseline: Tensor | None = None,
     constraints: list[Callable[[Tensor], Tensor]] | None = None,
@@ -1211,6 +1225,7 @@ def construct_inputs_qLogNEHVI(
     cache_root: bool | None = None,
     tau_relu: float = TAU_RELU,
     tau_max: float = TAU_MAX,
+    ref_point: Tensor | None = None,
 ) -> dict[str, Any]:
     """
     Construct kwargs for ``qLogNoisyExpectedHypervolumeImprovement``'s constructor."
@@ -1221,6 +1236,7 @@ def construct_inputs_qLogNEHVI(
             training_data=training_data,
             objective_thresholds=objective_thresholds,
             objective=objective,
+            ref_point=ref_point,
             X_baseline=X_baseline,
             constraints=constraints,
             alpha=alpha,
@@ -1421,11 +1437,12 @@ def construct_inputs_qHVKG(
     model: Model,
     training_data: MaybeDict[SupervisedDataset],
     bounds: list[tuple[float, float]],
-    objective_thresholds: Tensor,
+    objective_thresholds: Tensor | None = None,
     objective: MCMultiOutputObjective | None = None,
     posterior_transform: PosteriorTransform | None = None,
     num_fantasies: int = 8,
     num_pareto: int = 10,
+    ref_point: Tensor | None = None,
     **optimize_objective_kwargs: TOptimizeObjectiveKwargs,
 ) -> dict[str, Any]:
     r"""Construct kwargs for ``qKnowledgeGradient`` constructor."""
@@ -1434,7 +1451,9 @@ def construct_inputs_qHVKG(
     _bounds = torch.as_tensor(bounds, dtype=X.dtype, device=X.device)
 
     ref_point = _get_ref_point(
-        objective_thresholds=objective_thresholds, objective=objective
+        objective_thresholds=objective_thresholds,
+        objective=objective,
+        ref_point=ref_point,
     )
 
     acq_function = _get_hv_value_function(
@@ -1514,7 +1533,7 @@ def construct_inputs_qMFHVKG(
     training_data: MaybeDict[SupervisedDataset],
     bounds: list[tuple[float, float]],
     target_fidelities: dict[int, int | float],
-    objective_thresholds: Tensor,
+    objective_thresholds: Tensor | None = None,
     objective: MCMultiOutputObjective | None = None,
     posterior_transform: PosteriorTransform | None = None,
     fidelity_weights: dict[int, float] | None = None,
@@ -1522,6 +1541,7 @@ def construct_inputs_qMFHVKG(
     num_trace_observations: int = 0,
     num_fantasies: int = 8,
     num_pareto: int = 10,
+    ref_point: Tensor | None = None,
     **optimize_objective_kwargs: TOptimizeObjectiveKwargs,
 ) -> dict[str, Any]:
     r"""
@@ -1547,7 +1567,9 @@ def construct_inputs_qMFHVKG(
     _bounds = torch.as_tensor(bounds, dtype=X.dtype, device=X.device)
 
     ref_point = _get_ref_point(
-        objective_thresholds=objective_thresholds, objective=objective
+        objective_thresholds=objective_thresholds,
+        objective=objective,
+        ref_point=ref_point,
     )
 
     acq_function = _get_hv_value_function(
@@ -2010,17 +2032,52 @@ def construct_inputs_NIPV(
 
 
 def _get_ref_point(
-    objective_thresholds: Tensor,
+    objective_thresholds: Tensor | None = None,
     objective: MCMultiOutputObjective | None = None,
+    ref_point: Tensor | None = None,
 ) -> Tensor:
-    if objective is None:
-        ref_point = objective_thresholds
-    elif isinstance(objective, RiskMeasureMCObjective):
-        ref_point = objective.preprocessing_function(objective_thresholds)
-    else:
-        ref_point = objective(objective_thresholds)
+    """Get the reference point for multi-objective acquisition functions.
 
-    return ref_point
+    Args:
+        objective_thresholds: Deprecated. Raw objective thresholds that will be
+            transformed through the objective (if provided) to produce the
+            reference point. Use ``ref_point`` instead.
+        objective: The multi-output objective, used only with the deprecated
+            ``objective_thresholds`` path to transform thresholds into the
+            objective space.
+        ref_point: The maximization-aligned reference point of shape
+            ``(num_objectives,)``, used directly without any further processing.
+            This is the preferred way to specify the reference point.
+
+    Returns:
+        A ``(num_objectives,)``-dim Tensor representing the reference point
+        in the objective space, suitable for hypervolume computation.
+    """
+    if ref_point is not None:
+        if objective_thresholds is not None:
+            raise ValueError(
+                "Cannot specify both `ref_point` and `objective_thresholds`."
+            )
+        return ref_point
+    if objective_thresholds is None:
+        raise ValueError(
+            "Either `ref_point` or `objective_thresholds` must be provided."
+        )
+    warnings.warn(
+        "`objective_thresholds` is deprecated in favor of `ref_point`. "
+        "Unlike `objective_thresholds`, which gets transformed through the "
+        "objective, `ref_point` should be a maximization-aligned reference "
+        "point of shape `(num_objectives,)` and is used directly without "
+        "any further processing.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    if objective is None:
+        return objective_thresholds
+    elif isinstance(objective, RiskMeasureMCObjective):
+        return objective.preprocessing_function(objective_thresholds)
+    else:
+        return objective(objective_thresholds)
 
 
 def _construct_constraint_dict_from_tuple(

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -12,6 +12,7 @@ When adding tests for a new input constructor, please add a new case to
 from __future__ import annotations
 
 import math
+import warnings
 from collections.abc import Callable
 from functools import reduce
 from random import randint
@@ -39,6 +40,7 @@ from botorch.acquisition.bayesian_active_learning import (
 from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
 from botorch.acquisition.input_constructors import (
     _field_is_shared,
+    _get_ref_point,
     _register_acqf_input_constructor,
     acqf_input_constructor,
     ACQF_INPUT_CONSTRUCTOR_REGISTRY,
@@ -1413,6 +1415,141 @@ class TestMultiObjectiveAcquisitionFunctionInputConstructors(
         )
         self.assertEqual(kwargs["alpha"], 0.0)
 
+    def test_get_ref_point(self) -> None:
+        objective_thresholds = torch.rand(2)
+        ref_point = torch.rand(2)
+
+        with self.subTest("ref_point provided"):
+            result = _get_ref_point(ref_point=ref_point)
+            self.assertTrue(torch.equal(result, ref_point))
+
+        with self.subTest("objective_thresholds with deprecation warning"):
+            with warnings.catch_warnings(record=True) as ws:
+                warnings.simplefilter("always")
+                result = _get_ref_point(
+                    objective_thresholds=objective_thresholds,
+                )
+                self.assertTrue(torch.equal(result, objective_thresholds))
+                self.assertEqual(len(ws), 1)
+                self.assertTrue(issubclass(ws[0].category, DeprecationWarning))
+                self.assertIn("ref_point", str(ws[0].message))
+
+        with self.subTest("both raises ValueError"):
+            with self.assertRaisesRegex(ValueError, "Cannot specify both"):
+                _get_ref_point(
+                    objective_thresholds=objective_thresholds,
+                    ref_point=ref_point,
+                )
+
+        with self.subTest("neither raises ValueError"):
+            with self.assertRaisesRegex(
+                ValueError, "Either `ref_point` or `objective_thresholds`"
+            ):
+                _get_ref_point()
+
+        with self.subTest("objective_thresholds with objective"):
+            weights = torch.rand(2)
+            obj = WeightedMCMultiOutputObjective(weights=weights)
+            with warnings.catch_warnings(record=True):
+                warnings.simplefilter("always")
+                result = _get_ref_point(
+                    objective_thresholds=objective_thresholds,
+                    objective=obj,
+                )
+                self.assertTrue(torch.equal(result, obj(objective_thresholds)))
+
+        with self.subTest("ref_point with objective (no transform)"):
+            weights = torch.rand(2)
+            obj = WeightedMCMultiOutputObjective(weights=weights)
+            result = _get_ref_point(
+                objective=obj,
+                ref_point=ref_point,
+            )
+            # ref_point is used directly, no objective transform
+            self.assertTrue(torch.equal(result, ref_point))
+
+    def test_construct_inputs_ref_point(self) -> None:
+        """Test ref_point parameter across MOO input constructors."""
+        ref_point = torch.rand(2)
+        objective_thresholds = torch.rand(2)
+
+        with self.subTest("EHVI with ref_point"):
+            Y_pmean = torch.rand(3, 2)
+            mock_model = mock.Mock()
+            c = get_acqf_input_constructor(ExpectedHypervolumeImprovement)
+            kwargs = c(
+                model=mock_model,
+                training_data=self.blockX_blockY,
+                ref_point=ref_point,
+                Y_pmean=Y_pmean,
+            )
+            self.assertTrue(torch.equal(kwargs["ref_point"], ref_point))
+
+        with self.subTest("EHVI with both raises ValueError"):
+            c = get_acqf_input_constructor(ExpectedHypervolumeImprovement)
+            with self.assertRaisesRegex(ValueError, "Cannot specify both"):
+                c(
+                    model=mock_model,
+                    training_data=self.blockX_blockY,
+                    objective_thresholds=objective_thresholds,
+                    ref_point=ref_point,
+                    Y_pmean=Y_pmean,
+                )
+
+        with self.subTest("qEHVI with ref_point"):
+            mm = SingleTaskGP(torch.rand(1, 2), torch.rand(1, 2))
+            c = get_acqf_input_constructor(qExpectedHypervolumeImprovement)
+            kwargs = c(
+                model=mm,
+                training_data=self.blockX_blockY,
+                ref_point=ref_point,
+            )
+            self.assertTrue(torch.equal(kwargs["ref_point"], ref_point))
+
+        with self.subTest("qNEHVI with ref_point"):
+            mm = SingleTaskGP(torch.rand(1, 2), torch.rand(1, 2))
+            c = get_acqf_input_constructor(qNoisyExpectedHypervolumeImprovement)
+            kwargs = c(
+                model=mm,
+                training_data=self.blockX_blockY,
+                ref_point=ref_point,
+            )
+            self.assertTrue(torch.equal(kwargs["ref_point"], ref_point))
+
+        with self.subTest("qLogNEHVI with ref_point"):
+            mm = SingleTaskGP(torch.rand(1, 2), torch.rand(1, 2))
+            c = get_acqf_input_constructor(qLogNoisyExpectedHypervolumeImprovement)
+            kwargs = c(
+                model=mm,
+                training_data=self.blockX_blockY,
+                ref_point=ref_point,
+            )
+            self.assertTrue(torch.equal(kwargs["ref_point"], ref_point))
+
+        with self.subTest("qNEHVI with neither raises ValueError"):
+            mm = SingleTaskGP(torch.rand(1, 2), torch.rand(1, 2))
+            c = get_acqf_input_constructor(qNoisyExpectedHypervolumeImprovement)
+            with self.assertRaisesRegex(ValueError, "Either"):
+                c(
+                    model=mm,
+                    training_data=self.blockX_blockY,
+                )
+
+        with self.subTest("objective_thresholds triggers deprecation warning"):
+            mm = SingleTaskGP(torch.rand(1, 2), torch.rand(1, 2))
+            c = get_acqf_input_constructor(qNoisyExpectedHypervolumeImprovement)
+            with warnings.catch_warnings(record=True) as ws:
+                warnings.simplefilter("always")
+                kwargs = c(
+                    model=mm,
+                    training_data=self.blockX_blockY,
+                    objective_thresholds=objective_thresholds,
+                )
+                dep_warnings = [
+                    w for w in ws if issubclass(w.category, DeprecationWarning)
+                ]
+                self.assertTrue(len(dep_warnings) >= 1)
+
     def test_construct_inputs_qLogNParEGO(self) -> None:
         # Focusing on the unique attributes since the rest are same as qLogNEI.
         c = get_acqf_input_constructor(qLogNParEGO)
@@ -1624,6 +1761,24 @@ class TestKGandESAcquisitionFunctionInputConstructors(InputConstructorBaseTestCa
                         else objective_thresholds
                     )
                     self.assertTrue(torch.equal(kwargs["ref_point"], expected_obj_t))
+
+            with self.subTest("ref_point direct"):
+                direct_ref_point = torch.rand(2)
+                with mock.patch(
+                    target="botorch.acquisition.input_constructors.optimize_acqf",
+                    return_value=(None, current_value),
+                ):
+                    kwargs = get_kwargs(
+                        model=model,
+                        training_data=self.blockX_blockY,
+                        ref_point=direct_ref_point,
+                        objective=objective,
+                        bounds=self.bounds,
+                        num_fantasies=33,
+                        num_pareto=11,
+                        **input_constructor_extra_kwargs,
+                    )
+                self.assertTrue(torch.equal(kwargs["ref_point"], direct_ref_point))
 
     def test_construct_inputs_mes(self) -> None:
         func = get_acqf_input_constructor(qMaxValueEntropy)


### PR DESCRIPTION
Summary:
Add a `ref_point` parameter to MOO acquisition input constructors,
deprecating the `objective_thresholds` parameter. When `ref_point` is
provided, it is used directly without applying the objective transform,
avoiding double sign-flip bugs when callers pass pre-aligned thresholds.
`ref_point` is of shape `(num_objectives,)` and is aligned for maximization, so it can be directly passed to the acquisition functions.

When `ref_point` is not provided, the existing `objective_thresholds`
path is preserved for backward compatibility with a deprecation warning.

Updated constructors:
- `construct_inputs_EHVI`
- `construct_inputs_qEHVI`
- `construct_inputs_qNEHVI`
- `construct_inputs_qLogNEHVI`
- `construct_inputs_qHVKG`
- `construct_inputs_qMFHVKG`

Also updated the `_get_ref_point` helper and the
`allow_only_specific_variable_kwargs` allowlist.

A following diff is updating Ax to pass in maximization aligned `ref_point` input of shape `(num_objectives,)`. This diff handles BoTorch side changes in a backwards compatible manner to prepare for that change.

Differential Revision: D96473523


