### PR TITLE
Add custom_fit and compute_loss protocols for fitting extensibility

### DIFF
--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -107,6 +107,15 @@ def fit_gpytorch_mll(
     if optimizer is not None:  # defer to per-method defaults
         kwargs["optimizer"] = optimizer
 
+    if hasattr(mll.model, "custom_fit"):
+        return mll.model.custom_fit(
+            mll=mll,
+            closure=closure,
+            closure_kwargs=closure_kwargs,
+            optimizer_kwargs=optimizer_kwargs,
+            **kwargs,
+        )
+
     return FitGPyTorchMLL(
         mll,
         type(mll.likelihood),

--- a/botorch/optim/closures/model_closures.py
+++ b/botorch/optim/closures/model_closures.py
@@ -9,6 +9,7 @@ r"""Utilities for building model-based closures."""
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from functools import partial
 from itertools import chain, repeat
 from types import NoneType
 from typing import Any
@@ -55,6 +56,11 @@ def get_loss_closure(
         A closure that takes zero positional arguments and returns the negated
         value of ``mll``.
     """
+    if hasattr(mll, "compute_custom_loss"):
+        return mll.compute_custom_loss
+    if hasattr(mll.model, "compute_custom_loss"):
+        return partial(mll.model.compute_custom_loss, mll=mll)
+
     return GetLossClosure(
         mll, type(mll.likelihood), type(mll.model), data_loader, **kwargs
     )

--- a/test/optim/closures/test_model_closures.py
+++ b/test/optim/closures/test_model_closures.py
@@ -74,6 +74,61 @@ def _get_mlls(
     return train_X.to(device=device, dtype=torch.double), mlls
 
 
+class TestComputeLossProtocol(BotorchTestCase):
+    def test_compute_custom_loss_closure_dispatch_paths(self) -> None:
+        # If mll has a compute_custom_loss method, get_loss_closure returns it
+        # directly.
+        with self.subTest("compute_custom_loss_on_mll"):
+            _, mlls = _get_mlls(device=self.device)
+            mll = mlls[0]  # ExactMarginalLogLikelihood
+
+            sentinel = lambda **_kwargs: torch.tensor(42.0)  # noqa: E731
+            mll.compute_custom_loss = sentinel
+            result = get_loss_closure(mll)
+            self.assertIs(result, sentinel)
+            del mll.compute_custom_loss
+
+        # If mll.model has a compute_custom_loss method, get_loss_closure wraps it.
+        with self.subTest("compute_custom_loss_on_model"):
+            _, mlls = _get_mlls(device=self.device)
+            mll = mlls[0]
+
+            def my_compute_custom_loss(
+                *, mll: MarginalLogLikelihood, **_kwargs: object
+            ) -> Tensor:
+                return torch.tensor(-99.0)
+
+            mll.model.compute_custom_loss = my_compute_custom_loss
+            result = get_loss_closure(mll)
+            # Should be a partial wrapping my_compute_custom_loss with mll as first arg
+            self.assertEqual(result(), torch.tensor(-99.0))
+            del mll.model.compute_custom_loss
+
+        # Without compute_custom_loss, get_loss_closure uses the dispatcher.
+        with self.subTest("dispatcher_fallback"):
+            _, mlls = _get_mlls(device=self.device)
+            mll = mlls[0]
+            self.assertFalse(hasattr(mll, "compute_custom_loss"))
+            self.assertFalse(hasattr(mll.model, "compute_custom_loss"))
+            closure = get_loss_closure(mll)
+            loss = closure()
+            self.assertIsInstance(loss, Tensor)
+
+        # compute_custom_loss on mll takes priority over compute_custom_loss on model.
+        with self.subTest("mll_takes_priority_over_model"):
+            _, mlls = _get_mlls(device=self.device)
+            mll = mlls[0]
+
+            mll_sentinel = lambda **_kwargs: torch.tensor(1.0)  # noqa: E731
+            model_sentinel = lambda *, mll, **_kwargs: torch.tensor(2.0)  # noqa: E731
+            mll.compute_custom_loss = mll_sentinel
+            mll.model.compute_custom_loss = model_sentinel
+            result = get_loss_closure(mll)
+            self.assertIs(result, mll_sentinel)
+            del mll.compute_custom_loss
+            del mll.model.compute_custom_loss
+
+
 class TestLossClosures(BotorchTestCase):
     def test_main(self) -> None:
         for mll in _get_mlls(device=self.device)[1]:

--- a/test/test_fit.py
+++ b/test/test_fit.py
@@ -117,6 +117,44 @@ class TestFitAPI(BotorchTestCase):
                 optimizer_kwargs=None,
             )
 
+    def test_custom_fit_protocol(self):
+        """If model has custom_fit, fit_gpytorch_mll calls it directly."""
+        mock_custom_fit = MagicMock(return_value=self.mll)
+        self.mll.model.custom_fit = mock_custom_fit
+
+        with self.subTest("custom_fit_called"):
+            result = fit_gpytorch_mll(mll=self.mll, optimizer_kwargs={"maxiter": 5})
+            mock_custom_fit.assert_called_once_with(
+                mll=self.mll,
+                closure=None,
+                closure_kwargs=None,
+                optimizer_kwargs={"maxiter": 5},
+            )
+            self.assertIs(result, self.mll)
+
+        with self.subTest("custom_fit_with_optimizer"):
+            mock_custom_fit.reset_mock()
+            result = fit_gpytorch_mll(
+                mll=self.mll, optimizer="my_opt", optimizer_kwargs={"a": 1}
+            )
+            mock_custom_fit.assert_called_once_with(
+                mll=self.mll,
+                closure=None,
+                closure_kwargs=None,
+                optimizer="my_opt",
+                optimizer_kwargs={"a": 1},
+            )
+
+        with self.subTest("dispatcher_not_called"):
+            # Ensure the dispatcher is NOT called when custom_fit exists
+            with patch.object(fit, "FitGPyTorchMLL") as mock_dispatcher:
+                mock_custom_fit.reset_mock()
+                fit_gpytorch_mll(mll=self.mll)
+                mock_dispatcher.assert_not_called()
+                mock_custom_fit.assert_called_once()
+
+        del self.mll.model.custom_fit
+
 
 class TestFitFallback(BotorchTestCase):
     def setUp(self, suppress_input_warnings: bool = True) -> None:


### PR DESCRIPTION
Summary:
**Context**: I aim to clean up BoTorch model-fitting code. Users have found the dispatchers and high stack depth to be confusing, especially when debugging. These dispatchers provide a lot of flexibility for customization, but the customization is rarely used. In the use case I’m aware of, `fit_gpytorch_mll` is only customized based on the type of the `model`, and loss computation is only affected by the types of the `mll` and the `model`. This stack changes the way custom fitting and loss methods are added from registering with a dispatcher to adding `custom_fit` and `custom_loss` methods on `model` and `mll`.

Stack:
* This PR: new way of customizing
* Intermediate PR: Migrate uses of dispatchers to this new way
* D96592852 and D96592824: remove the dispatchers, `FitGPyTorchMLL` and `GetLossClosure`

**Design note**: The `hasattr(mll, "custom_fit")` usage here is a little janky, and if customization were more widely needed, it could make sense to rethink this, but custom fitting and custom losses are not a super common use case. If users have need for more customization, I would love to hear about it.

**This PR**:
Add ability to customize model fitting and loss computation without registering with the dispatchers with

* If `model` has a `custom_fit` method,
   `fit_gpytorch_mll` calls it directly instead of using the dispatcher. This
   lets models define their own fitting behavior. This will enable migration off of the `FitGPyTorchMLL` dispatcher. Dispatch will effectively happen only on `mll`.

2. `compute_loss` protocol on MLLs/models: If `mll` has a `compute_loss` method, `get_loss_closure` returns it directly. If `mll.model` has a
   `compute_loss` method, it wraps it with `functools.partial(model.compute_loss, mll=mll)`.

These protocols are checked before the existing dispatchers, so existing
dispatcher registrations continue to work unchanged.

Differential Revision: D96592835


