### PR TITLE
Fix PairwiseGP test that fails on CUDA

### DIFF
--- a/botorch/models/pairwise_gp.py
+++ b/botorch/models/pairwise_gp.py
@@ -887,7 +887,7 @@ class PairwiseGP(Model, GP, FantasizeMixin):
         self.D = torch.zeros(
             D_size, dtype=self.datapoints.dtype, device=self.datapoints.device
         )
-        comp_view = self.comparisons.view(-1, self.m, 2).long()
+        comp_view = self.comparisons.view(-1, self.m, 2).long().to(self.D.device)
         for i, sub_D in enumerate(self.D.view(-1, self.m, self.n)):
             sub_D.scatter_(1, comp_view[i, :, [0]], 1)
             sub_D.scatter_(1, comp_view[i, :, [1]], -1)

--- a/botorch/models/utils/priors.py
+++ b/botorch/models/utils/priors.py
@@ -59,12 +59,22 @@ class BetaPrior(Prior, Beta):
             )
         self._transform = transform
 
-    def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
-        super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
-        # Sync buffered values back into the underlying Dirichlet distribution.
+    def _update_dirichlet_concentration(self) -> None:
+        """
+        Sync buffered values back into the underlying Dirichlet distribution.
+        """
         c1 = getattr(self, f"{BUFFERED_PREFIX}concentration1")
         c0 = getattr(self, f"{BUFFERED_PREFIX}concentration0")
         self._dirichlet.concentration = torch.stack([c1, c0], dim=-1)
+
+    def _apply(self, fn: Callable):
+        to_return = super()._apply(fn)
+        self._update_dirichlet_concentration()
+        return to_return
+
+    def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
+        super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
+        self._update_dirichlet_concentration()
 
     def expand(self, batch_shape: torch.Size) -> "BetaPrior":
         batch_shape = torch.Size(batch_shape)

--- a/test/models/utils/test_priors.py
+++ b/test/models/utils/test_priors.py
@@ -4,15 +4,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
-
 import torch
 from botorch.models.utils.priors import BetaPrior
+from botorch.utils.testing import BotorchTestCase
 from gpytorch.priors.utils import BUFFERED_PREFIX
 from torch.distributions import Beta
 
 
-class TestBetaPrior(unittest.TestCase):
+class TestBetaPrior(BotorchTestCase):
     def test_init(self):
         prior = BetaPrior(1.2, 0.9)
         self.assertAlmostEqual(prior.concentration1.item(), 1.2)
@@ -82,3 +81,10 @@ class TestBetaPrior(unittest.TestCase):
         expanded = prior.expand(torch.Size([3, 2]))
         self.assertIs(expanded._transform, torch.sigmoid)
         self.assertEqual(expanded._validate_args, prior._validate_args)
+
+    def test_to_device(self) -> None:
+        prior = BetaPrior(1.2, 0.9).to(device=self.device)
+        self.assertEqual(prior._dirichlet.concentration.device.type, self.device.type)
+        self.assertEqual(prior._dirichlet.concentration.dtype, torch.float)
+        prior = prior.to(dtype=torch.double)
+        self.assertEqual(prior._dirichlet.concentration.dtype, torch.double)


### PR DESCRIPTION
Summary:
**Context**: `test_load_state_dict_recomputes_laplace` from `botorch.test.models.test_pairwise_gp.TestPairwiseGP` has been failing since it was added (D99173855) due to an issue with tensors on different devices.

**This PR**: Moves a tensor to the appropriate device

Reviewed By: ItsMrLin

Differential Revision: D101675014


