### PR TITLE
Pathwise thompson sampling as option for ACQF factory

### DIFF
--- a/botorch/acquisition/factory.py
+++ b/botorch/acquisition/factory.py
@@ -19,8 +19,8 @@ from botorch.acquisition.multi_objective import (
     monte_carlo as moo_monte_carlo,
 )
 from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform
-from botorch.acquisition.utils import compute_best_feasible_objective
 from botorch.acquisition.thompson_sampling import PathwiseThompsonSampling
+from botorch.acquisition.utils import compute_best_feasible_objective
 from botorch.models.model import Model
 from botorch.sampling.get_sampler import get_sampler
 from botorch.utils.multi_objective.box_decompositions.non_dominated import (

--- a/test/acquisition/test_factory.py
+++ b/test/acquisition/test_factory.py
@@ -19,12 +19,12 @@ from botorch.acquisition.objective import (
     MCAcquisitionObjective,
     ScalarizedPosteriorTransform,
 )
+from botorch.acquisition.thompson_sampling import PathwiseThompsonSampling
 from botorch.acquisition.utils import compute_best_feasible_objective
 from botorch.utils.multi_objective.box_decompositions.non_dominated import (
     FastNondominatedPartitioning,
     NondominatedPartitioning,
 )
-from botorch.acquisition.thompson_sampling import PathwiseThompsonSampling
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
 from gpytorch.distributions import MultivariateNormal
 from torch import Tensor


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR adds the option to initialise `PathwiseThompsonSampling` via `get_acquisition_function`. I know that only MC acqfs are currently supported in this method, but for me `PathwiseThompsonSampling` is still a good fit here as it also allows for any kind of `MCAcquisitionObjective` despite being technically an analytical acqf.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.


