### PR TITLE
Fix PairwiseGP stored-state management for eval and CV

### DIFF
--- a/botorch/models/pairwise_gp.py
+++ b/botorch/models/pairwise_gp.py
@@ -902,8 +902,18 @@ class PairwiseGP(Model, GP, FantasizeMixin):
     def load_state_dict(
         self, state_dict: dict[str, Tensor], strict: bool = False
     ) -> _IncompatibleKeys:
-        r"""Removes data related buffers from the ``state_dict`` and calls
-        ``super().load_state_dict`` with ``strict=False``.
+        r"""Load kernel hyperparameters and recompute Laplace approximation.
+
+        ``_load_from_state_dict`` filters out data-dependent buffers (utility,
+        covariance Cholesky, likelihood Hessian, etc.), loading only kernel
+        hyperparameters (lengthscale, outputscale). After loading, we recompute
+        the Laplace approximation so that the MAP utility and derived tensors
+        are consistent with both the loaded hyperparameters and the current
+        training data. Without this recomputation, the model would use stale
+        Laplace tensors computed during ``__init__`` with default hyperparameters,
+        producing an inconsistent (non-PSD) posterior -- e.g., during
+        cross-validation where the model is constructed on fold data and then
+        loaded with hyperparameters from the full model.
 
         Args:
             state_dict: The state dict.
@@ -919,7 +929,15 @@ class PairwiseGP(Model, GP, FantasizeMixin):
         if strict:
             raise UnsupportedError("Passing strict=True is not supported.")
 
