### PR TITLE
Fix test_cuda failure: use BotorchTestCase for TestBetaPrior

### DIFF
--- a/test/models/utils/test_priors.py
+++ b/test/models/utils/test_priors.py
@@ -4,15 +4,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
-
 import torch
 from botorch.models.utils.priors import BetaPrior
+from botorch.utils.testing import BotorchTestCase
 from gpytorch.priors.utils import BUFFERED_PREFIX
 from torch.distributions import Beta
 
 
-class TestBetaPrior(unittest.TestCase):
+class TestBetaPrior(BotorchTestCase):
     def test_init(self):
         prior = BetaPrior(1.2, 0.9)
         self.assertAlmostEqual(prior.concentration1.item(), 1.2)


### PR DESCRIPTION
Summary:
TestBetaPrior extends unittest.TestCase instead of BotorchTestCase, which causes test_cuda.py to hit a ValueError. The test_cuda dispatcher only handles BotorchTestCase, TestSuite, self-reference, and _FailedTest — plain unittest.TestCase hits the else branch and raises.

Switch to BotorchTestCase for consistency with the rest of the test suite.

Differential Revision: D100337776


