### PR TITLE
Speed up qLogEHVI using a fused kernel (#3275)

### DIFF
--- a/botorch/acquisition/multi_objective/logei.py
+++ b/botorch/acquisition/multi_objective/logei.py
@@ -6,16 +6,30 @@
 r"""
 Multi-objective variants of the LogEI family of acquisition functions, see
 [Ament2023logei]_ for details.
+
+A fused C++ kernel is available that accelerates the inner loop of
+``_compute_log_qehvi`` by ~1.5-3x on CPU.  It is loaded lazily on first
+acquisition function construction — either from a pre-compiled extension
+(Buck builds) or via JIT compilation (pip installs).  If loading fails the
+pure-Python implementation is used transparently.
+
+For pip installs, JIT compilation requires a C++ compiler (``gcc`` or
+``clang``) to be available on the system.  The ``ninja`` build system is
+included as a dependency.  The kernel is compiled once on first use (~7 s)
+and cached by PyTorch for subsequent imports.
 """
 
 from __future__ import annotations
 
+import os
+import warnings
 from collections.abc import Callable
 
 import torch
 from botorch.acquisition.logei import TAU_MAX, TAU_RELU
 from botorch.acquisition.multi_objective.base import MultiObjectiveMCAcquisitionFunction
 from botorch.acquisition.multi_objective.objective import MCMultiOutputObjective
+from botorch.logging import logger
 from botorch.models.model import Model
 from botorch.sampling.base import MCSampler
 from botorch.utils.multi_objective.box_decompositions.non_dominated import (
@@ -42,6 +56,116 @@ from botorch.utils.transforms import (
     t_batch_mode_transform,
 )
 from torch import Tensor
+
+_C = None  # Fused C++ kernel module, loaded lazily by _try_load_fused_kernel().
+_load_attempted = False  # Sentinel to avoid retrying after a failed load.
+
+
+def _try_load_fused_kernel() -> None:
+    """Load the fused C++ kernel if available, storing it in module-level ``_C``.
+
+    Tries the pre-compiled Buck extension first, then falls back to JIT
+    compilation for pip/source installs.  Called from ``__init__`` of the
+    acquisition functions so the cost is deferred until actually needed.
+    Only attempts loading once; subsequent calls are no-ops.
+    """
+    global _C, _load_attempted
+    if _load_attempted:
+        return
+    _load_attempted = True
+    try:  # pragma: no cover
+        import logei_fused_ext
+
+        _C = logei_fused_ext
+        return
+    except ImportError:
+        pass
+    try:
+        from torch.utils.cpp_extension import load as _load_ext
+
+        _cpp_src = os.path.join(
+            os.path.dirname(__file__), os.pardir, os.pardir, "csrc", "logei_fused.cpp"
+        )
+        _C = _load_ext(
+            name="logei_fused_ext",
+            sources=[os.path.abspath(_cpp_src)],
+            extra_cflags=["-O3", "-march=native"],
+            verbose=False,
+        )
+    except Exception as exc:  # pragma: no cover
+        warnings.warn(
+            f"Failed to compile fused qLogEHVI C++ extension: {exc}. "
+            "Falling back to the pure-Python implementation. "
+            "To get ~3x speedup, ensure a C++ compiler and the `ninja` "
+            "package are installed.",
+            stacklevel=2,
+        )
+        logger.debug("C++ extension compilation error", exc_info=True)
+
+
+class _FusedLogAreas(torch.autograd.Function):
+    """Custom autograd function wrapping the fused C++ kernel.
+
+    Fuses steps 1-4 of ``_compute_log_qehvi`` into a single C++ call.
+    In the pure-Python path these steps are:
+
+    1. ``_log_improvement`` — log smoothed ReLU of (obj - cell_lower),
+    2. ``_smooth_min`` — smooth minimum over subset elements,
+    3. ``_log_cell_lengths`` — smooth minimum with log cell side lengths,
+    4. ``sum`` over objectives to get log areas.
+    """
+
+    @staticmethod
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        obj_subsets: Tensor,
+        cell_lower: Tensor,
+        cell_upper: Tensor,
+        tau_relu: float,
+        tau_max: float,
+    ) -> Tensor:
+        batch_shape = obj_subsets.shape[:-3]
+        B = max(1, int(torch.Size(batch_shape).numel()))
+        obj_flat = obj_subsets.reshape(B, *obj_subsets.shape[-3:])
+
+        # Reshape cell bounds to 3-D (B_cells, nc, m) for the C++ kernel.
+        # Non-batched (2-D) bounds are left as-is; the kernel handles both.
+        nc, m_cells = cell_lower.shape[-2], cell_lower.shape[-1]
+        if cell_lower.ndim > 2:
+            cell_lower = cell_lower.reshape(-1, nc, m_cells)
+            cell_upper = cell_upper.reshape(-1, nc, m_cells)
+
+        result = _C.forward(obj_flat, cell_lower, cell_upper, tau_relu, tau_max)
+
+        ctx.save_for_backward(obj_flat, cell_lower, cell_upper)
+        ctx.tau_relu = tau_relu
+        ctx.tau_max = tau_max
+        ctx.orig_shape = obj_subsets.shape
+
+        return result.reshape(*batch_shape, result.shape[-2], result.shape[-1])
+
+    @staticmethod
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_output: Tensor,
+    ) -> tuple[Tensor | None, ...]:
+        obj_flat, cell_lower, cell_upper = ctx.saved_tensors
+        B = obj_flat.shape[0]
+
+        grad_flat = grad_output.reshape(B, *grad_output.shape[-2:])
+
+        grad_obj = _C.backward(
+            grad_flat,
+            obj_flat,
+            cell_lower,
+            cell_upper,
+            ctx.tau_relu,
+            ctx.tau_max,
+        )
+
+        # Gradients for: obj_subsets, cell_lower, cell_upper, tau_relu, tau_max.
+        # Only obj_subsets needs a gradient; the rest are non-differentiable.
+        return grad_obj.reshape(ctx.orig_shape), None, None, None, None
 
 
 class qLogExpectedHypervolumeImprovement(
@@ -142,9 +266,15 @@ class qLogExpectedHypervolumeImprovement(
         self.tau_relu = tau_relu
         self.tau_max = tau_max
         self.fat = fat
+        _try_load_fused_kernel()
 
     def _compute_log_qehvi(self, samples: Tensor, X: Tensor | None = None) -> Tensor:
         r"""Compute the expected (feasible) hypervolume improvement given MC samples.
+
+        When the fused C++ kernel is available and the cell bounds are not
+        batched (the common case for ``qLogEHVI``), steps 1-4 of the inner
+        loop are replaced by a single fused call for ~1.5-3x speedup on CPU.
+        Otherwise the pure-Python path is used.
 
         Args:
             samples: A ``sample_shape x batch_shape x q' x m``-dim tensor of samples.
@@ -181,29 +311,58 @@ class qLogExpectedHypervolumeImprovement(
             device=device,
         )
 
+        # The fused C++ kernel supports non-batched (qLogEHVI) and batched
+        # (qLogNEHVI, fully Bayesian) cell bounds, with fat=True on CPU.
+        # When obj has extra t-batch dims that broadcast against the cell
+        # bounds, we expand cell bounds to match before flattening.
         cell_batch_ndim = self.cell_lower_bounds.ndim - 2
-        # conditionally adding mc_samples dim if cell_batch_ndim > 0
-        # adding ones to shape equal in number to to batch_shape_ndim - cell_batch_ndim
-        # adding cell_bounds batch shape w/o 1st dimension
-        sample_batch_view_shape = torch.Size(
-            [
-                batch_shape[0] if cell_batch_ndim > 0 else 1,
-                *[1 for _ in range(len(batch_shape) - max(cell_batch_ndim, 1))],
-                *self.cell_lower_bounds.shape[1:-2],
-            ]
-        )
-        view_shape = (
-            *sample_batch_view_shape,
-            self.cell_upper_bounds.shape[-2],  # num_cells
-            1,  # adding for q_choose_i dimension
-            self.cell_upper_bounds.shape[-1],  # num_objectives
-        )
+        use_fused = _C is not None and self.fat and obj.device.type == "cpu"
+
+        if use_fused and cell_batch_ndim > 0:
+            # Expand cell bounds to match obj batch shape for 1:1 mapping.
+            # Insert 1-dims at t-batch positions, then expand + reshape to 3-D.
+            n_tbatch = len(batch_shape) - cell_batch_ndim
+            if n_tbatch > 0:
+                # cell shape: (mc, *model_batch, nc, m)
+                # target:     (mc, *t_batch, *model_batch, nc, m)
+                expand_shape = (
+                    self.cell_lower_bounds.shape[0],  # mc_samples
+                    *[1] * n_tbatch,  # 1s for t-batch dims
+                    *self.cell_lower_bounds.shape[1:],  # model_batch + nc + m
+                )
+                fused_cell_lower = self.cell_lower_bounds.view(expand_shape).expand(
+                    *batch_shape, *self.cell_lower_bounds.shape[-2:]
+                )
+                fused_cell_upper = self.cell_upper_bounds.view(expand_shape).expand(
+                    *batch_shape, *self.cell_upper_bounds.shape[-2:]
+                )
+            else:
+                fused_cell_lower = self.cell_lower_bounds
+                fused_cell_upper = self.cell_upper_bounds
+        elif use_fused:
+            fused_cell_lower = self.cell_lower_bounds
+            fused_cell_upper = self.cell_upper_bounds
+
+        if not use_fused:
+            # conditionally adding mc_samples dim if cell_batch_ndim > 0
+            # adding ones to shape equal in number to batch_shape_ndim -
+            # cell_batch_ndim
+            # adding cell_bounds batch shape w/o 1st dimension
+            sample_batch_view_shape = torch.Size(
+                [
+                    batch_shape[0] if cell_batch_ndim > 0 else 1,
+                    *[1 for _ in range(len(batch_shape) - max(cell_batch_ndim, 1))],
+                    *self.cell_lower_bounds.shape[1:-2],
+                ]
+            )
+            view_shape = (
+                *sample_batch_view_shape,
+                self.cell_upper_bounds.shape[-2],  # num_cells
+                1,  # adding for q_choose_i dimension
+                self.cell_upper_bounds.shape[-1],  # num_objectives
+            )
 
         for i in range(1, self.q_out + 1):
-            # TODO: we could use batches to compute (q choose i) and (q choose q-i)
-            # simultaneously since subsets of size i and q-i have the same number of
-            # elements. This would decrease the number of iterations, but increase
-            # memory usage.
             q_choose_i = q_subset_indices[f"q_choose_{i}"]  # q_choose_i x i
             # this tensor is mc_samples x batch_shape x i x q_choose_i x m
             obj_subsets = obj.index_select(dim=-2, index=q_choose_i.view(-1))
@@ -211,30 +370,33 @@ class qLogExpectedHypervolumeImprovement(
                 obj.shape[:-2] + q_choose_i.shape + obj.shape[-1:]
             )  # mc_samples x batch_shape x q_choose_i x i x m
 
-            # NOTE: the order of operations in non-log _compute_qehvi is 3), 1), 2).
-            # since 3) moved above 1), _log_improvement adds another Tensor dimension
-            # that keeps track of num_cells.
+            if use_fused:
+                # Fused C++ kernel: steps 1-4 in one pass.
+                # Input:  (*batch, n_subsets, i, m)
+                # Output: (*batch, num_cells, n_subsets)
+                log_areas_i = _FusedLogAreas.apply(
+                    obj_subsets,
+                    fused_cell_lower,
+                    fused_cell_upper,
+                    self.tau_relu,
+                    self.tau_max,
+                )
+            else:
+                # Pure-Python path (steps 1-4).
+                # 1) computes log smoothed improvement over cell lower bounds.
+                log_improvement_i = self._log_improvement(obj_subsets, view_shape)
 
-            # 1) computes log smoothed improvement over the cell lower bounds.
-            # mc_samples x batch_shape x num_cells x q_choose_i x i x m
-            log_improvement_i = self._log_improvement(obj_subsets, view_shape)
+                # 2) take the minimum log improvement over all i subsets.
+                log_improvement_i = self._smooth_min(
+                    log_improvement_i,
+                    dim=-2,
+                )
 
-            # 2) take the minimum log improvement over all i subsets.
-            # since all hyperrectangles share one vertex, the opposite vertex of the
-            # overlap is given by the component-wise minimum.
-            # negative of maximum of negative log_improvement is approximation to min.
-            log_improvement_i = self._smooth_min(
-                log_improvement_i,
-                dim=-2,
-            )  # mc_samples x batch_shape x num_cells x q_choose_i x m
+                # 3) compute the log lengths of the cells' sides.
+                log_lengths_i = self._log_cell_lengths(log_improvement_i, view_shape)
 
-            # 3) compute the log lengths of the cells' sides.
-            # mc_samples x batch_shape x num_cells x q_choose_i x m
-            log_lengths_i = self._log_cell_lengths(log_improvement_i, view_shape)
-
-            # 4) take product over hyperrectangle side lengths to compute area (m-dim).
-            # after, log_areas_i is mc_samples x batch_shape x num_cells x q_choose_i
-            log_areas_i = log_lengths_i.sum(dim=-1)  # areas_i = lengths_i.prod(dim=-1)
+                # 4) take product over hyperrectangle side lengths.
+                log_areas_i = log_lengths_i.sum(dim=-1)
 
             # 5) if constraints are present, apply a differentiable approximation of
             # the indicator function.
@@ -250,8 +412,6 @@ class qLogExpectedHypervolumeImprovement(
 
             # 7) Using the inclusion-exclusion principle, set the sign to be positive
             # for subsets of odd sizes and negative for subsets of even size
-            # in non-log space: areas_per_segment += (-1) ** (i + 1) * areas_i,
-            # but here in log space, we need to keep track of sign:
             log_areas_per_segment[..., i % 2] = logplusexp(
                 log_areas_per_segment[..., i % 2],
                 log_areas_i,
@@ -439,6 +599,7 @@ class qLogNoisyExpectedHypervolumeImprovement(
         self.tau_relu = tau_relu
         self.tau_max = tau_max
         self.fat = fat
+        _try_load_fused_kernel()
 
     @t_batch_mode_transform()
     @average_over_ensemble_models

--- a/botorch/csrc/logei_fused.cpp
+++ b/botorch/csrc/logei_fused.cpp
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Fused kernel for qLogEHVI / qLogNEHVI inner loop.
+//
+// Supports both non-batched cell bounds (num_cells, m) for qLogEHVI
+// and batched cell bounds (B_cells, num_cells, m) for qLogNEHVI.
+//
+// Optimizations:
+//   - Precomputed 1/tau (division → multiplication)
+//   - Fused log_fatplus_fwd_bwd (avoids redundant exp/sigmoid/cauchy)
+//   - Fused pareto_val_deriv (single denominator computation)
+//   - Local gradient accumulation buffer in backward
+//   - Transposed li layout: li[MAX_M][MAX_I] for contiguous fatmin reads
+
+#include <torch/extension.h>
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+// Leaky-tail coefficient for the "fat" softplus approximation.
+// Must match the Python-side ALPHA_RELU in botorch.utils.safe_math.
+constexpr double ALPHA_RELU = 0.1;
+
+// Static upper bounds for stack-allocated scratch arrays.
+// MAX_I: maximum subset size (q choose i).
+// MAX_M: maximum number of objectives.
+constexpr int MAX_I = 16;
+constexpr int MAX_M = 8;
+
+// Numerically stable softplus: log(1 + exp(y)).
+// Avoids overflow for large y and underflow for very negative y.
+template <typename T>
+inline T safe_softplus(T y) {
+  if (y > T(20)) {
+    return y;
+  }
+  if (y < T(-20)) {
+    return std::exp(y);
+  }
+  return std::log1p(std::exp(y));
+}
+
+// Numerically stable sigmoid: 1 / (1 + exp(-y)).
+// Uses the exp(y) form for negative y to avoid overflow in exp(-y).
+template <typename T>
+inline T safe_sigmoid(T y) {
+  if (y >= T(0)) {
+    T e = std::exp(-y);
+    return T(1) / (T(1) + e);
+  } else {
+    T e = std::exp(y);
+    return e / (T(1) + e);
+  }
+}
+
+// Cauchy-like density kernel: 1 / (1 + y^2).
+template <typename T>
+inline T cauchy_val(T y) {
+  return T(1) / (T(1) + y * y);
+}
+
+// Pareto density and its derivative, used in the smooth-min (fatmin).
+// f(z) = 2 / (2 + 2z + z^2), f'(z) = -2(2 + 2z) / (2 + 2z + z^2)^2.
+template <typename T>
+inline void pareto_val_deriv(T z, T& val, T& deriv) {
+  T d = T(2) + T(2) * z + z * z;
+  val = T(2) / d;
+  deriv = T(-2) * (T(2) + T(2) * z) / (d * d);
+}
+
+// Forward-only Pareto density (no derivative needed).
+template <typename T>
+inline T pareto_val_only(T z) {
+  T d = T(2) + T(2) * z + z * z;
+  return T(2) / d;
+}
+
+// log(fatplus(x, tau)): log of the fat-tailed softplus approximation to ReLU.
+// fatplus(x, tau) = tau * (softplus(x/tau) + ALPHA_RELU * cauchy(x/tau)).
+template <typename T>
+inline T log_fatplus_fwd(T x, T tau, T inv_tau) {
+  T y = x * inv_tau;
+  T f = safe_softplus(y) + T(ALPHA_RELU) * cauchy_val(y);
+  T val = tau * f;
+  return val > T(0) ? std::log(val) : T(-1e30);
+}
+
+// Combined forward + backward for log_fatplus. Computes both the value and
+// d(log_fatplus)/dx in a single pass, reusing intermediate quantities.
+template <typename T>
+inline void log_fatplus_fwd_bwd(T x, T tau, T inv_tau, T& val, T& grad) {
+  T y = x * inv_tau;
+  T cy = cauchy_val(y);
+  T sp = safe_softplus(y);
+  T f = sp + T(ALPHA_RELU) * cy;
+  T tf = tau * f;
+  if (tf <= T(0)) {
+    val = T(-1e30);
+    grad = T(0);
+    return;
+  }
+  val = std::log(tf);
+  T sg = safe_sigmoid(y);
+  T fp = sg - T(2) * T(ALPHA_RELU) * y * cy * cy;
+  grad = fp / (tau * f);
+}
+
+// Smooth minimum ("fatmin") of n values using Pareto-density weighting.
+// Returns min_smooth(x[0..n-1]) and optionally the gradient weights gw[].
+template <typename T>
+inline T compute_fatmin(const T* x, int n, T tau, T inv_tau, T* gw = nullptr) {
+  if (n == 1) {
+    if (gw) {
+      gw[0] = T(1);
+    }
+    return x[0];
+  }
+
+  T mn = x[0];
+  int ami = 0;
+  for (int j = 1; j < n; j++) {
+    if (x[j] < mn) {
+      mn = x[j];
+      ami = j;
+    }
+  }
+
+  if (mn < T(-1e29)) {
+    if (gw) {
+      for (int j = 0; j < n; j++) {
+        gw[j] = (j == ami) ? T(1) : T(0);
+      }
+    }
+    return mn;
+  }
+
+  T S = T(0);
+  T S_pd = T(0);
+  T pd[MAX_I];
+
+  if (gw) {
+    for (int j = 0; j < n; j++) {
+      T zj = (x[j] - mn) * inv_tau;
+      T pv, pder;
+      pareto_val_deriv(zj, pv, pder);
+      S += pv;
+      pd[j] = pder;
+      S_pd += pder;
+    }
+  } else {
+    for (int j = 0; j < n; j++) {
+      T zj = (x[j] - mn) * inv_tau;
+      S += pareto_val_only(zj);
+    }
+  }
+
+  T result = mn - tau * std::log(S);
+
+  if (gw) {
+    T pp0 = T(-1);
+    for (int j = 0; j < n; j++) {
+      if (j == ami) {
+        gw[j] = T(1) + (S_pd - pp0) / S;
+      } else {
+        gw[j] = -pd[j] / S;
+      }
+    }
+  }
+
+  return result;
+}
+
+} // namespace
+
+// Forward: obj_subsets (B, n_sub, i, m),
+//          cell bounds (B_cells, num_cells, m) or (num_cells, m)
+//        → (B, num_cells, n_sub)
+torch::Tensor fused_log_areas_forward(
+    const torch::Tensor& obj_subsets_,
+    const torch::Tensor& cell_lower_,
+    const torch::Tensor& cell_upper_,
+    double tau_relu,
+    double tau_max) {
+  auto obj = obj_subsets_.contiguous();
+  auto cl = cell_lower_.contiguous();
+  auto cu = cell_upper_.contiguous();
+
+  TORCH_CHECK(obj.dim() == 4, "obj_subsets must be 4-D");
+  TORCH_CHECK(
+      (cl.dim() == 2 || cl.dim() == 3) && cl.dim() == cu.dim(),
+      "cell bounds must be 2-D or 3-D");
+
+  const int64_t B = obj.size(0);
+  const int64_t n_sub = obj.size(1);
+  const int64_t isz = obj.size(2);
+  const int64_t m = obj.size(3);
+
+  // Support both (num_cells, m) and (B_cells, num_cells, m)
+  const bool batched_cells = cl.dim() == 3;
+  const int64_t B_cells = batched_cells ? cl.size(0) : 1;
+  const int64_t nc = batched_cells ? cl.size(1) : cl.size(0);
+
+  TORCH_CHECK(isz <= MAX_I && m <= MAX_M, "subset_size or m too large");
+
+  // Reshape cell bounds to 3-D for uniform indexing
+  auto cl3 = batched_cells ? cl : cl.unsqueeze(0);
+  auto cu3 = batched_cells ? cu : cu.unsqueeze(0);
+
+  auto out = torch::empty({B, nc, n_sub}, obj.options());
+
+  AT_DISPATCH_FLOATING_TYPES(obj.scalar_type(), "fused_fwd", [&] {
+    const scalar_t cu_clamp =
+        std::is_same<scalar_t, double>::value ? scalar_t(1e10) : scalar_t(1e8);
+    const scalar_t inv_tau_relu = scalar_t(1) / scalar_t(tau_relu);
+    const scalar_t inv_tau_max = scalar_t(1) / scalar_t(tau_max);
+
+    auto oa = obj.accessor<scalar_t, 4>();
+    auto la3 = cl3.accessor<scalar_t, 3>();
+    auto ua3 = cu3.accessor<scalar_t, 3>();
+    auto ra = out.accessor<scalar_t, 3>();
+
+    // Precompute log cell lengths: (B_cells, nc, m)
+    std::vector<scalar_t> lcl_buf(B_cells * nc * m);
+    for (int64_t bc = 0; bc < B_cells; bc++) {
+      for (int64_t c = 0; c < nc; c++) {
+        for (int64_t k = 0; k < m; k++) {
+          lcl_buf[(bc * nc + c) * m + k] =
+              std::log(std::min(ua3[bc][c][k], cu_clamp) - la3[bc][c][k]);
+        }
+      }
+    }
+
+    at::parallel_for(
+        0, B * n_sub, /*grain_size=*/1, [&](int64_t lo, int64_t hi) {
+          for (int64_t idx = lo; idx < hi; idx++) {
+            const int64_t b = idx / n_sub;
+            const int64_t s = idx % n_sub;
+            const int64_t bc = B_cells == 1 ? 0 : b;
+
+            for (int64_t c = 0; c < nc; c++) {
+              scalar_t li[MAX_M][MAX_I];
+              for (int j = 0; j < isz; j++) {
+                for (int k = 0; k < m; k++) {
+                  li[k][j] = log_fatplus_fwd(
+                      oa[b][s][j][k] - la3[bc][c][k],
+                      scalar_t(tau_relu),
+                      inv_tau_relu);
+                }
+              }
+
+              scalar_t area = scalar_t(0);
+              for (int k = 0; k < m; k++) {
+                scalar_t lim_k = compute_fatmin(
+                    li[k], (int)isz, scalar_t(tau_max), inv_tau_max);
+                scalar_t pair[2] = {lim_k, lcl_buf[(bc * nc + c) * m + k]};
+                area += compute_fatmin(pair, 2, scalar_t(tau_max), inv_tau_max);
+              }
+
+              ra[b][c][s] = area;
+            }
+          }
+        });
+  });
+
+  return out;
+}
+
+torch::Tensor fused_log_areas_backward(
+    const torch::Tensor& grad_output_,
+    const torch::Tensor& obj_subsets_,
+    const torch::Tensor& cell_lower_,
+    const torch::Tensor& cell_upper_,
+    double tau_relu,
+    double tau_max) {
+  auto go = grad_output_.contiguous();
+  auto obj = obj_subsets_.contiguous();
+  auto cl = cell_lower_.contiguous();
+  auto cu = cell_upper_.contiguous();
+
+  const int64_t B = obj.size(0);
+  const int64_t n_sub = obj.size(1);
+  const int64_t isz = obj.size(2);
+  const int64_t m = obj.size(3);
+
+  const bool batched_cells = cl.dim() == 3;
+  const int64_t B_cells = batched_cells ? cl.size(0) : 1;
+  const int64_t nc = batched_cells ? cl.size(1) : cl.size(0);
+
+  auto cl3 = batched_cells ? cl : cl.unsqueeze(0);
+  auto cu3 = batched_cells ? cu : cu.unsqueeze(0);
+
+  auto g_obj = torch::zeros_like(obj);
+
+  AT_DISPATCH_FLOATING_TYPES(obj.scalar_type(), "fused_bwd", [&] {
+    const scalar_t cu_clamp =
+        std::is_same<scalar_t, double>::value ? scalar_t(1e10) : scalar_t(1e8);
+    const scalar_t inv_tau_relu = scalar_t(1) / scalar_t(tau_relu);
+    const scalar_t inv_tau_max = scalar_t(1) / scalar_t(tau_max);
+
+    auto oa = obj.accessor<scalar_t, 4>();
+    auto la3 = cl3.accessor<scalar_t, 3>();
+    auto ua3 = cu3.accessor<scalar_t, 3>();
+    auto ga = go.accessor<scalar_t, 3>();
+    auto goa = g_obj.accessor<scalar_t, 4>();
+
+    std::vector<scalar_t> lcl_buf(B_cells * nc * m);
+    for (int64_t bc = 0; bc < B_cells; bc++) {
+      for (int64_t c = 0; c < nc; c++) {
+        for (int64_t k = 0; k < m; k++) {
+          lcl_buf[(bc * nc + c) * m + k] =
+              std::log(std::min(ua3[bc][c][k], cu_clamp) - la3[bc][c][k]);
+        }
+      }
+    }
+
+    at::parallel_for(
+        0, B * n_sub, /*grain_size=*/1, [&](int64_t lo, int64_t hi) {
+          for (int64_t idx = lo; idx < hi; idx++) {
+            const int64_t b = idx / n_sub;
+            const int64_t s = idx % n_sub;
+            const int64_t bc = B_cells == 1 ? 0 : b;
+
+            scalar_t g_buf[MAX_I][MAX_M] = {};
+
+            for (int64_t c = 0; c < nc; c++) {
+              const scalar_t g_out = ga[b][c][s];
+
+              scalar_t li[MAX_M][MAX_I];
+              scalar_t lg[MAX_M][MAX_I];
+              for (int j = 0; j < isz; j++) {
+                for (int k = 0; k < m; k++) {
+                  log_fatplus_fwd_bwd(
+                      oa[b][s][j][k] - la3[bc][c][k],
+                      scalar_t(tau_relu),
+                      inv_tau_relu,
+                      li[k][j],
+                      lg[k][j]);
+                }
+              }
+
+              for (int k = 0; k < m; k++) {
+                scalar_t fmg[MAX_I];
+                scalar_t lim_k = compute_fatmin(
+                    li[k], (int)isz, scalar_t(tau_max), inv_tau_max, fmg);
+
+                scalar_t pair[2] = {lim_k, lcl_buf[(bc * nc + c) * m + k]};
+                scalar_t fm2g[2];
+                compute_fatmin(pair, 2, scalar_t(tau_max), inv_tau_max, fm2g);
+
+                scalar_t g_lim = g_out * fm2g[0];
+
+                for (int j = 0; j < isz; j++) {
+                  g_buf[j][k] += g_lim * fmg[j] * lg[k][j];
+                }
+              }
+            }
+
+            for (int j = 0; j < isz; j++) {
+              for (int k = 0; k < m; k++) {
+                goa[b][s][j][k] = g_buf[j][k];
+              }
+            }
+          }
+        });
+  });
+
+  return g_obj;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, mod) {
+  mod.def("forward", &fused_log_areas_forward, "Fused log-areas forward");
+  mod.def("backward", &fused_log_areas_backward, "Fused log-areas backward");
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "scipy",
     "multipledispatch",
     "threadpoolctl",
+    "ninja",
 ]
 
 [project.optional-dependencies]
@@ -78,6 +79,7 @@ Repository = "https://github.com/meta-pytorch/botorch"
 
 [tool.setuptools]
 packages.find.exclude = ["test", "test.*", "test_community.*"]
+package-data.botorch = ["csrc/*.cpp"]
 
 [tool.setuptools_scm]
 local_scheme = "node-and-date"

--- a/test/acquisition/multi_objective/test_logei.py
+++ b/test/acquisition/multi_objective/test_logei.py
@@ -5,16 +5,28 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
+import unittest
 
+import botorch.acquisition.multi_objective.logei as logei_module
 import torch
 from botorch.acquisition.multi_objective.base import MultiObjectiveMCAcquisitionFunction
-from botorch.acquisition.multi_objective.logei import qLogExpectedHypervolumeImprovement
+from botorch.acquisition.multi_objective.logei import (
+    _try_load_fused_kernel,
+    qLogExpectedHypervolumeImprovement,
+    qLogNoisyExpectedHypervolumeImprovement,
+)
 from botorch.acquisition.multi_objective.objective import MCMultiOutputObjective
+from botorch.models import SingleTaskGP
 from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.multi_objective.box_decompositions.non_dominated import (
     NondominatedPartitioning,
 )
+from botorch.utils.sampling import draw_sobol_samples
 from botorch.utils.testing import BotorchTestCase, MockModel, MockPosterior
+
+# Trigger lazy loading so we can check availability for skipIf.
+_try_load_fused_kernel()
+_fused_C = logei_module._C
 
 
 class DummyMultiObjectiveMCAcquisitionFunction(MultiObjectiveMCAcquisitionFunction):
@@ -140,3 +152,231 @@ class TestLogQExpectedHypervolumeImprovement(BotorchTestCase):
             self.assertTrue(exp_log_res <= 1e-10)  # should be *very* small
         else:  # This is an interesting difference between the exp and the fat tail.
             self.assertEqual(0, exp_log_res)
+
+
+@unittest.skipIf(_fused_C is None, "C++ extension not available")
+class TestFusedKernelCorrectness(BotorchTestCase):
+    """Verify fused C++ kernel matches pure-Python path for values and gradients."""
+
+    def test_fused_kernel_is_loaded(self) -> None:
+        """Verify the pre-compiled C++ fused kernel extension is available."""
+        self.assertIsNotNone(
+            _fused_C,
+            "Fused C++ kernel (_C) is None — the pre-compiled extension "
+            "was not loaded. Check that the cpp_python_extension target "
+            "'logei_fused_ext' is built and included as a dependency.",
+        )
+        # Verify the extension exposes the expected functions.
+        self.assertTrue(hasattr(_fused_C, "forward"))
+        self.assertTrue(hasattr(_fused_C, "backward"))
+
+    def _compare_fused_vs_python(
+        self,
+        acqf: qLogExpectedHypervolumeImprovement,
+        test_X: torch.Tensor,
+        atol_val: float = 1e-6,
+        atol_grad: float = 1e-6,
+    ) -> None:
+        """Run acqf with fused kernel and Python fallback, compare results."""
+        test_X = test_X.clone().requires_grad_(True)
+
+        # Fused C++ path
+        torch.manual_seed(42)
+        val_fused = acqf(test_X)
+        val_fused.sum().backward()
+        grad_fused = test_X.grad.clone()
+        test_X.grad = None
+
+        # Python fallback path
+        saved = logei_module._C
+        logei_module._C = None
+        try:
+            torch.manual_seed(42)
+            val_python = acqf(test_X)
+            val_python.sum().backward()
+            grad_python = test_X.grad.clone()
+            test_X.grad = None
+        finally:
+            logei_module._C = saved
+
+        self.assertAllClose(val_fused, val_python, atol=atol_val, rtol=1e-6)
+        self.assertAllClose(grad_fused, grad_python, atol=atol_grad, rtol=1e-6)
+
+    def test_fused_kernel_qlogehvi(self) -> None:
+        """Test fused kernel for qLogEHVI across a grid of shapes."""
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        d = 4
+
+        configs = [
+            # (m, q, num_pareto, mc_samples)
+            (2, 1, 3, 8),
+            (2, 2, 5, 16),
+            (2, 4, 5, 16),
+            (2, 6, 3, 8),
+            (3, 2, 5, 8),
+            (3, 4, 3, 8),
+            (4, 2, 3, 8),
+            (4, 4, 3, 8),
+        ]
+
+        for m, q, num_pareto, mc_samples in configs:
+            with self.subTest(m=m, q=q, num_pareto=num_pareto, mc=mc_samples):
+                torch.manual_seed(0)
+                bounds = torch.stack(
+                    [torch.zeros(d, **tkwargs), torch.ones(d, **tkwargs)]
+                )
+                train_X = (
+                    draw_sobol_samples(bounds=bounds, n=num_pareto + 5, q=1)
+                    .squeeze(1)
+                    .to(**tkwargs)
+                )
+                train_Y = torch.randn(train_X.shape[0], m, **tkwargs)
+                model = SingleTaskGP(train_X, train_Y)
+                ref_point = train_Y.min(dim=0).values - 0.1
+                partitioning = NondominatedPartitioning(
+                    ref_point=ref_point, Y=train_Y[:num_pareto]
+                )
+                sampler = SobolQMCNormalSampler(sample_shape=torch.Size([mc_samples]))
+                acqf = qLogExpectedHypervolumeImprovement(
+                    model=model,
+                    ref_point=ref_point.tolist(),
+                    partitioning=partitioning,
+                    sampler=sampler,
+                )
+                test_X = torch.rand(q, d, **tkwargs)
+                self._compare_fused_vs_python(acqf, test_X)
+
+    def test_fused_kernel_qlognehvi(self) -> None:
+        """Test fused kernel for qLogNEHVI (batched cell bounds)."""
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        d = 4
+
+        configs = [
+            # (m, q, n_train, mc_samples)
+            (2, 2, 10, 8),
+            (2, 4, 15, 8),
+            (3, 2, 10, 8),
+        ]
+
+        for m, q, n_train, mc_samples in configs:
+            with self.subTest(m=m, q=q, n_train=n_train, mc=mc_samples):
+                torch.manual_seed(0)
+                train_X = torch.rand(n_train, d, **tkwargs)
+                train_Y = torch.randn(n_train, m, **tkwargs)
+                model = SingleTaskGP(train_X, train_Y)
+                ref_point = train_Y.min(dim=0).values - 0.1
+                sampler = SobolQMCNormalSampler(sample_shape=torch.Size([mc_samples]))
+                acqf = qLogNoisyExpectedHypervolumeImprovement(
+                    model=model,
+                    ref_point=ref_point.tolist(),
+                    X_baseline=train_X,
+                    sampler=sampler,
+                )
+                test_X = torch.rand(q, d, **tkwargs)
+                self._compare_fused_vs_python(acqf, test_X)
+
+    def test_fused_kernel_tbatch_broadcasting(self) -> None:
+        """Test fused kernel with t-batch dims (multi-restart optimization)."""
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        d = 4
+        m = 2
+
+        torch.manual_seed(0)
+        train_X = torch.rand(3, 10, d, **tkwargs)  # model batch = 3
+        train_Y = torch.randn(3, 10, m, **tkwargs)
+        model = SingleTaskGP(train_X, train_Y)
+        ref_point = train_Y.reshape(-1, m).min(dim=0).values - 0.1
+        sampler = IIDNormalSampler(sample_shape=torch.Size([4]), seed=0)
+
+        torch.manual_seed(0)
+        acqf = qLogNoisyExpectedHypervolumeImprovement(
+            model=model,
+            ref_point=ref_point.tolist(),
+            X_baseline=train_X[0],
+            sampler=sampler,
+            prune_baseline=False,
+            cache_root=False,
+        )
+
+        for batch_shape in [
+            torch.Size([]),
+            torch.Size([3]),
+            torch.Size([5, 3]),
+        ]:
+            with self.subTest(batch_shape=batch_shape):
+                test_X = torch.rand(*batch_shape, 2, d, **tkwargs)
+                self._compare_fused_vs_python(
+                    acqf, test_X, atol_val=1e-3, atol_grad=1e-3
+                )
+
+    def test_fused_kernel_branch_coverage(self) -> None:
+        """Test fused kernel with crafted inputs targeting specific C++ branches.
+
+        Uses MockModel to inject exact objective values, bypassing the GP.
+        With TAU_RELU=1e-6, safe_softplus branches at |obj - cell_lower| ≈ 2e-5:
+          y > 20 (linear):   obj - cell_lower > 2e-5
+          y < -20 (exp):     obj - cell_lower < -2e-5
+          -20 <= y <= 20:    |obj - cell_lower| < 2e-5
+
+        Case A (q=2, m=2): hits all three safe_softplus branches in one
+          forward pass (each subset element × objective dim lands in a
+          different regime) + compute_fatmin general case (n=2).
+        Case B (q=1, m=2): hits compute_fatmin identity path (n=1).
+        """
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        ref_point = [0.0, 0.0]
+        pareto_Y = torch.tensor([[3.0, 3.0]], **tkwargs)
+        partitioning = NondominatedPartitioning(
+            ref_point=torch.tensor(ref_point, **tkwargs),
+            Y=pareto_Y,
+        )
+        # cell_lower ≈ [0, 0], cell_upper ≈ [3, 3] from the partitioning.
+
+        # Case A: q=2, crafted to hit all safe_softplus branches.
+        # elem[0]: dim0 diff=+5e-6 (y=5, middle), dim1 diff=+4.0 (y=4e6, linear)
+        # elem[1]: dim0 diff=-6.0 (y=-6e6, exp), dim1 diff=+1e-5 (y=10, middle)
+        # q=2 -> compute_fatmin with n=2 (general case).
+        samples_a = torch.tensor(
+            [[[[0.000005, 4.0], [-6.0, 0.00001]]]],
+            **tkwargs,
+        )  # (mc=1, batch=1, q=2, m=2)
+        mm_a = MockModel(MockPosterior(samples=samples_a))
+        acqf_a = qLogExpectedHypervolumeImprovement(
+            model=mm_a,
+            ref_point=ref_point,
+            partitioning=partitioning,
+            sampler=IIDNormalSampler(sample_shape=torch.Size([1])),
+        )
+        X_a = torch.zeros(2, 1, **tkwargs)
+        # Compare forward values (no grad through MockModel).
+        val_fused = acqf_a(X_a)
+        saved = logei_module._C
+        logei_module._C = None
+        try:
+            val_python = acqf_a(X_a)
+        finally:
+            logei_module._C = saved
+        self.assertAllClose(val_fused, val_python, atol=1e-6, rtol=0)
+
+        # Case B: q=1, objectives far above cell_lower (linear regime).
+        # q=1 -> compute_fatmin with n=1 (identity path).
+        samples_b = torch.tensor(
+            [[[[5.0, 3.0]]]],
+            **tkwargs,
+        )  # (mc=1, batch=1, q=1, m=2)
+        mm_b = MockModel(MockPosterior(samples=samples_b))
+        acqf_b = qLogExpectedHypervolumeImprovement(
+            model=mm_b,
+            ref_point=ref_point,
+            partitioning=partitioning,
+            sampler=IIDNormalSampler(sample_shape=torch.Size([1])),
+        )
+        X_b = torch.zeros(1, 1, **tkwargs)
+        val_fused = acqf_b(X_b)
+        saved = logei_module._C
+        logei_module._C = None
+        try:
+            val_python = acqf_b(X_b)
+        finally:
+            logei_module._C = saved
+        self.assertAllClose(val_fused, val_python, atol=1e-6, rtol=0)


### PR DESCRIPTION
Summary:
Adds a fused C++ kernel that accelerates the inner loop of `_compute_log_qehvi` by ~1.5-3.5x on CPU. The kernel replaces ~25 intermediate tensor allocations per loop iteration with a single pass that keeps all intermediates in registers.

The speedup is transparent — users don't need to change any code. Both `qLogExpectedHypervolumeImprovement` and `qLogNoisyExpectedHypervolumeImprovement` (including fully Bayesian models) automatically use the fused kernel when available. The C++ extension is JIT-compiled on first import (~7s one-time cost, cached thereafter). If compilation fails (no C++ compiler), the existing pure-Python implementation is used automatically with a warning.

### What changes

- **`botorch/acquisition/multi_objective/logei.py`**: `_compute_log_qehvi` now uses a fused C++ kernel for steps 1-4 of the inner loop when `fat=True` and `device=cpu`. Falls back to the original Python path when the C++ extension is unavailable or `fat=False`. Supports all cell batch dimensions (non-batched for qLogEHVI, per-MC-sample batched for qLogNEHVI, and multi-batch for fully Bayesian qLogNEHVI).
- **`botorch/csrc/logei_fused.cpp`**: C++ forward + backward kernels accepting both 2-D `(num_cells, m)` and 3-D `(B_cells, num_cells, m)` cell bounds.
- **`pyproject.toml`**: Adds `ninja` dependency (tiny build-system binary required by `torch.utils.cpp_extension` for JIT compilation).

### Key optimizations in the C++ kernel
- Fused `log_fatplus` forward+backward (eliminates redundant `exp`/`sigmoid`/`cauchy`)
- Fused `pareto_val` + `pareto_deriv` (single denominator computation)
- Precomputed `1/tau` (division → multiplication)
- Transposed `li[M][I]` layout for contiguous `compute_fatmin` reads
- Local gradient accumulation buffer (one write to output per work item)


Test Plan:
### Correctness
- [x] Numerical verification: all configs pass with zero value difference and gradient differences at machine epsilon (~1e-15)
- [x] Gradient correctness verified via comparison with Python fallback across 8+ configs varying `m`, `q`, `num_pareto`
- [x] `qLogNoisyExpectedHypervolumeImprovement` verified numerically identical to Python fallback (batched cell bounds, `cell_batch_ndim=1`)
- [x] Fully Bayesian `qLogNoisyExpectedHypervolumeImprovement` with `SaasFullyBayesianSingleTaskGP` verified numerically identical to Python fallback (`cell_batch_ndim=2`)
- [x] Graceful fallback: emits warning and uses Python path when C++ compilation fails

# Internal Benchmarks
Uses Ax benchmarks. Results analyzed in N10381243. Table below generated by claude based on results in the notebook.

   ## Generation Time Speedup

  | Problem | Model | Fused (s) | Python (s) | Speedup |
  |---------|-------|-----------|------------|---------|
  | BraninCurrin | SingleTaskGP | 30.4 ± 1.3 | 44.7 ± 1.4 | **1.47x** |
  | BraninCurrin (q=5) | SingleTaskGP | 16.2 ± 0.7 | 22.3 ± 0.9 | **1.38x** |
  | BraninCurrin | SAAS | 104.6 ± 2.4 | 200.9 ± 31.1 | **1.92x** |
  | BraninCurrin (q=5) | SAAS | 54.8 ± 1.5 | 64.6 ± 1.6 | **1.18x** |
  | BraninCurrin_30d | SingleTaskGP | 253.9 ± 27.1 | 260.1 ± 18.0 | **1.02x** |
  | BraninCurrin_30d | SAAS | 811.3 ± 21.1 | 1037.3 ± 42.3 | **1.28x** |
  | Star Search (NE+QPS) | SingleTaskGP | 215.8 ± 12.2 | 242.6 ± 9.5 | **1.12x** |
  | Star Search (NE+QPS) | SAAS | 401.7 ± 11.8 | 489.0 ± 12.8 | **1.22x** |

  ## Key Observations

  - **Largest speedup on fully Bayesian models**: BraninCurrin with SAAS shows ~1.9x speedup. The fully Bayesian model draws multiple posterior samples, so the acquisition function inner loop runs more times, amplifying the kernel's
  per-evaluation speedup.
  - **Low-dimensional problems benefit more**: BraninCurrin (2D) shows larger speedups than BraninCurrin_30d (30D), where model fitting and acquisition optimization overhead dominate.
  - **Minimal speedup when fitting dominates**: BraninCurrin_30d with SingleTaskGP shows only 1.02x — gen time is dominated by L-BFGS acquisition optimization, not the acqf evaluation itself.
  - **Fit times are comparable** across fused/Python variants, as expected (the kernel only affects acquisition function evaluation).

  ## Benchmark Configuration

  - **Workflow run**: f1066539043
  - **Replications**: 20 per problem/method
  - **Methods**: `{SingleTaskGP, SaasFullyBayesianSingleTaskGP} × {fused C++ kernel, pure Python}`
  - **Problems**: BraninCurrin (q=1), BraninCurrin (q=5), BraninCurrin_30d, Star Search MOO (NE+QPS)



# Local benchmarks setup

Profiled on Apple Silicon (M-series), CPU only, `dtype=torch.double`.

Each benchmark constructs a `SingleTaskGP` model on random Sobol training data in `d=6` input dimensions with `m` objectives. A `NondominatedPartitioning` is built from a subset of training points to create the hyperrectangle cell decomposition. The acquisition function is evaluated on a `q x d` candidate batch.

**Parameters:**
- **`m`** — number of objectives (2, 3, or 4)
- **`q`** — candidate batch size, i.e. number of points evaluated jointly (1 to 8)
- **`np`** — number of points used for the Pareto partitioning; controls the number of hyperrectangle cells in the decomposition (5, 10, or 20)
- **`mc`** — number of MC posterior samples via `SobolQMCNormalSampler` (64 or 256)
- **`d = 6`** — input dimensionality (fixed)
- **`n_train = np + 10`** — total training points for the GP model (15 to 30)

**Timing:** 3 warmup evaluations, then 10 timed evaluations. Both forward-only and forward+backward (as used by L-BFGS-B during acquisition optimization) are measured.

### qLogEHVI benchmark results

```
variant         m  q  np   mc     fwd_ms ± std      fwd+bwd_ms ± std
------------------------------------------------------------------------
original        2  1   5   64       0.95 ±  0.01          1.55 ±  0.01
fused_cpp       2  1   5   64       0.83 ±  0.02          1.30 ±  0.02
original        2  2   5   64       1.42 ±  0.16          2.24 ±  0.19
fused_cpp       2  2   5   64       1.03 ±  0.10          1.64 ±  0.12
original        2  4   5   64       2.29 ±  0.21          3.86 ±  0.22
fused_cpp       2  4   5   64       1.19 ±  0.03          2.22 ±  0.14
original        2  4  10   64       2.72 ±  0.20          4.36 ±  0.20
fused_cpp       2  4  10   64       1.41 ±  0.14          2.42 ±  0.19
original        2  6   5   64       4.73 ±  0.15          8.41 ±  0.29
fused_cpp       2  6   5   64       1.93 ±  0.13          3.69 ±  0.25
original        2  6  10   64       6.35 ±  0.20         10.78 ±  0.20
fused_cpp       2  6  10   64       2.22 ±  0.14          4.29 ±  0.16
original        2  8   5   64      15.01 ±  0.50         32.29 ±  1.32
fused_cpp       2  8   5   64       4.99 ±  0.12         10.36 ±  0.90
original        3  4   5   64       3.59 ±  0.13          6.11 ±  0.24
fused_cpp       3  4   5   64       1.60 ±  0.15          2.79 ±  0.19
original        3  4  10   64      16.05 ±  0.81         34.87 ±  1.08
fused_cpp       3  4  10   64       5.35 ±  0.40         10.08 ±  0.24
original        4  2   5   64       5.98 ±  0.29         12.25 ±  1.82
fused_cpp       4  2   5   64       2.54 ±  0.11          4.36 ±  0.16
original        4  4   5   64      21.33 ±  0.48         46.11 ±  1.15
fused_cpp       4  4   5   64       7.10 ±  0.20         14.32 ±  0.31
original        2  4   5  256       4.46 ±  0.34          7.66 ±  0.34
fused_cpp       2  4   5  256       1.72 ±  0.15          3.13 ±  0.12
original        2  4  10  256       5.37 ±  0.38          9.72 ±  0.50
fused_cpp       2  4  10  256       2.00 ±  0.08          3.87 ±  0.17
```

#### qLogEHVI speedup summary

```
   m  q  np   mc       fwd     fwd+bwd
   2  1   5   64     1.15x       1.20x
   2  2   5   64     1.37x       1.37x
   2  4   5   64     1.93x       1.74x
   2  4   5  256     2.59x       2.45x
   2  4  10   64     1.93x       1.80x
   2  4  10  256     2.68x       2.51x
   2  4  20   64     2.11x       1.95x
   2  6   5   64     2.45x       2.28x
   2  6  10   64     2.87x       2.51x
   2  8   5   64     3.01x       3.12x
   3  2   5   64     1.36x       1.40x
   3  4   5   64     2.25x       2.19x
   3  4  10   64     3.00x       3.46x
   4  2   5   64     2.36x       2.81x
   4  4   5   64     3.00x       3.22x
```

### qLogNEHVI benchmark results

For qLogNEHVI, `n_train` is the number of baseline points (used for both the GP model and the per-sample Pareto decomposition). `mc` is the number of MC samples.

```
cfg (m, q, n_train, mc)    py_fwd  cpp_fwd  fwd_sp    py_fb   cpp_fb   fb_sp
(2, 2, 15, 32)               1.5ms    1.2ms   1.29x    2.4ms    1.8ms   1.35x
(2, 2, 15, 64)               1.8ms    1.2ms   1.43x    2.7ms    1.9ms   1.40x
(2, 2, 30, 32)               1.7ms    1.3ms   1.28x    2.5ms    2.0ms   1.26x
(2, 4, 15, 32)               3.0ms    1.8ms   1.70x    5.1ms    2.8ms   1.82x
(2, 4, 15, 64)               4.6ms    1.9ms   2.50x    7.3ms    3.4ms   2.13x
(2, 4, 30, 32)               3.9ms    1.8ms   2.19x    5.7ms    2.7ms   2.11x
(2, 6, 15, 32)               7.4ms    2.7ms   2.77x   13.2ms    5.1ms   2.61x
(3, 2, 15, 32)               2.2ms    1.5ms   1.45x    3.4ms    2.2ms   1.55x
(3, 2, 15, 64)               2.7ms    1.5ms   1.81x    4.1ms    2.3ms   1.77x
(3, 4, 15, 32)               5.0ms    1.9ms   2.70x    8.1ms    3.3ms   2.43x
(4, 2, 15, 32)               7.4ms    3.0ms   2.46x   12.3ms    5.5ms   2.23x
(4, 2, 15, 64)              13.0ms    3.8ms   3.47x   22.5ms    6.8ms   3.30x
```

Speedup scales with problem complexity (higher `q`, `m`, `mc`). Largest gains at `q>=4` with `m>=3` or more MC samples.


# Additional benchmarks for `optimize_acqf`

All benchmarks: CPU, `dtype=torch.double`, `d=6`, Apple Silicon (M-series).
Timing: `optimize_acqf` end-to-end (includes GP posterior, initial conditions, L-BFGS).
Each measurement: 1 warmup + mean of 3 timed runs.

## qLogEHVI (m=2) - varying q, np, mc, num_restarts

| q | np | mc | nr | rs | Python | Fused C++ | Speedup |
|---|----|----|----|----|--------|-----------|---------|
| 1 | 5 | 64 | 4 | 32 | 43ms | 37ms | 1.15x |
| 1 | 5 | 128 | 4 | 32 | 55ms | 41ms | 1.34x |
| 1 | 5 | 256 | 4 | 32 | 71ms | 49ms | 1.44x |
| 1 | 10 | 64 | 4 | 32 | 57ms | 45ms | 1.26x |
| 1 | 20 | 64 | 4 | 32 | 73ms | 59ms | 1.23x |
| 1 | 5 | 64 | 8 | 64 | 91ms | 66ms | 1.37x |
| 2 | 5 | 64 | 4 | 32 | 298ms | 203ms | 1.47x |
| 2 | 10 | 64 | 4 | 32 | 211ms | 170ms | 1.24x |
| 2 | 5 | 128 | 4 | 32 | 401ms | 293ms | 1.37x |
| 2 | 5 | 64 | 8 | 64 | 350ms | 215ms | 1.63x |
| 4 | 5 | 64 | 4 | 32 | 1751ms | 828ms | 2.11x |
| 4 | 10 | 64 | 4 | 32 | 992ms | 452ms | 2.19x |
| 4 | 5 | 128 | 4 | 32 | 3012ms | 1193ms | 2.53x |
| 4 | 5 | 64 | 8 | 64 | 3597ms | 1291ms | 2.79x |
| 4 | 10 | 128 | 8 | 64 | 3739ms | 1362ms | 2.75x |
| 6 | 5 | 64 | 4 | 32 | 12408ms | 3201ms | 3.88x |
| 6 | 10 | 64 | 4 | 32 | 5935ms | 1720ms | 3.45x |
| 8 | 5 | 64 | 4 | 32 | 51110ms | 15189ms | 3.36x |

## qLogEHVI (m=2, q=1, mc=128) - varying X_pending

This simulates sequential greedy optimization where q=1 is optimized
repeatedly with a growing set of pending points. The effective
`q_out = 1 + n_pending`.

| np | X_pending | Eff. q_out | Python | Fused C++ | Speedup |
|----|-----------|------------|--------|-----------|---------|
| 5 | 0 | 1 | 47ms | 36ms | 1.33x |
| 5 | 1 | 2 | 75ms | 44ms | 1.71x |
| 5 | 2 | 3 | 216ms | 101ms | 2.13x |
| 5 | 3 | 4 | 383ms | 137ms | 2.79x |
| 5 | 4 | 5 | 713ms | 248ms | 2.88x |
| 5 | 5 | 6 | 1425ms | 439ms | 3.25x |
| 5 | 7 | 8 | 8652ms | 2764ms | 3.13x |
| 10 | 0 | 1 | 102ms | 71ms | 1.43x |
| 10 | 3 | 4 | 932ms | 208ms | 4.49x |
| 10 | 5 | 6 | 3466ms | 848ms | 4.09x |
| 10 | 7 | 8 | 7130ms | 2729ms | 2.61x |

## qLogEHVI - varying m (number of objectives)

| m | q | np | mc | nr | rs | Python | Fused C++ | Speedup |
|---|---|----|----|----|----|--------|-----------|---------|
| 2 | 4 | 5 | 64 | 4 | 32 | 1751ms | 828ms | 2.11x |
| 2 | 4 | 10 | 64 | 4 | 32 | 992ms | 452ms | 2.19x |
| 3 | 4 | 5 | 64 | 4 | 32 | 5208ms | 1799ms | 2.90x |
| 4 | 1 | 5 | 64 | 4 | 32 | 568ms | 242ms | 2.35x |
| 4 | 4 | 5 | 64 | 4 | 32 | 50622ms | 15024ms | 3.37x |

## qLogNEHVI (m=2) - noisy variant

| q | n_train | mc | nr | rs | Python | Fused C++ | Speedup |
|---|---------|----|----|-----|--------|-----------|---------|
| 1 | 15 | 32 | 4 | 32 | 56ms | 49ms | 1.15x |
| 1 | 15 | 64 | 4 | 32 | 84ms | 55ms | 1.52x |
| 1 | 30 | 32 | 4 | 32 | 102ms | 77ms | 1.33x |
| 2 | 15 | 32 | 4 | 32 | 306ms | 198ms | 1.55x |
| 2 | 15 | 64 | 4 | 32 | 542ms | 346ms | 1.57x |
| 2 | 30 | 64 | 4 | 32 | 262ms | 183ms | 1.43x |
| 4 | 15 | 32 | 4 | 32 | 2795ms | 931ms | 3.00x |
| 4 | 15 | 64 | 4 | 32 | 4272ms | 1194ms | 3.58x |
| 4 | 15 | 64 | 8 | 64 | 10549ms | 2906ms | 3.63x |

Reviewed By: esantorella

Differential Revision: D100830661

Pulled By: saitcakmak


