### PR TITLE
Add default BetaPrior(2.5, 1.5) for MultiTaskGP task covariance (#3271)

### DIFF
--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -45,6 +45,7 @@ from botorch.models.utils.gpytorch_modules import (
     get_covar_module_with_dim_scaled_prior,
     MIN_INFERRED_NOISE_LEVEL,
 )
+from botorch.models.utils.priors import BetaPrior
 from botorch.posteriors.multitask import MultitaskGPPosterior
 from botorch.utils.datasets import MultiTaskDataset, SupervisedDataset
 from botorch.utils.types import _DefaultType, DEFAULT
@@ -158,7 +159,7 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
         mean_module: Module | None = None,
         covar_module: Module | None = None,
         likelihood: Likelihood | None = None,
-        task_covar_prior: Prior | None = None,
+        task_covar_prior: Prior | _DefaultType | None = DEFAULT,
         output_tasks: list[int] | None = None,
         rank: int | None = None,
         all_tasks: list[int] | None = None,
@@ -189,8 +190,9 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
                 outputs for. If omitted, return outputs for all task indices.
             rank: The rank to be used for the index kernel. If omitted, use a
                 full rank (i.e. number of tasks) kernel.
-            task_covar_prior : A Prior on the task covariance matrix. Must operate
-                on p.s.d. matrices. A common prior for this is the ``LKJ`` prior.
+            task_covar_prior : A Prior on the task covariance matrix. Defaults to
+                ``BetaPrior(2.5, 1.5)`` which biases task correlations toward
+                positive values. Pass ``None`` to use no prior.
             all_tasks: By default, multi-task GPs infer the list of all tasks from
                 the task features in ``train_X``. This is an experimental feature that
                 enables creation of multi-task GPs with tasks that don't appear in the
@@ -330,6 +332,8 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
                 data_covar_module.active_dims = self._base_idxr
 
         self._rank = rank if rank is not None else self.num_tasks
+        if task_covar_prior is DEFAULT:
+            task_covar_prior = BetaPrior(concentration1=2.5, concentration0=1.5)
         task_covar_module = PositiveIndexKernel(
             num_tasks=self.num_tasks,
             rank=self._rank,
@@ -479,7 +483,7 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
         training_data: SupervisedDataset | MultiTaskDataset,
         task_feature: int,
         output_tasks: list[int] | None = None,
-        task_covar_prior: Prior | None = None,
+        task_covar_prior: Prior | _DefaultType | None = DEFAULT,
         prior_config: dict | None = None,
         rank: int | None = None,
     ) -> dict[str, Any]:
@@ -491,14 +495,20 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
             output_tasks: A list of task indices for which to compute model
                 outputs for. If omitted, return outputs for all task indices.
             task_covar_prior: A GPyTorch ``Prior`` object to use as prior on
-                the cross-task covariance matrix,
+                the cross-task covariance matrix. Defaults to ``DEFAULT``
+                which uses ``BetaPrior(2.5, 1.5)`` in the model. Pass
+                ``None`` to use no prior.
             prior_config: Configuration for inter-task covariance prior.
                 Should only be used if ``task_covar_prior`` is not passed directly.
                 Must contain ``use_LKJ_prior`` indicator and should contain float
                 value ``eta``.
             rank: The rank of the cross-task covariance matrix.
         """
-        if task_covar_prior is not None and prior_config is not None:
+        if (
+            task_covar_prior is not DEFAULT
+            and task_covar_prior is not None
+            and prior_config is not None
+        ):
             raise ValueError(
                 "Only one of `task_covar_prior` and `prior_config` arguments expected."
             )
@@ -525,7 +535,7 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
         ):
             all_tasks = list(range(len(training_data.datasets)))
             base_inputs["all_tasks"] = all_tasks
-        if task_covar_prior is not None:
+        if task_covar_prior is not DEFAULT:
             base_inputs["task_covar_prior"] = task_covar_prior
         if rank is not None:
             base_inputs["rank"] = rank

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -22,6 +22,7 @@ from botorch.models.multitask import (
 )
 from botorch.models.transforms.input import InputTransform, Normalize
 from botorch.models.transforms.outcome import OutcomeTransform, Standardize
+from botorch.models.utils.priors import BetaPrior
 from botorch.posteriors import GPyTorchPosterior
 from botorch.posteriors.transformed import TransformedPosterior
 from botorch.utils.test_helpers import gen_multi_task_dataset
@@ -128,6 +129,58 @@ def _gen_kronecker_model_and_data(model_kwargs=None, batch_shape=None, **tkwargs
 class TestMultiTaskGP(BotorchTestCase):
     def test_supports_batched_models(self) -> None:
         self.assertFalse(MultiTaskGP._supports_batched_models)
+
+    def test_default_task_covar_prior(self) -> None:
+        tkwargs: dict[str, Any] = {"device": self.device, "dtype": torch.double}
+        _, (train_X, train_Y, _) = gen_multi_task_dataset(**tkwargs)
+
+        def _get_task_kernel(model):
+            _, task_covar_module = model.covar_module.kernels
+            return task_covar_module
+
+        # Default: BetaPrior is used
+        model = MultiTaskGP(train_X, train_Y, task_feature=0).to(**tkwargs)
+        task_kernel = _get_task_kernel(model)
+        self.assertTrue(hasattr(task_kernel, "IndexKernelPrior"))
+        self.assertIsInstance(task_kernel.IndexKernelPrior, BetaPrior)
+
+        # Explicit None: no prior
+        model_no_prior = MultiTaskGP(
+            train_X, train_Y, task_feature=0, task_covar_prior=None
+        ).to(**tkwargs)
+        task_kernel_none = _get_task_kernel(model_no_prior)
+        self.assertFalse(hasattr(task_kernel_none, "IndexKernelPrior"))
+
+        # Custom prior: passed through
+        custom_prior = SmoothedBoxPrior(0.0, 1.0)
+        model_custom = MultiTaskGP(
+            train_X, train_Y, task_feature=0, task_covar_prior=custom_prior
+        ).to(**tkwargs)
+        task_kernel_custom = _get_task_kernel(model_custom)
+        self.assertTrue(hasattr(task_kernel_custom, "IndexKernelPrior"))
+        self.assertIsInstance(task_kernel_custom.IndexKernelPrior, SmoothedBoxPrior)
+
+    def test_construct_inputs_task_covar_prior(self) -> None:
+        tkwargs: dict[str, Any] = {"device": self.device, "dtype": torch.double}
+        dataset, _ = gen_multi_task_dataset(**tkwargs)
+
+        # Default: task_covar_prior not in base_inputs (model uses DEFAULT)
+        base_inputs = MultiTaskGP.construct_inputs(dataset, task_feature=0)
+        self.assertNotIn("task_covar_prior", base_inputs)
+
+        # Explicit None: task_covar_prior=None passed through
+        base_inputs_none = MultiTaskGP.construct_inputs(
+            dataset, task_feature=0, task_covar_prior=None
+        )
+        self.assertIn("task_covar_prior", base_inputs_none)
+        self.assertIsNone(base_inputs_none["task_covar_prior"])
+
+        # Custom prior: passed through
+        custom_prior = SmoothedBoxPrior(0.0, 1.0)
+        base_inputs_custom = MultiTaskGP.construct_inputs(
+            dataset, task_feature=0, task_covar_prior=custom_prior
+        )
+        self.assertIs(base_inputs_custom["task_covar_prior"], custom_prior)
 
     def test_MultiTaskGP(self) -> None:
         bounds = torch.tensor([[0.0, 0.0], [1.0, 1.0]])


### PR DESCRIPTION
Summary:

Add a default BetaPrior(2.5, 1.5) on the task covariance correlations in
MultiTaskGP. This biases the model toward positive inter-task correlations,
which is the common case in transfer learning settings where source tasks
are expected to be informative for the target task.

Benchmarked on 5 zenith transfer learning problems with 40 replications
each, comparing MTGP with no prior, BetaPrior(1.2, 0.9), BetaPrior(2.5, 1.5),
and SingleTaskGP. The BetaPrior improves optimization performance across
benchmarks relative to the no-prior baseline.

Differential Revision: D100162296


