### PR TITLE
Fix DeprecationWarning in Standardize.untransform_posterior

### DIFF
--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -36,7 +36,11 @@ from botorch.models.transforms.utils import (
 from botorch.models.utils.assorted import get_task_value_remapping
 from botorch.posteriors import GPyTorchPosterior, Posterior, TransformedPosterior
 from botorch.utils.transforms import normalize_indices
-from linear_operator.operators import CholLinearOperator, DiagLinearOperator
+from linear_operator.operators import (
+    CholLinearOperator,
+    DiagLinearOperator,
+    TriangularLinearOperator,
+)
 from torch import Tensor
 from torch.nn import Module, ModuleDict
 
@@ -491,7 +495,9 @@ class Standardize(OutcomeTransform):
             or mvn._MultivariateNormal__unbroadcasted_scale_tril is not None
         ):
             # if already computed, we can save a lot of time using scale_tril
-            covar_tf = CholLinearOperator(mvn.scale_tril * scale_fac.unsqueeze(-1))
+            covar_tf = CholLinearOperator(
+                TriangularLinearOperator(mvn.scale_tril * scale_fac.unsqueeze(-1))
+            )
         else:
             lcv = mvn.lazy_covariance_matrix
             scale_fac = scale_fac.expand(lcv.shape[:-1])


### PR DESCRIPTION
## Motivation

Fixes a deprecation warning by wrapping `scale_tril` in a `TriangularLinearOperator` before passing it to `linear_operator.operators.CholLinearOperator`, which deprecated the use of dense tensors.

### Minimal Reproducing Example
```python
import warnings

import torch
from botorch.models.transforms.outcome import Standardize
from botorch.posteriors.gpytorch import GPyTorchPosterior
from gpytorch.distributions import MultivariateNormal

warnings.simplefilter("error")

mean = torch.tensor([1.0, 2.0])
covar = torch.eye(2) * 0.5
mvn = MultivariateNormal(mean, covar)
posterior = GPyTorchPosterior(mvn)
transform = Standardize(m=1)
transform(torch.tensor([[1.0], [2.0]]))
transform.untransform_posterior(posterior)
```

```python
DeprecationWarning: chol argument to CholLinearOperator should be a TriangularLinearOperator. Passing a dense tensor will cause errors in future versions.
```

## Comments

There might be other places where a similar fix is necessary – I guess the BoTorch team has a better overview 🙃 