### PR TITLE
Latent Kronecker Gaussian Processes with customized GPyTorch inference (#3234)

### DIFF
--- a/botorch/models/latent_kronecker_gp.py
+++ b/botorch/models/latent_kronecker_gp.py
@@ -39,7 +39,7 @@ from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.latent_kronecker import LatentKroneckerGPPosterior
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.types import _DefaultType, DEFAULT
-from gpytorch.distributions import MultivariateNormal
+from gpytorch.distributions import Distribution, MultivariateNormal
 from gpytorch.kernels import MaternKernel, ScaleKernel
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.likelihoods.likelihood import Likelihood
@@ -50,6 +50,7 @@ from linear_operator import settings
 from linear_operator.operators import (
     ConstantDiagLinearOperator,
     KroneckerProductLinearOperator,
+    LinearOperator,
     MaskedLinearOperator,
 )
 from torch import Tensor
@@ -109,12 +110,11 @@ class LatentKroneckerGP(GPyTorchModel, ExactGP, FantasizeMixin):
             covar_module_T: The module computing the covariance matrix of T.
                 If omitted, a ``MaternKernel`` wrapped in a ``ScaleKernel``
                 will be used.
-            input_transform: An input transform that is applied to X.
+            input_transform: An input transform that is applied to X in the
+                model's forward pass.
             outcome_transform: An outcome transform that is applied to Y.
                 Note that ``.train()`` will be called on the outcome transform during
                 instantiation of the model.
-            input_transform: An input transform that is applied in the model's
-                forward pass.
         """
         with torch.no_grad():
             # transform inputs here to check resulting shapes
@@ -133,8 +133,6 @@ class LatentKroneckerGP(GPyTorchModel, ExactGP, FantasizeMixin):
             raise BotorchTensorDimensionError(
                 f"Expected train_T with shape {expected_shape} but got {train_T.shape}."
             )
-        self.train_T = train_T
-
         mask_valid_batch = train_Y.isfinite()
         # flatten over batch_shape
         mask_valid_flat = mask_valid_batch.reshape(-1, *mask_valid_batch.shape[-2:])
@@ -160,7 +158,7 @@ class LatentKroneckerGP(GPyTorchModel, ExactGP, FantasizeMixin):
 
         ExactGP.__init__(
             self,
-            train_inputs=train_X,
+            train_inputs=[train_X, train_T],
             train_targets=train_Y,
             likelihood=likelihood,
         )
@@ -193,6 +191,76 @@ class LatentKroneckerGP(GPyTorchModel, ExactGP, FantasizeMixin):
 
         self.to(train_X)
 
+    @property
+    def train_T(self) -> Tensor:
+        """The training T values (second element of train_inputs).
+
+        T is stored in train_inputs (alongside X) to enable GPyTorch's
+        multi-input prediction strategy via ``_get_test_prior_mean_and_covariances``.
+        This also allows using different T values at test time, e.g., evaluating
+        the posterior at a subset of task indices.
+
+        The helper methods below (``transform_inputs``, ``_set_transformed_inputs``,
+        ``_revert_to_original_inputs``) ensure T is preserved through BoTorch's
+        input transform machinery, which expects single-input models.
+        """
+        return self.train_inputs[1]
+
+    def transform_inputs(
+        self,
+        X: Tensor,
+        input_transform: Module | None = None,
+    ) -> Tensor:
+        r"""Transform inputs.
+
+        Only transforms X, leaving T unchanged. The ``_is_T_input`` check is
+        needed because MLL closures call ``transform_inputs`` on each element
+        of ``train_inputs`` individually, including T.
+
+        Args:
+            X: A tensor of inputs. May be X or T from train_inputs.
+            input_transform: A Module that performs the input transformation.
+
+        Returns:
+            Transformed X, or T unchanged.
+        """
+        # Skip transform for T (identified by identity with train_T)
+        if self._is_T_input(X):
+            return X
+        return super().transform_inputs(X=X, input_transform=input_transform)
+
+    def _is_T_input(self, X: Tensor) -> bool:
+        """Check if X is the T input by identity comparison."""
+        return (
+            hasattr(self, "train_inputs")
+            and self.train_inputs is not None
+            and len(self.train_inputs) > 1
+            and X is self.train_inputs[1]
+        )
+
+    def _set_transformed_inputs(self) -> None:
+        r"""Transform X while preserving T in train_inputs."""
+        if not (hasattr(self, "train_inputs") and len(self.train_inputs) > 1):
+            return super()._set_transformed_inputs()
+
+        T = self.train_inputs[1]
+        super()._set_transformed_inputs()
+        # super() calls set_train_data which sets train_inputs = (X_tf,), losing T
+        if hasattr(self, "train_inputs"):
+            self.train_inputs = (self.train_inputs[0], T)
+
+    def _revert_to_original_inputs(self) -> None:
+        r"""Revert X while preserving T in train_inputs."""
+        T = (
+            self.train_inputs[1]
+            if (hasattr(self, "train_inputs") and len(self.train_inputs) > 1)
+            else None
+        )
+        super()._revert_to_original_inputs()
+        # super() calls set_train_data which sets train_inputs = (X,), losing T
+        if T is not None and hasattr(self, "train_inputs"):
+            self.train_inputs = (self.train_inputs[0], T)
+
     def use_iterative_methods(
         self,
         tol: float = 0.01,
@@ -219,20 +287,111 @@ class LatentKroneckerGP(GPyTorchModel, ExactGP, FantasizeMixin):
         mean = KroneckerProductLinearOperator(mean_X, mean_T).squeeze(-1)
         return mean[..., mask] if mask is not None else mean
 
-    def forward(self, X: Tensor, T: Tensor | None = None) -> MultivariateNormal:
+    def _get_test_prior_mean_and_covariances(
+        self,
+        train_inputs: list[Tensor],
+        test_inputs: list[Tensor],
+        **kwargs,
+    ) -> tuple[
+        Tensor,
+        LinearOperator,
+        LinearOperator,
+        torch.Size,
+        torch.Size,
+        type[Distribution],
+    ]:
+        """Computes Kronecker-structured covariances with masking for posterior.
+
+        This enables proper posterior mean and variance computation while maintaining
+        the Kronecker structure for efficiency. The test_train_covar is masked on the
+        train dimension to handle missing observations.
+
+        Args:
+            train_inputs: List containing [X_train, T_train].
+            test_inputs: List containing [X_test, T_test].
+            **kwargs: Additional arguments (unused, kept for compatibility).
+
+        Returns:
+            A tuple containing:
+            - test_mean: The prior mean evaluated on the test set
+            - test_test_covar: Covariance between test points (Kronecker structure)
+            - test_train_covar: Covariance between test and train points (masked)
+            - batch_shape: The batch shape of the model
+            - test_shape: Shape of the test output
+            - posterior_class: MultivariateNormal
+        """
+        X_train, T_train = train_inputs[0], train_inputs[1]
+        X_test, T_test = test_inputs[0], test_inputs[1]
+
+        # Compute Kronecker-structured covariances
+        K_X_test_test = self.covar_module_X(X_test)
+        K_T_test_test = self.covar_module_T(T_test)
+        K_X_test_train = self.covar_module_X(X_test, X_train)
+        K_T_test_train = self.covar_module_T(T_test, T_train)
+
+        test_test_covar = KroneckerProductLinearOperator(K_X_test_test, K_T_test_test)
+        test_train_covar_full = KroneckerProductLinearOperator(
+            K_X_test_train, K_T_test_train
+        )
+
+        # Apply masking for missing observations
+        # The train dimension needs masking, test dimension is full
+        n_test = X_test.shape[-2] * T_test.shape[-2]
+
+        # Create full test mask (all valid)
+        test_mask = torch.ones(n_test, dtype=torch.bool, device=X_test.device)
+
+        # Apply mask to test_train_covar (only train dimension masked)
+        test_train_covar = MaskedLinearOperator(
+            test_train_covar_full, row_mask=test_mask, col_mask=self.mask_valid
+        )
+
+        # Compute prior mean on test set
+        test_mean = self._get_mean(X_test, T_test)
+
+        batch_shape = torch.broadcast_shapes(X_train.shape[:-2], X_test.shape[:-2])
+        test_shape = torch.Size([n_test])
+
+        return (
+            test_mean,
+            test_test_covar,
+            test_train_covar,
+            batch_shape,
+            test_shape,
+            MultivariateNormal,
+        )
+
+    def __call__(self, *args, **kwargs):
+        """Forward pass that handles optional T parameter.
+
+        Appends ``self.train_T`` when only X is provided. This is necessary
+        because ``fit_gpytorch_mll`` and the MLL training pipeline call
+        ``model(train_X)`` with only the X input.
+
+        Args:
+            *args: Either (X,) or (X, T). If only X is provided, uses self.train_T.
+        """
+        if len(args) == 1:
+            args = (args[0], self.train_T)
+
+        return ExactGP.__call__(self, *args, **kwargs)
+
+    def forward(self, *args, **kwargs) -> MultivariateNormal:
         r"""
         Computes the joint distribution at the given input locations.
 
         Args:
-            X: A tensor of ``X``-locations at which to compute the joint distribution.
-            T: A tensor of ``T``-locations at which to compute the joint distribution.
-                If None, defaults to using ``self.train_T``.
+            *args: Either (X,) for backward compatibility, or (X, T).
+                If only X is provided, uses self.train_T for T.
 
         Returns:
             MultivariateNormal: The joint distribution at the specified input locations.
         """
-        if T is None:
+        if len(args) == 1:
+            X = args[0]
             T = self.train_T
+        else:
+            X, T = args[0], args[1]
 
         if self.training:
             X = self.transform_inputs(X)
@@ -261,23 +420,28 @@ class LatentKroneckerGP(GPyTorchModel, ExactGP, FantasizeMixin):
     ) -> GPyTorchPosterior:
         r"""Computes the posterior over model outputs at the provided points.
 
+        Leverages GPyTorch's inference stack with our custom Kronecker-structured
+        covariances (via the overridden ``_get_test_prior_mean_and_covariances``).
+        Sampling uses pathwise conditioning for efficiency.
+
+        NOTE: For efficient inference with large datasets, wrap the call in the
+        ``model.use_iterative_methods()`` context manager, e.g.:
+
+            >>> with model.use_iterative_methods():
+            ...     posterior = model.posterior(X, T)
+
         Args:
-            X: A ``(batch_shape) x q x d``-dim Tensor, where ``d`` is the dimension
-                of the feature space and ``q`` is the number of points considered
-                jointly.
-            T: A ``(batch_shape) x t x 1``-dim Tensor of ``T``-locations at which to
-                compute the posterior. If None, defaults to using ``self.train_T``.
-            observation_noise: If True, add the observation noise from the
-                likelihood to the posterior. If a Tensor, use it directly as the
-                observation noise (must be of shape ``(batch_shape) x q``). It is
-                assumed to be in the outcome-transformed space if an outcome
-                transform is used.
-            posterior_transform: An optional PosteriorTransform.
+            X: A ``(batch_shape) x q x d``-dim Tensor of test features.
+            T: A ``(batch_shape) x t x 1``-dim Tensor of test T values.
+                If None, defaults to using ``self.train_T``.
+            observation_noise: If True, add observation noise. Currently not
+                supported.
+            posterior_transform: An optional PosteriorTransform. Currently not
+                supported.
 
         Returns:
-            A ``GPyTorchPosterior`` object, representing a batch of ``b`` joint
-            distributions over ``q`` points. Includes observation noise if
-            specified.
+            A ``LatentKroneckerGPPosterior`` with proper mean/variance and efficient
+            pathwise sampling.
         """
         if posterior_transform is not None:
             raise NotImplementedError(
@@ -297,7 +461,24 @@ class LatentKroneckerGP(GPyTorchModel, ExactGP, FantasizeMixin):
 
         if T is None:
             T = self.train_T
-        return LatentKroneckerGPPosterior(self, X, T)
+
+        X_test = self.transform_inputs(X)
+
+        # Compute the real posterior distribution via GPyTorch's inference stack,
+        # which uses our overridden _get_test_prior_mean_and_covariances for
+        # Kronecker structure. This gives exact posterior mean and variance.
+        #
+        # NOTE: This eagerly computes the train-train solve (via GPyTorch's
+        # cached mean_cache), using either direct Cholesky or CG depending on
+        # whether use_iterative_methods() is active. This is the same system
+        # that pathwise sampling solves. The posterior covariance remains lazy
+        # (no Cholesky until .covariance_matrix is accessed; .variance only
+        # needs the diagonal). Sampling (rsample) still uses pathwise
+        # conditioning for efficiency, see
+        # LatentKroneckerGPPosterior.rsample_from_base_samples.
+        distribution = self(X_test, T)
+
+        return LatentKroneckerGPPosterior(self, distribution, X, T)
 
     def _rsample_from_base_samples(
         self,

--- a/botorch/posteriors/latent_kronecker.py
+++ b/botorch/posteriors/latent_kronecker.py
@@ -9,7 +9,6 @@ import torch
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from gpytorch.distributions import MultivariateNormal
-from linear_operator.operators import IdentityLinearOperator, ZeroLinearOperator
 from torch import Tensor
 
 
@@ -29,52 +28,42 @@ References
 
 class LatentKroneckerGPPosterior(GPyTorchPosterior):
     r"""
-    Dummy posterior class for a LatentKroneckerGP model.
-    Internally calls model._rsample_from_base_samples to draw posterior samples via
-    pathwise conditioning aka Matheron's rule [wilson2020sampling, wilson2021pathwise].
+    Posterior class for a LatentKroneckerGP model.
 
-    This is necessary because BoTorch instantiates the posterior object before creating
-    base samples, whereas pathwise conditioning requires the base samples first to
-    calculate the posterior samples. To cache expensive computations, which only have
-    to be performed once for the same base samples, the results are stored in the model
-    instead of the posterior object, because a new posterior object is created in each
-    acquisition function call.
+    Uses a real MultivariateNormal distribution for `.mean` and `.variance`,
+    while internally using pathwise conditioning (Matheron's rule) for efficient
+    sampling via `rsample` [wilson2020sampling, wilson2021pathwise].
+
+    This enables accessing `posterior.mean` and `posterior.variance` while
+    maintaining efficient sampling through `model._rsample_from_base_samples()`.
     """
 
     def __init__(
         self,
         model: GPyTorchModel,
+        distribution: MultivariateNormal,
         X: Tensor,
         T: Tensor,
     ) -> None:
-        r"""A dummy posterior for LatentKroneckerGP models.
+        r"""Initialize LatentKroneckerGPPosterior.
 
         Args:
             model: The LatentKroneckerGP model to which this posterior belongs to.
+            distribution: The posterior MultivariateNormal distribution computed
+                via the GPyTorch prediction stack.
             X: A ``(batch_shape) x q x d``-dim Tensor, where ``d`` is the dimension
                 of the feature space and ``q`` is the number of points considered
                 jointly, on which the posterior shall be evaluated.
             T: A ``(batch_shape) x t x 1``-dim Tensor of ``T``-locations at which to
-                evaluate the posterior. If None, defaults to using ``self.train_T``.
+                evaluate the posterior.
         """
+        super().__init__(distribution=distribution)
         self._dtype = X.dtype
         self._device = X.device
         self.batch_shape = model.batch_shape
         self.output_batch_shape = torch.broadcast_shapes(
             model.batch_shape, X.shape[:-2]
         )
-        output_dim = X.shape[-2] * T.shape[-2]
-        mean = ZeroLinearOperator(
-            *self.output_batch_shape, output_dim, dtype=X.dtype, device=X.device
-        )
-        covar = IdentityLinearOperator(
-            output_dim,
-            batch_shape=self.output_batch_shape,
-            dtype=X.dtype,
-            device=X.device,
-        )
-        dummy_mvn = MultivariateNormal(mean=mean, covariance_matrix=covar)
-        super().__init__(distribution=dummy_mvn)
         self.model = model
         self.X = X
         self.T = T
@@ -126,7 +115,7 @@ class LatentKroneckerGPPosterior(GPyTorchPosterior):
         This is intended to be used with a sampler that produces the corresponding base
         samples, and enables acquisition optimization via Sample Average Approximation.
 
-        Since this posterior is a dummy object, call the model to perform sampling.
+        Delegates to the model's pathwise conditioning implementation.
 
         Args:
             sample_shape: A ``torch.Size`` object specifying the sample shape. To

--- a/test/models/test_latent_kronecker_gp.py
+++ b/test/models/test_latent_kronecker_gp.py
@@ -6,6 +6,7 @@
 
 import itertools
 import warnings
+from unittest.mock import patch
 
 import torch
 from botorch.acquisition.objective import ScalarizedPosteriorTransform
@@ -22,6 +23,7 @@ from gpytorch.likelihoods import FixedNoiseGaussianLikelihood, GaussianLikelihoo
 from gpytorch.means import ConstantMean, ZeroMean
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from linear_operator import settings
+from linear_operator.utils.linear_cg import linear_cg as _linear_cg_fn
 from linear_operator.utils.warnings import NumericalWarning
 
 
@@ -43,63 +45,72 @@ def _get_data_with_missing_entries(
 
 
 class TestLatentKroneckerGP(BotorchTestCase):
-    def test_default_init(self):
-        for (
-            batch_shape,
-            n_train,
-            d,
-            t,
-            dtype,
-            use_transforms,
-        ) in itertools.product(
-            (  # batch_shape
-                torch.Size([]),
-                torch.Size([1]),
-                torch.Size([2, 3]),
-            ),
-            (10,),  # n_train
-            (1, 2),  # d
-            (1, 2),  # t
-            (torch.float, torch.double),  # dtype
-            (False, True),  # use_transforms
+    def _make_model(
+        self,
+        n_train=10,
+        d=2,
+        t=3,
+        batch_shape=None,
+        use_transforms=True,
+        tkwargs=None,
+        **model_kwargs,
+    ):
+        """Create data, transforms, and model for testing."""
+        if batch_shape is None:
+            batch_shape = torch.Size([])
+        if tkwargs is None:
+            tkwargs = {"device": self.device, "dtype": torch.double}
+        train_X, train_T, train_Y, mask = _get_data_with_missing_entries(
+            n_train=n_train, d=d, t=t, batch_shape=batch_shape, tkwargs=tkwargs
+        )
+        intf = Normalize(d=d, batch_shape=batch_shape) if use_transforms else None
+        octf = DEFAULT if use_transforms else None
+        model = LatentKroneckerGP(
+            train_X=train_X,
+            train_T=train_T,
+            train_Y=train_Y,
+            input_transform=intf,
+            outcome_transform=octf,
+            **model_kwargs,
+        )
+        model.to(**tkwargs)
+        return model, train_X, train_T, train_Y, mask, intf, octf
+
+    # --- Init helpers ---
+
+    def _test_default_init(self):
+        n_train = 10
+        for batch_shape, d, t, dtype, use_transforms in itertools.product(
+            (torch.Size([]), torch.Size([1]), torch.Size([2, 3])),
+            (1, 2),
+            (1, 2),
+            (torch.float, torch.double),
+            (False, True),
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
-
-            if use_transforms:
-                intf = Normalize(d=d, batch_shape=batch_shape)
-                octf = DEFAULT
-            else:
-                intf = None
-                octf = None
-
-            train_X, train_T, train_Y, mask = _get_data_with_missing_entries(
-                n_train=n_train, d=d, t=t, batch_shape=batch_shape, tkwargs=tkwargs
+            model, train_X, train_T, train_Y, mask, intf, octf = self._make_model(
+                n_train=n_train,
+                d=d,
+                t=t,
+                batch_shape=batch_shape,
+                use_transforms=use_transforms,
+                tkwargs=tkwargs,
             )
 
-            model = LatentKroneckerGP(
-                train_X=train_X,
-                train_T=train_T,
-                train_Y=train_Y,
-                input_transform=intf,
-                outcome_transform=octf,
-            )
-            model.to(**tkwargs)
-
-            # test init
             train_Y_flat = train_Y.reshape(*batch_shape, -1)[..., mask]
             if use_transforms:
                 self.assertIsInstance(model.input_transform, Normalize)
                 self.assertIsInstance(model.outcome_transform, Standardize)
+                train_Y_flat = model.outcome_transform(train_Y_flat.unsqueeze(-1))[
+                    0
+                ].squeeze(-1)
             else:
                 self.assertFalse(hasattr(model, "input_transform"))
                 self.assertFalse(hasattr(model, "outcome_transform"))
-            train_Y_flat = (
-                model.outcome_transform(train_Y_flat.unsqueeze(-1))[0].squeeze(-1)
-                if use_transforms
-                else train_Y_flat
-            )
             self.assertAllClose(model.train_inputs[0], train_X, atol=0.0)
-            self.assertAllClose(model.train_T, train_T, atol=0.0)
+            self.assertEqual(len(model.train_inputs), 2)
+            self.assertAllClose(model.train_inputs[1], train_T, atol=0.0)
+            self.assertIs(model.train_T, model.train_inputs[1])
             self.assertAllClose(model.train_targets, train_Y_flat, atol=0.0)
             self.assertIsInstance(model.likelihood, GaussianLikelihood)
             self.assertIsInstance(model.mean_module_X, ZeroMean)
@@ -108,75 +119,76 @@ class TestLatentKroneckerGP(BotorchTestCase):
             self.assertIsInstance(model.covar_module_T, ScaleKernel)
             self.assertIsInstance(model.covar_module_T.base_kernel, MaternKernel)
 
-    def test_custom_init(self):
-        # test whether custom likelihoods and mean/covar modules are set correctly.
-        for batch_shape, n_train, d, t, dtype in itertools.product(
-            (  # batch_shape
-                torch.Size([]),
-                torch.Size([1]),
-                torch.Size([2]),
-                torch.Size([2, 3]),
-            ),
-            (10,),  # n_train
-            (1, 2),  # d
-            (1, 3),  # t
-            (torch.float, torch.double),  # dtype
+    def _test_custom_init(self):
+        n_train = 10
+        for batch_shape, d, t, dtype in itertools.product(
+            (torch.Size([]), torch.Size([1]), torch.Size([2]), torch.Size([2, 3])),
+            (1, 2),
+            (1, 3),
+            (torch.float, torch.double),
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
-
             train_X, train_T, train_Y, _ = _get_data_with_missing_entries(
                 n_train=n_train, d=d, t=t, batch_shape=batch_shape, tkwargs=tkwargs
             )
 
+            # Error: incorrect T shape
             train_T_incorrect_shape = train_T.clone()[..., :-1, :]
             expected_shape = torch.Size([*batch_shape, train_Y.shape[-1], 1])
-            err_msg = f"Expected train_T with shape {expected_shape} "
-            err_msg += f"but got {train_T_incorrect_shape.shape}."
+            err_msg = (
+                f"Expected train_T with shape {expected_shape} "
+                f"but got {train_T_incorrect_shape.shape}."
+            )
             with self.assertRaises(BotorchTensorDimensionError) as e:
                 LatentKroneckerGP(
                     train_X=train_X, train_T=train_T_incorrect_shape, train_Y=train_Y
                 )
             self.assertEqual(err_msg, str(e.exception))
 
-            train_T_not_broadcastable = train_T.clone().unsqueeze(0)
-            train_T_not_broadcastable = train_T_not_broadcastable.repeat(
-                2, *([1] * len(train_T.shape))
+            # Error: non-broadcastable T
+            train_T_not_broadcastable = (
+                train_T.clone().unsqueeze(0).repeat(2, *([1] * len(train_T.shape)))
             )
-            with self.assertRaises(RuntimeError) as e:
+            with self.assertRaises(RuntimeError):
                 LatentKroneckerGP(
                     train_X=train_X, train_T=train_T_not_broadcastable, train_Y=train_Y
                 )
 
-            # only test if batch_shape is not empty or singleton
+            # Error: inhomogeneous missing pattern (only for non-trivial batch)
             if sum(batch_shape) > 1:
                 train_Y_inhomogeneous = train_Y.clone()
                 train_Y_inhomogeneous[..., 0, :, 0] = 0.0
                 train_Y_inhomogeneous[..., 1, :, 0] = torch.nan
-                err_msg = "Pattern of missing values in train_Y "
-                err_msg += "must be equal across batch_shape."
+                err_msg = (
+                    "Pattern of missing values in train_Y "
+                    "must be equal across batch_shape."
+                )
                 with self.assertRaises(ValueError) as e:
                     LatentKroneckerGP(
                         train_X=train_X, train_T=train_T, train_Y=train_Y_inhomogeneous
                     )
                 self.assertEqual(err_msg, str(e.exception))
 
+            # Custom modules
             likelihood = GaussianLikelihood(batch_shape=batch_shape)
             mean_module_X = ConstantMean(batch_shape=batch_shape)
             mean_module_T = ConstantMean(batch_shape=batch_shape)
             covar_module_X = RBFKernel(ard_num_dims=d, batch_shape=batch_shape)
             covar_module_T = RBFKernel(ard_num_dims=1, batch_shape=batch_shape)
 
-            model = LatentKroneckerGP(
-                train_X=train_X,
-                train_T=train_T,
-                train_Y=train_Y,
+            model, *_ = self._make_model(
+                n_train=n_train,
+                d=d,
+                t=t,
+                batch_shape=batch_shape,
+                use_transforms=False,
+                tkwargs=tkwargs,
                 likelihood=likelihood,
                 mean_module_X=mean_module_X,
                 mean_module_T=mean_module_T,
                 covar_module_X=covar_module_X,
                 covar_module_T=covar_module_T,
             )
-            model.to(**tkwargs)
 
             self.assertEqual(model.likelihood, likelihood)
             self.assertEqual(model.mean_module_X, mean_module_X)
@@ -184,66 +196,33 @@ class TestLatentKroneckerGP(BotorchTestCase):
             self.assertEqual(model.covar_module_X, covar_module_X)
             self.assertEqual(model.covar_module_T, covar_module_T)
 
-            # check devices
-            def _get_index(device):
-                return device.index if device.index is not None else 0
-
+            # Verify all model state is on the correct device
             device_type = self.device.type
-            device_idx = _get_index(self.device)
-
-            self.assertEqual(model.train_inputs[0].device.type, device_type)
-            self.assertEqual(_get_index(model.train_inputs[0].device), device_idx)
-            self.assertEqual(model.train_targets.device.type, device_type)
-            self.assertEqual(_get_index(model.train_targets.device), device_idx)
-            self.assertEqual(model.mask_valid.device.type, device_type)
-            self.assertEqual(_get_index(model.mask_valid.device), device_idx)
+            for tensor in (*model.train_inputs, model.train_targets, model.mask_valid):
+                self.assertEqual(tensor.device.type, device_type)
             for p in model.parameters():
                 self.assertEqual(p.device.type, device_type)
-                self.assertEqual(_get_index(p.device), device_idx)
 
-    def test_gp_train(self):
-        for (
-            batch_shape,
-            n_train,
-            d,
-            t,
-            dtype,
-            use_transforms,
-        ) in itertools.product(
-            (  # batch_shape
-                torch.Size([]),
-                torch.Size([1]),
-                torch.Size([2, 3]),
-            ),
-            (10,),  # n_train
-            (1, 2),  # d
-            (1, 2),  # t
-            (torch.float, torch.double),  # dtype
-            (False, True),  # use_transforms
+    # --- Training helpers ---
+
+    def _test_gp_train(self):
+        n_train = 10
+        for batch_shape, d, t, dtype, use_transforms in itertools.product(
+            (torch.Size([]), torch.Size([1]), torch.Size([2, 3])),
+            (1, 2),
+            (1, 2),
+            (torch.float, torch.double),
+            (False, True),
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
-
-            if use_transforms:
-                intf = Normalize(d=d, batch_shape=batch_shape)
-                octf = DEFAULT
-            else:
-                intf = None
-                octf = None
-
-            train_X, train_T, train_Y, _ = _get_data_with_missing_entries(
-                n_train=n_train, d=d, t=t, batch_shape=batch_shape, tkwargs=tkwargs
+            model, *_ = self._make_model(
+                n_train=n_train,
+                d=d,
+                t=t,
+                batch_shape=batch_shape,
+                use_transforms=use_transforms,
+                tkwargs=tkwargs,
             )
-
-            model = LatentKroneckerGP(
-                train_X=train_X,
-                train_T=train_T,
-                train_Y=train_Y,
-                input_transform=intf,
-                outcome_transform=octf,
-            )
-            model.to(**tkwargs)
-
-            # test optim
             model.train()
             mll = ExactMarginalLogLikelihood(model.likelihood, model)
             mll.to(**tkwargs)
@@ -253,39 +232,24 @@ class TestLatentKroneckerGP(BotorchTestCase):
                     mll, optimizer_kwargs={"options": {"maxiter": 1}}, max_attempts=1
                 )
 
+    # --- Eval helpers ---
+
     def _test_gp_eval_shapes(
         self,
         batch_shape: torch.Size,
         use_transforms: bool,
         tkwargs: dict,
     ):
-        n_train = 10
-        n_test = 7
-        d = 1
-        t = 2
-
-        if use_transforms:
-            intf = Normalize(d=d, batch_shape=batch_shape)
-            octf = DEFAULT
-        else:
-            intf = None
-            octf = None
-
-        train_X, train_T, train_Y, _ = _get_data_with_missing_entries(
-            n_train=n_train, d=d, t=t, batch_shape=batch_shape, tkwargs=tkwargs
+        n_test, d, t = 7, 1, 2
+        model, train_X, train_T, *_ = self._make_model(
+            d=d,
+            t=t,
+            batch_shape=batch_shape,
+            use_transforms=use_transforms,
+            tkwargs=tkwargs,
         )
-
-        test_T = train_T[..., :-1, :]
-
-        model = LatentKroneckerGP(
-            train_X=train_X,
-            train_T=train_T,
-            train_Y=train_Y,
-            input_transform=intf,
-            outcome_transform=octf,
-        )
-        model.to(**tkwargs)
         model.eval()
+        test_T = train_T[..., :-1, :]
 
         for test_shape in (
             torch.Size([]),
@@ -295,7 +259,6 @@ class TestLatentKroneckerGP(BotorchTestCase):
         ):
             test_X = torch.rand(*test_shape, n_test, d, **tkwargs)
 
-            # we expect an error if test_shape and batch_shape cannot be broadcasted
             try:
                 broadcast_shape = torch.broadcast_shapes(test_shape, batch_shape)
             except RuntimeError as e:
@@ -304,7 +267,6 @@ class TestLatentKroneckerGP(BotorchTestCase):
                 continue
             pred_shape = torch.Size([*broadcast_shape, n_test, t - 1])
 
-            # custom posterior samples
             posterior = model.posterior(test_X, test_T)
             self.assertEqual(posterior.batch_range, (0, -1))
             for sample_shape in (
@@ -313,7 +275,6 @@ class TestLatentKroneckerGP(BotorchTestCase):
                 torch.Size([2, 3]),
                 None,
             ):
-                # test posterior.rsample
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", category=NumericalWarning)
                     pred_samples = posterior.rsample(sample_shape=sample_shape)
@@ -326,7 +287,6 @@ class TestLatentKroneckerGP(BotorchTestCase):
                     pred_samples.shape,
                     posterior._extended_shape(torch.Size(expected_sample_shape)),
                 )
-                # test posterior.rsample_from_base_samples
                 base_samples = torch.randn(
                     *expected_sample_shape,
                     *posterior.base_sample_shape,
@@ -342,121 +302,31 @@ class TestLatentKroneckerGP(BotorchTestCase):
                     torch.Size([*expected_sample_shape, *pred_shape]),
                 )
                 if len(expected_sample_shape) > 0:
-                    # test incorrect base sample shape
                     incorrect_base_samples = torch.randn(
-                        5,
-                        *posterior.base_sample_shape,
-                        **tkwargs,
+                        5, *posterior.base_sample_shape, **tkwargs
                     )
                     with self.assertRaises(RuntimeError):
                         posterior.rsample_from_base_samples(
                             expected_sample_shape, incorrect_base_samples
                         )
 
-    def test_gp_eval_shapes_float_with_tf(self):
-        use_transforms = True
-        tkwargs = {"device": self.device, "dtype": torch.float}
-
-        for batch_shape in (
-            torch.Size([]),
-            torch.Size([1]),
-            torch.Size([2, 3]),
-        ):
-            self._test_gp_eval_shapes(
-                batch_shape=batch_shape,
-                use_transforms=use_transforms,
-                tkwargs=tkwargs,
-            )
-
-    def test_gp_eval_shapes_double_with_tf(self):
-        use_transforms = True
-        tkwargs = {"device": self.device, "dtype": torch.double}
-
-        for batch_shape in (
-            torch.Size([]),
-            torch.Size([1]),
-            torch.Size([2, 3]),
-        ):
-            self._test_gp_eval_shapes(
-                batch_shape=batch_shape,
-                use_transforms=use_transforms,
-                tkwargs=tkwargs,
-            )
-
-    def test_gp_eval_shapes_float_without_tf(self):
-        use_transforms = False
-        tkwargs = {"device": self.device, "dtype": torch.float}
-
-        for batch_shape in (
-            torch.Size([]),
-            torch.Size([1]),
-            torch.Size([2, 3]),
-        ):
-            self._test_gp_eval_shapes(
-                batch_shape=batch_shape,
-                use_transforms=use_transforms,
-                tkwargs=tkwargs,
-            )
-
-    def test_gp_eval_shapes_double_without_tf(self):
-        use_transforms = False
-        tkwargs = {"device": self.device, "dtype": torch.double}
-
-        for batch_shape in (
-            torch.Size([]),
-            torch.Size([1]),
-            torch.Size([2, 3]),
-        ):
-            self._test_gp_eval_shapes(
-                batch_shape=batch_shape,
-                use_transforms=use_transforms,
-                tkwargs=tkwargs,
-            )
-
-    def test_gp_eval_values(self):
-        for (
-            batch_shape,
-            n_train,
-            n_test,
-            d,
-            t,
-            dtype,
-            use_transforms,
-        ) in itertools.product(
-            (  # batch_shape
-                torch.Size([]),
-                torch.Size([1]),
-                torch.Size([2, 3]),
-            ),
-            (10,),  # n_train
-            (7,),  # n_test
-            (1,),  # d
-            (1,),  # t
-            (torch.float, torch.double),  # dtype
-            (False, True),  # use_transforms
+    def _test_gp_eval_values(self):
+        n_train, n_test, d, t = 10, 7, 1, 1
+        for batch_shape, dtype, use_transforms in itertools.product(
+            (torch.Size([]), torch.Size([1]), torch.Size([2, 3])),
+            (torch.float, torch.double),
+            (False, True),
         ):
             torch.manual_seed(12345)
             tkwargs = {"device": self.device, "dtype": dtype}
-
-            if use_transforms:
-                intf = Normalize(d=d, batch_shape=batch_shape)
-                octf = DEFAULT
-            else:
-                intf = None
-                octf = None
-
-            train_X, train_T, train_Y, _ = _get_data_with_missing_entries(
-                n_train=n_train, d=d, t=t, batch_shape=batch_shape, tkwargs=tkwargs
+            model, train_X, train_T, *_, intf, octf = self._make_model(
+                n_train=n_train,
+                d=d,
+                t=t,
+                batch_shape=batch_shape,
+                use_transforms=use_transforms,
+                tkwargs=tkwargs,
             )
-
-            model = LatentKroneckerGP(
-                train_X=train_X,
-                train_T=train_T,
-                train_Y=train_Y,
-                input_transform=intf,
-                outcome_transform=octf,
-            )
-            model.to(**tkwargs)
             model.eval()
 
             for test_shape in (
@@ -467,7 +337,6 @@ class TestLatentKroneckerGP(BotorchTestCase):
             ):
                 test_X = torch.rand(*test_shape, n_test, d, **tkwargs)
 
-                # we expect an error if test_shape and batch_shape cannot be broadcasted
                 try:
                     broadcast_shape = torch.broadcast_shapes(test_shape, batch_shape)
                 except RuntimeError as e:
@@ -498,7 +367,6 @@ class TestLatentKroneckerGP(BotorchTestCase):
                 self.assertEqual(pred_mean.shape, pred_shape)
                 self.assertEqual(pred_var.shape, pred_shape)
 
-                # check custom predictions and GPyTorch are roughly the same
                 self.assertLess(
                     (pred_mean - pred_samples.mean(dim=0)).norm() / pred_mean.norm(),
                     0.1,
@@ -507,82 +375,161 @@ class TestLatentKroneckerGP(BotorchTestCase):
                     (pred_var - pred_samples.var(dim=0)).norm() / pred_var.norm(), 0.1
                 )
 
-    def test_iterative_methods(self):
-        batch_shape = torch.Size([])
+    # --- Posterior helpers ---
+
+    def _test_not_implemented(self):
         tkwargs = {"device": self.device, "dtype": torch.double}
-
-        train_X, train_T, train_Y, _ = _get_data_with_missing_entries(
-            n_train=10, d=1, t=1, batch_shape=batch_shape, tkwargs=tkwargs
+        model, train_X, train_T, train_Y, *_ = self._make_model(
+            d=1, t=1, use_transforms=False, tkwargs=tkwargs
         )
+        cls_name = model.__class__.__name__
 
-        model = LatentKroneckerGP(train_X=train_X, train_T=train_T, train_Y=train_Y)
-        model.to(**tkwargs)
+        transform = ScalarizedPosteriorTransform(torch.tensor([1.0], **tkwargs))
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            f"Posterior transforms currently not supported for {cls_name}",
+        ):
+            model.posterior(train_X, posterior_transform=transform)
 
-        with model.use_iterative_methods():
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            f"Observation noise currently not supported for {cls_name}",
+        ):
+            model.posterior(train_X, observation_noise=True)
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            f"Conditioning currently not supported for {cls_name}",
+        ):
+            model.condition_on_observations(train_X, train_Y)
+
+        model, train_X, *_ = self._make_model(
+            d=1,
+            t=1,
+            use_transforms=False,
+            tkwargs=tkwargs,
+            likelihood=FixedNoiseGaussianLikelihood(torch.tensor([1.0]), **tkwargs),
+        )
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            f"Only GaussianLikelihood currently supported for {cls_name}",
+        ):
+            model.posterior(train_X)
+
+    def _test_posterior_mean_and_variance(self):
+        """Test posterior mean/variance match model(X) predictions."""
+        for dtype in (torch.float, torch.double):
+            for batch_shape in (torch.Size([]), torch.Size([2])):
+                tkwargs = {"device": self.device, "dtype": dtype}
+                n_test, d, t = 5, 2, 3
+                model, train_X, train_T, *_, intf, _ = self._make_model(
+                    d=d, t=t, batch_shape=batch_shape, tkwargs=tkwargs
+                )
+                model.eval()
+
+                test_X = torch.rand(*batch_shape, n_test, d, **tkwargs)
+                cg_tol = 1e-6 if dtype == torch.double else 1e-4
+                atol = cg_tol
+
+                # Verify model(X) and model(X, T) produce same results
+                with warnings.catch_warnings(), model.use_iterative_methods(tol=cg_tol):
+                    warnings.filterwarnings("ignore", category=NumericalWarning)
+                    pred_single = model(intf(test_X))
+                    pred_double = model(intf(test_X), train_T)
+                self.assertAllClose(pred_single.mean, pred_double.mean, atol=atol)
+
+                # Verify posterior.mean matches model(X).mean
+                with warnings.catch_warnings(), model.use_iterative_methods(tol=cg_tol):
+                    warnings.filterwarnings("ignore", category=NumericalWarning)
+                    model_mean = model(intf(test_X)).mean
+                    posterior = model.posterior(test_X, train_T)
+                n_x, n_t = test_X.shape[-2], train_T.shape[-2]
+                model_mean = model_mean.reshape(*model_mean.shape[:-1], n_x, n_t)
+                self.assertAllClose(
+                    model_mean,
+                    posterior.mean.reshape(model_mean.shape),
+                    atol=atol,
+                )
+
+                # Verify posterior variance is positive and finite
+                self.assertTrue((posterior.variance > 0).all())
+                self.assertTrue(posterior.variance.isfinite().all())
+
+                # Test _set_transformed_inputs fallback with single train input
+                saved_inputs = model.train_inputs
+                model.train_inputs = (saved_inputs[0],)
+                model._set_transformed_inputs()
+                model.train_inputs = saved_inputs
+
+                # Test forward() with single arg in training mode
+                model.train()
+                with warnings.catch_warnings(), model.use_iterative_methods(tol=cg_tol):
+                    warnings.filterwarnings("ignore", category=NumericalWarning)
+                    pred_1 = model.forward(train_X)
+                    pred_2 = model.forward(train_X, train_T)
+                self.assertAllClose(pred_1.mean, pred_2.mean, atol=atol)
+
+    def _test_solver_dispatch(self):
+        """Test that posterior uses Cholesky vs CG based on settings."""
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        data_kwargs = {"d": 2, "t": 3, "use_transforms": False, "tkwargs": tkwargs}
+        test_X = torch.rand(5, 2, **tkwargs)
+
+        # Test 1: Force CG by bypassing the Cholesky size threshold (default=800).
+        model, _, train_T, *_ = self._make_model(**data_kwargs)
+        model.eval()
+
+        with (
+            warnings.catch_warnings(),
+            model.use_iterative_methods(),
+            settings.max_cholesky_size(0),
+            patch(
+                "linear_operator.utils.linear_cg",
+                wraps=_linear_cg_fn,
+            ) as mock_cg,
+        ):
+            warnings.filterwarnings("ignore", category=NumericalWarning)
+            # Verify settings are correctly configured for CG
             self.assertTrue(settings._fast_covar_root_decomposition.off())
             self.assertTrue(settings._fast_log_prob.on())
             self.assertTrue(settings._fast_solves.on())
             self.assertEqual(settings.cg_tolerance.value(), 0.01)
             self.assertEqual(settings.max_cg_iterations.value(), 10000)
+            model.posterior(test_X, train_T)
+        self.assertTrue(mock_cg.called, "Expected CG solver to be used")
 
-    def test_not_implemented(self):
-        batch_shape = torch.Size([])
-        tkwargs = {"device": self.device, "dtype": torch.double}
+        # Test 2: Force Cholesky by disabling fast solves.
+        # Fresh model to avoid cached prediction strategy.
+        model, _, train_T, *_ = self._make_model(**data_kwargs)
+        model.eval()
 
-        train_X, train_T, train_Y, _ = _get_data_with_missing_entries(
-            n_train=10, d=1, t=1, batch_shape=batch_shape, tkwargs=tkwargs
-        )
+        with (
+            warnings.catch_warnings(),
+            settings.fast_computations(solves=False),
+            patch(
+                "linear_operator.utils.linear_cg",
+                wraps=_linear_cg_fn,
+            ) as mock_cg,
+        ):
+            warnings.filterwarnings("ignore", category=NumericalWarning)
+            self.assertTrue(settings._fast_solves.off())
+            model.posterior(test_X, train_T)
+        self.assertFalse(mock_cg.called, "Expected Cholesky solver, not CG")
 
-        model = LatentKroneckerGP(train_X=train_X, train_T=train_T, train_Y=train_Y)
-        model.to(**tkwargs)
+    # --- Data construction helpers ---
 
-        cls_name = model.__class__.__name__
-
-        transform = ScalarizedPosteriorTransform(torch.tensor([1.0], **tkwargs))
-        err_msg = f"Posterior transforms currently not supported for {cls_name}"
-        with self.assertRaisesRegex(NotImplementedError, err_msg):
-            model.posterior(train_X, posterior_transform=transform)
-
-        err_msg = f"Observation noise currently not supported for {cls_name}"
-        with self.assertRaisesRegex(NotImplementedError, err_msg):
-            model.posterior(train_X, observation_noise=True)
-
-        err_msg = f"Conditioning currently not supported for {cls_name}"
-        with self.assertRaisesRegex(NotImplementedError, err_msg):
-            model.condition_on_observations(train_X, train_Y)
-
-        likelihood = FixedNoiseGaussianLikelihood(
-            torch.tensor([1.0]), batch_shape=batch_shape, **tkwargs
-        )
-        model = LatentKroneckerGP(
-            train_X=train_X, train_T=train_T, train_Y=train_Y, likelihood=likelihood
-        )
-        model.to(**tkwargs)
-
-        err_msg = f"Only GaussianLikelihood currently supported for {cls_name}"
-        with self.assertRaisesRegex(NotImplementedError, err_msg):
-            model.posterior(train_X)
-
-    def test_construct_inputs(self) -> None:
+    def _test_construct_inputs(self) -> None:
         # This test relies on the fact that the random (missing) data generation
         # does not remove all occurrences of a particular X or T value. Therefore,
         # we fix the random seed and set n_train and t to slightly larger values.
-
         torch.manual_seed(12345)
-        for batch_shape, n_train, d, t, dtype in itertools.product(
-            (  # batch_shape
-                torch.Size([]),
-                torch.Size([1]),
-                torch.Size([2]),
-                torch.Size([2, 3]),
-            ),
-            (15,),  # n_train
-            (1, 2),  # d
-            (10,),  # t
-            (torch.float, torch.double),  # dtype
+        n_train, t = 15, 10
+        for batch_shape, d, dtype in itertools.product(
+            (torch.Size([]), torch.Size([1]), torch.Size([2]), torch.Size([2, 3])),
+            (1, 2),
+            (torch.float, torch.double),
         ):
             tkwargs = {"device": self.device, "dtype": dtype}
-
             train_X, train_T, train_Y, mask = _get_data_with_missing_entries(
                 n_train=n_train, d=d, t=t, batch_shape=batch_shape, tkwargs=tkwargs
             )
@@ -596,7 +543,6 @@ class TestLatentKroneckerGP(BotorchTestCase):
             )
             train_Y_supervised = train_Y.reshape(*batch_shape, n_train * t, 1)
 
-            # randomly permute data to test robustness to non-contiguous data
             idx = torch.randperm(n_train * t, device=self.device)
             train_X_supervised = train_X_supervised[..., idx, :][..., mask[idx], :]
             train_Y_supervised = train_Y_supervised[..., idx, :][..., mask[idx], :]
@@ -604,21 +550,53 @@ class TestLatentKroneckerGP(BotorchTestCase):
             dataset = SupervisedDataset(
                 X=train_X_supervised,
                 Y=train_Y_supervised,
-                Yvar=train_Y_supervised,  # just to check warning
+                Yvar=train_Y_supervised,
                 feature_names=[f"x_{i}" for i in range(d)] + ["step"],
                 outcome_names=["y"],
             )
 
-            w_msg = "Ignoring Yvar values in provided training data, because "
-            w_msg += "they are currently not supported by LatentKroneckerGP."
-            with self.assertWarnsRegex(InputDataWarning, w_msg):
+            with self.assertWarnsRegex(
+                InputDataWarning,
+                "Ignoring Yvar values in provided training data, because "
+                "they are currently not supported by LatentKroneckerGP.",
+            ):
                 model_inputs = LatentKroneckerGP.construct_inputs(dataset)
 
-            # this test generates train_X and train_T in sorted order
-            # the data is randomly permuted before passing to construct_inputs
-            # construct_inputs sorts the data, so we expect the results to be equal
             self.assertAllClose(model_inputs["train_X"], train_X, atol=0.0)
             self.assertAllClose(model_inputs["train_T"], train_T, atol=0.0)
             self.assertAllClose(
                 model_inputs["train_Y"], train_Y, atol=0.0, equal_nan=True
             )
+
+    # === Public test methods ===
+
+    def test_init(self):
+        self._test_default_init()
+        self._test_custom_init()
+
+    def test_train(self):
+        self._test_gp_train()
+
+    def test_eval(self):
+        for batch_shape in (
+            torch.Size([]),
+            torch.Size([1]),
+            torch.Size([2, 3]),
+        ):
+            for dtype in (torch.float, torch.double):
+                tkwargs = {"device": self.device, "dtype": dtype}
+                for use_transforms in (False, True):
+                    self._test_gp_eval_shapes(
+                        batch_shape=batch_shape,
+                        use_transforms=use_transforms,
+                        tkwargs=tkwargs,
+                    )
+        self._test_gp_eval_values()
+
+    def test_posterior(self):
+        self._test_not_implemented()
+        self._test_posterior_mean_and_variance()
+        self._test_solver_dispatch()
+
+    def test_construct_inputs(self):
+        self._test_construct_inputs()


### PR DESCRIPTION
Summary:

This commit improves the posterior inference stack of LKGP with partial observations, by leveraging the refactored GPyTorch posterior inference stack via `_get_test_prior_mean_and_covariances`.

The current GPyTorch implementation only masks out indices corresponding to `NaN` values [in the mean computation](https://www.internalfb.com/code/fbsource/[fbf7dc0a8abf]/fbcode/pytorch/gpytorch/gpytorch/models/exact_prediction_strategies.py?lines=351), but not the [posterior covariance computation](https://www.internalfb.com/code/fbsource/[fbf7dc0a8abf]/fbcode/pytorch/gpytorch/gpytorch/models/exact_prediction_strategies.py?lines=369). The design with `_get_test_prior_mean_and_covariances` allows us to override it in the LKGP / ProductGP implementation and take care of the masking there, which has the added benefit of keeping the special implementation close to the model definition, increasing code clarity.

Differential Revision: D92872372