-        return super().load_state_dict(state_dict=state_dict, strict=False)
+        result = super().load_state_dict(state_dict=state_dict, strict=False)
+
+        # Recompute Laplace approximation with the newly loaded kernel
+        # hyperparameters on the current training data.
+        if self.datapoints is not None and self.comparisons is not None:
+            transformed_dp = self.transform_inputs(self.datapoints)
+            self._update(transformed_dp)
+
+        return result
 
     def _load_from_state_dict(
         self,
@@ -1021,15 +1039,25 @@ class PairwiseGP(Model, GP, FantasizeMixin):
                 self._update_utility_derived_values()
 
             X, X_new = self._transform_batch_shape(transformed_dp, transformed_new_dp)
-            covar_chol, _ = self._transform_batch_shape(self.covar_chol, X_new)
-            hl, _ = self._transform_batch_shape(self.likelihood_hess, X_new)
-            hlcov_eye, _ = self._transform_batch_shape(self.hlcov_eye, X_new)
+
+            # Detach stored tensors from their training-time computation
+            # graphs. During training, these tensors (especially self.utility,
+            # computed via Newton updates) carry graphs through kernel
+            # hyperparameters for fit_gpytorch_mll backward. After training,
+            # those graphs are freed by the final training backward. In eval
+            # mode, we only need the tensor values for prediction — not the
+            # stale training graphs. Detaching enables callers (e.g.,
+            # sensitivity analysis) to call .backward() on predictions
+            # without hitting "backward through the graph a second time."
+            covar_chol, _ = self._transform_batch_shape(self.covar_chol.detach(), X_new)
+            hl, _ = self._transform_batch_shape(self.likelihood_hess.detach(), X_new)
+            hlcov_eye, _ = self._transform_batch_shape(self.hlcov_eye.detach(), X_new)
 
             # otherwise compute predictive mean and covariance
             covar_xnew_x = self._calc_covar(X_new, X)
             covar_x_xnew = covar_xnew_x.transpose(-1, -2)
             covar_xnew = self._calc_covar(X_new, X_new)
-            p = self.utility - self._prior_mean(X)
+            p = self.utility.detach() - self._prior_mean(X)
 
             covar_inv_p = torch.cholesky_solve(p.unsqueeze(-1), covar_chol)
             pred_mean = (covar_xnew_x @ covar_inv_p).squeeze(-1)

--- a/test/models/test_pairwise_gp.py
+++ b/test/models/test_pairwise_gp.py
@@ -423,10 +423,55 @@ class TestPairwiseGP(BotorchTestCase):
         for buffer_name in model._buffer_names:
             model.register_buffer(buffer_name, None)
 
-        # Check that instance buffers were not restored
+        # Check that instance buffers were not restored when data is None
+        # (the guard `if self.datapoints is not None` prevents _update)
         _ = model.load_state_dict(sd)
         for buffer_name in model._buffer_names:
             self.assertIsNone(model.get_buffer(buffer_name))
+
+    def test_load_state_dict_recomputes_laplace(self) -> None:
+        """Loading state_dict into a model with different training data
+        should recompute the Laplace approximation so the posterior is
+        consistent. This is the scenario during cross-validation: a new
+        model is constructed on fold data and loaded with hyperparameters
+        from the full model."""
+        tkwargs = {"device": self.device, "dtype": self.dtype}
+        # Full model: 5 datapoints, 4 comparisons
+        full_X = torch.rand(5, 2, **tkwargs)
+        full_comp = torch.tensor([[0, 1], [1, 2], [2, 3], [3, 4]])
+        full_model = PairwiseGP(datapoints=full_X, comparisons=full_comp)
+        fit_gpytorch_mll(
+            PairwiseLaplaceMarginalLogLikelihood(full_model.likelihood, full_model)
+        )
+        full_sd = full_model.state_dict()
+        full_utility = full_model.utility.clone()
+
+        # CV fold model: same datapoints, fewer comparisons
+        fold_comp = torch.tensor([[0, 1], [2, 3]])
+        fold_model = PairwiseGP(datapoints=full_X.clone(), comparisons=fold_comp)
+
+        # Before load_state_dict: utility was computed with default hyperparams
+        utility_before = fold_model.utility.clone()
+
+        # Load full model's hyperparameters — should recompute Laplace
+        fold_model.load_state_dict(full_sd)
+
+        # Utility should have been recomputed (different from both the
+        # full model's utility and the pre-load default-hyperparam utility)
+        utility_after = fold_model.utility
+        assert utility_after is not None
+        # Recomputed utility should differ from the pre-load utility
+        # (because kernel hyperparameters changed)
+        self.assertFalse(torch.allclose(utility_before, utility_after))
+        # Recomputed utility should also differ from the full model's
+        # (because comparisons differ)
+        self.assertFalse(torch.allclose(full_utility, utility_after))
+
+        # The posterior should be valid (no NotPSDError)
+        fold_model.eval()
+        X_test = torch.rand(3, 2, **tkwargs)
+        posterior = fold_model.posterior(X_test)
+        self.assertEqual(posterior.mean.shape, torch.Size([3, 1]))
 
     def test_helper_functions(self) -> None:
         for batch_shape in (torch.Size(), torch.Size([2])):


### PR DESCRIPTION
Summary:
## Summary

Two fixes to PairwiseGP's management of Laplace approximation intermediates (`utility`, `covar_chol`, `likelihood_hess`, `hlcov_eye`):

### Fix 1: Detach stored tensors in eval-mode forward

During training, `_update()` computes these tensors via Newton updates with `requires_grad_(True)`, building computation graphs through kernel hyperparameters for `fit_gpytorch_mll` backward. After training, `.backward()` frees these graphs -- but the tensors persist with stale graph references.

In eval mode, `forward()` reuses these stored tensors. Any caller that needs input gradients (e.g., sensitivity analysis DGSM) hits the freed graph and crashes with "backward through the graph a second time."

Fix: detach stored tensors in the eval-mode branch of `forward()`. In eval mode, callers only need prediction values and input gradients -- not hyperparameter gradients through training-time computation graphs.

### Fix 2: Recompute Laplace approximation in `load_state_dict`

Cross-validation crashes with `NotPSDError` when loading hyperparameters from a model fitted on different training data (e.g., full dataset → CV fold). Root cause: `_load_from_state_dict` correctly filters out data-dependent buffers, loading only kernel hyperparameters. But the Laplace tensors computed during `__init__` (with default hyperparameters) remain stale -- they don't match the loaded kernel hyperparameters. The eval-mode `forward()` then uses these mismatched tensors, producing an inconsistent (non-PSD) posterior covariance.

Fix: override `load_state_dict` to call `_update()` after loading, recomputing the Laplace approximation with the loaded kernel hyperparameters on the current training data. This requires no changes to Ax's generic `Surrogate` code -- PairwiseGP encapsulates its own state management.

Reviewed By: saitcakmak

Differential Revision: D99173855


